### PR TITLE
Logging level control via server.log_level (Closes #263)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -22,7 +22,7 @@ class API:
         self.data = data
         self.read_from_postgres = config.get('storage', {}).get('read_from') == 'postgres'
 
-    async def serve(self, loop):
+    async def serve(self):
         @app.get("/", response_class=HTMLResponse)
         async def root(request: Request):
             return templates.TemplateResponse(request=request, name="index.html.j2", context={})
@@ -308,7 +308,7 @@ class API:
                 allow_headers=["*"]
             )
 
-        conf = uvicorn.Config(app=app, host="0.0.0.0", port=9000, loop=loop, log_config=None)
+        conf = uvicorn.Config(app=app, host="0.0.0.0", port=9000, loop="asyncio", log_config=None)
         server = uvicorn.Server(conf)
         logger.info("Starting Uvicorn server bound at http://%s:%d", conf.host, conf.port)
         await server.serve()

--- a/api/api.py
+++ b/api/api.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 from fastapi.encoders import jsonable_encoder
 import uvicorn
@@ -9,6 +10,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from config import Config
 import utils
+
+logger = logging.getLogger(__name__)
 
 templates = Jinja2Templates(directory="./templates/api")
 app = FastAPI()
@@ -294,7 +297,7 @@ class API:
 
 
         allow_origins = os.getenv("ALLOW_ORIGINS", "").split(",")
-        print(f"Allowed origins: {allow_origins} {len(allow_origins)}")
+        logger.info("Allowed origins: %s (%d)", allow_origins, len(allow_origins))
 
         if(len(allow_origins) > 0):
             app.add_middleware(
@@ -305,8 +308,8 @@ class API:
                 allow_headers=["*"]
             )
 
-        conf = uvicorn.Config(app=app, host="0.0.0.0", port=9000, loop=loop)
+        conf = uvicorn.Config(app=app, host="0.0.0.0", port=9000, loop=loop, log_config=None)
         server = uvicorn.Server(conf)
-        print(f"Starting Uvicorn server bound at http://{conf.host}:{conf.port}")
+        logger.info("Starting Uvicorn server bound at http://%s:%d", conf.host, conf.port)
         await server.serve()
-        print("Uvicorn server stopped")
+        logger.info("Uvicorn server stopped")

--- a/bot/discord.py
+++ b/bot/discord.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-
 import asyncio
+import logging
 from discord.ext import commands
 import discord
 from dotenv import load_dotenv
-
 from bot.cogs.main_commands import MainCommands
 from memory_data_store import MemoryDataStore
+
+logger = logging.getLogger(__name__)
 
 
 class DiscordBot(commands.Bot):
@@ -23,27 +24,27 @@ class DiscordBot(commands.Bot):
         self.synced = False
 
     async def on_ready(self):
-        print('Discord: Ready!')
+        logger.info('Discord: Ready!')
         await self.wait_until_ready()
         if not self.synced:
-            print("Discord: Syncing commands")
+            logger.info("Discord: Syncing commands")
             guild = discord.Object(id=self.config['integrations']['discord']['guild'])
             self.tree.copy_global_to(guild=guild)
             await self.tree.sync(guild = discord.Object(id=self.config['integrations']['discord']['guild']))
             self.synced = True
 
-
     async def on_message(self, message):
-        print(f'Discord: {message.channel.id}: {message.author}: {message.content}')
+        logger.debug('Discord: %s: %s: %s', message.channel.id, message.author, message.content)
         if message.content.startswith('!test'):
             await message.channel.send('Test successful!')
         await self.process_commands(message)
 
     async def start_server(self):
-        print("Starting Discord Bot")
+        logger.info("Starting Discord Bot")
         await self.add_cog(MainCommands(self, self.config, self.data))
         await self.start(self.config['integrations']['discord']['token'])
-        print("Discord Bot Done!")
+        logger.info("Discord Bot Done!")
+
 
 async def main():
     load_dotenv()

--- a/data_renderer.py
+++ b/data_renderer.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-
 import asyncio
 import json
-
+import logging
 from encoders import _JSONEncoder
+
+logger = logging.getLogger(__name__)
+
 
 class DataRenderer:
   def __init__(self, config, data):
@@ -15,7 +17,7 @@ class DataRenderer:
 
   def _render(self):
     self.save_file("chat.json", self.data.chat)
-    print(f"Saved {len(self.data.chat['channels']['0']['messages'])} chat messages to file ({self.config['paths']['data']}/chat.json)")
+    logger.debug("Saved %d chat messages to file (%s/chat.json)", len(self.data.chat['channels']['0']['messages']), self.config['paths']['data'])
 
     nodes = {}
     for id, node in self.data.nodes.items():
@@ -24,17 +26,16 @@ class DataRenderer:
         if len(id) != 8: # 8 hex chars required, if not, we abandon it
           continue
         nodes[id] = node
-
     self.save_file("nodes.json", nodes)
-    print(f"Saved {len(nodes)} nodes to file ({self.config['paths']['data']}/nodes.json)")
+    logger.debug("Saved %d nodes to file (%s/nodes.json)", len(nodes), self.config['paths']['data'])
 
     self.save_file("telemetry.json", self.data.telemetry)
-    print(f"Saved {len(self.data.telemetry)} telemetry to file ({self.config['paths']['data']}/telemetry.json)")
+    logger.debug("Saved %d telemetry to file (%s/telemetry.json)", len(self.data.telemetry), self.config['paths']['data'])
 
     self.save_file("traceroutes.json", self.data.traceroutes)
-    print(f"Saved {len(self.data.traceroutes)} traceroutes to file ({self.config['paths']['data']}/traceroutes.json)")
+    logger.debug("Saved %d traceroutes to file (%s/traceroutes.json)", len(self.data.traceroutes), self.config['paths']['data'])
 
   def save_file(self, filename, data):
-    print(f"Saving {filename}")
+    logger.debug("Saving %s", filename)
     with open(f"{self.config['paths']['data']}/{filename}", "w", encoding='utf-8') as f:
       json.dump(data, f, indent=2, sort_keys=True, cls=_JSONEncoder)

--- a/main.py
+++ b/main.py
@@ -89,9 +89,17 @@ async def main() -> None:
 
     # --- Apply log level from config ---
     log_level_name = config.get("server", {}).get("log_level", "INFO").upper()
-    log_level = getattr(logging, log_level_name, logging.INFO)
-    logging.getLogger().setLevel(log_level)
-    logger.info("Log level set to: %s", log_level_name)
+    valid_levels = logging.getLevelNamesMapping()
+    if log_level_name in valid_levels:
+        effective_log_level = valid_levels[log_level_name]
+    else:
+        logger.warning(
+            "Invalid log level '%s' in config; falling back to INFO",
+            log_level_name,
+        )
+        effective_log_level = logging.INFO
+    logging.getLogger().setLevel(effective_log_level)
+    logger.info("Log level set to: %s", logging.getLevelName(effective_log_level))
 
     # Banner + version: best-effort only
     # NOTE: Banner intentionally uses print() for clean stdout display
@@ -129,7 +137,6 @@ async def main() -> None:
 
     await data.save()
 
-    loop = asyncio.get_running_loop()
     api_server = api.API(config, data)
 
     background_tasks: list[asyncio.Task] = []
@@ -165,7 +172,7 @@ async def main() -> None:
     # API is critical: await it in the foreground.
     try:
         logger.info("API starting (critical)")
-        await api_server.serve(loop)
+        await api_server.serve()
     finally:
         # If API exits or we get cancelled, stop secondaries.
         logger.info("Shutting down background services...")

--- a/main.py
+++ b/main.py
@@ -87,7 +87,14 @@ async def supervise(
 async def main() -> None:
     config, data = init_runtime()
 
+    # --- Apply log level from config ---
+    log_level_name = config.get("server", {}).get("log_level", "INFO").upper()
+    log_level = getattr(logging, log_level_name, logging.INFO)
+    logging.getLogger().setLevel(log_level)
+    logger.info("Log level set to: %s", log_level_name)
+
     # Banner + version: best-effort only
+    # NOTE: Banner intentionally uses print() for clean stdout display
     banner = _read_text_file("banner")
     if banner:
         print(banner)

--- a/memory_data_store.py
+++ b/memory_data_store.py
@@ -103,7 +103,7 @@ class MemoryDataStore:
               n['position']['geocoded'] = geocoded
               n['position']['last_geocoding'] = datetime.now().astimezone(ZoneInfo(self.config['server']['timezone']))
           except Exception as e:
-            print(f"Failed to geocode position: {e}")
+            logger.warning("Failed to geocode position: %s", e)
 
     n['active'] = True
     if 'last_seen' in n and n['last_seen'] is not None and isinstance(n['last_seen'], str):
@@ -127,7 +127,7 @@ class MemoryDataStore:
           # No running loop in this thread/context
           asyncio.run(self.pg_storage.write_node(id, n))
       except Exception as e:
-        logger.error(f"Failed to write node {id} to Postgres (non-blocking): {e}")
+        logger.error("Failed to write node %s to Postgres (non-blocking): %s", id, e)
 
   async def load(self):
     storage = self.config.get("storage", {})
@@ -169,7 +169,7 @@ class MemoryDataStore:
             node['since'] = None
           nodes[id] = node
         self.nodes = nodes
-      print(f"Loaded {len(self.nodes)} existing nodes from file ({self.config['paths']['data']}/nodes.json)")
+      logger.info("Loaded %d existing nodes from file (%s/nodes.json)", len(self.nodes), self.config['paths']['data'])
     except FileNotFoundError:
       self.nodes = {}
     if self.config['server']['node_id'] not in self.nodes:
@@ -181,13 +181,13 @@ class MemoryDataStore:
       if nodes_overrides is not None:
         for id, node_override in nodes_overrides.items():
           if id in self.nodes:
-            print(f"Overriding node {id}")
+            logger.debug("Overriding node %s", id)
             node = self.nodes[id]
             if 'position' in node_override:
-              print("Overriding node position")
+              logger.debug("Overriding node %s position", id)
               node['position'] = node_override['position']
             self.nodes[id] = node
-        print(f"Loaded {len(nodes_overrides.keys())} nodes overrides from file ({self.config['paths']['data']}/nodes-overrides.json)")
+        logger.info("Loaded %d nodes overrides from file (%s/nodes-overrides.json)", len(nodes_overrides.keys()), self.config['paths']['data'])
     except FileNotFoundError:
       pass
 
@@ -195,7 +195,7 @@ class MemoryDataStore:
       chat = self.load_json_file(f"{self.config['paths']['data']}/chat.json")
       if chat is not None:
         self.chat = chat
-      print(f"Loaded {len(self.chat['channels']['0']['messages'])} chat messages from file ({self.config['paths']['data']}/chat.json)")
+      logger.info("Loaded %d chat messages from file (%s/chat.json)", len(self.chat['channels']['0']['messages']), self.config['paths']['data'])
     except FileNotFoundError:
       self.chat = {
           'channels': {
@@ -219,8 +219,8 @@ class MemoryDataStore:
         if id not in self.telemetry_by_node:
           self.telemetry_by_node[id] = []
         self.telemetry_by_node[id].insert(0, msg)
-      print(f"Loaded {len(self.telemetry)} telemetry messages from file ({self.config['paths']['data']}/telemetry.json)")
-      print(f"Loaded telemetry data for {len(self.telemetry_by_node)} nodes")
+      logger.info("Loaded %d telemetry messages from file (%s/telemetry.json)", len(self.telemetry), self.config['paths']['data'])
+      logger.info("Loaded telemetry data for %d nodes", len(self.telemetry_by_node))
     except FileNotFoundError:
       self.telemetry = []
       self.telemetry_by_node = {}
@@ -238,8 +238,8 @@ class MemoryDataStore:
           if id not in self.traceroutes_by_node:
             self.traceroutes_by_node[id] = []
           self.traceroutes_by_node[id].insert(0, msg)
-        print(f"Loaded {len(self.traceroutes)} traceroutes from file ({self.config['paths']['data']}/traceroutes.json)")
-        print(f"Loaded traceroutes data for {len(self.traceroutes_by_node)} nodes")
+        logger.info("Loaded %d traceroutes from file (%s/traceroutes.json)", len(self.traceroutes), self.config['paths']['data'])
+        logger.info("Loaded traceroutes data for %d nodes", len(self.traceroutes_by_node))
     except FileNotFoundError:
         self.traceroutes = []
         self.traceroutes_by_node = {}
@@ -254,7 +254,7 @@ class MemoryDataStore:
       await self.pg_storage.ensure_schema()
 
       # NOTE: your current code intentionally does NOT load rows into memory.
-      # If your API still reads from self.nodes/chat/telemetry, you’ll get empty results.
+      # If your API still reads from self.nodes/chat/telemetry, you'll get empty results.
       self.nodes = {}
       self.chat = {'channels': {'0': {'name': 'General', 'messages': []}}}
       self.telemetry = []
@@ -272,7 +272,7 @@ class MemoryDataStore:
       self.nodes['ffffffff'] = broadcast_node
       await self.pg_storage.write_node('ffffffff', broadcast_node)
 
-      print("PostgreSQL mode: Data will be queried directly from database")
+      logger.info("PostgreSQL mode: Data will be queried directly from database")
 
     except Exception as e:
       logger.exception("Failed to initialize PostgreSQL connection, falling back to JSON: %s", e)
@@ -297,20 +297,26 @@ class MemoryDataStore:
     since_last_backfill = (save_start - last_backfill).total_seconds()
     last_backup = self.config['server']['last_backup'] if 'last_backup' in self.config['server'] else self.config['server']['start_time']
     since_last_backup = (save_start - last_backup).total_seconds()
-    print(f"Save (since last): data: {since_last_data} (threshhold: {self.config['server']['intervals']['data_save']}), render: {since_last_render} (threshhold: {self.config['server']['intervals']['render']}), enrich: {since_last_backfill} (threshhold: {self.config['server']['enrich']['interval']}), backup: {since_last_backup} (threshhold: {self.config['server']['backups']['interval']})")
+    logger.debug(
+      "Save (since last): data: %s (threshold: %s), render: %s (threshold: %s), enrich: %s (threshold: %s), backup: %s (threshold: %s)",
+      since_last_data, self.config['server']['intervals']['data_save'],
+      since_last_render, self.config['server']['intervals']['render'],
+      since_last_backfill, self.config['server']['enrich']['interval'],
+      since_last_backup, self.config['server']['backups']['interval'],
+    )
 
     if 'enrich' in self.config['server'] and self.config['server']['enrich']['enabled']:
       if since_last_backfill >= self.config['server']['enrich']['interval']:
         await self.backfill_node_infos()
         end = datetime.now(ZoneInfo(self.config['server']['timezone']))
-        print(f"Enriched in {round(end.timestamp() - save_start.timestamp(), 2)} seconds")
+        logger.debug("Enriched in %.2f seconds", end.timestamp() - save_start.timestamp())
         self.config['server']['last_backfill'] = end
 
     if since_last_data >= self.config['server']['intervals']['data_save']:
         data_renderer = DataRenderer(self.config, copy.deepcopy(self))
         await data_renderer.render()
         end = datetime.now(ZoneInfo(self.config['server']['timezone']))
-        print(f"Saved json data in {round(end.timestamp() - save_start.timestamp(), 2)} seconds")
+        logger.debug("Saved json data in %.2f seconds", end.timestamp() - save_start.timestamp())
         self.config['server']['last_data_save'] = end
         self.graph = self.graph_node(self.config['server']['node_id'])
 
@@ -318,14 +324,14 @@ class MemoryDataStore:
         static_html_renderer = StaticHTMLRenderer(self.config, copy.deepcopy(self))
         await static_html_renderer.render()
         end = datetime.now(ZoneInfo(self.config['server']['timezone']))
-        print(f"Rendered in {round(end.timestamp() - save_start.timestamp(), 2)} seconds")
+        logger.debug("Rendered in %.2f seconds", end.timestamp() - save_start.timestamp())
         self.config['server']['last_render'] = end
 
     if 'backups' in self.config['server'] and self.config['server']['backups']['enabled']:
       if since_last_backup >= self.config['server']['backups']['interval']:
         await self.backup()
         end = datetime.now(ZoneInfo(self.config['server']['timezone']))
-        print(f"Backed up in {round(end.timestamp() - save_start.timestamp(), 2)} seconds")
+        logger.debug("Backed up in %.2f seconds", end.timestamp() - save_start.timestamp())
         self.config['server']['last_backup'] = end
 
   ### helpers
@@ -335,7 +341,7 @@ class MemoryDataStore:
     base_name = f"{self.config['paths']['backups']}/backup-{now}"
     tmp_path = f"/tmp/meshinfo/backup-{now}"
 
-    print(f"Backing up to {base_name}.tar.bz2")
+    logger.info("Backing up to %s.tar.bz2", base_name)
     os.makedirs(tmp_path, exist_ok=True)
     shutil.copytree("output/data", f"{tmp_path}/data")
     shutil.copytree("output/static-html", f"{tmp_path}/static-html")
@@ -347,15 +353,15 @@ class MemoryDataStore:
       root_dir=tmp_path,
       base_dir=".",
       verbose=True)
-    print(f"Backed up to {base_name}.tar.bz2")
+    logger.info("Backed up to %s.tar.bz2", base_name)
     shutil.rmtree(tmp_path)
 
     if 'max_backups' in self.config['server']['backups'] and self.config['server']['backups']['max_backups'] > 0:
       files = glob.glob(f"{self.config['paths']['backups']}/*")
       files.sort(key=os.path.getmtime)
-      print(f"Deleting old backups (max {self.config['server']['backups']['max_backups']}, found {len(files)})")
+      logger.debug("Deleting old backups (max %d, found %d)", self.config['server']['backups']['max_backups'], len(files))
       for file in files[:-self.config['server']['backups']['max_backups']]:
-        print(f"Deleting old backup: {file}")
+        logger.debug("Deleting old backup: %s", file)
         os.remove(file)
 
   async def backfill_node_infos(self):
@@ -363,36 +369,34 @@ class MemoryDataStore:
     for id, node in self.nodes.items():
       if 'shortname' not in node or 'longname' not in node or node['shortname'] == 'UNK' or node['longname'] == 'Unknown':
         nodes_needing_enrichment[id] = node
-    print(f"Nodes needing enrichment: {len(nodes_needing_enrichment)}")
+    logger.info("Nodes needing enrichment: %d", len(nodes_needing_enrichment))
     if len(nodes_needing_enrichment) > 0:
       await self.enrich_nodes(nodes_needing_enrichment)
 
   async def enrich_nodes(self, node_to_enrich):
     async with aiohttp.ClientSession() as session:
         node_ids = list(node_to_enrich.keys())
-        print(f"Enriching nodes: {','.join(node_ids)}")
+        logger.info("Enriching nodes: %s", ','.join(node_ids))
         if self.config['server']['enrich']['provider'] == 'bayme':
           for node_id in node_ids:
-            print(f"Enriching {node_id}")
+            logger.debug("Enriching %s", node_id)
             url = f"https://data.bayme.sh/api/node/infos?ids={node_id}"
             try:
               async with session.get(url) as response:
-                # print(f"Response code: {response.status_code}")
                 if response.status == 200:
                   data = await response.json()
                   for node_id, node_info in data.items():
-                    print(f"Got info for {node_id}")
+                    logger.debug("Got info for %s", node_id)
                     if node_id in self.nodes:
-                      print(f"Enriched {node_id}")
+                      logger.debug("Enriched %s", node_id)
                       node = self.nodes[node_id]
                       node['shortname'] = node_info['shortName']
                       node['longname'] = node_info['longName']
                       self.nodes[node_id] = node
                 else:
-                    print(f"Failed to get info for {node_id}")
+                    logger.warning("Failed to get info for %s", node_id)
             except Exception as e:
-              print(f"Failed to get info for {node_id}")
-              print(e)
+              logger.warning("Failed to get info for %s: %s", node_id, e)
         elif self.config['server']['enrich']['provider'] == 'world.meshinfo.network':
           url = f"https://world.meshinfo.network/api/v1/nodes?ids={','.join(node_ids)}"
           try:
@@ -400,18 +404,17 @@ class MemoryDataStore:
               if response.status == 200:
                 data = await response.json()
                 for node_id, node_info in data.items():
-                  print(f"Got info for {node_id}")
+                  logger.debug("Got info for %s", node_id)
                   if node_id in self.nodes:
-                    print(f"Enriched {node_id}")
+                    logger.debug("Enriched %s", node_id)
                     node = self.nodes[node_id]
                     node['shortname'] = node_info['shortName']
                     node['longname'] = node_info['longName']
                     self.nodes[node_id] = node
               else:
-                  print(f"Failed to get info for {node_ids}")
+                  logger.warning("Failed to get info for %s", node_ids)
           except Exception as e:
-            print(f"Failed to get info for {node_ids}")
-            print(e)
+            logger.warning("Failed to get info for %s: %s", node_ids, e)
 
   def find_node_by_int_id(self, id: int):
     return self.nodes.get(utils.convert_node_id_from_int_to_hex(id), None)
@@ -459,8 +462,7 @@ class MemoryDataStore:
     return None
 
   def graph_node(self, node_id: str) -> dict|None:
-    if self.config['debug']:
-        print(f"Graphing node: {node_id}")
+    logger.debug("Graphing node: %s", node_id)
 
     visited = set()  # Set to keep track of visited nodes
 
@@ -472,8 +474,7 @@ class MemoryDataStore:
         if level > 1 and node_id in visited:
             return node  # Return the node if it has already been visited
 
-        if self.config['debug']:
-          print("%s - %s" % ("  " * level, node_id))
+        logger.debug("%s - %s", "  " * level, node_id)
 
         visited.add(node_id)  # Mark the node as visited
 
@@ -481,7 +482,6 @@ class MemoryDataStore:
         neighbors_heard_by = []
 
         if node['neighborinfo'] and node['neighborinfo']['neighbors']:
-            # print(f"Node {node_id} has {len(node['neighborinfo']['neighbors'])} neighbors")
             for neighbor in node['neighborinfo']['neighbors']:
                 nid = utils.convert_node_id_from_int_to_hex(neighbor["node_id"])
                 if start_id is not None and start_id == nid or (self.config['server']['graph']['max_depth'] is not None and level >= self.config['server']['graph']['max_depth']):

--- a/mqtt.py
+++ b/mqtt.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import datetime
 import json
+import logging
 import time
 import traceback
 from zoneinfo import ZoneInfo
@@ -17,6 +18,8 @@ from cryptography.hazmat.backends import default_backend
 from encoders import _JSONDecoder
 from models.node import Node
 import utils
+
+logger = logging.getLogger(__name__)
 
 key = "AQ=="
 key_hash = "1PG7OiApB1nwvP+rz05pAQ==" # AQ==
@@ -36,7 +39,7 @@ class MQTT:
     ### actions
 
     async def connect(self):
-        print(f"Connecting to MQTT broker at {self.config['broker']['host']}:{self.config['broker']['port']}")
+        logger.info("Connecting to MQTT broker at %s:%d", self.config['broker']['host'], self.config['broker']['port'])
         while True:
             try:
                 async with aiomqtt.Client(
@@ -46,17 +49,14 @@ class MQTT:
                     username = self.config["broker"]["username"],
                     password = self.config["broker"]["password"],
                 ) as client:
-                    print("Connected to MQTT broker at %s:%d" % (
-                        self.config["broker"]["host"],
-                        self.config["broker"]["port"],
-                    ))
+                    logger.info("Connected to MQTT broker at %s:%d", self.config["broker"]["host"], self.config["broker"]["port"])
                     if "topics" in self.config["broker"] and self.config["broker"]["topics"] is not None and isinstance(self.config["broker"]["topics"], list):
                         for topic in self.config["broker"]["topics"]:
                             await client.subscribe(topic)
                     elif "topic" in self.config["broker"] and self.config["broker"]["topic"] is not None and isinstance(self.config["broker"]["topic"], str):
                         await client.subscribe(self.config["broker"]["topic"])
                     else:
-                        print("No MQTT topics to subscribe to defined in config broker.topics or broker.topic")
+                        logger.error("No MQTT topics to subscribe to defined in config broker.topics or broker.topic")
                         exit(1)
 
                     self.data.mqtt_connect_time = datetime.datetime.now(ZoneInfo(self.config['server']['timezone']))
@@ -66,15 +66,14 @@ class MQTT:
                         msg.timestamp = time.monotonic() # type: ignore
                         await self.process_mqtt_msg(client, msg)
             except aiomqtt.MqttError as err:
-                print(f"Disconnected from MQTT broker: {err}")
-                print("Reconnecting...")
+                logger.warning("Disconnected from MQTT broker: %s", err)
+                logger.info("Reconnecting...")
                 await asyncio.sleep(5)
 
     async def process_mqtt_msg(self, client, msg):
         if self.config['broker']['decoders']['protobuf']['enabled']:
             if'/2/e/' in msg.topic.value or '/2/map/' in msg.topic.value:
-                if self.config['debug']:
-                    print(f"Received a protobuf message: {msg.topic} {msg.payload}")
+                logger.debug("Received a protobuf message: %s %s", msg.topic, msg.payload)
                 is_encrypted = False
                 mp = mesh_pb2.MeshPacket()
                 outs = {}
@@ -84,10 +83,8 @@ class MQTT:
                     se.ParseFromString(msg.payload)
                     mp = se.packet
                     outs = json.loads(MessageToJson(mp, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
-                    if self.config['debug']:
-                        print(f"Decoded protobuf message: {outs}")
+                    logger.debug("Decoded protobuf message: %s", outs)
                 except Exception as _:
-                    # print(f"*** ParseFromString: {str(e)}")
                     pass
 
                 if mp.HasField("encrypted") and not mp.HasField("decoded"):
@@ -95,8 +92,7 @@ class MQTT:
                     for key_item in self.config['broker']['channels']['encryption']:
                         key_bytes = base64.b64decode(key_item['key'].encode('ascii'))
                         try:
-                            if self.config['debug']:
-                                print(f"Attempting decryption with key: {key}")
+                            logger.debug("Attempting decryption with key: %s", key)
                             nonce_packet_id = getattr(mp, "id").to_bytes(8, "little")
                             nonce_from_node = getattr(mp, "from").to_bytes(8, "little")
                             nonce = nonce_packet_id + nonce_from_node
@@ -109,8 +105,7 @@ class MQTT:
                             outs = json.loads(MessageToJson(mp, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
                             break
                         except Exception as e:
-                            if self.config['debug']:
-                                print(f"*** Decryption failed: {str(e)}")
+                            logger.debug("Decryption failed: %s", e)
                             continue
 
                 outs['rssi'] = mp.rx_rssi
@@ -126,8 +121,7 @@ class MQTT:
                         text = payload_bytes.decode("utf-8")
                         outs["type"] = "text"
                         outs["payload"] = {"text": text}
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: text: {outs}")
+                        logger.debug("Decoded protobuf message: text: %s", outs)
                         await self.handle_text(outs)
 
                     except UnicodeDecodeError:
@@ -136,8 +130,7 @@ class MQTT:
                             "text_b64": base64.b64encode(payload_bytes).decode("ascii"),
                             "len": len(payload_bytes),
                         }
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: text_binary: {outs}")
+                        logger.debug("Decoded protobuf message: text_binary: %s", outs)
                         # log it, but don't treat as chat text
                         await self.handle_log(outs)
 
@@ -147,13 +140,12 @@ class MQTT:
                         out = json.loads(MessageToJson(report, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True, always_print_fields_with_no_presence=True))
                         outs["type"] = "mapreport"
                         outs["payload"] = out
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: mapreport: {outs}")
+                        logger.debug("Decoded protobuf message: mapreport: %s", outs)
                         # self.handle_mapreport(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
 
                 elif mp.decoded.portnum == portnums_pb2.NEIGHBORINFO_APP:
                     try:
@@ -161,13 +153,12 @@ class MQTT:
                         out = json.loads(MessageToJson(info, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True, always_print_fields_with_no_presence=True))
                         outs["type"] = "neighborinfo"
                         outs["payload"] = out
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: neighborinfo: {outs}")
+                        logger.debug("Decoded protobuf message: neighborinfo: %s", outs)
                         await self.handle_neighborinfo(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
 
                 elif mp.decoded.portnum == portnums_pb2.NODEINFO_APP:
                     try:
@@ -178,13 +169,12 @@ class MQTT:
                         out["id"] = out['id'].replace('!', '')
                         outs["type"] = "nodeinfo"
                         outs["payload"] = out
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: nodeinfo: {outs}")
+                        logger.debug("Decoded protobuf message: nodeinfo: %s", outs)
                         await self.handle_nodeinfo(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
 
                 elif mp.decoded.portnum == portnums_pb2.ROUTING_APP:
                     try:
@@ -192,13 +182,12 @@ class MQTT:
                         out = json.loads(MessageToJson(data, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
                         outs["type"] = "routing"
                         outs["payload"] = out
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: routing: {outs}")
+                        logger.debug("Decoded protobuf message: routing: %s", outs)
                         # self.handle_routing(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
 
                 elif mp.decoded.portnum == portnums_pb2.TRACEROUTE_APP:
                     try:
@@ -212,13 +201,12 @@ class MQTT:
                             outs["route"] = route
                         outs["type"] = "traceroute"
                         outs["payload"] = out
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: traceroute: {outs}")
+                        logger.debug("Decoded protobuf message: traceroute: %s", outs)
                         await self.handle_traceroute(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
 
                 elif mp.decoded.portnum == portnums_pb2.POSITION_APP:
                     try:
@@ -226,13 +214,12 @@ class MQTT:
                         out = json.loads(MessageToJson(pos, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
                         outs["type"] = "position"
                         outs["payload"] = out
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: position: {outs}")
+                        logger.debug("Decoded protobuf message: position: %s", outs)
                         await self.handle_position(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
 
                 elif mp.decoded.portnum == portnums_pb2.TELEMETRY_APP:
                     try:
@@ -247,40 +234,37 @@ class MQTT:
                             outs["payload"] = out['device_metrics']
                         if 'environment_metrics' in out:
                             outs["payload"] = out['environment_metrics']
-                        if self.config['debug']:
-                            print(f"Decoded protobuf message: telemetry: {outs}")
+                        logger.debug("Decoded protobuf message: telemetry: %s", outs)
                         await self.handle_telemetry(outs)
                     except UnicodeDecodeError as e:
-                        print(f"*** Unicode decoding error: text: {str(e)}")
+                        logger.warning("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
-                        print(f"*** Protobuf decode error: text: {str(e)}")
+                        logger.warning("Protobuf decode error: text: %s", e)
                     except Exception as e:
-                        print(e)
+                        logger.error("Telemetry processing error: %s", e)
 
                 else:
-                    if self.config['debug']:
-                        print(f"Received an unknown protobuf message: {mp}")
+                    logger.debug("Received an unknown protobuf message: %s", mp)
                     outs["type"] = "unknown"
                     if mp.decoded.payload is not None:
                         try:
                             outs["payload"] = mp.decoded.payload.decode("utf-8")
                         except UnicodeDecodeError as e:
-                            print(f"*** Unicode decoding error: text: {str(e)}")
+                            logger.warning("Unicode decoding error: text: %s", e)
                             outs["payload"] = {}
                         except DecodeError as e:
-                            print(f"*** Protobuf decode error: text: {str(e)}")
+                            logger.warning("Protobuf decode error: text: %s", e)
                             outs["payload"] = {}
                     else:
                         outs["payload"] = {}
 
-                print(outs)
+                logger.debug("Processed message: %s", outs)
                 await self.handle_log(outs)
                 await self.prune_expired_nodes()
 
         elif self.config['broker']['decoders']['json']['enabled']:
             if '/2/json' in msg.topic.value:
-                if self.config['debug']:
-                    print(f"Received a JSON message: {msg.topic} {msg.payload}")
+                logger.debug("Received a JSON message: %s %s", msg.topic, msg.payload)
                 try:
                     decoded = msg.payload.decode("utf-8")
                     j = json.loads(decoded, cls=_JSONDecoder)
@@ -314,22 +298,21 @@ class MQTT:
                         await self.handle_traceroute(j)
                     await self.prune_expired_nodes()
                 except Exception as e:
-                    print(e)
-                    traceback.print_exc()
+                    logger.error("JSON message processing error: %s", e, exc_info=True)
 
     async def publish(self, client, topic, msg):
         result = await client.publish(topic, msg)
         status = result[0]
         if status == 0:
-            print(f"Send `{msg}` to topic `{topic}`")
+            logger.debug("Sent message to topic %s", topic)
             return True
         else:
-            print(f"Failed to send message to topic {topic}")
+            logger.warning("Failed to send message to topic %s", topic)
             return False
 
     async def subscribe(self, client, topic):
         client.subscribe(topic)
-        print(f"Subscribed to topic `{topic}`")
+        logger.info("Subscribed to topic %s", topic)
 
     async def unsubscribe(self, client, topic):
         client.unsubscribe(topic)
@@ -338,8 +321,7 @@ class MQTT:
 
     async def handle_log(self, msg):
         topic = msg['topic'] if 'topic' in msg else 'unknown'
-        if self.config['debug']:
-            print(f"MQTT >> {topic} -- {msg}")
+        logger.debug("MQTT >> %s -- %s", topic, msg)
 
         self.data.mqtt_messages.append(msg)
 
@@ -354,9 +336,9 @@ class MQTT:
             try:
                 await self.data.pg_storage.write_mqtt_message(clean_msg)
             except Exception as e:
-                print(f"*** Failed to write mqtt_message to postgres: {e}")
+                logger.error("Failed to write mqtt_message to postgres: %s", e)
                 if self.config.get('debug'):
-                    traceback.print_exc()
+                    logger.debug("Postgres write traceback", exc_info=True)
 
         with open(f'{self.config["paths"]["data"]}/message-log.jsonl', 'a', encoding='utf-8') as f:
             f.write(json.dumps(clean_msg, ensure_ascii=False, default=str) + "\n")
@@ -373,12 +355,12 @@ class MQTT:
             node = self.data.nodes[id]
             node['neighborinfo'] = msg['payload']
             self.data.update_node(id, node)
-            print(f"Node {id} updated with neighborinfo")
+            logger.debug("Node %s updated with neighborinfo", id)
         else:
             node = Node.default_node(id)
             node['neighborinfo'] = msg['payload']
             self.data.update_node(id, node)
-            print(f"Node {id} skeleton added with neighborinfo")
+            logger.debug("Node %s skeleton added with neighborinfo", id)
         await self.data.save()
 
     async def handle_nodeinfo(self, msg):
@@ -391,10 +373,10 @@ class MQTT:
         id = msg['payload']['id']
         if id in self.data.nodes:
             node = self.data.nodes[id]
-            print(f"Updating node {id}")
+            logger.debug("Updating node %s", id)
         else:
             node = Node.default_node(id)
-            print(f"Discovered node {id}")
+            logger.debug("Discovered node %s", id)
 
         if 'hardware' in msg['payload']:
             node['hardware'] = msg['payload']['hardware']
@@ -433,12 +415,12 @@ class MQTT:
             node = self.data.nodes[id]
             node['position'] = msg['payload'] if 'payload' in msg else None
             self.data.update_node(id, node)
-            print(f"Node {id} updated with position")
+            logger.debug("Node %s updated with position", id)
         else:
             node = Node.default_node(id)
             node['position'] = msg['payload'] if 'payload' in msg else None
             self.data.update_node(id, node)
-            print(f"Node {id} skeleton added with position")
+            logger.debug("Node %s skeleton added with position", id)
         await self.data.save()
 
     async def handle_telemetry(self, msg):
@@ -453,12 +435,12 @@ class MQTT:
             node = self.data.nodes[id]
             node['telemetry'] = msg['payload'] if 'payload' in msg else None
             self.data.update_node(id, node)
-            print(f"Node {id} updated with telemetry")
+            logger.debug("Node %s updated with telemetry", id)
         else:
             node = Node.default_node(id)
             node['telemetry'] = msg['payload'] if 'payload' in msg else None
             self.data.update_node(id, node)
-            print(f"Node {id} skeleton added with telemetry")
+            logger.debug("Node %s skeleton added with telemetry", id)
 
         if id not in self.data.telemetry_by_node:
             self.data.telemetry_by_node[id] = []
@@ -564,12 +546,12 @@ class MQTT:
             try:
                 since = (now - last_seen).seconds
             except Exception:
-                print(f"Node {id} has invalid last_seen: {node['last_seen']}")
+                logger.warning("Node %s has invalid last_seen: %s", id, node['last_seen'])
                 self.data.nodes[id]['last_seen'] = None
                 self.data.nodes[id]['active'] = False
             if node['active'] and since >= self.config['server']['node_activity_prune_threshold']:
                 ids_to_delete.append(node['id'])
-                print(f"Node {id} pruned (last heard {since} seconds ago)")
+                logger.debug("Node %s pruned (last heard %d seconds ago)", id, since)
 
         for id in ids_to_delete:
             self.data.nodes[id]['active'] = False

--- a/mqtt.py
+++ b/mqtt.py
@@ -56,8 +56,7 @@ class MQTT:
                     elif "topic" in self.config["broker"] and self.config["broker"]["topic"] is not None and isinstance(self.config["broker"]["topic"], str):
                         await client.subscribe(self.config["broker"]["topic"])
                     else:
-                        logger.error("No MQTT topics to subscribe to defined in config broker.topics or broker.topic")
-                        exit(1)
+                        raise RuntimeError("No MQTT topics to subscribe to defined in config broker.topics or broker.topic")
 
                     self.data.mqtt_connect_time = datetime.datetime.now(ZoneInfo(self.config['server']['timezone']))
                     async for msg in client.messages:

--- a/static_html_renderer.py
+++ b/static_html_renderer.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import datetime
 import json
+import logging
 from zoneinfo import ZoneInfo
 from jinja2 import Environment, FileSystemLoader
 
@@ -11,6 +12,9 @@ import encoders
 import geo
 import meshtastic_support
 import utils
+
+logger = logging.getLogger(__name__)
+
 
 class StaticHTMLRenderer:
   def __init__(self, config, data):
@@ -36,7 +40,7 @@ class StaticHTMLRenderer:
     self.render_stats()
     self.render_telemetry()
     self.render_traceroutes()
-    print("Done rendering static HTML files")
+    logger.debug("Done rendering static HTML files")
 
   def save_file(self, filename, content):
     with open(f"{self.output_path}/{filename}", "w", encoding='utf-8') as f:
@@ -50,8 +54,7 @@ class StaticHTMLRenderer:
     return html
 
   def render_html_and_save(self, filename, **kwargs):
-    if self.config['debug']:
-      print(f"Rendering {filename}")
+    logger.debug("Rendering %s", filename)
     html = self.render_html(filename, **kwargs)
     self.save_file(filename, html)
 

--- a/utils.py
+++ b/utils.py
@@ -3,10 +3,7 @@ import datetime
 import logging
 import requests
 from geo import distance_between_two_points
-
 logger = logging.getLogger(__name__)
-
-
 def calculate_distance_between_nodes(node1, node2):
   if node1 is None or node2 is None:
     return None
@@ -20,16 +17,13 @@ def calculate_distance_between_nodes(node1, node2):
     node2["position"]["latitude_i"] / 10000000,
     node2["position"]["longitude_i"] / 10000000
   ), 2)
-
 def convert_node_id_from_int_to_hex(id: int):
   id_hex = f'{id:08x}'
   return id_hex
-
 def convert_node_id_from_hex_to_int(id: str):
   if id.startswith('!'):
       id = id.replace('!', '')
   return int(id, 16)
-
 def days_since_datetime(dt: datetime.datetime):
   # Returns the number of days since the given datetime using UTC
   now = datetime.datetime.now(datetime.timezone.utc)
@@ -37,18 +31,25 @@ def days_since_datetime(dt: datetime.datetime):
     dt = datetime.datetime.fromisoformat(dt)
   diff = now - dt
   return diff.days
-
 def geocode_position(api_key: str, latitude: float, longitude: float):
   if latitude is None or longitude is None:
     return None
   logger.debug("Geocoding %s, %s", latitude, longitude)
   url = f"https://geocode.maps.co/reverse?lat={latitude}&lon={longitude}&api_key={api_key}"
-  response = requests.get(url)
+  try:
+    response = requests.get(url, timeout=5)
+  except requests.RequestException as exc:
+    logger.warning("Geocoding request failed for %s, %s: %s", latitude, longitude, exc)
+    return None
   if response.status_code != 200:
     return None
-  logger.debug("Geocoded %s, %s to %s", latitude, longitude, response.json())
-  return response.json()
-
+  try:
+    data = response.json()
+  except ValueError as exc:
+    logger.warning("Failed to decode geocoding response for %s, %s: %s", latitude, longitude, exc)
+    return None
+  logger.debug("Geocoded %s, %s to %s", latitude, longitude, data)
+  return data
 def filter_dict(d, whitelist):
     """
     Recursively filter a dictionary to only include whitelisted keys.

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-
 import datetime
+import logging
 import requests
 from geo import distance_between_two_points
+
+logger = logging.getLogger(__name__)
+
 
 def calculate_distance_between_nodes(node1, node2):
   if node1 is None or node2 is None:
@@ -38,18 +41,17 @@ def days_since_datetime(dt: datetime.datetime):
 def geocode_position(api_key: str, latitude: float, longitude: float):
   if latitude is None or longitude is None:
     return None
-  print(f"Geocoding {latitude}, {longitude}")
+  logger.debug("Geocoding %s, %s", latitude, longitude)
   url = f"https://geocode.maps.co/reverse?lat={latitude}&lon={longitude}&api_key={api_key}"
   response = requests.get(url)
   if response.status_code != 200:
     return None
-  print(f"Geocoded {latitude}, {longitude} to {response.json()}")
+  logger.debug("Geocoded %s, %s to %s", latitude, longitude, response.json())
   return response.json()
 
 def filter_dict(d, whitelist):
     """
     Recursively filter a dictionary to only include whitelisted keys.
-
     :param d: The original dictionary or list.
     :param whitelist: A dictionary that mirrors the structure of `d` with the keys you want to keep.
                       Nested dictionaries and lists should be specified with the keys you want to retain.


### PR DESCRIPTION
This PR converts all print() calls across the Python backend to structured logging calls, and wires up the server.log_level config field (added in #262) so it actually controls log verbosity at runtime.
Files changed:

- main.py — Reads server.log_level from config and applies it to the root logger at startup. Banner print() intentionally kept for clean stdout display.
- mqtt.py — Biggest change. ~55 print() calls converted. Per-message decoding, node updates, and payload dumps → DEBUG. Connection/disconnection → INFO/WARNING. Decode errors → WARNING. Removes the if self.config['debug']: guards since log level now handles visibility.
- memory_data_store.py — Data load summaries stay INFO. Periodic save/render/enrich/backup timing → DEBUG. Geocode failures → WARNING.
- data_renderer.py — Per-file save notifications → DEBUG.
- static_html_renderer.py — Per-file rendering → DEBUG, completion → DEBUG.
- api.py — CORS origins and Uvicorn startup → INFO. Added log_config=None to Uvicorn so it inherits the root logger format.
- discord.py — Ready/sync → INFO, per-message → DEBUG.
- utils.py — Geocoding → DEBUG.

Behavior at default INFO level:

Startup shows config validation, version, timezone, data loading, connections, and service status. During normal operation, logs are essentially silent — only warnings (disconnections, decode errors, invalid data) and errors appear. Set "log_level": "DEBUG" in config.json to restore the old verbose output for troubleshooting.

Known issue: Uvicorn's logger is named `uvicorn.error` so it will print such without the messages being real errors. This is a well-known source of confusion in the Uvicorn community. 