### PR TITLE
feat: spiderfy overlapping map nodes for disambiguation (#344)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -31,6 +31,16 @@ import { MapSettingsPanel } from "./map/MapSettingsPanel";
 import { LS_KEYS, readJson, toMapboxStyleUrl, writeJson } from "./map/storage";
 import type { IFeatureNode, IMapNode, MapProvider, NodeLike } from "./map/types";
 import {
+  autoSpiderfyVisibleClusters,
+  removeSpiderfyLayers,
+  spiderfy,
+  unspiderfy,
+  updateSpiderfyPositions,
+  SPIDERFY_LAYER_NODES,
+  SPIDERFY_LAYER_LABELS,
+  SPIDERFY_SOURCE_NODES,
+} from "./map/spiderfy";
+import {
   applyMapboxClusterVisibility,
   buildNodesGeoJSON,
   bumpOlRender,
@@ -82,6 +92,7 @@ export function Map() {
   const mbSelectedIdRef = useRef<string | null>(null);
   const mbHandlersBoundRef = useRef(false);
   const mbCurrentStyleUrlRef = useRef<string | null>(null);
+  const mbKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
 
   const { data: rawNodes = {} } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
@@ -310,18 +321,14 @@ export function Map() {
     const selectedId = mbSelectedIdRef.current;
 
     if (map && selectedId) {
-      // Clear selection ring (feature-state) for both sources (clustered + plain)
-      try {
-        if (map.getSource("nodes_clustered")) {
-          map.setFeatureState({ source: "nodes_clustered", id: selectedId }, { selected: false });
-        }
-      } catch {}
-
-      try {
-        if (map.getSource("nodes_plain")) {
-          map.setFeatureState({ source: "nodes_plain", id: selectedId }, { selected: false });
-        }
-      } catch {}
+      // Clear selection ring (feature-state) for all node sources
+      for (const src of ["nodes_clustered", "nodes_plain", SPIDERFY_SOURCE_NODES]) {
+        try {
+          if (map.getSource(src)) {
+            map.setFeatureState({ source: src, id: selectedId }, { selected: false });
+          }
+        } catch {}
+      }
     }
 
     mbSelectedIdRef.current = null;
@@ -431,21 +438,20 @@ export function Map() {
 
     mbMapRef.current = map;
 
+    const NODE_SOURCES = ["nodes_clustered", "nodes_plain", SPIDERFY_SOURCE_NODES] as const;
+
     const clearSelected = () => {
       const prev = mbSelectedIdRef.current;
       if (!prev) return;
-      try {
-        map.setFeatureState({ source: "nodes_clustered", id: prev }, { selected: false });
-      } catch (error) {
-        if (process.env.NODE_ENV !== "production") {
-          console.error("Failed to clear feature state for nodes_clustered", error);
-        }
-      }
-      try {
-        map.setFeatureState({ source: "nodes_plain", id: prev }, { selected: false });
-      } catch (error) {
-        if (process.env.NODE_ENV !== "production") {
-          console.error("Failed to clear feature state for nodes_plain", error);
+      for (const src of NODE_SOURCES) {
+        try {
+          if (map.getSource(src)) {
+            map.setFeatureState({ source: src, id: prev }, { selected: false });
+          }
+        } catch (error) {
+          if (process.env.NODE_ENV !== "production") {
+            console.error(`Failed to clear feature state for ${src}`, error);
+          }
         }
       }
       mbSelectedIdRef.current = null;
@@ -458,18 +464,15 @@ export function Map() {
 
       mbSelectedIdRef.current = id;
 
-      try {
-        map.setFeatureState({ source: "nodes_clustered", id }, { selected: true });
-      } catch (error) {
-        if (process.env.NODE_ENV !== "production") {
-          console.error("Failed to set feature state for nodes_clustered", error);
-        }
-      }
-      try {
-        map.setFeatureState({ source: "nodes_plain", id }, { selected: true });
-      } catch (error) {
-        if (process.env.NODE_ENV !== "production") {
-          console.error("Failed to set feature state for nodes_plain", error);
+      for (const src of NODE_SOURCES) {
+        try {
+          if (map.getSource(src)) {
+            map.setFeatureState({ source: src, id }, { selected: true });
+          }
+        } catch (error) {
+          if (process.env.NODE_ENV !== "production") {
+            console.error(`Failed to set feature state for ${src}`, error);
+          }
         }
       }
     };
@@ -507,7 +510,7 @@ export function Map() {
           data: buildNodesGeoJSON(nodesRef.current, recentDaysRef.current),
           cluster: true,
           clusterRadius: 50,
-          clusterMaxZoom: 14,
+          clusterMaxZoom: 24,
         });
       }
 
@@ -736,7 +739,7 @@ export function Map() {
       bindHover("clusters");
       bindHover("plain-nodes");
 
-      // Clicking a cluster zooms in
+      // Clicking a cluster: zoom in, or spiderfy if can't expand further
       map.on("click", "clusters", (e) => {
         const features = map.queryRenderedFeatures(e.point, { layers: ["clusters"] });
         const cluster = features[0];
@@ -751,7 +754,17 @@ export function Map() {
           if (zoom == null) return;
 
           const [lng, lat] = (cluster.geometry as any).coordinates as [number, number];
-          map.easeTo({ center: [lng, lat], zoom });
+          const maxZoom = map.getMaxZoom();
+
+          if (zoom >= maxZoom) {
+            // Can't expand further — spiderfy the nodes
+            clearMapboxSelectionAndOverlays();
+            void spiderfy(map, clusterId, [lng, lat], map.getZoom());
+          } else {
+            // Zoom in, collapsing any existing spiderfy
+            removeSpiderfyLayers(map);
+            map.easeTo({ center: [lng, lat], zoom });
+          }
         });
       });
 
@@ -773,23 +786,63 @@ export function Map() {
         void handleNodeClick(id);
       });
 
-      // Clicking empty space clears
+      // Clicking spiderfied nodes
+      map.on("click", SPIDERFY_LAYER_NODES, (e) => {
+        const feature = e.features?.[0];
+        if (!feature) return;
+        const id = (feature.properties?.id ?? "") as string;
+        if (!id) return;
+        void handleNodeClick(id);
+      });
+
+      bindHover(SPIDERFY_LAYER_NODES);
+
+      // Clicking empty space clears selection and collapses spiderfy
       map.on("click", (e) => {
-        const hitNode =
-          map.queryRenderedFeatures(e.point, {
-            layers: ["unclustered-nodes", "plain-nodes", "unclustered-labels", "plain-labels"],
-          }).length > 0;
+        // Build the list of interactive layers, including spiderfy layers if present
+        const nodeLayers = ["unclustered-nodes", "plain-nodes", "unclustered-labels", "plain-labels"];
+        if (map.getLayer(SPIDERFY_LAYER_NODES)) nodeLayers.push(SPIDERFY_LAYER_NODES);
+        if (map.getLayer(SPIDERFY_LAYER_LABELS)) nodeLayers.push(SPIDERFY_LAYER_LABELS);
+
+        const hitNode = map.queryRenderedFeatures(e.point, { layers: nodeLayers }).length > 0;
         const hitCluster =
           map.queryRenderedFeatures(e.point, { layers: ["clusters"] }).length > 0;
         if (hitNode || hitCluster) return;
 
+        void unspiderfy(map);
         clearMapboxSelectionAndOverlays();
       });
+
+      // Update spiderfy positions when zoom changes (keeps fan-out consistent)
+      map.on("zoomend", () => {
+        updateSpiderfyPositions(map);
+      });
+
+      // Auto-spiderfy clusters that can't expand further
+      map.on("idle", () => {
+        if (clusterEnabledRef.current) {
+          void autoSpiderfyVisibleClusters(map);
+        }
+      });
+
+      // Escape key collapses spiderfy
+      const handleKeydown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          void unspiderfy(map);
+          clearMapboxSelectionAndOverlays();
+        }
+      };
+      mbKeydownHandlerRef.current = handleKeydown;
+      document.addEventListener("keydown", handleKeydown);
     };
 
     map.on("style.load", ensureSourcesAndLayers);
 
     return () => {
+      if (mbKeydownHandlerRef.current) {
+        document.removeEventListener("keydown", mbKeydownHandlerRef.current);
+        mbKeydownHandlerRef.current = null;
+      }
       if (mbMapRef.current) {
         mbMapRef.current.remove();
         mbMapRef.current = null;

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -41,6 +41,14 @@ import {
   SPIDERFY_SOURCE_NODES,
 } from "./map/spiderfy";
 import {
+  autoOlSpiderfy,
+  createOlClusterLayer,
+  handleOlClusterClick,
+  removeOlSpiderfy,
+  updateOlSpiderfyPositions,
+  type OlClusterSetup,
+} from "./map/spiderfy-ol";
+import {
   applyMapboxClusterVisibility,
   buildNodesGeoJSON,
   bumpOlRender,
@@ -86,6 +94,7 @@ export function Map() {
   const [olMap, setOlMap] = useState<OlMap>();
   const olBaseLayerRef = useRef<ReturnType<typeof createBaseTileLayer> | null>(null);
   const olNodesSourceRef = useRef<VectorSource<Feature<Point>> | null>(null);
+  const olClusterSetupRef = useRef<OlClusterSetup | null>(null);
 
   // Mapbox refs (Mapbox path)
   const mbMapRef = useRef<MbMap | null>(null);
@@ -1048,46 +1057,31 @@ export function Map() {
       })
       .filter((f): f is Feature<Point> => Boolean(f));
 
+    // Create both plain and clustered layers — toggle via clusterEnabled
     const nodeSource = new VectorSource({ features });
     olNodesSourceRef.current = nodeSource;
 
-    const vectorLayer = new VectorLayer({
+    const plainLayer = new VectorLayer({
       style: defaultStyle,
       source: nodeSource,
     });
-    map.addLayer(vectorLayer);
+
+    const clusterSetup = createOlClusterLayer(features);
+    olClusterSetupRef.current = clusterSetup;
+
+    // Add the appropriate layer based on cluster setting
+    if (clusterEnabledRef.current) {
+      map.addLayer(clusterSetup.clusterLayer);
+    } else {
+      map.addLayer(plainLayer);
+    }
 
     const { nodePanel, nodeTitle, nodeSubtitle, nodeContent } = getDetailsDom();
     if (!nodePanel || !nodeTitle || !nodeSubtitle || !nodeContent) return;
 
     const neighborLayers: VectorLayer<VectorSource<Feature>, Feature>[] = [];
 
-    const selectedStyle = new Style({
-      image: new Circle({
-        radius: 6,
-        fill: new Fill({ color: "rgba(0, 0, 240, 1)" }),
-        stroke: new Stroke({ color: "orange", width: 2 }),
-      }),
-    });
-
-    const select = new Select({ condition: click, style: selectedStyle });
-    map.addInteraction(select);
-
-    map.on("singleclick", async (event) => {
-      neighborLayers.forEach((layer) => map.removeLayer(layer));
-      neighborLayers.length = 0;
-
-      if (map.hasFeatureAtPixel(event.pixel) !== true) {
-        clearDetailsPanel();
-        return;
-      }
-
-      const feature = map.forEachFeatureAtPixel(event.pixel, (f) => f);
-      if (!feature) return;
-
-      const props = feature.getProperties();
-      const { node } = props as { node: IFeatureNode };
-
+    const handleNodeDetails = async (node: IFeatureNode) => {
       const displayName = await reverseGeocode(node.position[0], node.position[1]);
 
       const nodeLike: NodeLike = {
@@ -1113,19 +1107,17 @@ export function Map() {
         html,
       });
 
-      // Draw neighbor lines (OpenLayers map overlay)
+      // Draw neighbor lines
       node.neighbors?.forEach((neighbor) => {
         const nnode = nodes[neighbor.id];
         if (!nnode?.map_position) return;
 
         const points: Coordinate[] = [node.position, nnode.map_position];
-
         for (let i = 0; i < points.length; i++) {
           points[i] = transform(points[i], "EPSG:4326", "EPSG:3857");
         }
 
         const featureLine = new Feature({ geometry: new LineString(points) });
-
         const vectorLine = new Vector({});
         vectorLine.addFeature(featureLine);
 
@@ -1139,7 +1131,71 @@ export function Map() {
         neighborLayers.push(vectorLineLayer);
         map.addLayer(vectorLineLayer);
       });
+    };
+
+    // Select interaction for non-clustered mode
+    const selectedStyle = new Style({
+      image: new Circle({
+        radius: 6,
+        fill: new Fill({ color: "rgba(0, 0, 240, 1)" }),
+        stroke: new Stroke({ color: "orange", width: 2 }),
+      }),
     });
+
+    const select = new Select({ condition: click, style: selectedStyle });
+    map.addInteraction(select);
+
+    map.on("singleclick", async (event) => {
+      neighborLayers.forEach((layer) => map.removeLayer(layer));
+      neighborLayers.length = 0;
+
+      if (clusterEnabledRef.current) {
+        // Clustered mode — use spiderfy-aware click handler
+        const node = handleOlClusterClick(map, clusterSetup.clusterSource, event.pixel);
+        if (node) {
+          select.getFeatures().clear();
+          void handleNodeDetails(node);
+        } else if (!map.hasFeatureAtPixel(event.pixel)) {
+          clearDetailsPanel();
+        }
+        return;
+      }
+
+      // Plain mode — original behavior
+      if (map.hasFeatureAtPixel(event.pixel) !== true) {
+        clearDetailsPanel();
+        return;
+      }
+
+      const feature = map.forEachFeatureAtPixel(event.pixel, (f) => f);
+      if (!feature) return;
+
+      const props = feature.getProperties();
+      const { node } = props as { node: IFeatureNode };
+      if (!node?.id) return;
+
+      void handleNodeDetails(node);
+    });
+
+    // Zoom handlers for OL spiderfy
+    map.getView().on("change:resolution", () => {
+      updateOlSpiderfyPositions(map);
+    });
+
+    map.on("moveend", () => {
+      if (clusterEnabledRef.current) {
+        autoOlSpiderfy(map, clusterSetup.clusterSource);
+      }
+    });
+
+    // Escape key for OL spiderfy
+    const olKeydownHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        removeOlSpiderfy(map);
+        clearDetailsPanel();
+      }
+    };
+    document.addEventListener("keydown", olKeydownHandler);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [provider, serverNode, olMap]);
@@ -1148,10 +1204,6 @@ export function Map() {
   useEffect(() => {
     if (provider !== "osm") return;
     if (!olMap) return;
-    if (!olNodesSourceRef.current) return;
-
-    const src = olNodesSourceRef.current;
-    src.clear();
 
     const nodeEntries = computeRecentNodes(nodes, recentDays);
     const features = nodeEntries
@@ -1176,7 +1228,38 @@ export function Map() {
       })
       .filter((f): f is Feature<Point> => Boolean(f));
 
-    src.addFeatures(features);
+    // Update plain source
+    if (olNodesSourceRef.current) {
+      olNodesSourceRef.current.clear();
+      olNodesSourceRef.current.addFeatures(features);
+    }
+
+    // Update cluster source (uses its own feature source)
+    if (olClusterSetupRef.current) {
+      removeOlSpiderfy(olMap); // clear spiderfy before updating features
+      olClusterSetupRef.current.featureSource.clear();
+      // Re-create features for cluster source (separate instances)
+      const clusterFeatures = nodeEntries
+        .map(([id, node]) => {
+          if (!node.map_position) return null;
+          const f = new Feature({
+            geometry: new Point(fromLonLat([node.map_position[0], node.map_position[1]])),
+            node: {
+              id,
+              shortname: node.shortname,
+              longname: node.longname,
+              last_seen: node.last_seen,
+              position: [node.map_position[0], node.map_position[1]] as Coordinate,
+              online: node.online,
+              neighbors: node.neighbors,
+            } satisfies IFeatureNode,
+          });
+          f.setStyle(node.online ? onlineStyle : offlineStyle);
+          return f;
+        })
+        .filter((f): f is Feature<Point> => Boolean(f));
+      olClusterSetupRef.current.featureSource.addFeatures(clusterFeatures as Feature[]);
+    }
   }, [nodes, recentDays, provider, olMap]);
 
   // OpenLayers: swap basemap live
@@ -1192,6 +1275,51 @@ export function Map() {
 
     bumpOlRender(olMap);
   }, [osmBasemap, provider, olMap]);
+
+  // OpenLayers: cluster toggle — swap between plain and clustered layers
+  useEffect(() => {
+    if (provider !== "osm") return;
+    if (!olMap) return;
+
+    const clusterSetup = olClusterSetupRef.current;
+    if (!clusterSetup) return;
+
+    // Remove spiderfy when toggling
+    removeOlSpiderfy(olMap);
+
+    const layers = olMap.getLayers();
+
+    if (clusterEnabled) {
+      // Remove any plain node layer (index 1+), add cluster layer
+      for (let i = layers.getLength() - 1; i >= 1; i--) {
+        const layer = layers.item(i);
+        // Only remove plain vector layers that use our node source
+        if (layer instanceof VectorLayer && (layer as VectorLayer<VectorSource>).getSource() === olNodesSourceRef.current) {
+          layers.removeAt(i);
+        }
+      }
+      if (!layers.getArray().includes(clusterSetup.clusterLayer)) {
+        olMap.addLayer(clusterSetup.clusterLayer);
+      }
+    } else {
+      // Remove cluster layer, add plain layer
+      if (layers.getArray().includes(clusterSetup.clusterLayer)) {
+        olMap.removeLayer(clusterSetup.clusterLayer);
+      }
+      // Re-add a plain layer if not present
+      const hasPlain = layers.getArray().some(
+        (l) => l instanceof VectorLayer && (l as VectorLayer<VectorSource>).getSource() === olNodesSourceRef.current
+      );
+      if (!hasPlain && olNodesSourceRef.current) {
+        olMap.addLayer(
+          new VectorLayer({
+            style: defaultStyle,
+            source: olNodesSourceRef.current,
+          })
+        );
+      }
+    }
+  }, [clusterEnabled, provider, olMap]);
 
   // ----------------------------
   // Settings panel UI

--- a/frontend/src/pages/map/MapSettingsPanel.tsx
+++ b/frontend/src/pages/map/MapSettingsPanel.tsx
@@ -220,7 +220,7 @@ export function MapSettingsPanel({
                     Node Clustering
                   </label>
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    {!usingMapbox ? "Mapbox only" : "Group nearby nodes"}
+                    Group nearby nodes
                   </p>
                 </div>
                 <div className="relative">
@@ -229,9 +229,8 @@ export function MapSettingsPanel({
                     type="checkbox"
                     checked={clusterEnabled}
                     onChange={(e) => setClusterEnabled(e.target.checked)}
-                    disabled={!usingMapbox}
                     className="h-4 w-4 rounded-sm border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
-                    aria-label="Toggle node clustering (Mapbox only)"
+                    aria-label="Toggle node clustering"
                   />
                 </div>
               </div>

--- a/frontend/src/pages/map/spiderfy-ol.ts
+++ b/frontend/src/pages/map/spiderfy-ol.ts
@@ -438,6 +438,27 @@ export function updateOlSpiderfyPositions(map: OlMap): void {
 }
 
 /**
+ * Check if all children of a cluster are co-located (within ~5px of each other).
+ * This means they can't separate further by zooming — same as Mapbox's
+ * "expansion zoom >= max zoom" check.
+ */
+function areChildrenColocated(map: OlMap, children: Feature[]): boolean {
+  if (children.length < 2) return false;
+
+  const first = (children[0].getGeometry() as Point).getCoordinates();
+  const resolution = map.getView().getResolution() ?? 1;
+  // ~5 pixels — truly overlapping, not just nearby
+  const threshold = 5 * resolution;
+
+  return children.every((c) => {
+    const pos = (c.getGeometry() as Point).getCoordinates();
+    const dx = pos[0] - first[0];
+    const dy = pos[1] - first[1];
+    return Math.sqrt(dx * dx + dy * dy) < threshold;
+  });
+}
+
+/**
  * Auto-spiderfy visible clusters that can't expand further.
  * For OL, we check if any cluster at high zoom still has > 1 child.
  */
@@ -457,20 +478,9 @@ export function autoOlSpiderfy(
     const children = (cf.get("features") ?? []) as Feature[];
     if (children.length < 2) continue;
 
-    // At high zoom, if children share (nearly) the same position, spiderfy
-    // Check if all children are within a tiny distance of each other
-    const first = (children[0].getGeometry() as Point).getCoordinates();
-    const resolution = map.getView().getResolution() ?? 1;
-    const threshold = CLUSTER_DISTANCE * resolution; // cluster distance in map units
-
-    const allClose = children.every((c) => {
-      const pos = (c.getGeometry() as Point).getCoordinates();
-      const dx = pos[0] - first[0];
-      const dy = pos[1] - first[1];
-      return Math.sqrt(dx * dx + dy * dy) < threshold;
-    });
-
-    if (allClose) {
+    // Only auto-spiderfy truly co-located nodes (within ~5px of each other)
+    // This matches the Mapbox behavior of only spiderfying when nodes can't separate
+    if (areChildrenColocated(map, children)) {
       olSpiderfy(map, cf);
       return; // one at a time
     }
@@ -563,17 +573,17 @@ export function handleOlClusterClick(
     return (children[0].get("node") as IFeatureNode) ?? null;
   }
 
-  // It's a cluster — check if we should zoom in or spiderfy
+  // It's a cluster — check if nodes are co-located (can't separate) or just nearby
   const view = map.getView();
   const zoom = view.getZoom() ?? 0;
 
-  // At high zoom, spiderfy instead of zooming
-  if (zoom >= AUTO_SPIDERFY_MIN_ZOOM) {
+  if (areChildrenColocated(map, children)) {
+    // Nodes are at the same position — spiderfy (zooming won't help)
     olSpiderfy(map, feature);
     return null;
   }
 
-  // Zoom in to try to separate the cluster
+  // Nodes are nearby but separable — zoom in to split the cluster
   const geom = feature.getGeometry() as Point;
   const coords = geom.getCoordinates();
   view.animate({

--- a/frontend/src/pages/map/spiderfy-ol.ts
+++ b/frontend/src/pages/map/spiderfy-ol.ts
@@ -1,0 +1,586 @@
+/**
+ * OpenLayers clustering + spiderfy module.
+ *
+ * Uses ol/source/Cluster to group overlapping nodes, then fans them out
+ * in a circle/spiral when the user clicks a cluster that can't separate.
+ */
+
+import { Feature } from "ol";
+import type { Map as OlMap } from "ol";
+import type { Coordinate } from "ol/coordinate";
+import { LineString, Point } from "ol/geom";
+import VectorLayer from "ol/layer/Vector";
+import { toLonLat } from "ol/proj";
+import Cluster from "ol/source/Cluster";
+import VectorSource from "ol/source/Vector";
+import { Circle, Fill, Stroke, Style, Text } from "ol/style";
+
+import type { IFeatureNode } from "./types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cluster distance in pixels */
+const CLUSTER_DISTANCE = 50;
+
+/** Animation duration in ms */
+const ANIMATE_MS = 320;
+
+/** Zoom level at which auto-spiderfy activates */
+const AUTO_SPIDERFY_MIN_ZOOM = 14;
+
+/** Golden angle in radians for Fermat spiral */
+const GOLDEN_ANGLE = 2.399963229728653;
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const onlineFill = new Fill({ color: "rgba(50, 240, 50, 1)" });
+const offlineFill = new Fill({ color: "rgba(0, 0, 0, 0.50)" });
+const whiteStroke = new Stroke({ color: "white", width: 2 });
+const orangeStroke = new Stroke({ color: "orange", width: 2 });
+const clusterFill = new Fill({ color: "rgba(59, 130, 246, 0.85)" });
+
+/** Style for cluster circles with count label. */
+function clusterStyle(size: number): Style {
+  let radius = 14;
+  if (size >= 50) radius = 30;
+  else if (size >= 25) radius = 24;
+  else if (size >= 10) radius = 18;
+
+  return new Style({
+    image: new Circle({
+      radius,
+      fill: clusterFill,
+      stroke: new Stroke({ color: "white", width: 2 }),
+    }),
+    text: new Text({
+      text: size >= 1000 ? `${Math.round(size / 100) / 10}k` : size.toString(),
+      fill: new Fill({ color: "#ffffff" }),
+      font: "12px sans-serif",
+    }),
+  });
+}
+
+/** Style for individual (unclustered) node. */
+function nodeStyle(online: boolean, selected: boolean): Style {
+  return new Style({
+    image: new Circle({
+      radius: selected ? 10 : 6,
+      fill: online ? onlineFill : offlineFill,
+      stroke: selected ? orangeStroke : whiteStroke,
+    }),
+  });
+}
+
+/** Style for spiderfied node (same as regular node but always shown). */
+function spiderfiedNodeStyle(online: boolean, selected: boolean): Style {
+  return new Style({
+    image: new Circle({
+      radius: selected ? 10 : 6,
+      fill: online ? onlineFill : offlineFill,
+      stroke: selected ? orangeStroke : whiteStroke,
+    }),
+    text: new Text({
+      text: "", // will be set per-feature
+      offsetY: 14,
+      fill: new Fill({ color: "#ffffff" }),
+      stroke: new Stroke({ color: "#000000", width: 3 }),
+      font: "13px sans-serif",
+    }),
+  });
+}
+
+const legStyle = new Style({
+  stroke: new Stroke({
+    color: "rgba(255, 255, 255, 0.55)",
+    width: 1.5,
+    lineDash: [6, 8],
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Spiderfy state
+// ---------------------------------------------------------------------------
+
+interface OlSpiderfyState {
+  clusterFeature: Feature;
+  center: Coordinate; // EPSG:3857
+  centerLonLat: [number, number]; // EPSG:4326
+  childFeatures: Feature<Point>[];
+  spiderLayer: VectorLayer<VectorSource<Feature>, Feature>;
+  legLayer: VectorLayer<VectorSource<Feature>, Feature>;
+  animationId: number | null;
+}
+
+let activeState: OlSpiderfyState | null = null;
+
+// ---------------------------------------------------------------------------
+// Position calculation (in EPSG:3857 meters)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert pixel offset to meters in EPSG:3857 at a given resolution.
+ * resolution = meters per pixel at current zoom.
+ */
+function pixelsToMeters(pixels: number, resolution: number): number {
+  return pixels * resolution;
+}
+
+function circlePositions(
+  center: Coordinate,
+  count: number,
+  resolution: number,
+  radiusPx: number = 40,
+): Coordinate[] {
+  const radius = pixelsToMeters(radiusPx, resolution);
+  const positions: Coordinate[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const angle = (2 * Math.PI * i) / count - Math.PI / 2;
+    positions.push([
+      center[0] + radius * Math.cos(angle),
+      center[1] + radius * Math.sin(angle),
+    ]);
+  }
+
+  return positions;
+}
+
+function spiralPositions(
+  center: Coordinate,
+  count: number,
+  resolution: number,
+  baseRadiusPx: number = 30,
+): Coordinate[] {
+  const positions: Coordinate[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const angle = i * GOLDEN_ANGLE;
+    const r = pixelsToMeters(baseRadiusPx * Math.sqrt(i + 1), resolution);
+    positions.push([
+      center[0] + r * Math.cos(angle),
+      center[1] + r * Math.sin(angle),
+    ]);
+  }
+
+  return positions;
+}
+
+function computeSpiderfiedPositions(
+  center: Coordinate,
+  count: number,
+  resolution: number,
+): Coordinate[] {
+  if (count <= 8) {
+    return circlePositions(center, count, resolution);
+  }
+  return spiralPositions(center, count, resolution);
+}
+
+/**
+ * Compute the edge offset for spider legs (same logic as Mapbox version).
+ */
+function clusterRadiusPx(pointCount: number): number {
+  let r = 14;
+  if (pointCount >= 50) r = 30;
+  else if (pointCount >= 25) r = 24;
+  else if (pointCount >= 10) r = 18;
+  return r + 2;
+}
+
+// ---------------------------------------------------------------------------
+// Interpolation for animation
+// ---------------------------------------------------------------------------
+
+function interpolate(from: Coordinate, to: Coordinate, t: number): Coordinate {
+  const eased = 1 - Math.pow(1 - t, 3); // ease-out cubic
+  return [
+    from[0] + (to[0] - from[0]) * eased,
+    from[1] + (to[1] - from[1]) * eased,
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Core functions
+// ---------------------------------------------------------------------------
+
+/** Check if spiderfy is currently active. */
+export function isOlSpiderfied(): boolean {
+  return activeState !== null;
+}
+
+/** Remove spiderfy layers from the map. */
+export function removeOlSpiderfy(map: OlMap): void {
+  if (!activeState) return;
+
+  if (activeState.animationId != null) {
+    cancelAnimationFrame(activeState.animationId);
+  }
+
+  map.removeLayer(activeState.legLayer);
+  map.removeLayer(activeState.spiderLayer);
+  activeState = null;
+}
+
+/**
+ * Spiderfy a cluster feature — fan out its children with animation.
+ */
+export function olSpiderfy(
+  map: OlMap,
+  clusterFeature: Feature,
+  animate: boolean = true,
+): void {
+  // Remove any prior spiderfy
+  removeOlSpiderfy(map);
+
+  const childFeatures = (clusterFeature.get("features") ?? []) as Feature<Point>[];
+  if (childFeatures.length < 2) return;
+
+  const clusterGeom = clusterFeature.getGeometry() as Point | undefined;
+  if (!clusterGeom) return;
+
+  const center = clusterGeom.getCoordinates();
+  const centerLonLat = toLonLat(center) as [number, number];
+  const resolution = map.getView().getResolution() ?? 1;
+
+  const finalPositions = computeSpiderfiedPositions(center, childFeatures.length, resolution);
+
+  // Create spider node features
+  const spiderFeatures: Feature<Point>[] = childFeatures.map((child, i) => {
+    const nodeData = child.get("node") as IFeatureNode | undefined;
+    const f = new Feature<Point>({
+      geometry: new Point(animate ? center.slice() : finalPositions[i]),
+      node: nodeData,
+      _spiderfied: true,
+      _targetPosition: finalPositions[i],
+    });
+
+    const online = nodeData?.online ?? false;
+    const style = spiderfiedNodeStyle(online, false);
+    // Set the label text
+    const textStyle = style.getText();
+    if (textStyle && nodeData?.shortname) {
+      textStyle.setText(nodeData.shortname);
+    }
+    f.setStyle(style);
+
+    return f;
+  });
+
+  // Create leg features (lines from cluster edge to each spider node)
+  const edgeOffset = pixelsToMeters(clusterRadiusPx(childFeatures.length), resolution);
+  const legFeatures: Feature<LineString>[] = finalPositions.map((pos) => {
+    const dx = pos[0] - center[0];
+    const dy = pos[1] - center[1];
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    const legStart: Coordinate = dist > 0
+      ? [center[0] + (dx / dist) * edgeOffset, center[1] + (dy / dist) * edgeOffset]
+      : center;
+
+    const f = new Feature<LineString>({
+      geometry: new LineString([legStart, animate ? center.slice() : pos]),
+    });
+    f.setStyle(legStyle);
+    return f;
+  });
+
+  // Create layers
+  const spiderSource = new VectorSource({ features: spiderFeatures as Feature[] });
+  const spiderLayer = new VectorLayer({
+    source: spiderSource,
+    zIndex: 100,
+  });
+
+  const legSource = new VectorSource({ features: legFeatures as Feature[] });
+  const legLayer = new VectorLayer({
+    source: legSource,
+    zIndex: 99,
+  });
+
+  map.addLayer(legLayer);
+  map.addLayer(spiderLayer);
+
+  activeState = {
+    clusterFeature,
+    center,
+    centerLonLat,
+    childFeatures,
+    spiderLayer,
+    legLayer,
+    animationId: null,
+  };
+
+  if (!animate) return;
+
+  // Animate fan-out
+  const start = performance.now();
+
+  function frame(now: number) {
+    if (!activeState) return;
+
+    const elapsed = now - start;
+    const t = Math.min(elapsed / ANIMATE_MS, 1);
+
+    for (let i = 0; i < spiderFeatures.length; i++) {
+      const currentPos = interpolate(center, finalPositions[i], t);
+      spiderFeatures[i].getGeometry()!.setCoordinates(currentPos);
+
+      // Update leg endpoint
+      const legGeom = legFeatures[i].getGeometry()!;
+      const coords = legGeom.getCoordinates();
+      legGeom.setCoordinates([coords[0], currentPos]);
+    }
+
+    if (t < 1) {
+      activeState.animationId = requestAnimationFrame(frame);
+    } else {
+      if (activeState) activeState.animationId = null;
+    }
+  }
+
+  activeState.animationId = requestAnimationFrame(frame);
+}
+
+/**
+ * Animate collapse of spiderfied nodes back to center, then remove.
+ */
+export function olUnspiderfy(map: OlMap): void {
+  if (!activeState) return;
+
+  const { center, spiderLayer, legLayer, animationId } = activeState;
+
+  if (animationId != null) {
+    cancelAnimationFrame(animationId);
+  }
+
+  const spiderFeatures = spiderLayer.getSource()?.getFeatures() ?? [];
+  const legFeatures = legLayer.getSource()?.getFeatures() ?? [];
+
+  // Capture current positions
+  const currentPositions: Coordinate[] = spiderFeatures.map((f) => {
+    const geom = f.getGeometry() as Point;
+    return geom.getCoordinates().slice();
+  });
+
+  // Clear activeState early to prevent re-spiderfy during collapse
+  const stateRef = activeState;
+  activeState = null;
+
+  const start = performance.now();
+  const collapseDuration = ANIMATE_MS * 0.7;
+
+  function frame(now: number) {
+    const elapsed = now - start;
+    const t = Math.min(elapsed / collapseDuration, 1);
+
+    for (let i = 0; i < spiderFeatures.length; i++) {
+      const pos = interpolate(currentPositions[i], center, t);
+      (spiderFeatures[i].getGeometry() as Point).setCoordinates(pos);
+
+      if (i < legFeatures.length) {
+        const legGeom = legFeatures[i].getGeometry() as LineString;
+        const coords = legGeom.getCoordinates();
+        legGeom.setCoordinates([coords[0], pos]);
+      }
+    }
+
+    if (t < 1) {
+      requestAnimationFrame(frame);
+    } else {
+      map.removeLayer(stateRef.legLayer);
+      map.removeLayer(stateRef.spiderLayer);
+    }
+  }
+
+  requestAnimationFrame(frame);
+}
+
+/**
+ * Update spiderfy positions after zoom change.
+ */
+export function updateOlSpiderfyPositions(map: OlMap): void {
+  if (!activeState) return;
+
+  const zoom = map.getView().getZoom() ?? 0;
+
+  // Collapse if zoomed out past threshold
+  if (zoom < AUTO_SPIDERFY_MIN_ZOOM) {
+    removeOlSpiderfy(map);
+    return;
+  }
+
+  const { center, childFeatures, spiderLayer, legLayer } = activeState;
+  const resolution = map.getView().getResolution() ?? 1;
+
+  const positions = computeSpiderfiedPositions(center, childFeatures.length, resolution);
+  const edgeOffset = pixelsToMeters(clusterRadiusPx(childFeatures.length), resolution);
+
+  const spiderFeatures = spiderLayer.getSource()?.getFeatures() ?? [];
+  const legFeatures = legLayer.getSource()?.getFeatures() ?? [];
+
+  for (let i = 0; i < spiderFeatures.length && i < positions.length; i++) {
+    (spiderFeatures[i].getGeometry() as Point).setCoordinates(positions[i]);
+
+    if (i < legFeatures.length) {
+      const dx = positions[i][0] - center[0];
+      const dy = positions[i][1] - center[1];
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const legStart: Coordinate = dist > 0
+        ? [center[0] + (dx / dist) * edgeOffset, center[1] + (dy / dist) * edgeOffset]
+        : center;
+      (legFeatures[i].getGeometry() as LineString).setCoordinates([legStart, positions[i]]);
+    }
+  }
+}
+
+/**
+ * Auto-spiderfy visible clusters that can't expand further.
+ * For OL, we check if any cluster at high zoom still has > 1 child.
+ */
+export function autoOlSpiderfy(
+  map: OlMap,
+  clusterSource: Cluster,
+): void {
+  if (activeState) return;
+
+  const zoom = map.getView().getZoom() ?? 0;
+  if (zoom < AUTO_SPIDERFY_MIN_ZOOM) return;
+
+  // Get all cluster features from the cluster source
+  const clusterFeatures = clusterSource.getFeatures();
+
+  for (const cf of clusterFeatures) {
+    const children = (cf.get("features") ?? []) as Feature[];
+    if (children.length < 2) continue;
+
+    // At high zoom, if children share (nearly) the same position, spiderfy
+    // Check if all children are within a tiny distance of each other
+    const first = (children[0].getGeometry() as Point).getCoordinates();
+    const resolution = map.getView().getResolution() ?? 1;
+    const threshold = CLUSTER_DISTANCE * resolution; // cluster distance in map units
+
+    const allClose = children.every((c) => {
+      const pos = (c.getGeometry() as Point).getCoordinates();
+      const dx = pos[0] - first[0];
+      const dy = pos[1] - first[1];
+      return Math.sqrt(dx * dx + dy * dy) < threshold;
+    });
+
+    if (allClose) {
+      olSpiderfy(map, cf);
+      return; // one at a time
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Create clustered source + layer (replaces the plain VectorSource/VectorLayer)
+// ---------------------------------------------------------------------------
+
+export interface OlClusterSetup {
+  /** The raw feature source (add/remove node features here) */
+  featureSource: VectorSource;
+  /** The cluster source wrapping featureSource */
+  clusterSource: Cluster;
+  /** The cluster layer to add to the map */
+  clusterLayer: VectorLayer<Cluster, Feature>;
+}
+
+/**
+ * Create clustered OL source + layer.
+ * The returned featureSource is where you add/remove node Features.
+ */
+export function createOlClusterLayer(features: Feature<Point>[]): OlClusterSetup {
+  const featureSource = new VectorSource({ features: features as Feature[] });
+
+  const clusterSource = new Cluster({
+    distance: CLUSTER_DISTANCE,
+    source: featureSource,
+  });
+
+  const styleCache: Record<string, Style> = {};
+
+  const clusterLayer = new VectorLayer({
+    source: clusterSource,
+    style(feature) {
+      const children = (feature.get("features") ?? []) as Feature[];
+      const size = children.length;
+
+      if (size === 1) {
+        // Single node — use its own style
+        const nodeData = children[0].get("node") as IFeatureNode | undefined;
+        const online = nodeData?.online ?? false;
+        return nodeStyle(online, false);
+      }
+
+      // Cluster
+      const key = `cluster-${size}`;
+      if (!styleCache[key]) {
+        styleCache[key] = clusterStyle(size);
+      }
+      return styleCache[key];
+    },
+  });
+
+  return { featureSource, clusterSource, clusterLayer };
+}
+
+/**
+ * Handle a click on the OL map when clustering is enabled.
+ * Returns the IFeatureNode if a single node was clicked, or null.
+ * Handles spiderfy expansion for clusters.
+ */
+export function handleOlClusterClick(
+  map: OlMap,
+  _clusterSource: Cluster,
+  pixel: number[],
+): IFeatureNode | null {
+  const feature = map.forEachFeatureAtPixel(pixel, (f) => f) as Feature | undefined;
+  if (!feature) {
+    olUnspiderfy(map);
+    return null;
+  }
+
+  // Check if this is a spiderfied node
+  if (feature.get("_spiderfied")) {
+    return (feature.get("node") as IFeatureNode) ?? null;
+  }
+
+  const children = feature.get("features") as Feature[] | undefined;
+
+  // Not a cluster feature (e.g. neighbor line) — ignore
+  if (!children) {
+    return null;
+  }
+
+  if (children.length === 1) {
+    // Single node — return it for details panel
+    olUnspiderfy(map);
+    return (children[0].get("node") as IFeatureNode) ?? null;
+  }
+
+  // It's a cluster — check if we should zoom in or spiderfy
+  const view = map.getView();
+  const zoom = view.getZoom() ?? 0;
+
+  // At high zoom, spiderfy instead of zooming
+  if (zoom >= AUTO_SPIDERFY_MIN_ZOOM) {
+    olSpiderfy(map, feature);
+    return null;
+  }
+
+  // Zoom in to try to separate the cluster
+  const geom = feature.getGeometry() as Point;
+  const coords = geom.getCoordinates();
+  view.animate({
+    center: coords,
+    zoom: Math.min(zoom + 2, view.getMaxZoom() ?? 22),
+    duration: 300,
+  });
+
+  return null;
+}

--- a/frontend/src/pages/map/spiderfy.ts
+++ b/frontend/src/pages/map/spiderfy.ts
@@ -1,0 +1,552 @@
+/**
+ * Spiderfy module for Mapbox GL JS
+ *
+ * When co-located nodes share coordinates and a cluster can't expand further,
+ * this fans them out in a circle (≤8 nodes) or Fermat spiral (>8 nodes)
+ * with animated "spider leg" lines connecting each to the true position.
+ */
+
+import type {
+  Feature as GeoFeature,
+  FeatureCollection,
+  GeoJsonProperties,
+  LineString as GeoLineString,
+  Point as GeoPoint,
+} from "geojson";
+import type { GeoJSONSource as MbGeoJSONSource, Map as MbMap } from "mapbox-gl";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SPIDERFY_SOURCE_NODES = "spiderfy-nodes";
+export const SPIDERFY_SOURCE_LEGS = "spiderfy-legs";
+export const SPIDERFY_LAYER_NODES = "spiderfy-node-circles";
+export const SPIDERFY_LAYER_LABELS = "spiderfy-node-labels";
+export const SPIDERFY_LAYER_LEGS = "spiderfy-legs-line";
+
+/** Animation duration in ms */
+const ANIMATE_MS = 320;
+
+/** Golden angle in radians — produces optimal spacing in Fermat spirals */
+const GOLDEN_ANGLE = 2.399963229728653; // 137.508°
+
+// ---------------------------------------------------------------------------
+// Active spiderfy state — tracks what's currently fanned out
+// ---------------------------------------------------------------------------
+
+interface SpiderfyState {
+  clusterId: number;
+  center: [number, number];
+  leaves: GeoFeature<GeoPoint, GeoJsonProperties>[];
+  lastZoom: number;
+}
+
+let activeState: SpiderfyState | null = null;
+
+/** Get the currently active spiderfy state (for external inspection). */
+export function getActiveSpiderfyState(): SpiderfyState | null {
+  return activeState;
+}
+
+// ---------------------------------------------------------------------------
+// Position calculation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a pixel offset to geographic degrees at a given zoom level.
+ * At zoom z, one degree of longitude ≈ 256 * 2^z / 360 pixels.
+ */
+function pixelsToDegrees(pixels: number, zoom: number): number {
+  const worldSize = 256 * Math.pow(2, zoom);
+  return (pixels / worldSize) * 360;
+}
+
+/** Arrange `count` points evenly around a circle of `radiusPx` pixels. */
+function circlePositions(
+  center: [number, number],
+  count: number,
+  zoom: number,
+  radiusPx: number = 40,
+): [number, number][] {
+  const radius = pixelsToDegrees(radiusPx, zoom);
+  const positions: [number, number][] = [];
+
+  for (let i = 0; i < count; i++) {
+    const angle = (2 * Math.PI * i) / count - Math.PI / 2; // start at top
+    positions.push([
+      center[0] + radius * Math.cos(angle),
+      center[1] + radius * Math.sin(angle),
+    ]);
+  }
+
+  return positions;
+}
+
+/** Arrange `count` points in a Fermat spiral of increasing radius. */
+function spiralPositions(
+  center: [number, number],
+  count: number,
+  zoom: number,
+  baseRadiusPx: number = 30,
+): [number, number][] {
+  const positions: [number, number][] = [];
+
+  for (let i = 0; i < count; i++) {
+    const angle = i * GOLDEN_ANGLE;
+    const r = pixelsToDegrees(baseRadiusPx * Math.sqrt(i + 1), zoom);
+    positions.push([
+      center[0] + r * Math.cos(angle),
+      center[1] + r * Math.sin(angle),
+    ]);
+  }
+
+  return positions;
+}
+
+/** Pick circle (≤8) or spiral (>8) layout. */
+function computeSpiderfiedPositions(
+  center: [number, number],
+  count: number,
+  zoom: number,
+): [number, number][] {
+  if (count <= 8) {
+    return circlePositions(center, count, zoom);
+  }
+  return spiralPositions(center, count, zoom);
+}
+
+// ---------------------------------------------------------------------------
+// GeoJSON builders
+// ---------------------------------------------------------------------------
+
+function buildSpiderfiedNodesGeoJSON(
+  leaves: GeoFeature<GeoPoint, GeoJsonProperties>[],
+  positions: [number, number][],
+): FeatureCollection<GeoPoint, GeoJsonProperties> {
+  const features: GeoFeature<GeoPoint, GeoJsonProperties>[] = leaves.map((leaf, i) => ({
+    type: "Feature",
+    id: leaf.properties?.id ?? `spider-${i}`,
+    properties: {
+      ...leaf.properties,
+      _spiderfied: true,
+    },
+    geometry: {
+      type: "Point",
+      coordinates: positions[i],
+    },
+  }));
+
+  return { type: "FeatureCollection", features };
+}
+
+/**
+ * Compute the cluster circle radius in pixels for a given point count.
+ * Mirrors the Mapbox layer paint: step(point_count, 14, 10→18, 25→24, 50→30)
+ * Plus 2px for the stroke width.
+ */
+function clusterRadiusPx(pointCount: number): number {
+  let r = 14;
+  if (pointCount >= 50) r = 30;
+  else if (pointCount >= 25) r = 24;
+  else if (pointCount >= 10) r = 18;
+  return r + 2; // account for stroke
+}
+
+function buildSpiderLegsGeoJSON(
+  center: [number, number],
+  positions: [number, number][],
+  zoom: number,
+  pointCount: number,
+): FeatureCollection<GeoLineString, GeoJsonProperties> {
+  // Offset leg start from center to the edge of the cluster circle
+  const edgeOffsetDeg = pixelsToDegrees(clusterRadiusPx(pointCount), zoom);
+
+  const features: GeoFeature<GeoLineString, GeoJsonProperties>[] = positions.map((pos, i) => {
+    // Direction from center to this node
+    const dx = pos[0] - center[0];
+    const dy = pos[1] - center[1];
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    // Start at the circle edge along the direction toward this node
+    const legStart: [number, number] = dist > 0
+      ? [center[0] + (dx / dist) * edgeOffsetDeg, center[1] + (dy / dist) * edgeOffsetDeg]
+      : center;
+
+    return {
+      type: "Feature",
+      properties: { index: i, centerLng: center[0], centerLat: center[1] },
+      geometry: {
+        type: "LineString",
+        coordinates: [legStart, pos],
+      },
+    };
+  });
+
+  return { type: "FeatureCollection", features };
+}
+
+/** Interpolate positions between center and target for animation frames. */
+function interpolatePositions(
+  center: [number, number],
+  targets: [number, number][],
+  t: number,
+): [number, number][] {
+  // ease-out cubic for a snappy, decelerating feel
+  const eased = 1 - Math.pow(1 - t, 3);
+  return targets.map(([lng, lat]) => [
+    center[0] + (lng - center[0]) * eased,
+    center[1] + (lat - center[1]) * eased,
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Layer management
+// ---------------------------------------------------------------------------
+
+/** Check whether spiderfy layers are currently on the map. */
+export function isSpiderfied(map: MbMap): boolean {
+  return !!map.getSource(SPIDERFY_SOURCE_NODES);
+}
+
+/** Remove all spiderfy layers and sources (safe to call when none exist). */
+export function removeSpiderfyLayers(map: MbMap): void {
+  activeState = null;
+  for (const id of [SPIDERFY_LAYER_LABELS, SPIDERFY_LAYER_NODES, SPIDERFY_LAYER_LEGS]) {
+    if (map.getLayer(id)) map.removeLayer(id);
+  }
+  for (const id of [SPIDERFY_SOURCE_NODES, SPIDERFY_SOURCE_LEGS]) {
+    if (map.getSource(id)) map.removeSource(id);
+  }
+}
+
+/** Create spiderfy sources and layers (empty data initially). */
+function addSpiderfyLayers(map: MbMap): void {
+  // Sources
+  map.addSource(SPIDERFY_SOURCE_LEGS, {
+    type: "geojson",
+    data: { type: "FeatureCollection", features: [] },
+  });
+
+  map.addSource(SPIDERFY_SOURCE_NODES, {
+    type: "geojson",
+    data: { type: "FeatureCollection", features: [] },
+  });
+
+  // Spider legs — thin dashed lines from cluster center to fanned-out node
+  map.addLayer({
+    id: SPIDERFY_LAYER_LEGS,
+    type: "line",
+    source: SPIDERFY_SOURCE_LEGS,
+    paint: {
+      "line-width": 1.5,
+      "line-color": "rgba(255, 255, 255, 0.55)",
+      "line-dasharray": [2, 3],
+    },
+  });
+
+  // Spiderfied node circles — mirrors unclustered-nodes styling
+  map.addLayer({
+    id: SPIDERFY_LAYER_NODES,
+    type: "circle",
+    source: SPIDERFY_SOURCE_NODES,
+    paint: {
+      "circle-radius": [
+        "case",
+        ["boolean", ["feature-state", "selected"], false],
+        10,
+        6,
+      ],
+      "circle-color": [
+        "case",
+        ["boolean", ["get", "online"], false],
+        "#32f032",
+        "rgba(0,0,0,0.50)",
+      ],
+      "circle-stroke-width": 2,
+      "circle-stroke-color": [
+        "case",
+        ["boolean", ["feature-state", "selected"], false],
+        "orange",
+        "white",
+      ],
+    },
+  });
+
+  // Spiderfied node labels — mirrors unclustered-labels styling
+  map.addLayer({
+    id: SPIDERFY_LAYER_LABELS,
+    type: "symbol",
+    source: SPIDERFY_SOURCE_NODES,
+    layout: {
+      "text-field": ["get", "shortname"],
+      "text-size": 13,
+      "text-offset": [0, 1.2],
+      "text-anchor": "top",
+      "text-optional": true,
+    },
+    paint: {
+      "text-halo-color": "#000000",
+      "text-halo-width": 1.25,
+      "text-color": "#ffffff",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Fan out the leaves of a cluster in a circle/spiral with animated transition.
+ *
+ * Resolves once the final position is set (animation complete).
+ */
+export async function spiderfy(
+  map: MbMap,
+  clusterId: number,
+  center: [number, number],
+  zoom: number,
+  animate: boolean = true,
+): Promise<void> {
+  // Remove any prior spiderfy state
+  removeSpiderfyLayers(map);
+
+  // Fetch cluster leaves
+  const source = map.getSource("nodes_clustered") as MbGeoJSONSource | undefined;
+  if (!source) return;
+
+  const leaves = await new Promise<GeoFeature<GeoPoint, GeoJsonProperties>[]>((resolve, reject) => {
+    source.getClusterLeaves(clusterId, Infinity, 0, (err, features) => {
+      if (err) return reject(err);
+      resolve((features ?? []) as GeoFeature<GeoPoint, GeoJsonProperties>[]);
+    });
+  });
+
+  if (leaves.length === 0) return;
+
+  // Store active state so we can update positions on zoom
+  activeState = { clusterId, center, leaves, lastZoom: zoom };
+
+  // Compute final fanned-out positions
+  const finalPositions = computeSpiderfiedPositions(center, leaves.length, zoom);
+
+  // Create layers
+  addSpiderfyLayers(map);
+
+  const nodeSource = map.getSource(SPIDERFY_SOURCE_NODES) as MbGeoJSONSource;
+  const legSource = map.getSource(SPIDERFY_SOURCE_LEGS) as MbGeoJSONSource;
+
+  if (!animate) {
+    // Instant placement (used for zoom updates)
+    nodeSource.setData(buildSpiderfiedNodesGeoJSON(leaves, finalPositions));
+    legSource.setData(buildSpiderLegsGeoJSON(center, finalPositions, zoom, leaves.length));
+    return;
+  }
+
+  // Animate the fan-out
+  return new Promise<void>((resolve) => {
+    const start = performance.now();
+
+    function frame(now: number) {
+      const elapsed = now - start;
+      const t = Math.min(elapsed / ANIMATE_MS, 1);
+
+      const currentPositions = interpolatePositions(center, finalPositions, t);
+
+      nodeSource.setData(buildSpiderfiedNodesGeoJSON(leaves, currentPositions));
+      legSource.setData(buildSpiderLegsGeoJSON(center, currentPositions, zoom, leaves.length));
+
+      if (t < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        resolve();
+      }
+    }
+
+    requestAnimationFrame(frame);
+  });
+}
+
+/**
+ * Animate the collapse of spiderfied nodes back to center, then remove layers.
+ */
+export async function unspiderfy(map: MbMap): Promise<void> {
+  if (!isSpiderfied(map)) return;
+
+  const state = activeState;
+  const nodeSource = map.getSource(SPIDERFY_SOURCE_NODES) as MbGeoJSONSource | undefined;
+  const legSource = map.getSource(SPIDERFY_SOURCE_LEGS) as MbGeoJSONSource | undefined;
+
+  if (!nodeSource || !legSource) {
+    removeSpiderfyLayers(map);
+    return;
+  }
+
+  // Read current spiderfied feature positions to animate back
+  const renderedNodes = map.queryRenderedFeatures(undefined as any, {
+    layers: [SPIDERFY_LAYER_NODES],
+  });
+
+  if (renderedNodes.length === 0) {
+    removeSpiderfyLayers(map);
+    return;
+  }
+
+  // Get the true center from state or from leg properties
+  let center: [number, number];
+  if (state) {
+    center = state.center;
+  } else {
+    const renderedLegs = map.queryRenderedFeatures(undefined as any, {
+      layers: [SPIDERFY_LAYER_LEGS],
+    });
+    if (renderedLegs.length > 0 && renderedLegs[0].properties?.centerLng != null) {
+      center = [renderedLegs[0].properties.centerLng, renderedLegs[0].properties.centerLat];
+    } else {
+      removeSpiderfyLayers(map);
+      return;
+    }
+  }
+
+  const currentPositions: [number, number][] = renderedNodes.map((f) => {
+    const coords = (f.geometry as GeoPoint).coordinates;
+    return [coords[0], coords[1]];
+  });
+
+  // Build leaf-like features for the collapse animation
+  const collapseFeatures: GeoFeature<GeoPoint, GeoJsonProperties>[] = renderedNodes.map((f) => ({
+    type: "Feature",
+    id: f.properties?.id ?? f.id,
+    properties: f.properties,
+    geometry: f.geometry as GeoPoint,
+  }));
+
+  // Clear state immediately so idle handler doesn't re-spiderfy during collapse
+  activeState = null;
+
+  return new Promise<void>((resolve) => {
+    const start = performance.now();
+    const collapseDuration = ANIMATE_MS * 0.7; // slightly faster collapse
+
+    function frame(now: number) {
+      const elapsed = now - start;
+      const t = Math.min(elapsed / collapseDuration, 1);
+
+      // Reverse: interpolate from current positions toward center
+      const positions = interpolatePositions(center, currentPositions, 1 - t);
+
+      try {
+        nodeSource!.setData(buildSpiderfiedNodesGeoJSON(collapseFeatures, positions));
+        legSource!.setData(buildSpiderLegsGeoJSON(center, positions, map.getZoom(), collapseFeatures.length));
+      } catch {
+        // Source may have been removed during animation (e.g. style change)
+        removeSpiderfyLayers(map);
+        resolve();
+        return;
+      }
+
+      if (t < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        removeSpiderfyLayers(map);
+        resolve();
+      }
+    }
+
+    requestAnimationFrame(frame);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Update positions on zoom (no remove/re-add, just recompute coordinates)
+// ---------------------------------------------------------------------------
+
+/**
+ * Recompute spiderfied node positions for the current zoom level.
+ * Call on `zoomend` to keep the fan-out visually consistent.
+ * Does nothing if no spiderfy is active.
+ */
+export function updateSpiderfyPositions(map: MbMap): void {
+  if (!activeState) return;
+  if (!isSpiderfied(map)) return;
+
+  const zoom = map.getZoom();
+
+  // Collapse if user zoomed out past the auto-spiderfy threshold
+  if (zoom < AUTO_SPIDERFY_MIN_ZOOM) {
+    removeSpiderfyLayers(map);
+    return;
+  }
+
+  const { center, leaves } = activeState;
+  activeState.lastZoom = zoom;
+
+  const positions = computeSpiderfiedPositions(center, leaves.length, zoom);
+
+  try {
+    const nodeSource = map.getSource(SPIDERFY_SOURCE_NODES) as MbGeoJSONSource | undefined;
+    const legSource = map.getSource(SPIDERFY_SOURCE_LEGS) as MbGeoJSONSource | undefined;
+    if (!nodeSource || !legSource) return;
+
+    nodeSource.setData(buildSpiderfiedNodesGeoJSON(leaves, positions));
+    legSource.setData(buildSpiderLegsGeoJSON(center, positions, zoom, leaves.length));
+  } catch {
+    // Sources may have been removed
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-spiderfy
+// ---------------------------------------------------------------------------
+
+/**
+ * Automatically spiderfy visible clusters that can't expand further.
+ * Call on `idle`. Checks all visible clusters regardless of zoom level —
+ * if a cluster's expansion zoom >= maxZoom, it gets spiderfied.
+ */
+/** Zoom level at which individual nodes would normally appear (pre-spiderfy). */
+const AUTO_SPIDERFY_MIN_ZOOM = 14;
+
+export async function autoSpiderfyVisibleClusters(map: MbMap): Promise<void> {
+  // Don't re-spiderfy if already active (prevents idle → spiderfy → idle loop)
+  if (activeState) return;
+  if (!map.getLayer("clusters")) return;
+
+  const maxZoom = map.getMaxZoom();
+  const currentZoom = map.getZoom();
+
+  // Only auto-spiderfy when zoomed in to street/neighborhood level
+  if (currentZoom < AUTO_SPIDERFY_MIN_ZOOM) return;
+
+  // Query visible cluster features
+  const clusterFeatures = map.queryRenderedFeatures(undefined as any, {
+    layers: ["clusters"],
+  });
+
+  if (clusterFeatures.length === 0) return;
+
+  const source = map.getSource("nodes_clustered") as MbGeoJSONSource | undefined;
+  if (!source) return;
+
+  // Find clusters that can't expand and spiderfy them
+  for (const cluster of clusterFeatures) {
+    const clusterId = cluster.properties?.cluster_id;
+    if (clusterId == null) continue;
+
+    const expansionZoom = await new Promise<number | null>((resolve) => {
+      source.getClusterExpansionZoom(clusterId, (err, zoom) => {
+        if (err) return resolve(null);
+        resolve(zoom ?? null);
+      });
+    });
+
+    if (expansionZoom == null) continue;
+
+    if (expansionZoom >= maxZoom) {
+      const [lng, lat] = (cluster.geometry as any).coordinates as [number, number];
+      await spiderfy(map, clusterId, [lng, lat], map.getZoom());
+      return; // one cluster at a time to avoid visual clutter
+    }
+  }
+}

--- a/frontend/src/pages/map/utils.ts
+++ b/frontend/src/pages/map/utils.ts
@@ -8,6 +8,7 @@ import type {
 import type { Map as MbMap } from "mapbox-gl";
 import type { Map as OlMap } from "ol";
 
+import { removeSpiderfyLayers } from "./spiderfy";
 import type { IMapNode } from "./types";
 
 export function escapeHtml(text: string): string {
@@ -117,4 +118,9 @@ export function applyMapboxClusterVisibility(map: MbMap, enabled: boolean): void
   // plain set
   set("plain-nodes", !enabled);
   set("plain-labels", !enabled);
+
+  // Clear spiderfy when switching away from clustered mode
+  if (!enabled) {
+    removeSpiderfyLayers(map);
+  }
 }


### PR DESCRIPTION
- Adds spiderfy behavior for overlapping/co-located nodes on both Mapbox and OpenLayers map providers
- When nodes share the same coordinates, they stay clustered and fan out in a circle (≤8 nodes) or Fermat spiral (>8) with animated spider legs when clicked or auto-expanded at high zoom
- Clustering is now supported on both providers (previously Mapbox only) with a unified toggle in Map Settings

Closes #344 