### PR TITLE
20240912 limit nodes by last seen

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -25,8 +25,16 @@ class API:
 
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
-            # get nodes that have been updated within last 7 days
-            nodes = { k: v for k, v in self.data.nodes.items() if utils.days_since_datetime(v["last_seen"]) <= 7 }
+            # get nodes that have been updated within last X days
+            days_to_limit = 7
+            if "days" in request.query_params.keys():
+                days_param: str|None = request.query_params.get("days")
+                if days_param is not None:
+                    days_to_limit = int(days_param)
+            if days_to_limit < 1:
+                days_to_limit = 1
+
+            nodes = { k: v for k, v in self.data.nodes.items() if utils.days_since_datetime(v["last_seen"]) <= days_to_limit }
 
             # filter nodes by query parameters
             if "ids" in request.query_params.keys():

--- a/api/api.py
+++ b/api/api.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from fastapi.encoders import jsonable_encoder
 import uvicorn
@@ -24,7 +25,10 @@ class API:
 
         @app.get("/v1/nodes")
         async def nodes(request: Request) -> JSONResponse:
-            nodes = self.data.nodes
+            # get nodes that have been updated within last 7 days
+            nodes = { k: v for k, v in self.data.nodes.items() if utils.days_since_datetime(v["last_seen"]) <= 7 }
+
+            # filter nodes by query parameters
             if "ids" in request.query_params.keys():
                 ids: str|None = request.query_params.get("ids")
                 if ids is not None:

--- a/utils.py
+++ b/utils.py
@@ -33,7 +33,6 @@ def days_since_datetime(dt: datetime.datetime):
   if isinstance(dt, str):
     dt = datetime.datetime.fromisoformat(dt)
   diff = now - dt
-  print(diff.days, type(diff.days))
   return diff.days
 
 def geocode_position(api_key: str, latitude: float, longitude: float):

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import datetime
 import requests
 from geo import distance_between_two_points
 
@@ -26,6 +27,15 @@ def convert_node_id_from_hex_to_int(id: str):
       id = id.replace('!', '')
   return int(id, 16)
 
+def days_since_datetime(dt: datetime.datetime):
+  # Returns the number of days since the given datetime using UTC
+  now = datetime.datetime.now(datetime.timezone.utc)
+  if isinstance(dt, str):
+    dt = datetime.datetime.fromisoformat(dt)
+  diff = now - dt
+  print(diff.days, type(diff.days))
+  return diff.days
+
 def geocode_position(api_key: str, latitude: float, longitude: float):
   if latitude is None or longitude is None:
     return None
@@ -40,7 +50,7 @@ def geocode_position(api_key: str, latitude: float, longitude: float):
 def filter_dict(d, whitelist):
     """
     Recursively filter a dictionary to only include whitelisted keys.
-    
+
     :param d: The original dictionary or list.
     :param whitelist: A dictionary that mirrors the structure of `d` with the keys you want to keep.
                       Nested dictionaries and lists should be specified with the keys you want to retain.


### PR DESCRIPTION
Let's limit the nodes returned by the API to last seen within 7 days. This should reduce the clutter on the map, while also hiding older nodes in general. Note that this does not PURGE old data (we will address that concept later).