### PR TITLE
Add support for node role

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -82,7 +82,7 @@ class MQTT:
                 mp = se.packet
                 outs = json.loads(MessageToJson(mp, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
                 print(f"Decoded protobuf message: {outs}")
-            except Exception as e:
+            except Exception as _:
                 # print(f"*** ParseFromString: {str(e)}")
                 pass
 

--- a/static_html_renderer.py
+++ b/static_html_renderer.py
@@ -250,6 +250,7 @@ class StaticHTMLRenderer:
         "shortname": node["shortname"],
         "longname": node["longname"],
         "hardware": node["hardware"],
+        "role": node["role"] if "role" in node else None,
         "position": self._serialize_position(node["position"]) if node["position"] else None,
         "neighborinfo": self._serialize_neighborinfo(node) if node['neighborinfo'] else None,
         "telemetry": node["telemetry"],

--- a/templates/static/node.html.j2
+++ b/templates/static/node.html.j2
@@ -111,6 +111,39 @@
               </td>
             </tr>
             <tr>
+              <th class="p-1" align=left>Role</th>
+              <td class="p-1">
+              {% if node.role is not none %}
+                {% if node.role == 0 %}
+                Client
+                {% elif node.role == 1 %}
+                Client Mute
+                {% elif node.role == 2 %}
+                Router
+                {% elif node.role == 3 %}
+                Router Client
+                {% elif node.role == 4 %}
+                Repeater
+                {% elif node.role == 5 %}
+                Tracker
+                {% elif node.role == 6 %}
+                Sensor
+                {% elif node.role == 7 %}
+                ATAK
+                {% elif node.role == 8 %}
+                Client Hidden
+                {% elif node.role == 9 %}
+                Lost and Found
+                {% elif node.role == 10 %}
+                ATAK Tracker
+                {% else %}
+                Unknown
+                {% endif %}
+              {% else %}
+                Unknown
+              {% endif %}
+            </tr>
+            <tr>
               <th class="p-1" align=left>Position</th>
               <td class="p-1">
               {% if node.position and node.position.latitude_i and node.position.longitude_i %}

--- a/templates/static/nodes.html.j2
+++ b/templates/static/nodes.html.j2
@@ -16,6 +16,7 @@
           <th class="border border-gray-500 bg-gray-400" colspan=2>ID</th>
           <th class="border border-gray-500 bg-gray-400" colspan=2>Name</th>
           <th class="hidden sm:table-cell border border-gray-500 bg-gray-400">HW</th>
+          <th class="border border-gray-500 bg-gray-400">Role</th>
           <th class="hidden xl:table-cell border border-gray-500 bg-gray-400" colspan=4>Last Position</th>
           <th class="hidden md:table-cell border border-gray-500 bg-gray-400">Neighbors</th>
           <th class="hidden 2xl:table-cell border border-gray-500 bg-gray-400" colspan=4>Telemetry</th>
@@ -27,6 +28,7 @@
           <th class="border border-gray-500 bg-gray-400">Short</th>
           <th class="border border-gray-500 bg-gray-400">Long</th>
           <th class="hidden sm:table-cell border border-gray-500 bg-gray-400"></th>
+          <th class="border border-gray-500 bg-gray-400"></th>
           <th class="hidden xl:table-cell border border-gray-500 bg-gray-400">Altitude</th>
           <th class="hidden xl:table-cell border border-gray-500 bg-gray-400">Latitude</th>
           <th class="hidden xl:table-cell border border-gray-500 bg-gray-400">Longitude</th>
@@ -77,6 +79,33 @@
               {% if meshtastic_support.HardwareModel(node.hardware) and meshtastic_support.HardwareModel(node.hardware) in meshtastic_support.HARDWARE_PHOTOS %}
               <img src="images/hardware/{{ meshtastic_support.HARDWARE_PHOTOS[meshtastic_support.HardwareModel(node.hardware)] }}" alt="{{ meshtastic_support.HardwareModel(node.hardware).name }}" title="{{ meshtastic_support.HardwareModel(node.hardware).name }}" class="w-8 h-8 object-cover">
               {% endif %}
+            {% endif %}
+          </td>
+          <td class="p-1 border border-gray-400 text-nowrap" align=center>
+            {% if node.role is not none %}
+            {% if node.role == 0 %}
+            <span title="Client">C</span>
+            {% elif node.role == 1 %}
+            <span title="Client Mute">CM</span>
+            {% elif node.role == 2 %}
+            <span title="Router">R</span>
+            {% elif node.role == 3 %}
+            <span title="Router Client">RC</span>
+            {% elif node.role == 4 %}
+            <span title="Repeater">RE</span>
+            {% elif node.role == 5 %}
+            <span title="Tracker">T</span>
+            {% elif node.role == 6 %}
+            <span title="Sensor">S</span>
+            {% elif node.role == 7 %}
+            <span title="ATAK">A</span>
+            {% elif node.role == 8 %}
+            <span title="Client Hidden">CH</span>
+            {% elif node.role == 9 %}
+            <span title="Lost and Found">LF</span>
+            {% elif node.role == 10 %}
+            <span title="ATAK Tracker">AT</span>
+            {% endif %}
             {% endif %}
           </td>
           {% if node.position %}


### PR DESCRIPTION
This adds support for a node's role in the backend and in the UI.

Admittedly this is a bit rushed, so there is some code that should be refactored for reuse, but I am slamming this in ;) I'll catch it in a future update.

In the Nodes table, the role is kept as an abbreviation, and hovering over it reveals the title.
<img width="677" alt="Screenshot 2024-07-18 at 1 14 01 AM" src="https://github.com/user-attachments/assets/e054fd0a-79d8-458d-b6bb-b3b3e968d548">

On the Node Detail page, the role is specified in full text.
<img width="704" alt="Screenshot 2024-07-18 at 1 14 09 AM" src="https://github.com/user-attachments/assets/2b94d143-bebe-4549-a6ae-54f44e186d25">
