### PR TITLE
Fix telemetry variant overwrite and add missing metrics

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -476,10 +476,24 @@ class MQTT:
         if payload is not None:
             self.data.telemetry.insert(0, msg)
             self.data.telemetry_by_node[id].insert(0, msg)
-            
+
             # Real-time write to Postgres if enabled
             if 'postgres' in self.config.get('storage', {}).get('write_to', []):
+                # Write to telemetry history table
                 await self.data.pg_storage.write_telemetry(id, msg)
+
+                # Update node_telemetry_current with variant-aware write.
+                # For JSONB variants (power_metrics, air_quality, etc.) this
+                # stores the payload in the correct JSONB column. For typed
+                # variants (device_metrics, environment_metrics) it updates
+                # the individual typed columns as before.
+                try:
+                    async with self.data.pg_storage.pool.acquire() as conn:
+                        await self.data.pg_storage._write_node_telemetry_current(
+                            conn, id, payload, telemetry_type=telemetry_type
+                        )
+                except Exception as e:
+                    logger.error("Failed to update node_telemetry_current for node %s: %s", id, e)
 
         await self.data.save()
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -244,8 +244,9 @@ class MQTT:
                             outs["payload"] = out['environment_metrics']
                             outs["telemetry_type"] = "environment_metrics"
                         else:
-                            # Unknown or empty telemetry variant
+                            # Unknown or empty telemetry variant; mark telemetry_type explicitly
                             outs["payload"] = out
+                            outs["telemetry_type"] = "unknown"
                             logger.debug("Telemetry with unrecognized variant=%s: %s", variant, out)
 
                         logger.debug("Decoded protobuf message: telemetry (variant=%s): %s", variant, outs)
@@ -463,9 +464,6 @@ class MQTT:
             # Merge: new fields overwrite, but fields not in this payload survive
             existing.update(payload)
             node['telemetry'] = existing
-        else:
-            # No payload; don't wipe existing telemetry
-            pass
 
         self.data.update_node(id, node)
         logger.debug("Node %s updated with telemetry (variant=%s)", id, telemetry_type)
@@ -487,13 +485,19 @@ class MQTT:
                 # stores the payload in the correct JSONB column. For typed
                 # variants (device_metrics, environment_metrics) it updates
                 # the individual typed columns as before.
-                try:
-                    async with self.data.pg_storage.pool.acquire() as conn:
-                        await self.data.pg_storage._write_node_telemetry_current(
-                            conn, id, payload, telemetry_type=telemetry_type
-                        )
-                except Exception as e:
-                    logger.error("Failed to update node_telemetry_current for node %s: %s", id, e)
+                if self.data.pg_storage and self.data.pg_storage.pool:
+                    try:
+                        async with self.data.pg_storage.pool.acquire() as conn:
+                            await self.data.pg_storage._write_node_telemetry_current(
+                                conn, id, payload, telemetry_type=telemetry_type
+                            )
+                    except Exception as e:
+                        logger.error("Failed to update node_telemetry_current for node %s: %s", id, e)
+                else:
+                    logger.warning(
+                        "handle_telemetry: pg_storage or pool not available; "
+                        "skipping node_telemetry_current update for node %s", id
+                    )
 
         await self.data.save()
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -229,11 +229,26 @@ class MQTT:
                                 ZoneInfo(self.config['server']['timezone'])
                             )
                         outs["type"] = "telemetry"
-                        if 'device_metrics' in out:
+
+                        # Determine the telemetry variant using protobuf oneof
+                        variant = env.WhichOneof('variant')
+                        outs["telemetry_type"] = variant  # e.g. "device_metrics", "environment_metrics", etc.
+
+                        if variant and variant in out:
+                            outs["payload"] = out[variant]
+                        elif 'device_metrics' in out:
+                            # Fallback for edge cases where WhichOneof returns None
                             outs["payload"] = out['device_metrics']
-                        if 'environment_metrics' in out:
+                            outs["telemetry_type"] = "device_metrics"
+                        elif 'environment_metrics' in out:
                             outs["payload"] = out['environment_metrics']
-                        logger.debug("Decoded protobuf message: telemetry: %s", outs)
+                            outs["telemetry_type"] = "environment_metrics"
+                        else:
+                            # Unknown or empty telemetry variant
+                            outs["payload"] = out
+                            logger.debug("Telemetry with unrecognized variant=%s: %s", variant, out)
+
+                        logger.debug("Decoded protobuf message: telemetry (variant=%s): %s", variant, outs)
                         await self.handle_telemetry(outs)
                     except UnicodeDecodeError as e:
                         logger.warning("Unicode decoding error: text: %s", e)
@@ -430,21 +445,35 @@ class MQTT:
             msg['sender'] = msg['sender'].replace('!', '')
 
         id = msg['from']
+        telemetry_type = msg.get('telemetry_type')
+        payload = msg.get('payload')
+
         if id in self.data.nodes:
             node = self.data.nodes[id]
-            node['telemetry'] = msg['payload'] if 'payload' in msg else None
-            self.data.update_node(id, node)
-            logger.debug("Node %s updated with telemetry", id)
         else:
             node = Node.default_node(id)
-            node['telemetry'] = msg['payload'] if 'payload' in msg else None
-            self.data.update_node(id, node)
-            logger.debug("Node %s skeleton added with telemetry", id)
+
+        # Merge incoming telemetry into the node's existing telemetry dict
+        # instead of replacing it entirely. This preserves device_metrics
+        # fields when an environment_metrics message arrives, and vice versa.
+        if payload is not None:
+            existing = node.get('telemetry')
+            if existing is None or not isinstance(existing, dict):
+                existing = {}
+            # Merge: new fields overwrite, but fields not in this payload survive
+            existing.update(payload)
+            node['telemetry'] = existing
+        else:
+            # No payload; don't wipe existing telemetry
+            pass
+
+        self.data.update_node(id, node)
+        logger.debug("Node %s updated with telemetry (variant=%s)", id, telemetry_type)
 
         if id not in self.data.telemetry_by_node:
             self.data.telemetry_by_node[id] = []
 
-        if 'payload' in msg:
+        if payload is not None:
             self.data.telemetry.insert(0, msg)
             self.data.telemetry_by_node[id].insert(0, msg)
             

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -50,14 +50,19 @@ CREATE TABLE IF NOT EXISTS node_neighborinfo (
 );
 
 -- Node telemetry current - stores the most recent telemetry per node
+-- Device metrics and environment metrics have dedicated typed columns.
+-- Other telemetry variants (power, air quality, local stats, health,
+-- host metrics, traffic management) are stored as JSONB columns.
 CREATE TABLE IF NOT EXISTS node_telemetry_current (
     id SERIAL PRIMARY KEY,
     node_id VARCHAR(8) NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    -- device_metrics fields
     battery_level INTEGER,
     voltage REAL,
     channel_utilization REAL,
     air_util_tx REAL,
     uptime_seconds INTEGER,
+    -- environment_metrics fields
     temperature REAL,
     relative_humidity REAL,
     barometric_pressure REAL,
@@ -71,6 +76,21 @@ CREATE TABLE IF NOT EXISTS node_telemetry_current (
     wind_direction INTEGER,
     wind_speed REAL,
     weight REAL,
+    current REAL,               -- current measured (A)
+    wind_gust REAL,             -- wind gust in m/s
+    wind_lull REAL,             -- wind lull in m/s
+    radiation REAL,             -- radiation in µR/h
+    rainfall_1h REAL,           -- rainfall last hour in mm
+    rainfall_24h REAL,          -- rainfall last 24h in mm
+    soil_moisture INTEGER,      -- soil moisture % (1-100)
+    soil_temperature REAL,      -- soil temperature in °C
+    -- JSONB columns for other telemetry variants (latest snapshot per node)
+    power_metrics JSONB,                -- PowerMetrics (multi-channel voltage/current)
+    air_quality_metrics JSONB,          -- AirQualityMetrics (PM, CO2, particles, etc.)
+    local_stats JSONB,                  -- LocalStats (mesh statistics)
+    health_metrics JSONB,               -- HealthMetrics (heart rate, SpO2, temp)
+    host_metrics JSONB,                 -- HostMetrics (Linux host system metrics)
+    traffic_management_stats JSONB,     -- TrafficManagementStats
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UNIQUE(node_id)

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS telemetry (
     snr REAL,
     timestamp BIGINT,
     rx_time TIMESTAMP WITH TIME ZONE,
+    telemetry_type TEXT,
     payload JSONB,  -- Complete telemetry payload
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     CONSTRAINT telemetry_from_node_id_message_id_key UNIQUE (from_node_id, message_id)
@@ -98,6 +99,9 @@ CREATE TABLE IF NOT EXISTS telemetry (
 CREATE INDEX IF NOT EXISTS idx_telemetry_from_node_id ON telemetry(from_node_id);
 CREATE INDEX IF NOT EXISTS idx_telemetry_created_at ON telemetry(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_telemetry_rx_time ON telemetry(rx_time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_type ON telemetry(telemetry_type);
+CREATE INDEX IF NOT EXISTS idx_telemetry_node_type ON telemetry(from_node_id, telemetry_type);
 
 -- Chat channels table
 CREATE TABLE IF NOT EXISTS chat_channels (

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -25,11 +25,13 @@ class PostgresStorage:
     # partial updates so that a device_metrics message never NULLs out
     # environment_metrics columns and vice versa.
     TELEMETRY_COLUMNS = {
+        # device_metrics fields
         "battery_level": "battery_level",
         "voltage": "voltage",
         "channel_utilization": "channel_utilization",
         "air_util_tx": "air_util_tx",
         "uptime_seconds": "uptime_seconds",
+        # environment_metrics fields
         "temperature": "temperature",
         "relative_humidity": "relative_humidity",
         "barometric_pressure": "barometric_pressure",
@@ -43,7 +45,58 @@ class PostgresStorage:
         "wind_direction": "wind_direction",
         "wind_speed": "wind_speed",
         "weight": "weight",
+        "current": "current",
+        "wind_gust": "wind_gust",
+        "wind_lull": "wind_lull",
+        "radiation": "radiation",
+        "rainfall_1h": "rainfall_1h",
+        "rainfall_24h": "rainfall_24h",
+        "soil_moisture": "soil_moisture",
+        "soil_temperature": "soil_temperature",
     }
+
+    # Telemetry variant names (from protobuf WhichOneof) that are stored as
+    # JSONB columns on node_telemetry_current rather than as individual typed
+    # columns. The dict value is the Postgres column name.
+    TELEMETRY_JSONB_VARIANTS = {
+        "power_metrics": "power_metrics",
+        "air_quality_metrics": "air_quality_metrics",
+        "local_stats": "local_stats",
+        "health_metrics": "health_metrics",
+        "host_metrics": "host_metrics",
+        "traffic_management_stats": "traffic_management_stats",
+    }
+
+    # All typed telemetry field names used in read queries. Kept in sync with
+    # TELEMETRY_COLUMNS values for use in load_nodes / query_nodes_filtered.
+    _TYPED_TELEMETRY_FIELDS = [
+        "battery_level",
+        "voltage",
+        "channel_utilization",
+        "air_util_tx",
+        "uptime_seconds",
+        "temperature",
+        "relative_humidity",
+        "barometric_pressure",
+        "gas_resistance",
+        "iaq",
+        "distance",
+        "lux",
+        "white_lux",
+        "ir_lux",
+        "uv_lux",
+        "wind_direction",
+        "wind_speed",
+        "weight",
+        "current",
+        "wind_gust",
+        "wind_lull",
+        "radiation",
+        "rainfall_1h",
+        "rainfall_24h",
+        "soil_moisture",
+        "soil_temperature",
+    ]
 
     def __init__(self, config: Dict[str, Any]):
         """Initialize Postgres storage with configuration."""
@@ -224,6 +277,31 @@ class PostgresStorage:
             except json.JSONDecodeError:
                 return default
         return default
+
+    # --------------------------- telemetry read helper ---------------------------
+
+    def _build_telemetry_dict_from_row(self, row) -> Optional[Dict[str, Any]]:
+        """
+        Build a telemetry dict from a node_telemetry_current row.
+        Merges typed columns and JSONB variant columns into a single dict.
+        Used by load_nodes() and query_nodes_filtered() to avoid duplication.
+        """
+        telemetry: Dict[str, Any] = {}
+
+        # Typed columns (device_metrics + environment_metrics fields)
+        for field in self._TYPED_TELEMETRY_FIELDS:
+            val = row.get(field)
+            if val is not None:
+                telemetry[field] = val
+
+        # JSONB variant columns — merge their fields into the flat dict
+        # so the API response stays compatible with the in-memory structure
+        for variant_name, col_name in self.TELEMETRY_JSONB_VARIANTS.items():
+            variant_data = self._jsonb(row.get(col_name), None)
+            if variant_data and isinstance(variant_data, dict):
+                telemetry.update(variant_data)
+
+        return telemetry if telemetry else None
 
     # ============================================================================
     # WRITE OPERATIONS - Real-time writes for dual-write pattern
@@ -407,7 +485,8 @@ class PostgresStorage:
             neighbors_json,
         )
 
-    async def _write_node_telemetry_current(self, conn, node_id: str, telemetry: Dict[str, Any]):
+    async def _write_node_telemetry_current(self, conn, node_id: str, telemetry: Dict[str, Any],
+                                             telemetry_type: Optional[str] = None):
         """
         Write current node telemetry state (latest snapshot per node).
 
@@ -415,6 +494,9 @@ class PostgresStorage:
         in the incoming telemetry dict are written. This prevents a
         device_metrics message from NULLing out environment_metrics columns
         and vice versa.
+
+        For JSONB variant types (power_metrics, air_quality_metrics, etc.),
+        the entire payload is stored as a JSONB blob in the corresponding column.
         """
         # Normalize + ensure FK target exists
         node_norm = await self._ensure_node_stub(conn, node_id)
@@ -422,6 +504,24 @@ class PostgresStorage:
             logger.warning("_write_node_telemetry_current: could not normalize node_id=%r; skipping", node_id)
             return
 
+        # Check if this is a JSONB variant type
+        if telemetry_type and telemetry_type in self.TELEMETRY_JSONB_VARIANTS:
+            col_name = self.TELEMETRY_JSONB_VARIANTS[telemetry_type]
+            payload_json = json.dumps(telemetry, ensure_ascii=False)
+
+            sql = f"""
+                INSERT INTO node_telemetry_current (node_id, {col_name})
+                VALUES ($1, $2::jsonb)
+                ON CONFLICT (node_id) DO UPDATE SET
+                    {col_name} = EXCLUDED.{col_name},
+                    updated_at = NOW()
+                WHERE
+                    node_telemetry_current.{col_name} IS DISTINCT FROM EXCLUDED.{col_name}
+            """
+            await conn.execute(sql, node_norm, payload_json)
+            return
+
+        # Otherwise, handle typed columns (device_metrics / environment_metrics)
         # Collect only the columns that are actually present in this payload.
         # We intentionally include keys whose value is None — that means the
         # protobuf explicitly sent a zero/null for that field, which we should
@@ -909,30 +1009,7 @@ class PostgresStorage:
                 for row in telemetry_rows:
                     node_id = row["node_id"]
                     if node_id in nodes:
-                        telemetry = {}
-                        for field in [
-                            "battery_level",
-                            "voltage",
-                            "channel_utilization",
-                            "air_util_tx",
-                            "uptime_seconds",
-                            "temperature",
-                            "relative_humidity",
-                            "barometric_pressure",
-                            "gas_resistance",
-                            "iaq",
-                            "distance",
-                            "lux",
-                            "white_lux",
-                            "ir_lux",
-                            "uv_lux",
-                            "wind_direction",
-                            "wind_speed",
-                            "weight",
-                        ]:
-                            if row[field] is not None:
-                                telemetry[field] = row[field]
-                        nodes[node_id]["telemetry"] = telemetry if telemetry else None
+                        nodes[node_id]["telemetry"] = self._build_telemetry_dict_from_row(row)
 
                 logger.info(f"Loaded {len(nodes)} nodes from PostgreSQL")
                 return nodes
@@ -1250,30 +1327,7 @@ class PostgresStorage:
                     for row in telemetry_rows:
                         node_id = row["node_id"]
                         if node_id in nodes:
-                            telemetry = {}
-                            for field in [
-                                "battery_level",
-                                "voltage",
-                                "channel_utilization",
-                                "air_util_tx",
-                                "uptime_seconds",
-                                "temperature",
-                                "relative_humidity",
-                                "barometric_pressure",
-                                "gas_resistance",
-                                "iaq",
-                                "distance",
-                                "lux",
-                                "white_lux",
-                                "ir_lux",
-                                "uv_lux",
-                                "wind_direction",
-                                "wind_speed",
-                                "weight",
-                            ]:
-                                if row[field] is not None:
-                                    telemetry[field] = row[field]
-                            nodes[node_id]["telemetry"] = telemetry if telemetry else None
+                            nodes[node_id]["telemetry"] = self._build_telemetry_dict_from_row(row)
 
                 return nodes
 

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -67,36 +67,10 @@ class PostgresStorage:
         "traffic_management_stats": "traffic_management_stats",
     }
 
-    # All typed telemetry field names used in read queries. Kept in sync with
-    # TELEMETRY_COLUMNS values for use in load_nodes / query_nodes_filtered.
-    _TYPED_TELEMETRY_FIELDS = [
-        "battery_level",
-        "voltage",
-        "channel_utilization",
-        "air_util_tx",
-        "uptime_seconds",
-        "temperature",
-        "relative_humidity",
-        "barometric_pressure",
-        "gas_resistance",
-        "iaq",
-        "distance",
-        "lux",
-        "white_lux",
-        "ir_lux",
-        "uv_lux",
-        "wind_direction",
-        "wind_speed",
-        "weight",
-        "current",
-        "wind_gust",
-        "wind_lull",
-        "radiation",
-        "rainfall_1h",
-        "rainfall_24h",
-        "soil_moisture",
-        "soil_temperature",
-    ]
+    # All typed telemetry field names used in read queries. Derived directly
+    # from TELEMETRY_COLUMNS to stay in sync — adding a new field to
+    # TELEMETRY_COLUMNS automatically includes it here.
+    _TYPED_TELEMETRY_FIELDS = list(TELEMETRY_COLUMNS.values())
 
     def __init__(self, config: Dict[str, Any]):
         """Initialize Postgres storage with configuration."""
@@ -285,6 +259,11 @@ class PostgresStorage:
         Build a telemetry dict from a node_telemetry_current row.
         Merges typed columns and JSONB variant columns into a single dict.
         Used by load_nodes() and query_nodes_filtered() to avoid duplication.
+
+        If a JSONB variant field collides with an already-populated typed column
+        key, the existing value is kept and a debug warning is logged. This
+        mirrors the protobuf oneof guarantee (no real collisions expected) but
+        guards against malformed data silently overwriting values.
         """
         telemetry: Dict[str, Any] = {}
 
@@ -295,11 +274,21 @@ class PostgresStorage:
                 telemetry[field] = val
 
         # JSONB variant columns — merge their fields into the flat dict
-        # so the API response stays compatible with the in-memory structure
+        # so the API response stays compatible with the in-memory structure.
+        # If a field name collides with an existing key, keep the original
+        # value and log a debug warning to avoid silent overwrites.
         for variant_name, col_name in self.TELEMETRY_JSONB_VARIANTS.items():
             variant_data = self._jsonb(row.get(col_name), None)
             if variant_data and isinstance(variant_data, dict):
-                telemetry.update(variant_data)
+                for key, value in variant_data.items():
+                    if key in telemetry:
+                        logger.debug(
+                            "Telemetry key collision for '%s' in variant '%s'; keeping existing value.",
+                            key,
+                            variant_name,
+                        )
+                        continue
+                    telemetry[key] = value
 
         return telemetry if telemetry else None
 

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -20,6 +20,31 @@ logger = logging.getLogger(__name__)
 class PostgresStorage:
     """PostgreSQL storage backend with connection pooling and error handling."""
 
+    # Maps telemetry payload field names to their Postgres column names in
+    # node_telemetry_current. Used by _write_node_telemetry_current to build
+    # partial updates so that a device_metrics message never NULLs out
+    # environment_metrics columns and vice versa.
+    TELEMETRY_COLUMNS = {
+        "battery_level": "battery_level",
+        "voltage": "voltage",
+        "channel_utilization": "channel_utilization",
+        "air_util_tx": "air_util_tx",
+        "uptime_seconds": "uptime_seconds",
+        "temperature": "temperature",
+        "relative_humidity": "relative_humidity",
+        "barometric_pressure": "barometric_pressure",
+        "gas_resistance": "gas_resistance",
+        "iaq": "iaq",
+        "distance": "distance",
+        "lux": "lux",
+        "white_lux": "white_lux",
+        "ir_lux": "ir_lux",
+        "uv_lux": "uv_lux",
+        "wind_direction": "wind_direction",
+        "wind_speed": "wind_speed",
+        "weight": "weight",
+    }
+
     def __init__(self, config: Dict[str, Any]):
         """Initialize Postgres storage with configuration."""
         self.config = config
@@ -383,83 +408,65 @@ class PostgresStorage:
         )
 
     async def _write_node_telemetry_current(self, conn, node_id: str, telemetry: Dict[str, Any]):
-        """Write current node telemetry state (latest snapshot per node)."""
+        """
+        Write current node telemetry state (latest snapshot per node).
 
+        Uses a partial update strategy: only columns whose keys are present
+        in the incoming telemetry dict are written. This prevents a
+        device_metrics message from NULLing out environment_metrics columns
+        and vice versa.
+        """
         # Normalize + ensure FK target exists
         node_norm = await self._ensure_node_stub(conn, node_id)
         if not node_norm:
             logger.warning("_write_node_telemetry_current: could not normalize node_id=%r; skipping", node_id)
             return
 
-        await conn.execute(
-            """
-            INSERT INTO node_telemetry_current (
-                node_id, battery_level, voltage, channel_utilization, air_util_tx,
-                uptime_seconds, temperature, relative_humidity, barometric_pressure,
-                gas_resistance, iaq, distance, lux, white_lux, ir_lux, uv_lux,
-                wind_direction, wind_speed, weight
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+        # Collect only the columns that are actually present in this payload.
+        # We intentionally include keys whose value is None — that means the
+        # protobuf explicitly sent a zero/null for that field, which we should
+        # store. But we skip keys that aren't in the payload at all.
+        present: Dict[str, Any] = {}
+        for payload_key, col_name in self.TELEMETRY_COLUMNS.items():
+            if payload_key in telemetry:
+                present[col_name] = telemetry[payload_key]
+
+        if not present:
+            logger.debug("_write_node_telemetry_current: no recognized telemetry fields for node %s; skipping", node_norm)
+            return
+
+        # Build dynamic SQL for the partial upsert.
+        # INSERT creates the row with only the present columns (others default to NULL).
+        # ON CONFLICT updates only the present columns, leaving the rest untouched.
+        col_names = list(present.keys())
+        col_values = list(present.values())
+
+        # Parameter numbers: $1 = node_id, $2.. = column values
+        insert_cols = ["node_id"] + col_names
+        insert_placeholders = ", ".join(f"${i}" for i in range(1, len(insert_cols) + 1))
+        insert_cols_str = ", ".join(insert_cols)
+
+        # Build SET clause for ON CONFLICT: only update the present columns
+        set_parts = []
+        where_parts = []
+        for col in col_names:
+            set_parts.append(f"{col} = EXCLUDED.{col}")
+            where_parts.append(f"node_telemetry_current.{col} IS DISTINCT FROM EXCLUDED.{col}")
+
+        set_parts.append("updated_at = NOW()")
+        set_clause = ", ".join(set_parts)
+        where_clause = " OR ".join(where_parts)
+
+        sql = f"""
+            INSERT INTO node_telemetry_current ({insert_cols_str})
+            VALUES ({insert_placeholders})
             ON CONFLICT (node_id) DO UPDATE SET
-                battery_level = EXCLUDED.battery_level,
-                voltage = EXCLUDED.voltage,
-                channel_utilization = EXCLUDED.channel_utilization,
-                air_util_tx = EXCLUDED.air_util_tx,
-                uptime_seconds = EXCLUDED.uptime_seconds,
-                temperature = EXCLUDED.temperature,
-                relative_humidity = EXCLUDED.relative_humidity,
-                barometric_pressure = EXCLUDED.barometric_pressure,
-                gas_resistance = EXCLUDED.gas_resistance,
-                iaq = EXCLUDED.iaq,
-                distance = EXCLUDED.distance,
-                lux = EXCLUDED.lux,
-                white_lux = EXCLUDED.white_lux,
-                ir_lux = EXCLUDED.ir_lux,
-                uv_lux = EXCLUDED.uv_lux,
-                wind_direction = EXCLUDED.wind_direction,
-                wind_speed = EXCLUDED.wind_speed,
-                weight = EXCLUDED.weight,
-                updated_at = NOW()
+                {set_clause}
             WHERE
-                node_telemetry_current.battery_level IS DISTINCT FROM EXCLUDED.battery_level
-                OR node_telemetry_current.voltage IS DISTINCT FROM EXCLUDED.voltage
-                OR node_telemetry_current.channel_utilization IS DISTINCT FROM EXCLUDED.channel_utilization
-                OR node_telemetry_current.air_util_tx IS DISTINCT FROM EXCLUDED.air_util_tx
-                OR node_telemetry_current.uptime_seconds IS DISTINCT FROM EXCLUDED.uptime_seconds
-                OR node_telemetry_current.temperature IS DISTINCT FROM EXCLUDED.temperature
-                OR node_telemetry_current.relative_humidity IS DISTINCT FROM EXCLUDED.relative_humidity
-                OR node_telemetry_current.barometric_pressure IS DISTINCT FROM EXCLUDED.barometric_pressure
-                OR node_telemetry_current.gas_resistance IS DISTINCT FROM EXCLUDED.gas_resistance
-                OR node_telemetry_current.iaq IS DISTINCT FROM EXCLUDED.iaq
-                OR node_telemetry_current.distance IS DISTINCT FROM EXCLUDED.distance
-                OR node_telemetry_current.lux IS DISTINCT FROM EXCLUDED.lux
-                OR node_telemetry_current.white_lux IS DISTINCT FROM EXCLUDED.white_lux
-                OR node_telemetry_current.ir_lux IS DISTINCT FROM EXCLUDED.ir_lux
-                OR node_telemetry_current.uv_lux IS DISTINCT FROM EXCLUDED.uv_lux
-                OR node_telemetry_current.wind_direction IS DISTINCT FROM EXCLUDED.wind_direction
-                OR node_telemetry_current.wind_speed IS DISTINCT FROM EXCLUDED.wind_speed
-                OR node_telemetry_current.weight IS DISTINCT FROM EXCLUDED.weight
-            """,
-            node_norm,
-            telemetry.get("battery_level"),
-            telemetry.get("voltage"),
-            telemetry.get("channel_utilization"),
-            telemetry.get("air_util_tx"),
-            telemetry.get("uptime_seconds"),
-            telemetry.get("temperature"),
-            telemetry.get("relative_humidity"),
-            telemetry.get("barometric_pressure"),
-            telemetry.get("gas_resistance"),
-            telemetry.get("iaq"),
-            telemetry.get("distance"),
-            telemetry.get("lux"),
-            telemetry.get("white_lux"),
-            telemetry.get("ir_lux"),
-            telemetry.get("uv_lux"),
-            telemetry.get("wind_direction"),
-            telemetry.get("wind_speed"),
-            telemetry.get("weight"),
-        )
+                {where_clause}
+        """
+
+        await conn.execute(sql, node_norm, *col_values)
 
     async def write_telemetry(self, node_id: str, telemetry_msg: Dict[str, Any]) -> None:
         """
@@ -467,7 +474,7 @@ class PostgresStorage:
 
         Args:
             node_id: from-node id (any supported form; will be normalized)
-            telemetry_msg: Telemetry message dictionary
+            telemetry_msg: Telemetry message dictionary (now includes 'telemetry_type')
         """
         if not self._ready("write_telemetry"):
             return
@@ -504,6 +511,9 @@ class PostgresStorage:
 
                 rx_time = self._ts_to_dt(telemetry_msg.get("timestamp"))
 
+                # telemetry_type: "device_metrics", "environment_metrics", etc.
+                telemetry_type = telemetry_msg.get("telemetry_type")
+
                 msg_id = telemetry_msg.get("id")
                 if msg_id is None:
                     logger.warning("write_telemetry: missing telemetry_msg['id']; skipping insert")
@@ -518,9 +528,10 @@ class PostgresStorage:
                     """
                     INSERT INTO telemetry (
                         from_node_id, to_node_id, sender_node_id, message_id, channel,
-                        packet_id, hops_away, rssi, snr, timestamp, rx_time, payload
+                        packet_id, hops_away, rssi, snr, timestamp, rx_time,
+                        telemetry_type, payload
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb)
                     ON CONFLICT (from_node_id, message_id) DO NOTHING
                     """,
                     from_id,
@@ -534,6 +545,7 @@ class PostgresStorage:
                     telemetry_msg.get("snr"),
                     telemetry_msg.get("timestamp"),
                     rx_time,
+                    telemetry_type,
                     payload_json,
                 )
 
@@ -1019,6 +1031,7 @@ class PostgresStorage:
                         "rssi": row["rssi"],
                         "snr": row["snr"],
                         "timestamp": row["timestamp"],
+                        "telemetry_type": row.get("telemetry_type"),
                         "payload": self._jsonb(row["payload"], {}),
                     }
 
@@ -1305,6 +1318,7 @@ class PostgresStorage:
                             "rssi": row["rssi"],
                             "snr": row["snr"],
                             "timestamp": row["timestamp"],
+                            "telemetry_type": row.get("telemetry_type"),
                             "payload": self._jsonb(row["payload"], {}),
                         }
                     )
@@ -1478,6 +1492,7 @@ class PostgresStorage:
                             "rssi": row["rssi"],
                             "snr": row["snr"],
                             "timestamp": row["timestamp"],
+                            "telemetry_type": row.get("telemetry_type"),
                             "payload": self._jsonb(row["payload"], {}),
                         }
                     )


### PR DESCRIPTION
This closes #265 and #60 

in MQTT.py:

- Use protobuf `WhichOneof('variant')` to detect the telemetry type (device_metrics, environment_metrics, air_quality_metrics, etc.
- Tag each message with `telemetry_type` for downstream use
- Merge incoming payload into existing `node['telemetry']` dict instead of replacing it

Postgres.py:

- Rewrite `_write_node_telemetry_current` to use dynamic partial SQL — only INSERT/UPDATE columns actually present in the incoming payload, leaving all other columns untouched
- Add `telemetry_type` column to the write_telemetry INSERT (history table)
- Include `telemetry_type` in all telemetry read methods

schema.sql:

- Add `telemetry_type TEXT` column to telemetry table in schema for fresh installs
- Idempotent `ALTER TABLE` migration for existing databases with indexes on `telemetry_type` and `(from_node_id, telemetry_type)`

-----------------------------------
- **New typed columns** on `node_telemetry_current` for the 8 missing `environment_metrics` fields
- **JSONB columns** on `node_telemetry_current` for each non-device/environment variant (`power_metrics`, `air_quality_metrics`, `local_stats`, `health_metrics`, `host_metrics`, `traffic_management_stats`). This keeps the schema simple and future-proof — new fields added upstream by Meshtastic are stored automatically without needing `ALTER TABLE`.
- **Variant-aware writes** in `_write_node_telemetry_current`: accepts an optional `telemetry_type` parameter. JSONB variants store the whole payload blob; typed variants use the existing partial-upsert logic.
- **Direct `node_telemetry_current` update in `handle_telemetry`** (`mqtt.py`): passes `telemetry_type` through so the JSONB path is used for the appropriate variants.
- **Shared read helper** `_build_telemetry_dict_from_row` in `postgres.py` that merges typed columns and JSONB variant data into a single flat dict for API compatibility. Used by both `load_nodes()` and `query_nodes_filtered()`.

### Telemetry variants now supported

| Variant | Storage | Example fields |
|---------|---------|----------------|
| `device_metrics` | Typed columns | `battery_level`, `voltage`, `channel_utilization`, `air_util_tx`, `uptime_seconds` |
| `environment_metrics` | Typed columns | `temperature`, `relative_humidity`, `barometric_pressure`, `wind_speed`, `rainfall_1h`, `soil_moisture`, + more |
| `power_metrics` | JSONB | `ch1_voltage`, `ch1_current` … `ch8_voltage`, `ch8_current` |
| `air_quality_metrics` | JSONB | `pm10_standard`, `pm25_standard`, `co2`, `particles_03um`, + more |
| `local_stats` | JSONB | `num_packets_tx`, `num_packets_rx`, `num_online_nodes`, `noise_floor`, + more |
| `health_metrics` | JSONB | `heart_bpm`, `spO2`, `temperature` |
| `host_metrics` | JSONB | `uptime_seconds`, `freemem_bytes`, `load1`, `load5`, `load15` |
| `traffic_management_stats` | JSONB | `packets_inspected`, `rate_limit_drops`, `position_dedup_drops`, + more |