### PR TITLE
Simplification of message handling in mqtt.py and other minor enhancements

### DIFF
--- a/data_renderer.py
+++ b/data_renderer.py
@@ -28,13 +28,30 @@ class DataRenderer:
     self.save_file("nodes.json", nodes)
     print(f"Saved {len(nodes)} nodes to file ({self.config['paths']['data']}/nodes.json)")
 
-    self.save_file("telemetry.json", self.data.telemetry)
-    print(f"Saved {len(self.data.telemetry)} telemetry to file ({self.config['paths']['data']}/telemetry.json)")
+    self.save_file("telemetry.json", self.data.telemetry, 'telemetry')
 
-    self.save_file("traceroutes.json", self.data.traceroutes)
-    print(f"Saved {len(self.data.traceroutes)} traceroutes to file ({self.config['paths']['data']}/traceroutes.json)")
+    self.save_file("traceroutes.json", self.data.traceroutes, 'traceroutes')
 
-  def save_file(self, filename, data):
+  def save_file(self, filename, data, settings_key=None):
+
+    data_to_save = data
+
+    # check settings to see if we should store this data and (if it's a list) up to how many items
+    if settings_key:
+      history_settings = self.config.get('history', {}).get(settings_key, {})
+
+      if history_settings.get('store', True):
+        limit = history_settings.get('storage_limit', 0)
+        if isinstance(data, list) and limit > 0:
+          data_to_save = data[:limit]
+      else:
+        print(f"Not configured to save {settings_key}")
+        return
+
     print(f"Saving {filename}")
+
     with open(f"{self.config['paths']['data']}/{filename}", "w", encoding='utf-8') as f:
-      json.dump(data, f, indent=2, sort_keys=True, cls=_JSONEncoder)
+      json.dump(data_to_save, f, indent=2, sort_keys=True, cls=_JSONEncoder)
+
+    if settings_key:
+      print(f"Saved {len(data_to_save)} {settings_key} to file ({self.config['paths']['data']}/{filename}.json)")

--- a/memory_data_store.py
+++ b/memory_data_store.py
@@ -30,6 +30,7 @@ class MemoryDataStore:
     self.mqtt_messages: list = []
     self.mqtt_connect_time: datetime = self.config['server']['start_time']
     self.nodes: dict = {}
+    self.nodes_overrides: dict = {}
     self.telemetry: list = []
     self.telemetry_by_node: dict = {}
     self.traceroutes: list = []
@@ -94,10 +95,19 @@ class MemoryDataStore:
           if id in self.nodes:
             print(f"Overriding node {id}")
             node = self.nodes[id]
-            if 'position' in node_override:
-              print("Overriding node position")
-              node['position'] = node_override['position']
+            for k, v in nodes_overrides[id].items():
+              # ignore this key, which can be used to store lists of what keys to ignore when updating a node
+              if k =='ignore_update_keys':
+                pass
+              # If the override for this node has 'purge': True, then remove the node from the data
+              elif k == 'purge' and v:
+                print(f"Purging node {id} completely")
+                self.nodes.pop[id]
+              else:
+                print(f"Overriding node {id} {k} with {v}")
+                node[k] = v
             self.nodes[id] = node
+        self.nodes_overrides = nodes_overrides
         print(f"Loaded {len(nodes_overrides.keys())} nodes overrides from file ({self.config['paths']['data']}/nodes-overrides.json)")
     except FileNotFoundError:
       pass

--- a/mqtt.py
+++ b/mqtt.py
@@ -352,9 +352,19 @@ class MQTT:
             node = Node.default_node(node_id)
             info_string = create_string
 
+        # obtain node override data and purge if need be
+        overrides = self.data.nodes_overrides.get(id, {})
+        if overrides.get("purge", False):
+            if id in self.data.nodes:
+                self.data.nodes.pop(id)
+            return
+
+        # may want to ignore some keys for some nodes, including any keys overriden at startup
+        ignored_keys = overrides.get('ignore_update_keys', list(overrides.keys()))
+
         # update node with keyword arguments
         if updates:
-            node.update(updates)
+            node.update({k:v for k,v in updates.items() if k not in ignored_keys})
 
         # record time first seen if not already there
         if 'first_seen' not in node:

--- a/mqtt.py
+++ b/mqtt.py
@@ -586,7 +586,7 @@ class MQTT:
                 continue
             last_seen = datetime.datetime.fromisoformat(node['last_seen']).astimezone() if isinstance(node['last_seen'], str) else node['last_seen']
             try:
-                since = (now - last_seen).seconds
+                since = (now - last_seen).total_seconds()
             except Exception:
                 print(f"Node {id} has invalid last_seen: {node['last_seen']}")
                 self.data.nodes[id]['last_seen'] = None

--- a/mqtt.py
+++ b/mqtt.py
@@ -281,7 +281,6 @@ class MQTT:
                 if self.config['debug']:
                     print(f"Received a JSON message: {msg.topic} {msg.payload}")
                 try:
-                    await self.handle_log(msg)
                     decoded = msg.payload.decode("utf-8")
                     j = json.loads(decoded, cls=_JSONDecoder)
                     j['topic'] = msg.topic.value
@@ -307,6 +306,7 @@ class MQTT:
                                 route.append(id)
                             j['route'] = route
                         await self.handle_traceroute(j)
+                    await self.handle_log(j)
                     await self.prune_expired_nodes()
                 except Exception as e:
                     print(e)

--- a/mqtt.py
+++ b/mqtt.py
@@ -492,12 +492,16 @@ class MQTT:
                                    telemetry=msg['payload'] if 'payload' in msg else None
                                   )
 
-        if id not in self.data.telemetry_by_node:
-            self.data.telemetry_by_node[id] = []
+        # only hold onto data about telemetry if our config has us saving it (store) and/or keeping it in memory (retain)
+        history_settings = self.config.get('history', {}).get('telemetry', {})
+        if history_settings.get('store', True) or history_settings.get('retain', True):
 
-        if 'payload' in msg:
-            self.data.telemetry.insert(0, msg)
-            self.data.telemetry_by_node[id].insert(0, msg)
+            if id not in self.data.telemetry_by_node:
+                self.data.telemetry_by_node[id] = []
+
+            if 'payload' in msg:
+                self.data.telemetry.insert(0, msg)
+                self.data.telemetry_by_node[id].insert(0, msg)
 
         await self.data.save()
 
@@ -561,11 +565,13 @@ class MQTT:
 
             msg['route_ids'].append(node_id)
 
-        if id in self.data.traceroutes_by_node:
-            self.data.traceroutes_by_node[id].insert(0, msg)
-        else:
-            self.data.traceroutes_by_node[id] = [msg]
-        self.data.traceroutes.insert(0, msg)
+        history_settings = self.config.get('history', {}).get('traceroutes', {})
+        if history_settings.get('store', True) or history_settings.get('retain', True):
+            if id in self.data.traceroutes_by_node:
+                self.data.traceroutes_by_node[id].insert(0, msg)
+            else:
+                self.data.traceroutes_by_node[id] = [msg]
+            self.data.traceroutes.insert(0, msg)
         await self.data.save()
 
     ### helpers

--- a/templates/static/chat.html.j2
+++ b/templates/static/chat.html.j2
@@ -5,7 +5,7 @@
 {% block content %}
     <h5 class="mb-2 text-gray-500">Chat</h5>
     <h1 class="mb-2 text-xl">Chat</h1>
-    {% for channel in chat['channels'] if channel in config['broker']['channels']['display'] %}
+    {% for channel in chat['channels'] if 'all' in config['broker']['channels']['display'] or channel in config['broker']['channels']['display']%}
     <p class="mb-2">
       There are <b>{{ chat['channels'][channel]['messages']|count }}</b> messages on <a href="#channel-{{ channel }}">channel {{ channel }}</a> that have
       been heard by the mesh by <a href="node_{{ config['server']['node_id'] }}.html">{{ config['server']['node_id'] }}</a> ({{ config['server']['node_id'] }}).
@@ -17,7 +17,7 @@
         <label for="tabs" class="sr-only">Select a tab</label>
         <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
         <select id="tabs" name="tabs" class="block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm">
-          {% for channel in chat['channels'] if channel in config['broker']['channels']['display'] %}
+          {% for channel in chat['channels'] if 'all' in config['broker']['channels']['display'] or channel in config['broker']['channels']['display'] %}
           <option>Channel {{ channel }}</option>
           {% endfor %}
         </select>
@@ -26,7 +26,7 @@
         <div class="border-b border-gray-200">
           <nav class="-mb-px flex space-x-8" aria-label="Tabs">
             <!-- Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:border-gray-200 hover:text-gray-700" -->
-            {% for channel in chat['channels'] if channel in config['broker']['channels']['display'] %}
+            {% for channel in chat['channels'] if 'all' in config['broker']['channels']['display'] or channel in config['broker']['channels']['display'] %}
             <a href="#"
                 class="flex whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-200 hover:text-gray-700"
                 onChange=""
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    {% for channel in chat['channels'] if channel in config['broker']['channels']['display'] %}
+    {% for channel in chat['channels'] if 'all' in config['broker']['channels']['display'] or channel in config['broker']['channels']['display'] %}
     <div id="tab-channel-{{ channel }}" class="mt-4" role="tabpanel" aria-labelledby="tab-{{ channel }}">
       <table class="w-full max-w-full table-fixed border-collapse border border-gray-500 bg-gray-50">
         <thead>

--- a/templates/static/neighbors.html.j2
+++ b/templates/static/neighbors.html.j2
@@ -116,7 +116,7 @@
           <td class="p-1 border border-gray-400"></td>
           {% endif %}
           <td class="hidden xl:table-cell p-1 border border-gray-400">{{ node.last_seen_human }}</td>
-          <td class="hidden xl:table-cell p-1 text-nowrap border border-gray-400" align=right>{{ node.since.seconds }} secs</td>
+          <td class="hidden xl:table-cell p-1 text-nowrap border border-gray-400" align=right>{{ node.since.total_seconds() }} secs</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/static/nodes.html.j2
+++ b/templates/static/nodes.html.j2
@@ -167,7 +167,7 @@
           <td class="hidden 2xl:table-cell p-1 border border-gray-400"></td>
           <td class="hidden 2xl:table-cell p-1 border border-gray-400"></td>
           {% endif %}
-          <td class="p-1 border border-gray-400 text-nowrap" align=right title="{{ node.last_seen_human }}">{{ node.since.seconds }} secs</td>
+          <td class="p-1 border border-gray-400 text-nowrap" align=right title="{{ node.last_seen_human }}">{{ node.since.total_seconds()|int }} secs</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/static/traceroutes.html.j2
+++ b/templates/static/traceroutes.html.j2
@@ -54,7 +54,7 @@
               {% endif %}
             {% endfor %}
           </td>
-          <td class="p-1 border border-gray-400" align=center>{{ item.route | length }}</td>
+          <td class="p-1 border border-gray-400" align=center>{{ item.route_ids | length }}</td>
         </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Hi, not sure if you would prefer this as separate requests. Some of the enhancements depend on some refactoring to mqtt.py, so for now I've put the commits together.

As far as I can tell it does not introduce any breaking changes, at least with respect to the current JSON & jinja-served parts of the site.

The most significant commit is [Simplifying common message handling](https://github.com/MeshAddicts/meshinfo/commit/cb3175ff7de549a02d32f7032529c0b7448cb84e), which adds node_create_or_update() and handle_common() and moves much of the code from individual .handle_MSGTYPE() calls into those 2 helper methods to reduce repetition. Common arguments to MessageToJson are also brought out into a separate variable (common_MTJ_kwargs) for clarity.

The adjustments in that commit mostly aren't intended to change how mqtt.py operates, going so far as to retain some differences in message handling that may be unnecessary artifacts. But there are 3 other changes brought in by the commit: 
- Messages that can't be decoded are now nevertheless considered by a new .handle_default() method, as are routing messages that were previously completely ignored.
- Every message will consequently trigger an update to the relevant node's data (including the "since" time), and addresses that do not communicate on any channel that we have keys for could show up in the list of nodes/active nodes if they are ever passed to us via MQTT. (For me that's a feature, but if it's considered a problem I could code up something to hide or disregard those.)
- A 'first_seen' field is added to nodes if not already present in the data (for future use).


The other commits:
- Change the usage of since.seconds to since.total_seconds() as the former may result in issues where timedelta.days > 1.
- Allow greater ability to use nodes-overrides to override different keys in a node, or use it to prevent updates to particular keys, or to purge a node's ID entirely (e.g. if there is a request for removal).
- Allow all chat channels to be displayed if desired [perhaps this config change might break the new React code - not sure].
- Fix a bug in the handling of JSON MQTT messages.
- Add extra fields to messages: hops_away if it's missing and can be calculated, and 'sender' as the presumed MQTT uplink source. The former fills in missing parts in the traceroute page and the latter is for consistency with JSON messages (and for future use).
- Add the ability to limit whether telemetry and traceroute data is retained in memory and/or stored in the JSON files, and if stored, how much is stored. It has some minor & partial refactoring of the JSON save code along the way.