### PR TITLE
fix: startup log ordering and frontend PathError crash loop

### DIFF
--- a/frontend/scripts/server.js
+++ b/frontend/scripts/server.js
@@ -18,7 +18,7 @@ app.use((req, res, next) => {
 });
 
 // Handle every other route with index.html, which will contain a script tag to your application's JavaScript
-app.get("/*", (req, res) => {
+app.get("/*splat", (req, res) => {
   res.sendFile(path.join(__dirname, "../dist", "index.html"));
 });
 

--- a/main.py
+++ b/main.py
@@ -87,21 +87,7 @@ async def supervise(
 async def main() -> None:
     config, data = init_runtime()
 
-    # --- Apply log level from config ---
-    log_level_name = config.get("server", {}).get("log_level", "INFO").upper()
-    valid_levels = logging.getLevelNamesMapping()
-    if log_level_name in valid_levels:
-        effective_log_level = valid_levels[log_level_name]
-    else:
-        logger.warning(
-            "Invalid log level '%s' in config; falling back to INFO",
-            log_level_name,
-        )
-        effective_log_level = logging.INFO
-    logging.getLogger().setLevel(effective_log_level)
-    logger.info("Log level set to: %s", logging.getLevelName(effective_log_level))
-
-    # Banner + version: best-effort only
+    # Banner + version: best-effort only, shown first
     # NOTE: Banner intentionally uses print() for clean stdout display
     banner = _read_text_file("banner")
     if banner:
@@ -116,6 +102,20 @@ async def main() -> None:
         )
     else:
         logger.info("Version file not found/invalid; continuing without version info")
+
+    # --- Apply log level from config ---
+    log_level_name = config.get("server", {}).get("log_level", "INFO").upper()
+    valid_levels = logging.getLevelNamesMapping()
+    if log_level_name in valid_levels:
+        effective_log_level = valid_levels[log_level_name]
+    else:
+        logger.warning(
+            "Invalid log level '%s' in config; falling back to INFO",
+            log_level_name,
+        )
+        effective_log_level = logging.INFO
+    logging.getLogger().setLevel(effective_log_level)
+    logger.info("Log level set to: %s", logging.getLevelName(effective_log_level))
 
     # Ensure directories exist
     os.makedirs(config["paths"]["data"], exist_ok=True)


### PR DESCRIPTION
- Move banner and version logging to the top of main() so they appear before log level and timezone lines at startup
- Fix PathError crash loop in frontend/scripts/server.js by changing "/*" to "/*splat" — path-to-regexp v8 requires named wildcard segments