### PR TITLE
Fix hex conversion

### DIFF
--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -189,9 +189,6 @@ class PostgresStorage:
                 except ValueError:
                     return None
 
-            if v.isdigit():
-                return f"{int(v) & 0xFFFFFFFF:08x}"
-
             v = v.lower()
             if all(c in "0123456789abcdef" for c in v):
                 if len(v) < 8:


### PR DESCRIPTION
Closes issue #285 

**Solution:** I believe the best fix would be to remove the `isdigit()` lines entirely and let the safety check at lines 195-202 handle this with hex validation:

`v = v.lower()
            if all(c in "0123456789abcdef" for c in v):
                if len(v) < 8:
                    return v.zfill(8)
                if len(v) == 8:
                    return v
                # Explicit: too long to be a uint32 / schema node id
                return None`

**Safety considerations:** 
- `mqtt.py` fields `from, to, sender` are all converted to hex prior to any storage calls, so they'd pass through hex validation
- Python integers are handled before the `isdigit()` check, so those won't be affected by the removal of `isdigit()`
- Strings with `!` or `0x` prefix are handled prior to `isdigit()`
- If somehow a truly decimal string made its way to the hex validation function it would fail and return `None` which is better behavior than the current misinterpretation. 