### PR TITLE
Prevent disk fill-ups by fixing Mosquitto logging

### DIFF
--- a/mosquitto/config/mosquitto.conf
+++ b/mosquitto/config/mosquitto.conf
@@ -2,6 +2,7 @@
 log_type error
 log_type warning
 log_type notice
+log_timestamp true
 
 # Set the location of the log file
 log_dest stdout

--- a/mosquitto/config/mosquitto.conf
+++ b/mosquitto/config/mosquitto.conf
@@ -1,9 +1,10 @@
 # Enable logging
-log_type all
-log_dest stdout
+log_type error
+log_type warning
+log_type notice
 
 # Set the location of the log file
-log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
 
 # Set the port on which Mosquitto will listen for incoming connections
 listener 1883 0.0.0.0


### PR DESCRIPTION
Removes Mosquitto file logging and reduces log verbosity so high-volume bridge traffic doesn’t generate multi-GB mosquitto.log files. Logs now go to stdout.