### PR TITLE
Make MemoryDataStore.save async.

### DIFF
--- a/data_renderer.py
+++ b/data_renderer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import asyncio
 import json
 
 from encoders import _JSONEncoder
@@ -9,7 +10,10 @@ class DataRenderer:
     self.config = config
     self.data = data
 
-  def render(self):
+  async def render(self):
+      await asyncio.to_thread(self._render)
+
+  def _render(self):
     self.save_file("chat.json", self.data.chat)
     print(f"Saved {len(self.data.chat['channels']['0']['messages'])} chat messages to file ({self.config['paths']['data']}/chat.json)")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiomqtt
+aiohttp
 jinja2
 scipy
 python-dotenv

--- a/static_html_renderer.py
+++ b/static_html_renderer.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import asyncio
+import copy
 import datetime
 import json
 from zoneinfo import ZoneInfo
@@ -16,7 +18,10 @@ class StaticHTMLRenderer:
     self.output_path = self.config['paths']['output']
     self.template_path = f"{self.config['paths']['templates']}/static"
 
-  def render(self):
+  async def render(self):
+      await asyncio.to_thread(self._render)
+
+  def _render(self):
     self.render_index()
     self.render_chat()
     self.render_map()


### PR DESCRIPTION
The save method renders all the html and json to disk which is a slow operation that can would block the event loop. We move both to a thread pool which works on a clone of the MemoryDataStore.

The save method also makes network I/O to fetch node details of nodes. This was making clocking network calls with requests. This now uses aiohttp which is async and will not block the event loop.

Fixes: #37 