### PR TITLE
20240710 api endpoints for nodes and node

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -39,6 +39,17 @@ class API:
                                 nodes_to_keep.append(node_id)
                         nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
 
+            if "shortname" in request.query_params.keys():
+                shortname: str|None = request.query_params.get("shortname")
+                if shortname is not None:
+                    shortname = shortname.strip()
+                    if shortname != "":
+                        nodes_to_keep = []
+                        for id in nodes:
+                            if shortname.lower() in nodes[id]["shortname"].lower():
+                                nodes_to_keep.append(id)
+                        nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
+
             if "status" in request.query_params.keys():
                 status: str|None = request.query_params.get("status")
                 if status is not None:

--- a/api/api.py
+++ b/api/api.py
@@ -20,11 +20,6 @@ class API:
         async def root(request: Request):
             return templates.TemplateResponse(request=request, name="index.html.j2", context={})
 
-        @app.get("/v1/config")
-        async def config(request: Request) -> JSONResponse:
-            # TODO: Sanitize config (i.e. username, password, api_key, etc)
-            return jsonable_encoder({ "config": self.config })
-
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
             return jsonable_encoder({"nodes": self.data.nodes })
@@ -42,6 +37,11 @@ class API:
                 return jsonable_encoder({ "node": self.data.nodes[utils.convert_node_id_from_int_to_hex(node_id)] })
             else:
                 return JSONResponse(status_code=404, content={"error": "Node not found"})
+
+        @app.get("/v1/server/config")
+        async def config(request: Request) -> JSONResponse:
+            # TODO: Sanitize config (i.e. username, password, api_key, etc)
+            return jsonable_encoder({ "config": self.config })
 
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -22,6 +22,8 @@ class API:
 
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
+            if request.query_params.get("ids"):
+                return jsonable_encoder({ "nodes": [ self.data.nodes[id] for id in request.query_params.get("ids").split(",") ] })
             return jsonable_encoder({"nodes": self.data.nodes })
 
         @app.get("/v1/nodes/{id}")

--- a/api/api.py
+++ b/api/api.py
@@ -39,14 +39,25 @@ class API:
                                 nodes_to_keep.append(node_id)
                         nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
 
-            if "shortname" in request.query_params.keys():
-                shortname: str|None = request.query_params.get("shortname")
+            if "long_name" in request.query_params.keys():
+                longname: str|None = request.query_params.get("long_name")
+                if longname is not None:
+                    longname = longname.strip()
+                    if longname != "":
+                        nodes_to_keep = []
+                        for id in nodes:
+                            if longname.lower() in nodes[id]["long_name"].lower():
+                                nodes_to_keep.append(id)
+                        nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
+
+            if "short_name" in request.query_params.keys():
+                shortname: str|None = request.query_params.get("short_name")
                 if shortname is not None:
                     shortname = shortname.strip()
                     if shortname != "":
                         nodes_to_keep = []
                         for id in nodes:
-                            if shortname.lower() in nodes[id]["shortname"].lower():
+                            if shortname.lower() in nodes[id]["short_name"].lower():
                                 nodes_to_keep.append(id)
                         nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
 

--- a/api/api.py
+++ b/api/api.py
@@ -20,6 +20,11 @@ class API:
         async def root(request: Request):
             return templates.TemplateResponse(request=request, name="index.html.j2", context={})
 
+        @app.get("/v1/config")
+        async def config(request: Request) -> JSONResponse:
+            # TODO: Sanitize config (i.e. username, password, api_key, etc)
+            return jsonable_encoder({ "config": self.config })
+
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
             return jsonable_encoder({"nodes": self.data.nodes })
@@ -37,6 +42,8 @@ class API:
                 return jsonable_encoder({ "node": self.data.nodes[utils.convert_node_id_from_int_to_hex(node_id)] })
             else:
                 return JSONResponse(status_code=404, content={"error": "Node not found"})
+
+
 
         config = uvicorn.Config(app, host="0.0.0.0", port=9000, loop=loop)
         server = uvicorn.Server(config)

--- a/api/api.py
+++ b/api/api.py
@@ -5,6 +5,8 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
+import utils
+
 templates = Jinja2Templates(directory="./templates/api")
 app = FastAPI()
 
@@ -18,9 +20,23 @@ class API:
         async def root(request: Request):
             return templates.TemplateResponse(request=request, name="index.html.j2", context={})
 
-        @app.get("/nodes")
+        @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
             return jsonable_encoder(self.data.nodes)
+
+        @app.get("/v1/nodes/{id}")
+        async def node(request: Request, id: str) -> JSONResponse:
+            try:
+                node_id = int(id)
+            except ValueError:
+                node_id = id
+
+            if isinstance(node_id, str) and id in self.data.nodes:
+                return jsonable_encoder(self.data.nodes[node_id])
+            elif isinstance(node_id, int) and utils.convert_node_id_from_int_to_hex(node_id) in self.data.nodes:
+                return jsonable_encoder(self.data.nodes[utils.convert_node_id_from_int_to_hex(node_id)])
+            else:
+                return JSONResponse(status_code=404, content={"error": "Node not found"})
 
         config = uvicorn.Config(app, host="0.0.0.0", port=9000, loop=loop)
         server = uvicorn.Server(config)

--- a/api/api.py
+++ b/api/api.py
@@ -22,7 +22,7 @@ class API:
 
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
-            return jsonable_encoder(self.data.nodes)
+            return jsonable_encoder({"nodes": self.data.nodes })
 
         @app.get("/v1/nodes/{id}")
         async def node(request: Request, id: str) -> JSONResponse:
@@ -32,9 +32,9 @@ class API:
                 node_id = id
 
             if isinstance(node_id, str) and id in self.data.nodes:
-                return jsonable_encoder(self.data.nodes[node_id])
+                return jsonable_encoder({ "node": self.data.nodes[node_id] })
             elif isinstance(node_id, int) and utils.convert_node_id_from_int_to_hex(node_id) in self.data.nodes:
-                return jsonable_encoder(self.data.nodes[utils.convert_node_id_from_int_to_hex(node_id)])
+                return jsonable_encoder({ "node": self.data.nodes[utils.convert_node_id_from_int_to_hex(node_id)] })
             else:
                 return JSONResponse(status_code=404, content={"error": "Node not found"})
 

--- a/api/api.py
+++ b/api/api.py
@@ -22,9 +22,25 @@ class API:
 
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
-            if request.query_params.get("ids"):
-                return jsonable_encoder({ "nodes": [ self.data.nodes[id] for id in request.query_params.get("ids").split(",") ] })
-            return jsonable_encoder({"nodes": self.data.nodes })
+            nodes = []
+            if "ids" in request.query_params.keys():
+                ids: str|None = request.query_params.get("ids")
+                if ids is not None:
+                    ids = ids.strip()
+                    if ids != "":
+                        nodes = []
+                        for id in ids.split(","):
+                            try:
+                                node_id = int(id)
+                                node_id = utils.convert_node_id_from_int_to_hex(node_id)
+                            except ValueError:
+                                node_id = id
+                            if id in self.data.nodes:
+                                nodes.append(self.data.nodes[id])
+            else:
+                nodes = self.data.nodes
+
+            return jsonable_encoder({"nodes": nodes })
 
         @app.get("/v1/nodes/{id}")
         async def node(request: Request, id: str) -> JSONResponse:

--- a/api/api.py
+++ b/api/api.py
@@ -46,7 +46,7 @@ class API:
                     if longname != "":
                         nodes_to_keep = []
                         for id in nodes:
-                            if longname.lower() in nodes[id]["long_name"].lower():
+                            if longname.lower() in nodes[id]["longname"].lower():
                                 nodes_to_keep.append(id)
                         nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
 
@@ -57,7 +57,7 @@ class API:
                     if shortname != "":
                         nodes_to_keep = []
                         for id in nodes:
-                            if shortname.lower() in nodes[id]["short_name"].lower():
+                            if shortname.lower() in nodes[id]["shortname"].lower():
                                 nodes_to_keep.append(id)
                         nodes = { k: v for k, v in nodes.items() if k in nodes_to_keep }
 


### PR DESCRIPTION
To start addressing https://github.com/MeshAddicts/meshinfo/issues/34.

Includes:
* `/v1/nodes`
* `/v1/node/:id`

The `/v1/nodes` endpoint accepts the following params:
* `ids` (comma-separated list of ids in either hex or int format, or a combination of both)
* `short_name` (case insensitive filter for short names)
* `long_name` (case insensitive filter for long names)
* `status` (either `online` or `offline`)