### PR TITLE
add server-side pagination addressing slow chat loads

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -236,7 +236,25 @@ class API:
         @app.get("/v1/chat")
         async def chat(request: Request) -> JSONResponse:
             if self.read_from_postgres:
-                chat_data = await self.data.pg_storage.query_all_chat()
+                # Parse query params
+                channel = request.query_params.get("channel")  # e.g. "8", "0"
+                range_param = request.query_params.get("range", "24h")  # "1h","24h","7d","all"
+
+                range_map = {
+                    "1h": 3600,
+                    "24h": 86400,
+                    "7d": 604800,
+                    "all": None,
+                }
+                range_seconds = range_map.get(range_param)
+                # If range_param is unrecognized, default to 24h
+                if range_param not in range_map:
+                    range_seconds = 86400
+
+                chat_data = await self.data.pg_storage.query_chat_filtered(
+                    channel_id=channel,
+                    range_seconds=range_seconds,
+                )
                 return jsonable_encoder(chat_data)
             else:
                 return jsonable_encoder(self.data.chat)

--- a/api/api.py
+++ b/api/api.py
@@ -237,7 +237,7 @@ class API:
         async def chat(request: Request) -> JSONResponse:
             if self.read_from_postgres:
                 # Parse query params
-                channel = request.query_params.get("channel")  # e.g. "8", "0"
+                channel = request.query_params.get("channel") or "0"  # e.g. "8", "0"
                 range_param = request.query_params.get("range", "24h")  # "1h","24h","7d","all"
 
                 range_map = {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,36 +1,39 @@
 import {
-  ReactNode,
-  useCallback,
-  useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState,
+  useDeferredValue,
+  useRef,
+  useCallback,
+  ReactNode,
 } from "react";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { VirtuosoHandle } from "react-virtuoso";
 
-import { HeardBy } from "../components/HeardBy";
 import { useChatSearchParams } from "../hooks/useChatSearchParams";
+
+import { HeardBy } from "../components/HeardBy";
 import {
   useGetChatsQuery,
   useGetConfigQuery,
   useGetNodesQuery,
 } from "../slices/apiSlice";
+
 import {
-  csvEscape,
   DirKey,
-  downloadBlob,
   FocusMode,
-  isBroadcast,
   RangeKey,
   SortKey,
+  csvEscape,
+  downloadBlob,
+  isBroadcast,
 } from "./chat/chatUtils";
-import { DetailsPanel } from "./chat/DetailsPanel";
-import { ExportMenu } from "./chat/ExportMenu";
+
 import { FiltersDrawer } from "./chat/FiltersDrawer";
-import { FocusPanel } from "./chat/FocusPanel";
+import { ExportMenu } from "./chat/ExportMenu";
 import { MessageList } from "./chat/MessageList";
+import { FocusPanel } from "./chat/FocusPanel";
+import { DetailsPanel } from "./chat/DetailsPanel";
 
 type ViewDef = {
   key: string; // canonical URL key: "mediumfast"
@@ -142,11 +145,20 @@ function StatusChip({
 }
 
 export const Chat = () => {
-  const { data: chat, fulfilledTimeStamp: dataUpdatedAt, isFetching, refetch } = useGetChatsQuery();
+  // ── 1. Non-chat data queries ──
   const { data: nodes = {} } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
 
-  // ---- Channel metadata (from broker config)
+  // ── 2. Raw URL params for early channel resolution ──
+  // We need channel + range BEFORE the full views pipeline runs,
+  // so we read them directly from the URL here to break the
+  // circular dependency (channelEntries → views → selectedChannel
+  // → chat query → channelEntries).
+  const [searchParamsRaw] = useSearchParams();
+  const rawCh = normalizeKey(searchParamsRaw.get("ch") || "");
+  const rawRange = (searchParamsRaw.get("r") || "24h") as string;
+
+  // ── 3. Channel metadata helpers (from broker config) ──
   const channelMeta = (config?.broker?.channels as any)?.meta ?? {};
   const rawChannelLabel = (id: string) =>
     channelMeta?.[id]?.label ? String(channelMeta[id].label) : `Channel ${id}`;
@@ -173,22 +185,84 @@ export const Chat = () => {
     return parts.join("\n");
   };
 
-  // ---- Available channels from data (source of messages)
+  // ── 4. Resolve channel ID from config + raw URL ──
+  // This lets the chat query fire immediately using only config
+  // data, without waiting for chat data to build the full views.
+  const resolvedChannelId = useMemo(() => {
+    const viewsConfig = (config?.broker?.channels as any)?.views;
+    if (!Array.isArray(viewsConfig) || viewsConfig.length === 0)
+      return undefined;
+
+    // Try matching the raw URL ch param against config views
+    if (rawCh) {
+      for (const v of viewsConfig) {
+        const chans = Array.isArray(v?.channels)
+          ? v.channels.map(String)
+          : [];
+        if (chans.length !== 1) continue;
+
+        const key = normalizeKey(String(v?.label ?? v?.id ?? ""));
+        const id = normalizeKey(String(v?.id ?? ""));
+        const short = normalizeKey(String(v?.short ?? ""));
+        const channelId = chans[0];
+
+        if (
+          rawCh === key ||
+          rawCh === id ||
+          rawCh === short ||
+          rawCh === channelId
+        ) {
+          return channelId;
+        }
+      }
+    }
+
+    // Fall back to the default view's channel
+    const def =
+      viewsConfig.find((v: any) => v.default) ?? viewsConfig[0];
+    return def?.channels?.[0] ? String(def.channels[0]) : undefined;
+  }, [config, rawCh]);
+
+  // ── 5. Chat query (fires with resolved channel + range) ──
+  const chatQueryParams = useMemo(() => {
+    const params: { channel?: string; range?: string } = {};
+    if (resolvedChannelId) params.channel = resolvedChannelId;
+    params.range = rawRange;
+    return params;
+  }, [resolvedChannelId, rawRange]);
+
+  const {
+    data: chat,
+    fulfilledTimeStamp: dataUpdatedAt,
+    isFetching,
+    refetch,
+  } = useGetChatsQuery(chatQueryParams);
+
+  // ── 6. Stable chat ref (prevents skeleton flash on filter change) ──
+  const prevChatRef = useRef(chat);
+  if (chat) prevChatRef.current = chat;
+  const effectiveChat = chat ?? prevChatRef.current;
+
+  // ── 7. Channel entries from chat data (now below query) ──
   const channelEntries = useMemo(() => {
-    const entries = Object.entries(chat?.channels ?? {});
+    const entries = Object.entries(effectiveChat?.channels ?? {});
     const allow = config?.broker?.channels?.display;
     if (Array.isArray(allow) && allow.length > 0) {
       return entries.filter(([id]) => allow.includes(id));
     }
     return entries;
-  }, [chat?.channels, config?.broker?.channels?.display]);
+  }, [effectiveChat?.channels, config?.broker?.channels?.display]);
 
+  // null = chat hasn't loaded yet, allow all views through
   const availableChannelIds = useMemo(
-    () => new Set(channelEntries.map(([id]) => String(id))),
+    () =>
+      channelEntries.length > 0
+        ? new Set(channelEntries.map(([id]) => String(id)))
+        : null,
     [channelEntries]
   );
 
-  // ---- Build “views” from broker.channels.views (single-channel ones)
+  // ── 8. Build "views" from broker.channels.views (single-channel ones) ──
   const views: ViewDef[] = useMemo(() => {
     const vraw = (config?.broker?.channels as any)?.views;
     const out: ViewDef[] = [];
@@ -198,7 +272,7 @@ export const Chat = () => {
         const chans = Array.isArray(v?.channels) ? v.channels.map(String) : [];
         if (chans.length !== 1) continue;
         const channelId = chans[0];
-        if (!availableChannelIds.has(channelId)) continue;
+        if (availableChannelIds && !availableChannelIds.has(channelId)) continue;
 
         const label = String(v?.label ?? v?.id ?? rawChannelLabel(channelId));
         const short = v?.short ? String(v.short) : rawChannelShort(channelId);
@@ -254,13 +328,12 @@ export const Chat = () => {
     }
 
     return out;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- rawChannel* helpers are stable
   }, [config, channelEntries, availableChannelIds]);
 
   const defaultViewKey =
     views.find((v) => v.isDefault)?.key ?? views[0]?.key ?? "";
 
-  // ---- URL + canonicalization (ch becomes preset slug)
+  // ── 9. URL + canonicalization (ch becomes preset slug) ──
   const {
     searchParams,
     urlCh,
@@ -287,14 +360,41 @@ export const Chat = () => {
     defaultCh: defaultViewKey,
   });
 
-  // UI state
+  // ── 10. Selected view (for display / pills) ──
+  const selectedView = useMemo(() => {
+    const v = views.find((x) => x.key === urlCh);
+    return v ?? views.find((x) => x.key === defaultViewKey) ?? views[0];
+  }, [views, urlCh, defaultViewKey]);
+
+  const selectedChannel = selectedView?.channelId;
+
+  // ── View-based label helpers ──
+  const channelLabel = (id: string) => {
+    const v = views.find((x) => x.channelId === id);
+    return v?.label ?? rawChannelLabel(id);
+  };
+
+  const channelTooltip = (id: string) => {
+    const v = views.find((x) => x.channelId === id);
+    return v?.tooltip ?? rawChannelTooltip(id);
+  };
+
+  // ── 11. Derived state from chat data ──
+  const selectedChannelObj = useMemo(() => {
+    if (!selectedChannel) return undefined;
+    return (effectiveChat?.channels as any)?.[selectedChannel];
+  }, [effectiveChat?.channels, selectedChannel]);
+
+  const totalMessages = selectedChannelObj?.totalMessages ?? 0;
+
+  // ── UI state ──
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
   // Mobile sheets
   const [mobileSheet, setMobileSheet] = useState<MobileSheetKey | null>(null);
 
-// Track lg breakpoint (1024px) to gate mobile/desktop behaviors
+  // Track lg breakpoint (1024px) to gate mobile/desktop behaviors
   const [isLgUp, setIsLgUp] = useState(() => {
     if (typeof window === "undefined") return true;
     return window.matchMedia("(min-width: 1024px)").matches;
@@ -331,7 +431,6 @@ export const Chat = () => {
     if (urlMsg && urlMsg !== prev) {
       setMobileSheet("details");
     }
-
   }, [urlMsg, isLgUp]);
 
   // Live / auto-follow toggle
@@ -351,9 +450,9 @@ export const Chat = () => {
     []
   );
 
-    // Export menu
-    const [exportOpen, setExportOpen] = useState(false);
-    const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  // Export menu
+  const [exportOpen, setExportOpen] = useState(false);
+  const exportMenuRef = useRef<HTMLDivElement | null>(null);
 
   // Search input
   const [qInput, setQInput] = useState(urlQ);
@@ -367,7 +466,7 @@ export const Chat = () => {
   // Keep local search input synced on back/forward
   useEffect(() => {
     setQInput(urlQ);
-     
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlQ]);
 
   // Update URL q from deferred input (replace)
@@ -376,30 +475,6 @@ export const Chat = () => {
     setParam("q", qDeferred, "replace");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qDeferred]);
-
-  const selectedView = useMemo(() => {
-    const v = views.find((x) => x.key === urlCh);
-    return v ?? views.find((x) => x.key === defaultViewKey) ?? views[0];
-  }, [views, urlCh, defaultViewKey]);
-
-  const selectedChannel = selectedView?.channelId;
-
-  const channelLabel = (id: string) => {
-    const v = views.find((x) => x.channelId === id);
-    return v?.label ?? rawChannelLabel(id);
-  };
-
-  const channelTooltip = (id: string) => {
-    const v = views.find((x) => x.channelId === id);
-    return v?.tooltip ?? rawChannelTooltip(id);
-  };
-
-  const selectedChannelObj = useMemo(() => {
-    if (!selectedChannel) return undefined;
-    return (chat?.channels as any)?.[selectedChannel];
-  }, [chat?.channels, selectedChannel]);
-
-  const totalMessages = selectedChannelObj?.totalMessages ?? 0;
 
   // Range threshold
   const rangeThreshold = useMemo(() => {
@@ -416,7 +491,7 @@ export const Chat = () => {
   // Messages (filtered + sorted)
   const messages = useMemo(() => {
     if (!selectedChannel) return [];
-    const channelObj = (chat?.channels as any)?.[selectedChannel];
+    const channelObj = (effectiveChat?.channels as any)?.[selectedChannel];
     if (!channelObj?.messages) return [];
 
     let msgs = [...channelObj.messages];
@@ -505,7 +580,7 @@ export const Chat = () => {
 
     return msgs;
   }, [
-    chat?.channels,
+    effectiveChat?.channels,
     selectedChannel,
     rangeThreshold,
     urlType,
@@ -834,7 +909,7 @@ export const Chat = () => {
   // Virtualized list ref
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
 
-  // Scroll selected message into view (Commit 8)
+  // Scroll selected message into view
   const pendingScrollRef = useRef<string | null>(null);
   useEffect(() => {
     if (!urlMsg) {
@@ -877,7 +952,7 @@ export const Chat = () => {
     return () => {
       timers.forEach(clearTimeout);
     };
-     
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlMsg, messages, selectedChannel]);
 
   // Export menu click-outside (desktop only)
@@ -936,7 +1011,7 @@ export const Chat = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filtersOpen, exportOpen, urlMsg, mobileSheet]);
 
-  // ---- Export rows + handlers (Commit 6)
+  // ---- Export rows + handlers ----
   const exportRows = useMemo(() => {
     const ch = selectedChannel ?? "";
     return (messages as any[]).map((m) => {
@@ -1091,28 +1166,28 @@ export const Chat = () => {
     return `Auto-follow is active at the ${edge}.`;
   }, [liveEnabled, followState.selectionPinned, followState.atEdge, followEdge]);
 
-    const advancedCount = useMemo(() => {
-      let n = 0;
-      if (typeof urlHopsMin === "number") n += 1;
-      if (typeof urlHopsMax === "number") n += 1;
-      if (urlFrom.trim()) n += 1;
-      if (urlTo.trim()) n += 1;
-      if (urlVia.trim()) n += 1;
-      if (onlyUnknownEndpoints) n += 1;
-      if (requireVia) n += 1;
-      return n;
-    }, [
-      urlHopsMin,
-      urlHopsMax,
-      urlFrom,
-      urlTo,
-      urlVia,
-      onlyUnknownEndpoints,
-      requireVia,
-    ]);
+  const advancedCount = useMemo(() => {
+    let n = 0;
+    if (typeof urlHopsMin === "number") n += 1;
+    if (typeof urlHopsMax === "number") n += 1;
+    if (urlFrom.trim()) n += 1;
+    if (urlTo.trim()) n += 1;
+    if (urlVia.trim()) n += 1;
+    if (onlyUnknownEndpoints) n += 1;
+    if (requireVia) n += 1;
+    return n;
+  }, [
+    urlHopsMin,
+    urlHopsMax,
+    urlFrom,
+    urlTo,
+    urlVia,
+    onlyUnknownEndpoints,
+    requireVia,
+  ]);
 
   // ── Loading skeleton ──
-  const isFirstLoad = !chat;
+  const isFirstLoad = !effectiveChat;
 
   if (isFirstLoad) {
     return (
@@ -1337,7 +1412,7 @@ export const Chat = () => {
           <div className="mt-3 flex gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
             {views.map((v) => {
               const active = v.key === selectedView?.key;
-              const chObj: any = (chat?.channels as any)?.[v.channelId];
+              const chObj: any = (effectiveChat?.channels as any)?.[v.channelId];
               const count = chObj?.totalMessages ?? 0;
 
               return (

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -40,7 +40,7 @@ type ViewDef = {
   label: string; // "MediumFast"
   short?: string; // "MF"
   channelId: string; // "0"
-  aliases: string[]; // ["mf","0","MediumFast",...]D
+  aliases: string[]; // ["mf","0","MediumFast",...]
   tooltip?: string;
   isDefault?: boolean;
 };

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -7,7 +7,7 @@ import {
   useCallback,
   ReactNode,
 } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { VirtuosoHandle } from "react-virtuoso";
 
 import { useChatSearchParams } from "../hooks/useChatSearchParams";
@@ -145,11 +145,20 @@ function StatusChip({
 }
 
 export const Chat = () => {
-  const { data: chat, fulfilledTimeStamp: dataUpdatedAt, isFetching, refetch } = useGetChatsQuery();
+  // ── 1. Non-chat data queries ──
   const { data: nodes = {} } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
 
-  // ---- Channel metadata (from broker config)
+  // ── 2. Raw URL params for early channel resolution ──
+  // We need channel + range BEFORE the full views pipeline runs,
+  // so we read them directly from the URL here to break the
+  // circular dependency (channelEntries → views → selectedChannel
+  // → chat query → channelEntries).
+  const [searchParamsRaw] = useSearchParams();
+  const rawCh = normalizeKey(searchParamsRaw.get("ch") || "");
+  const rawRange = (searchParamsRaw.get("r") || "24h") as string;
+
+  // ── 3. Channel metadata helpers (from broker config) ──
   const channelMeta = (config?.broker?.channels as any)?.meta ?? {};
   const rawChannelLabel = (id: string) =>
     channelMeta?.[id]?.label ? String(channelMeta[id].label) : `Channel ${id}`;
@@ -176,22 +185,84 @@ export const Chat = () => {
     return parts.join("\n");
   };
 
-  // ---- Available channels from data (source of messages)
+  // ── 4. Resolve channel ID from config + raw URL ──
+  // This lets the chat query fire immediately using only config
+  // data, without waiting for chat data to build the full views.
+  const resolvedChannelId = useMemo(() => {
+    const viewsConfig = (config?.broker?.channels as any)?.views;
+    if (!Array.isArray(viewsConfig) || viewsConfig.length === 0)
+      return undefined;
+
+    // Try matching the raw URL ch param against config views
+    if (rawCh) {
+      for (const v of viewsConfig) {
+        const chans = Array.isArray(v?.channels)
+          ? v.channels.map(String)
+          : [];
+        if (chans.length !== 1) continue;
+
+        const key = normalizeKey(String(v?.label ?? v?.id ?? ""));
+        const id = normalizeKey(String(v?.id ?? ""));
+        const short = normalizeKey(String(v?.short ?? ""));
+        const channelId = chans[0];
+
+        if (
+          rawCh === key ||
+          rawCh === id ||
+          rawCh === short ||
+          rawCh === channelId
+        ) {
+          return channelId;
+        }
+      }
+    }
+
+    // Fall back to the default view's channel
+    const def =
+      viewsConfig.find((v: any) => v.default) ?? viewsConfig[0];
+    return def?.channels?.[0] ? String(def.channels[0]) : undefined;
+  }, [config, rawCh]);
+
+  // ── 5. Chat query (fires with resolved channel + range) ──
+  const chatQueryParams = useMemo(() => {
+    const params: { channel?: string; range?: string } = {};
+    if (resolvedChannelId) params.channel = resolvedChannelId;
+    params.range = rawRange;
+    return params;
+  }, [resolvedChannelId, rawRange]);
+
+  const {
+    data: chat,
+    fulfilledTimeStamp: dataUpdatedAt,
+    isFetching,
+    refetch,
+  } = useGetChatsQuery(chatQueryParams);
+
+  // ── 6. Stable chat ref (prevents skeleton flash on filter change) ──
+  const prevChatRef = useRef(chat);
+  if (chat) prevChatRef.current = chat;
+  const effectiveChat = chat ?? prevChatRef.current;
+
+  // ── 7. Channel entries from chat data (now below query) ──
   const channelEntries = useMemo(() => {
-    const entries = Object.entries(chat?.channels ?? {});
+    const entries = Object.entries(effectiveChat?.channels ?? {});
     const allow = config?.broker?.channels?.display;
     if (Array.isArray(allow) && allow.length > 0) {
       return entries.filter(([id]) => allow.includes(id));
     }
     return entries;
-  }, [chat?.channels, config?.broker?.channels?.display]);
+  }, [effectiveChat?.channels, config?.broker?.channels?.display]);
 
+  // null = chat hasn't loaded yet, allow all views through
   const availableChannelIds = useMemo(
-    () => new Set(channelEntries.map(([id]) => String(id))),
+    () =>
+      channelEntries.length > 0
+        ? new Set(channelEntries.map(([id]) => String(id)))
+        : null,
     [channelEntries]
   );
 
-  // ---- Build “views” from broker.channels.views (single-channel ones)
+  // ── 8. Build "views" from broker.channels.views (single-channel ones) ──
   const views: ViewDef[] = useMemo(() => {
     const vraw = (config?.broker?.channels as any)?.views;
     const out: ViewDef[] = [];
@@ -201,7 +272,7 @@ export const Chat = () => {
         const chans = Array.isArray(v?.channels) ? v.channels.map(String) : [];
         if (chans.length !== 1) continue;
         const channelId = chans[0];
-        if (!availableChannelIds.has(channelId)) continue;
+        if (availableChannelIds && !availableChannelIds.has(channelId)) continue;
 
         const label = String(v?.label ?? v?.id ?? rawChannelLabel(channelId));
         const short = v?.short ? String(v.short) : rawChannelShort(channelId);
@@ -262,7 +333,7 @@ export const Chat = () => {
   const defaultViewKey =
     views.find((v) => v.isDefault)?.key ?? views[0]?.key ?? "";
 
-  // ---- URL + canonicalization (ch becomes preset slug)
+  // ── 9. URL + canonicalization (ch becomes preset slug) ──
   const {
     searchParams,
     urlCh,
@@ -289,14 +360,41 @@ export const Chat = () => {
     defaultCh: defaultViewKey,
   });
 
-  // UI state
+  // ── 10. Selected view (for display / pills) ──
+  const selectedView = useMemo(() => {
+    const v = views.find((x) => x.key === urlCh);
+    return v ?? views.find((x) => x.key === defaultViewKey) ?? views[0];
+  }, [views, urlCh, defaultViewKey]);
+
+  const selectedChannel = selectedView?.channelId;
+
+  // ── View-based label helpers ──
+  const channelLabel = (id: string) => {
+    const v = views.find((x) => x.channelId === id);
+    return v?.label ?? rawChannelLabel(id);
+  };
+
+  const channelTooltip = (id: string) => {
+    const v = views.find((x) => x.channelId === id);
+    return v?.tooltip ?? rawChannelTooltip(id);
+  };
+
+  // ── 11. Derived state from chat data ──
+  const selectedChannelObj = useMemo(() => {
+    if (!selectedChannel) return undefined;
+    return (effectiveChat?.channels as any)?.[selectedChannel];
+  }, [effectiveChat?.channels, selectedChannel]);
+
+  const totalMessages = selectedChannelObj?.totalMessages ?? 0;
+
+  // ── UI state ──
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
   // Mobile sheets
   const [mobileSheet, setMobileSheet] = useState<MobileSheetKey | null>(null);
 
-// Track lg breakpoint (1024px) to gate mobile/desktop behaviors
+  // Track lg breakpoint (1024px) to gate mobile/desktop behaviors
   const [isLgUp, setIsLgUp] = useState(() => {
     if (typeof window === "undefined") return true;
     return window.matchMedia("(min-width: 1024px)").matches;
@@ -333,7 +431,6 @@ export const Chat = () => {
     if (urlMsg && urlMsg !== prev) {
       setMobileSheet("details");
     }
-
   }, [urlMsg, isLgUp]);
 
   // Live / auto-follow toggle
@@ -353,9 +450,9 @@ export const Chat = () => {
     []
   );
 
-    // Export menu
-    const [exportOpen, setExportOpen] = useState(false);
-    const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  // Export menu
+  const [exportOpen, setExportOpen] = useState(false);
+  const exportMenuRef = useRef<HTMLDivElement | null>(null);
 
   // Search input
   const [qInput, setQInput] = useState(urlQ);
@@ -379,30 +476,6 @@ export const Chat = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qDeferred]);
 
-  const selectedView = useMemo(() => {
-    const v = views.find((x) => x.key === urlCh);
-    return v ?? views.find((x) => x.key === defaultViewKey) ?? views[0];
-  }, [views, urlCh, defaultViewKey]);
-
-  const selectedChannel = selectedView?.channelId;
-
-  const channelLabel = (id: string) => {
-    const v = views.find((x) => x.channelId === id);
-    return v?.label ?? rawChannelLabel(id);
-  };
-
-  const channelTooltip = (id: string) => {
-    const v = views.find((x) => x.channelId === id);
-    return v?.tooltip ?? rawChannelTooltip(id);
-  };
-
-  const selectedChannelObj = useMemo(() => {
-    if (!selectedChannel) return undefined;
-    return (chat?.channels as any)?.[selectedChannel];
-  }, [chat?.channels, selectedChannel]);
-
-  const totalMessages = selectedChannelObj?.totalMessages ?? 0;
-
   // Range threshold
   const rangeThreshold = useMemo(() => {
     const now = Math.floor(Date.now() / 1000);
@@ -418,7 +491,7 @@ export const Chat = () => {
   // Messages (filtered + sorted)
   const messages = useMemo(() => {
     if (!selectedChannel) return [];
-    const channelObj = (chat?.channels as any)?.[selectedChannel];
+    const channelObj = (effectiveChat?.channels as any)?.[selectedChannel];
     if (!channelObj?.messages) return [];
 
     let msgs = [...channelObj.messages];
@@ -507,7 +580,7 @@ export const Chat = () => {
 
     return msgs;
   }, [
-    chat?.channels,
+    effectiveChat?.channels,
     selectedChannel,
     rangeThreshold,
     urlType,
@@ -836,7 +909,7 @@ export const Chat = () => {
   // Virtualized list ref
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
 
-  // Scroll selected message into view (Commit 8)
+  // Scroll selected message into view
   const pendingScrollRef = useRef<string | null>(null);
   useEffect(() => {
     if (!urlMsg) {
@@ -938,7 +1011,7 @@ export const Chat = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filtersOpen, exportOpen, urlMsg, mobileSheet]);
 
-  // ---- Export rows + handlers (Commit 6)
+  // ---- Export rows + handlers ----
   const exportRows = useMemo(() => {
     const ch = selectedChannel ?? "";
     return (messages as any[]).map((m) => {
@@ -1093,28 +1166,28 @@ export const Chat = () => {
     return `Auto-follow is active at the ${edge}.`;
   }, [liveEnabled, followState.selectionPinned, followState.atEdge, followEdge]);
 
-    const advancedCount = useMemo(() => {
-      let n = 0;
-      if (typeof urlHopsMin === "number") n += 1;
-      if (typeof urlHopsMax === "number") n += 1;
-      if (urlFrom.trim()) n += 1;
-      if (urlTo.trim()) n += 1;
-      if (urlVia.trim()) n += 1;
-      if (onlyUnknownEndpoints) n += 1;
-      if (requireVia) n += 1;
-      return n;
-    }, [
-      urlHopsMin,
-      urlHopsMax,
-      urlFrom,
-      urlTo,
-      urlVia,
-      onlyUnknownEndpoints,
-      requireVia,
-    ]);
+  const advancedCount = useMemo(() => {
+    let n = 0;
+    if (typeof urlHopsMin === "number") n += 1;
+    if (typeof urlHopsMax === "number") n += 1;
+    if (urlFrom.trim()) n += 1;
+    if (urlTo.trim()) n += 1;
+    if (urlVia.trim()) n += 1;
+    if (onlyUnknownEndpoints) n += 1;
+    if (requireVia) n += 1;
+    return n;
+  }, [
+    urlHopsMin,
+    urlHopsMax,
+    urlFrom,
+    urlTo,
+    urlVia,
+    onlyUnknownEndpoints,
+    requireVia,
+  ]);
 
   // ── Loading skeleton ──
-  const isFirstLoad = !chat;
+  const isFirstLoad = !effectiveChat;
 
   if (isFirstLoad) {
     return (
@@ -1339,7 +1412,7 @@ export const Chat = () => {
           <div className="mt-3 flex gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
             {views.map((v) => {
               const active = v.key === selectedView?.key;
-              const chObj: any = (chat?.channels as any)?.[v.channelId];
+              const chObj: any = (effectiveChat?.channels as any)?.[v.channelId];
               const count = chObj?.totalMessages ?? 0;
 
               return (

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -190,8 +190,12 @@ export const Chat = () => {
   // data, without waiting for chat data to build the full views.
   const resolvedChannelId = useMemo(() => {
     const viewsConfig = (config?.broker?.channels as any)?.views;
-    if (!Array.isArray(viewsConfig) || viewsConfig.length === 0)
-      return undefined;
+    if (!Array.isArray(viewsConfig) || viewsConfig.length === 0) {
+      // No views config — fall back to the raw URL channel if it looks
+      // like a numeric channel id, otherwise default to "0".
+      if (rawCh && /^[0-9]+$/.test(rawCh)) return rawCh;
+      return "0";
+    }
 
     // Try matching the raw URL ch param against config views
     if (rawCh) {
@@ -220,7 +224,10 @@ export const Chat = () => {
     // Fall back to the default view's channel
     const def =
       viewsConfig.find((v: any) => v.default) ?? viewsConfig[0];
-    return def?.channels?.[0] ? String(def.channels[0]) : undefined;
+    if (def?.channels?.[0]) return String(def.channels[0]);
+    // Views exist but no channel resolved — still scope the query
+    if (rawCh && /^[0-9]+$/.test(rawCh)) return rawCh;
+    return "0";
   }, [config, rawCh]);
 
   // ── 5. Chat query (fires with resolved channel + range) ──

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -33,38 +33,50 @@ export const apiSlice = createApi({
         response.config,
       providesTags: [{ type: "Config", id: "LIST" }],
     }),
-    getChats: builder.query<IChatResponse, void>({
-      query: () => "chat",
-      transformResponse: (response: IChatResponse) => {
+    getChats: builder.query<
+        IChatResponse,
+        { channel?: string; range?: string } | void
+    >({
+        query: (params) => {
+        const sp = new URLSearchParams();
+        if (params && params.channel) sp.set("channel", params.channel);
+        if (params && params.range) sp.set("range", params.range);
+        const qs = sp.toString();
+        return qs ? `chat?${qs}` : "chat";
+        },
+        transformResponse: (response: IChatResponse) => {
         const channels = Object.fromEntries(
-          Object.entries(response.channels).map(([id, channel]) => [
+            Object.entries(response.channels).map(([id, channel]) => [
             id,
             {
-              ...channel,
-              totalMessages: channel.messages.length,
-              messages: Object.values(
+                ...channel,
+                // Use backend-provided totalMessages if available,
+                // fall back to response array length for backward compat
+                totalMessages:
+                (channel as any).totalMessages ?? channel.messages.length,
+                messages: Object.values(
                 channel.messages.reduce(
-                  (acc, message) => ({
+                    (acc, message) => ({
                     ...acc,
                     [message.id]: {
-                      ...message,
-                      sender: (acc[message.id]?.sender ?? []).concat(
+                        ...message,
+                        sender: (acc[message.id]?.sender ?? []).concat(
                         message.sender
-                      ),
+                        ),
                     },
-                  }),
-                  {} as Record<
+                    }),
+                    {} as Record<
                     string,
                     IChatResponse["channels"]["0"]["messages"][0]
-                  >
+                    >
                 )
-              ).sort((a, b) => b.timestamp - a.timestamp),
+                ).sort((a, b) => b.timestamp - a.timestamp),
             },
-          ])
+            ])
         );
         return { channels };
-      },
-      providesTags: [{ type: "Chat", id: "LIST" }],
+        },
+        providesTags: [{ type: "Chat", id: "LIST" }],
     }),
     getNodes: builder.query<INodesResponse, void | { status: "online" }>({
       query: () => "nodes",

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -244,3 +244,6 @@ DROP TRIGGER IF EXISTS update_node_telemetry_current_updated_at ON node_telemetr
 CREATE TRIGGER update_node_telemetry_current_updated_at
 BEFORE UPDATE ON node_telemetry_current
 FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_channel_timestamp
+ON chat_messages (channel_id, timestamp DESC);

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1502,6 +1502,115 @@ class PostgresStorage:
             logger.error(f"Failed to query chat from PostgreSQL: {e}")
             return {"channels": {"0": {"name": "General", "messages": []}}}
 
+    async def query_chat_filtered(
+        self,
+        channel_id: Optional[str] = None,
+        range_seconds: Optional[int] = None,
+        limit: int = 10000,
+    ) -> Dict[str, Any]:
+        """
+        Query chat channels with optional filtering by channel and time range.
+
+        Always returns all channels with totalMessages counts (for UI pills).
+        Only populates the messages array for the requested channel.
+
+        Args:
+            channel_id: If provided, only include messages for this channel.
+                        Other channels get empty messages arrays.
+            range_seconds: If provided, only include messages with
+                        timestamp >= (now_unix - range_seconds).
+            limit: Max messages to return.
+
+        Returns:
+            Chat structure: { channels: { "<id>": { name, totalMessages, messages[] } } }
+        """
+        if not self.enabled or not self.pool:
+            return {"channels": {"0": {"name": "General", "totalMessages": 0, "messages": []}}}
+
+        try:
+            async with self.pool.acquire() as conn:
+                chat: Dict[str, Any] = {"channels": {}}
+
+                # ── 1. Load ALL channels with their total message counts ──
+                channel_rows = await conn.fetch(
+                    """
+                    SELECT cc.id, cc.name, COUNT(cm.id) AS total_messages
+                    FROM chat_channels cc
+                    LEFT JOIN chat_messages cm ON cc.id = cm.channel_id
+                    GROUP BY cc.id, cc.name
+                    ORDER BY cc.id
+                    """
+                )
+
+                for row in channel_rows:
+                    chat["channels"][row["id"]] = {
+                        "name": row["name"],
+                        "totalMessages": row["total_messages"],
+                        "messages": [],
+                    }
+
+                # ── 2. Load messages for the target channel(s) ──
+                where_parts = []
+                params: list = []
+                param_num = 1
+
+                if channel_id is not None:
+                    where_parts.append(f"channel_id = ${param_num}")
+                    params.append(channel_id)
+                    param_num += 1
+
+                if range_seconds is not None:
+                    import time
+                    threshold = int(time.time()) - range_seconds
+                    where_parts.append(f"timestamp >= ${param_num}")
+                    params.append(threshold)
+                    param_num += 1
+
+                where_clause = " AND ".join(where_parts) if where_parts else "TRUE"
+
+                params.append(limit)
+                limit_param = f"${param_num}"
+
+                message_rows = await conn.fetch(
+                    f"""
+                    SELECT * FROM chat_messages
+                    WHERE {where_clause}
+                    ORDER BY timestamp DESC
+                    LIMIT {limit_param}
+                    """,
+                    *params,
+                )
+
+                for row in message_rows:
+                    ch_id = row["channel_id"] or "0"
+                    if ch_id not in chat["channels"]:
+                        chat["channels"][ch_id] = {
+                            "name": f"Channel {ch_id}",
+                            "totalMessages": 0,
+                            "messages": [],
+                        }
+
+                    chat["channels"][ch_id]["messages"].append(
+                        {
+                            "id": row["id"],
+                            "from": row["from_node_id"],
+                            "to": row["to_node_id"],
+                            "sender": row["sender_node_id"],
+                            "channel": ch_id,
+                            "text": row["text"],
+                            "timestamp": row["timestamp"],
+                            "hops_away": row["hops_away"],
+                            "rssi": row["rssi"],
+                            "snr": row["snr"],
+                        }
+                    )
+
+                return chat
+
+        except Exception as e:
+            logger.error(f"Failed to query filtered chat from PostgreSQL: {e}")
+            return {"channels": {"0": {"name": "General", "totalMessages": 0, "messages": []}}}
+
     async def query_all_telemetry(self, limit: int = 1000) -> List[Dict[str, Any]]:
         """Query all telemetry records."""
         if not self.enabled or not self.pool:

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1515,8 +1515,8 @@ class PostgresStorage:
         Only populates the messages array for the requested channel.
 
         Args:
-            channel_id: If provided, only include messages for this channel.
-                        Other channels get empty messages arrays.
+            channel_id: Only include messages for this channel (defaults to "0"
+                        at the API layer). Other channels get empty messages arrays.
             range_seconds: If provided, only include messages with
                         timestamp >= (now_unix - range_seconds).
             limit: Max messages to return.

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1505,6 +1505,115 @@ class PostgresStorage:
             logger.error(f"Failed to query chat from PostgreSQL: {e}")
             return {"channels": {"0": {"name": "General", "messages": []}}}
 
+    async def query_chat_filtered(
+        self,
+        channel_id: Optional[str] = None,
+        range_seconds: Optional[int] = None,
+        limit: int = 10000,
+    ) -> Dict[str, Any]:
+        """
+        Query chat channels with optional filtering by channel and time range.
+
+        Always returns all channels with totalMessages counts (for UI pills).
+        Only populates the messages array for the requested channel.
+
+        Args:
+            channel_id: If provided, only include messages for this channel.
+                        Other channels get empty messages arrays.
+            range_seconds: If provided, only include messages with
+                        timestamp >= (now_unix - range_seconds).
+            limit: Max messages to return.
+
+        Returns:
+            Chat structure: { channels: { "<id>": { name, totalMessages, messages[] } } }
+        """
+        if not self.enabled or not self.pool:
+            return {"channels": {"0": {"name": "General", "totalMessages": 0, "messages": []}}}
+
+        try:
+            async with self.pool.acquire() as conn:
+                chat: Dict[str, Any] = {"channels": {}}
+
+                # ── 1. Load ALL channels with their total message counts ──
+                channel_rows = await conn.fetch(
+                    """
+                    SELECT cc.id, cc.name, COUNT(cm.id) AS total_messages
+                    FROM chat_channels cc
+                    LEFT JOIN chat_messages cm ON cc.id = cm.channel_id
+                    GROUP BY cc.id, cc.name
+                    ORDER BY cc.id
+                    """
+                )
+
+                for row in channel_rows:
+                    chat["channels"][row["id"]] = {
+                        "name": row["name"],
+                        "totalMessages": row["total_messages"],
+                        "messages": [],
+                    }
+
+                # ── 2. Load messages for the target channel(s) ──
+                where_parts = []
+                params: list = []
+                param_num = 1
+
+                if channel_id is not None:
+                    where_parts.append(f"channel_id = ${param_num}")
+                    params.append(channel_id)
+                    param_num += 1
+
+                if range_seconds is not None:
+                    import time
+                    threshold = int(time.time()) - range_seconds
+                    where_parts.append(f"timestamp >= ${param_num}")
+                    params.append(threshold)
+                    param_num += 1
+
+                where_clause = " AND ".join(where_parts) if where_parts else "TRUE"
+
+                params.append(limit)
+                limit_param = f"${param_num}"
+
+                message_rows = await conn.fetch(
+                    f"""
+                    SELECT * FROM chat_messages
+                    WHERE {where_clause}
+                    ORDER BY timestamp DESC
+                    LIMIT {limit_param}
+                    """,
+                    *params,
+                )
+
+                for row in message_rows:
+                    ch_id = row["channel_id"] or "0"
+                    if ch_id not in chat["channels"]:
+                        chat["channels"][ch_id] = {
+                            "name": f"Channel {ch_id}",
+                            "totalMessages": 0,
+                            "messages": [],
+                        }
+
+                    chat["channels"][ch_id]["messages"].append(
+                        {
+                            "id": row["id"],
+                            "from": row["from_node_id"],
+                            "to": row["to_node_id"],
+                            "sender": row["sender_node_id"],
+                            "channel": ch_id,
+                            "text": row["text"],
+                            "timestamp": row["timestamp"],
+                            "hops_away": row["hops_away"],
+                            "rssi": row["rssi"],
+                            "snr": row["snr"],
+                        }
+                    )
+
+                return chat
+
+        except Exception as e:
+            logger.error(f"Failed to query filtered chat from PostgreSQL: {e}")
+            return {"channels": {"0": {"name": "General", "totalMessages": 0, "messages": []}}}
+
     async def query_all_telemetry(self, limit: int = 1000) -> List[Dict[str, Any]]:
         """Query all telemetry records."""
         if not self.enabled or not self.pool:


### PR DESCRIPTION
Closes #280 

Add server-side filtering to GET /v1/chat with channel and range query
params (1h, 24h, 7d, all). New query_chat_filtered() method in
postgres.py returns all channels with totalMessages counts but only
populates messages for the requested channel/time range.

Changes:
- api/api.py: Parse channel and range query params, call new filtered query
- storage/db/postgres.py: New query_chat_filtered() with channel + time range filtering
- postgres/sql/schema.sql: Add composite index on (channel_id, timestamp DESC)
- frontend/src/pages/Chat.tsx: UI driven by server-side filters instead of client-side
- frontend/src/slices/apiSlice.ts: RTK Query endpoints pass channel and range to API