### PR TITLE
ci: add backend CI check and improve workflow naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-backend:
+    name: Build Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - run: pip install -r requirements.txt
+
   build-frontend:
     name: Build Frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 
 on:
   pull_request:
@@ -6,7 +6,8 @@ on:
     branches: [ develop ]
 
 jobs:
-  python:
+  python-tests:
+    name: Python Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -17,7 +18,8 @@ jobs:
       - run: python -m pip install pytest pytest-cov
       - run: python -m pytest -q tests
 
-  frontend:
+  frontend-tests:
+    name: Frontend Tests
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

- Added `Build Backend` job to `ci.yml` to validate `requirements.txt` and
  Python dependencies on every PR, catching issues before they reach `docker.yml`
- Renamed `tests` workflow to `Tests` and job IDs/names to `Python Tests` and
  `Frontend Tests` for clarity in the checks UI
