### PR TITLE
Dependabot for all package types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
     schedule:
       interval: "daily"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,6 @@
   },
   "eslint.nodePath": "frontend/.yarn/sdks",
   "typescript.tsdk": "frontend/.yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "python.analysis.typeCheckingMode": "basic"
 }


### PR DESCRIPTION
Enable dependabot for GitHub Actions, NPM, and Docker.

Also fix a small json error in the vscode settings.