### PR TITLE
Create global timestamp function and deploy throughout

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -34,26 +34,6 @@ export const Chat = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channels]);
 
-    // DEBUG: Remove this after fixing the issue
-  useEffect(() => {
-    if (selectedChannel && chat?.channels[selectedChannel]?.messages) {
-      const messages = chat.channels[selectedChannel].messages;
-      console.log('=== DEBUG: Message timestamps ===');
-      console.log('First 10 raw messages:', messages.slice(0, 10).map(m => ({
-        timestamp: m.timestamp,
-        formatted: formatTimestamp(m.timestamp),
-        text: m.text?.substring(0, 30)
-      })));
-      
-      const sorted = [...messages].sort((a, b) => b.timestamp - a.timestamp);
-      console.log('First 10 AFTER sort:', sorted.slice(0, 10).map(m => ({
-        timestamp: m.timestamp,
-        formatted: formatTimestamp(m.timestamp),
-        text: m.text?.substring(0, 30)
-      })));
-    }
-  }, [selectedChannel, chat]);
-
   return (
     <div className="">
       <h5 className="mb-2 text-gray-500 dark:text-gray-400">Chat</h5>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,6 +1,6 @@
-import { format } from "date-fns-tz";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { formatTimestamp } from "../utils/formatTimestamp";
 
 import { HeardBy } from "../components/HeardBy";
 import {
@@ -33,6 +33,26 @@ export const Chat = () => {
     // only on channels change, not on selectedChannel
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channels]);
+
+    // DEBUG: Remove this after fixing the issue
+  useEffect(() => {
+    if (selectedChannel && chat?.channels[selectedChannel]?.messages) {
+      const messages = chat.channels[selectedChannel].messages;
+      console.log('=== DEBUG: Message timestamps ===');
+      console.log('First 10 raw messages:', messages.slice(0, 10).map(m => ({
+        timestamp: m.timestamp,
+        formatted: formatTimestamp(m.timestamp),
+        text: m.text?.substring(0, 30)
+      })));
+      
+      const sorted = [...messages].sort((a, b) => b.timestamp - a.timestamp);
+      console.log('First 10 AFTER sort:', sorted.slice(0, 10).map(m => ({
+        timestamp: m.timestamp,
+        formatted: formatTimestamp(m.timestamp),
+        text: m.text?.substring(0, 30)
+      })));
+    }
+  }, [selectedChannel, chat]);
 
   return (
     <div className="">
@@ -143,10 +163,8 @@ export const Chat = () => {
                     key={`chat-message-${message.id}-${i}`}
                   >
                     <td className="p-1 border border-gray-400 text-nowrap">
-                      {format(
-                        new Date(message.timestamp * 1000),
-                        "yyyy-MM-dd HH:MM:SS xx",
-                        { timeZone: config?.server?.timezone }
+                      {formatTimestamp(message.timestamp) || (
+                        <span className="text-gray-500">Unknown</span>
                       )}
                     </td>
                     <td className="p-1 text-center border border-gray-400">

--- a/frontend/src/pages/MeshLog.tsx
+++ b/frontend/src/pages/MeshLog.tsx
@@ -1,5 +1,6 @@
 import { HeardBy } from "../components/HeardBy";
 import { useGetMessagesQuery } from "../slices/apiSlice";
+import { formatTimestamp } from "../utils/formatTimestamp";
 
 export const MeshLog = () => {
   const { data: messages } = useGetMessagesQuery();
@@ -36,9 +37,7 @@ export const MeshLog = () => {
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`messages-${index}`}>
                 <td className="p-1 border border-gray-400">
-                  {message.timestamp
-                    ? new Date(message.timestamp * 1000).toLocaleString()
-                    : ""}
+                  {formatTimestamp(message.timestamp)}
                 </td>
                 <td className="p-1 border border-gray-400">
                   {JSON.stringify(message)}

--- a/frontend/src/pages/MeshLog.tsx
+++ b/frontend/src/pages/MeshLog.tsx
@@ -37,7 +37,7 @@ export const MeshLog = () => {
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`messages-${index}`}>
                 <td className="p-1 border border-gray-400">
-                  {formatTimestamp(message.timestamp)}
+                  {formatTimestamp(message.timestamp) || <span className="text-gray-500">Unknown</span>}
                 </td>
                 <td className="p-1 border border-gray-400">
                   {JSON.stringify(message)}

--- a/frontend/src/pages/MqttLog.tsx
+++ b/frontend/src/pages/MqttLog.tsx
@@ -1,5 +1,6 @@
 import { HeardBy } from "../components/HeardBy";
 import { useGetMqttMessagesQuery } from "../slices/apiSlice";
+import { formatTimestamp } from "../utils/formatTimestamp";
 
 export const MqttLog = () => {
   const { data: messages } = useGetMqttMessagesQuery();
@@ -19,16 +20,16 @@ export const MqttLog = () => {
         are shown.
       </p>
 
-      <table className="w-full max-w-full table-auto border-collapse border border-gray-500 bg-gray-50 dark:bg-gray-300">
+      <table className="w-full max-w-full table-auto border-collapse border border-gray-500 bg-gray-50 dark:bg-gray-800">
         <thead>
           <tr>
-            <th className="border border-gray-500 bg-gray-400 dark:bg-gray-900 ">
+            <th className="border border-gray-500 bg-gray-400 dark:bg-gray-800">
               Timestamp
             </th>
-            <th className="border border-gray-500 bg-gray-400 dark:bg-gray-900">
+            <th className="border border-gray-500 bg-gray-400 dark:bg-gray-800">
               Topic
             </th>
-            <th className="border border-gray-500 bg-gray-400 dark:bg-gray-900">
+            <th className="border border-gray-500 bg-gray-400 dark:bg-gray-800">
               Message
             </th>
           </tr>
@@ -41,9 +42,11 @@ export const MqttLog = () => {
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`mqtt-message-${index}`}>
                 <td className="p-1 border border-gray-400 text-nowrap">
-                  {message.timestamp
-                    ? new Date(message.timestamp * 1000).toLocaleString()
-                    : ""}
+                  {message.timestamp ? (
+                    formatTimestamp(message.timestamp)
+                  ) : (
+                    <span className="text-gray-500">Unknown</span>
+                  )}
                 </td>
                 <td className="p-1 border border-gray-400 text-nowrap">
                   {message.topic}

--- a/frontend/src/pages/Telemetry.tsx
+++ b/frontend/src/pages/Telemetry.tsx
@@ -1,5 +1,6 @@
 import { HeardBy } from "../components/HeardBy";
 import { useGetNodesQuery, useGetTelemetryQuery } from "../slices/apiSlice";
+import { formatTimestamp } from "../utils/formatTimestamp";
 
 export const Telemetry = () => {
   const { data: telemetry } = useGetTelemetryQuery();
@@ -144,19 +145,7 @@ export const Telemetry = () => {
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`telemetry-${index}`}>
                 <td className="p-1 border border-gray-400 text-nowrap">
-                  {"timestamp" in item ? (
-                    new Date(item.timestamp * 1000).toLocaleString(undefined, {
-                      year: "numeric",
-                      month: "2-digit",
-                      day: "2-digit",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      second: "2-digit",
-                      hour12: false,
-                    })
-                  ) : (
-                    <span className="text-gray-500">Unknown</span>
-                  )}
+                  {formatTimestamp(item.timestamp) || <span className="text-gray-500">Unknown</span>}
                 </td>
                 <td className="p-1 border border-gray-400">
                   {inode ? (

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { formatTimestamp } from "../utils/formatTimestamp";
 
 import { HeardBy } from "../components/HeardBy";
 import { useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
@@ -73,7 +74,7 @@ export const Traceroutes = () => {
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`traceroute-${index}`}>
                 <td className="p-1 border border-gray-400 text-nowrap">
-                  {new Date(item.timestamp * 1000).toLocaleString()}
+                  {formatTimestamp(item.timestamp)}
                 </td>
                 <td className="p-1 border border-gray-400">
                   {fnode ? (

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -74,7 +74,7 @@ export const Traceroutes = () => {
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`traceroute-${index}`}>
                 <td className="p-1 border border-gray-400 text-nowrap">
-                  {formatTimestamp(item.timestamp)}
+                  {formatTimestamp(item.timestamp) || <span className="text-gray-500">Unknown</span>}
                 </td>
                 <td className="p-1 border border-gray-400">
                   {fnode ? (

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -58,7 +58,7 @@ export const apiSlice = createApi({
                     IChatResponse["channels"]["0"]["messages"][0]
                   >
                 )
-              ),
+              ).sort((a, b) => b.timestamp - a.timestamp),
             },
           ])
         );

--- a/frontend/src/utils/formatTimestamp.ts
+++ b/frontend/src/utils/formatTimestamp.ts
@@ -1,0 +1,27 @@
+export function formatTimestamp(
+  timestamp?: number | null,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  if (timestamp == null || Number.isNaN(timestamp)) {
+    return "";
+  }
+
+  // Heuristic: < 1e12 → seconds, otherwise assume ms
+  const ms = timestamp < 1e12 ? timestamp * 1000 : timestamp;
+
+  const date = new Date(ms);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    ...options,
+  });
+}


### PR DESCRIPTION
Introduces a global formatTimestamp utility function and refactors timestamp formatting across the app to use it consistently.

Changes:

- Added formatTimestamp.ts helper in /utils that handles seconds/milliseconds conversion and null values
- Updated Traceroutes.tsx, MeshLog.tsx, Telemetry.tsx, Chat.tsx, and MqttLog.tsx to use the new helper
- Fixed chat message sorting by timestamp in transformResponse
- Fixed MqttLog.tsx to correct background tailwind

Address issue #114 