### PR TITLE
fix useRef type parameters for React 19 compatibility

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -459,7 +459,7 @@ export const Chat = () => {
 
   // Export menu
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   // Search input
   const [qInput, setQInput] = useState(urlQ);
@@ -914,7 +914,7 @@ export const Chat = () => {
   }, [messages, urlNode]);
 
   // Virtualized list ref
-  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   // Scroll selected message into view
   const pendingScrollRef = useRef<string | null>(null);

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -610,7 +610,7 @@ export const Log = () => {
 
   // Export popover
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!exportOpen) return;
@@ -781,7 +781,7 @@ export const Log = () => {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [controlsOpen, exportOpen]);
 
-  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   const activeFilterCount = useMemo(() => {
     let n = 0;

--- a/frontend/src/pages/Neighbors.tsx
+++ b/frontend/src/pages/Neighbors.tsx
@@ -765,11 +765,11 @@ export const Neighbors = () => {
   }, [selectedId, isLgUp]);
 
   // Virtuoso ref
-  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   // Export
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!exportOpen || !isLgUp) return;

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -429,7 +429,7 @@ export const Nodes = () => {
 
   // Export menu
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   // click-outside for export menu (desktop)
   useEffect(() => {

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -107,7 +107,7 @@ export const Stats = () => {
 
   const [copied, setCopied] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   // click-outside for export menu
   useEffect(() => {

--- a/frontend/src/pages/Telemetry.tsx
+++ b/frontend/src/pages/Telemetry.tsx
@@ -211,7 +211,7 @@ export const Telemetry = () => {
 
   // Export menu (desktop)
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   // Export menu click-outside (desktop only)
   useEffect(() => {

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -285,7 +285,7 @@ export const Traceroutes = () => {
 
   // Export menu (desktop)
   const [exportOpen, setExportOpen] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement | null>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
 
   // Export menu click-outside (desktop only)
   useEffect(() => {

--- a/frontend/src/pages/nodes/NodesList.tsx
+++ b/frontend/src/pages/nodes/NodesList.tsx
@@ -52,7 +52,7 @@ export function NodesList({
   onAtTopChange?: (atTop: boolean) => void;
   totalSeen: number;
 }) {
-  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   // Keep the "Seen X sec" counters smooth without re-rendering the entire page.
   const [currentDate, setCurrentDate] = useState(() => new Date());


### PR DESCRIPTION
- Fix useRef<T | null>(null) → useRef<T>(null) across 8 files to resolve TypeScript errors with React 19 / @types/react 19
- React 19 changed useRef(null) to return RefObject<T | null>, causing type mismatches when passed to components expecting RefObject<T>
- No runtime behavior change — purely a type-level fix