### PR TITLE
Resolve non numerical values for temperature's

### DIFF
--- a/templates/static/node.html.j2
+++ b/templates/static/node.html.j2
@@ -41,7 +41,7 @@
           <span class="mr-4 align-middle" title="Temperature">
             <img src="images/icons/temperature.svg" alt="Temperature" class="w-4 h-4 inline-block align-middle">
             {% if node.telemetry.temperature is number %}
-              {{ node.telemetry.temperature | round(1) }}&deg;C
+              {{ node.telemetry.temperature | default("0") | float | round(1) }}&deg;C
             {% else %}
               {{ node.telemetry.temperature }}
             {% endif %}

--- a/templates/static/telemetry.html.j2
+++ b/templates/static/telemetry.html.j2
@@ -171,7 +171,7 @@
         <td class="hidden lg:table-cell p-1 border border-gray-400 text-nowrap" align=right>
           {% if item.payload.temperature is defined %}
             {% if item.payload.temperature is number %}
-              {{ item.payload.temperature | round(2) }}&deg;C
+              {{ item.payload.temperature | default("0") | float | round(2) }} &deg;C
             {% else %}
               {{ item.payload.temperature }}
             {% endif %}


### PR DESCRIPTION
Specifically with a users with a Wio Tracker 1110 Dev Kit for Meshtastic produce sometimes the value NAN for temperature. This appears to be the only device I've seen it from but this change would resolve any future issues. When meshinfo sees this value it crashes the app. Has been stable for a week on my states current setup and the node continues to run.