### PR TITLE
Add node legend, neighbor link display modes, and My Node selection to map

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -25,11 +25,11 @@ import { reverseGeocode } from "../maps/geocoder";
 import { useGetConfigQuery, useGetNodesQuery } from "../slices/apiSlice";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
 import { clearDetailsPanel, getDetailsDom, setDetailsPanelContent } from "./map/detailsDom";
-import { buildMapboxLinkFeatureCollection, buildNodeDetailsHtml } from "./map/detailsHtml";
+import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildNodeDetailsHtml, computeHeardByIds } from "./map/detailsHtml";
 import { MapDetailsPanel } from "./map/MapDetailsPanel";
 import { MapSettingsPanel } from "./map/MapSettingsPanel";
 import { LS_KEYS, readJson, toMapboxStyleUrl, writeJson } from "./map/storage";
-import type { IFeatureNode, IMapNode, MapProvider, NodeLike } from "./map/types";
+import type { IFeatureNode, IMapNode, LinkMode, MapProvider, NodeLike } from "./map/types";
 import {
   autoSpiderfyVisibleClusters,
   removeSpiderfyLayers,
@@ -95,6 +95,7 @@ export function Map() {
   const olBaseLayerRef = useRef<ReturnType<typeof createBaseTileLayer> | null>(null);
   const olNodesSourceRef = useRef<VectorSource<Feature<Point>> | null>(null);
   const olClusterSetupRef = useRef<OlClusterSetup | null>(null);
+  const olPersistentLinksLayerRef = useRef<VectorLayer<VectorSource<Feature>, Feature> | null>(null);
 
   // Mapbox refs (Mapbox path)
   const mbMapRef = useRef<MbMap | null>(null);
@@ -143,6 +144,15 @@ export function Map() {
     return stored ?? true;
   });
 
+  const [linkMode, setLinkMode] = useState<LinkMode>(() => {
+    const stored = readJson<LinkMode | null>(LS_KEYS.linkMode, null);
+    return stored ?? "selected";
+  });
+
+  const [myNodeId, setMyNodeId] = useState<string>(() => {
+    return readJson<string>(LS_KEYS.myNodeId, "");
+  });
+
   // Settings panel visibility
   const [settingsPanelOpen, setSettingsPanelOpen] = useState<boolean>(() => {
     const stored = readJson<boolean | null>(LS_KEYS.settingsPanelOpen, null);
@@ -156,6 +166,8 @@ export function Map() {
   useEffect(() => writeJson(LS_KEYS.osmBasemap, osmBasemap), [osmBasemap]);
   useEffect(() => writeJson(LS_KEYS.recentDays, recentDays), [recentDays]);
   useEffect(() => writeJson(LS_KEYS.clusterEnabled, clusterEnabled), [clusterEnabled]);
+  useEffect(() => writeJson(LS_KEYS.linkMode, linkMode), [linkMode]);
+  useEffect(() => writeJson(LS_KEYS.myNodeId, myNodeId), [myNodeId]);
   useEffect(() => writeJson(LS_KEYS.settingsPanelOpen, settingsPanelOpen), [settingsPanelOpen]);
 
   // If token disappears / not configured, force provider to osm
@@ -244,6 +256,8 @@ export function Map() {
   const nodesRef = useRef(nodes);
   const recentDaysRef = useRef(recentDays);
   const clusterEnabledRef = useRef(clusterEnabled);
+  const linkModeRef = useRef(linkMode);
+  const myNodeIdRef = useRef(myNodeId);
 
   useEffect(() => {
     nodesRef.current = nodes;
@@ -256,6 +270,14 @@ export function Map() {
   useEffect(() => {
     clusterEnabledRef.current = clusterEnabled;
   }, [clusterEnabled]);
+
+  useEffect(() => {
+    linkModeRef.current = linkMode;
+  }, [linkMode]);
+
+  useEffect(() => {
+    myNodeIdRef.current = myNodeId;
+  }, [myNodeId]);
 
   // ----------------------------
   // Deep-link: ?node=<id> flies to a specific node
@@ -325,6 +347,104 @@ export function Map() {
     return () => timers.forEach(clearTimeout);
   }, [urlNodeId, flyToTarget, olMap, setSearchParams]);
 
+  /** Show a brief toast confirming "My Node" was set. */
+  function showMyNodeToast(name: string) {
+    const existing = document.getElementById("my-node-toast");
+    if (existing) existing.remove();
+
+    const toast = document.createElement("div");
+    toast.id = "my-node-toast";
+    toast.textContent = `My Node set to ${name}`;
+    toast.className =
+      "fixed top-4 left-1/2 -translate-x-1/2 z-[9999] px-4 py-2 rounded-lg shadow-lg " +
+      "bg-gray-900/95 text-white text-sm backdrop-blur-md border border-gray-700 " +
+      "transition-opacity duration-300";
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      toast.style.opacity = "0";
+      setTimeout(() => toast.remove(), 300);
+    }, 2000);
+  }
+
+  /** Compute the persistent link GeoJSON for the current linkMode (all/mynode). */
+  function computePersistentLinks() {
+    const mode = linkModeRef.current;
+    const liveNodes = nodesRef.current;
+
+    if (mode === "all") {
+      return buildAllLinksFeatureCollection(liveNodes);
+    }
+
+    if (mode === "mynode") {
+      const id = myNodeIdRef.current;
+      const node = liveNodes[id];
+      if (node?.map_position) {
+        const nodeLike: NodeLike = {
+          id,
+          shortname: node.shortname,
+          longname: node.longname,
+          last_seen: node.last_seen,
+          online: Boolean(node.online),
+          position: node.map_position,
+          neighbors: node.neighbors,
+        };
+        const heardBy = computeHeardByIds(liveNodes, id);
+        return buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy });
+      }
+    }
+
+    return emptyLineFeatureCollection();
+  }
+
+  /** Build OL line features for the current persistent link mode. */
+  function buildOlPersistentLinkFeatures(): Feature<LineString>[] {
+    const geojson = computePersistentLinks();
+    return geojson.features.map((f) => {
+      const coords = f.geometry.coordinates.map((c) =>
+        transform([c[0], c[1]], "EPSG:4326", "EPSG:3857")
+      );
+      const line = new Feature({ geometry: new LineString(coords) });
+      const kind = f.properties?.kind ?? "neighbor";
+      const color = kind === "both" ? "#FF66FF" : kind === "heard_by" ? "#6666FF" : "#66FF66";
+      line.setStyle(
+        new Style({
+          stroke: new Stroke({ color, width: 4 }),
+        })
+      );
+      return line;
+    });
+  }
+
+  /** Refresh the OL persistent links layer. */
+  function refreshOlPersistentLinks(map: OlMap) {
+    // Remove old layer
+    if (olPersistentLinksLayerRef.current) {
+      map.removeLayer(olPersistentLinksLayerRef.current);
+      olPersistentLinksLayerRef.current = null;
+    }
+
+    const mode = linkModeRef.current;
+    if (mode === "selected") return;
+
+    const features = buildOlPersistentLinkFeatures();
+    if (features.length === 0) return;
+
+    const source = new VectorSource({ features: features as Feature[] });
+    const layer = new VectorLayer({ source });
+    olPersistentLinksLayerRef.current = layer;
+    map.addLayer(layer);
+  }
+
+  /** Push persistent link data to the Mapbox "links" source. */
+  function refreshMapboxLinks() {
+    const map = mbMapRef.current;
+    if (!map) return;
+    try {
+      const linksSource = map.getSource("links") as MbGeoJSONSource | undefined;
+      linksSource?.setData(computePersistentLinks());
+    } catch {}
+  }
+
   function clearMapboxSelectionAndOverlays() {
     const map = mbMapRef.current;
     const selectedId = mbSelectedIdRef.current;
@@ -342,11 +462,11 @@ export function Map() {
 
     mbSelectedIdRef.current = null;
 
-    // Clear link lines if present
+    // Restore persistent links (all/mynode) or clear if mode is "selected"
     if (map) {
       try {
         const linksSource = map.getSource("links") as MbGeoJSONSource | undefined;
-        linksSource?.setData(emptyLineFeatureCollection());
+        linksSource?.setData(computePersistentLinks());
       } catch {}
     }
 
@@ -834,6 +954,61 @@ export function Map() {
         }
       });
 
+      // Right-click / long-press: "Set as My Node"
+      const findNodeIdAtPoint = (point: mapboxgl.PointLike): string | null => {
+        const nodeLayers = ["unclustered-nodes", "plain-nodes"];
+        if (map.getLayer(SPIDERFY_LAYER_NODES)) nodeLayers.push(SPIDERFY_LAYER_NODES);
+        const features = map.queryRenderedFeatures(point, { layers: nodeLayers });
+        return (features[0]?.properties?.id as string) ?? null;
+      };
+
+      // Right-click (desktop)
+      map.on("contextmenu", (e) => {
+        const id = findNodeIdAtPoint(e.point);
+        if (!id) return;
+        e.preventDefault();
+        const node = nodesRef.current[id];
+        const name = node?.shortname || node?.longname || id;
+        showMyNodeToast(name);
+        setMyNodeId(id);
+        setLinkMode("mynode");
+      });
+
+      // Long-press (mobile) — 500ms threshold
+      let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+      let longPressPoint: mapboxgl.PointLike | null = null;
+
+      const canvas = map.getCanvas();
+      canvas.addEventListener("touchstart", (e) => {
+        if (e.touches.length !== 1) return;
+        const rect = canvas.getBoundingClientRect();
+        longPressPoint = [
+          e.touches[0].clientX - rect.left,
+          e.touches[0].clientY - rect.top,
+        ];
+        longPressTimer = setTimeout(() => {
+          if (!longPressPoint) return;
+          const id = findNodeIdAtPoint(longPressPoint);
+          if (!id) return;
+          const node = nodesRef.current[id];
+          const name = node?.shortname || node?.longname || id;
+          showMyNodeToast(name);
+          setMyNodeId(id);
+          setLinkMode("mynode");
+          longPressPoint = null;
+        }, 500);
+      }, { passive: true });
+
+      canvas.addEventListener("touchmove", () => {
+        if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+        longPressPoint = null;
+      }, { passive: true });
+
+      canvas.addEventListener("touchend", () => {
+        if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+        longPressPoint = null;
+      }, { passive: true });
+
       // Escape key collapses spiderfy
       const handleKeydown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
@@ -930,6 +1105,28 @@ export function Map() {
       }
     }
   }, [nodes, recentDays, provider]);
+
+  // Mapbox: react to linkMode / myNodeId / nodes changes for persistent links
+  useEffect(() => {
+    const map = mbMapRef.current;
+    if (!map) return;
+    if (provider !== "mapbox") return;
+
+    // In "selected" mode, don't override — handleNodeClick manages links
+    if (linkMode === "selected" && !mbSelectedIdRef.current) {
+      // Clear any lingering persistent links
+      try {
+        const linksSource = map.getSource("links") as MbGeoJSONSource | undefined;
+        linksSource?.setData(emptyLineFeatureCollection());
+      } catch {}
+      return;
+    }
+
+    if (linkMode !== "selected") {
+      refreshMapboxLinks();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [linkMode, myNodeId, nodes, provider]);
 
   // ----------------------------
   // OpenLayers: init (OSM path)
@@ -1145,6 +1342,63 @@ export function Map() {
     const select = new Select({ condition: click, style: selectedStyle });
     map.addInteraction(select);
 
+    // Draw persistent links if mode is all/mynode at init
+    refreshOlPersistentLinks(map);
+
+    // Right-click / long-press: "Set as My Node" (OL)
+    const findOlNodeAtPixel = (pixel: number[]): IFeatureNode | null => {
+      let found: IFeatureNode | null = null;
+      map.forEachFeatureAtPixel(pixel, (f) => {
+        const props = f.getProperties();
+        if (props.node?.id) found = props.node as IFeatureNode;
+      });
+      return found;
+    };
+
+    map.getViewport().addEventListener("contextmenu", (e) => {
+      const pixel = map.getEventPixel(e);
+      const node = findOlNodeAtPixel(pixel);
+      if (!node) return;
+      e.preventDefault();
+      const name = node.shortname || node.longname || node.id;
+      showMyNodeToast(name);
+      setMyNodeId(node.id);
+      setLinkMode("mynode");
+    });
+
+    // Long-press for mobile (OL)
+    let olLongPressTimer: ReturnType<typeof setTimeout> | null = null;
+    let olLongPressPixel: number[] | null = null;
+
+    map.getViewport().addEventListener("touchstart", (e) => {
+      if (e.touches.length !== 1) return;
+      const rect = map.getViewport().getBoundingClientRect();
+      olLongPressPixel = [
+        e.touches[0].clientX - rect.left,
+        e.touches[0].clientY - rect.top,
+      ];
+      olLongPressTimer = setTimeout(() => {
+        if (!olLongPressPixel) return;
+        const node = findOlNodeAtPixel(olLongPressPixel);
+        if (!node) return;
+        const name = node.shortname || node.longname || node.id;
+        showMyNodeToast(name);
+        setMyNodeId(node.id);
+        setLinkMode("mynode");
+        olLongPressPixel = null;
+      }, 500);
+    }, { passive: true });
+
+    map.getViewport().addEventListener("touchmove", () => {
+      if (olLongPressTimer) { clearTimeout(olLongPressTimer); olLongPressTimer = null; }
+      olLongPressPixel = null;
+    }, { passive: true });
+
+    map.getViewport().addEventListener("touchend", () => {
+      if (olLongPressTimer) { clearTimeout(olLongPressTimer); olLongPressTimer = null; }
+      olLongPressPixel = null;
+    }, { passive: true });
+
     map.on("singleclick", async (event) => {
       neighborLayers.forEach((layer) => map.removeLayer(layer));
       neighborLayers.length = 0;
@@ -1321,11 +1575,29 @@ export function Map() {
     }
   }, [clusterEnabled, provider, olMap]);
 
+  // OpenLayers: react to linkMode / myNodeId / nodes changes for persistent links
+  useEffect(() => {
+    if (provider !== "osm") return;
+    if (!olMap) return;
+    refreshOlPersistentLinks(olMap);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [linkMode, myNodeId, nodes, provider, olMap]);
+
   // ----------------------------
   // Settings panel UI
   // ----------------------------
   const canUseMapbox = hasMapbox;
   const usingMapbox = provider === "mapbox" && canUseMapbox;
+
+  // Flat sorted list of nodes with positions for the My Node picker
+  const nodeList = useMemo(
+    () =>
+      Object.entries(nodes)
+        .filter(([, n]) => n.map_position)
+        .map(([id, n]) => ({ id, shortname: n.shortname, longname: n.longname }))
+        .sort((a, b) => (a.shortname ?? "").localeCompare(b.shortname ?? "")),
+    [nodes]
+  );
 
   return (
     <div className="relative w-full h-full min-h-0 overflow-hidden overscroll-none">
@@ -1346,6 +1618,11 @@ export function Map() {
         setRecentDays={setRecentDays}
         clusterEnabled={clusterEnabled}
         setClusterEnabled={setClusterEnabled}
+        linkMode={linkMode}
+        setLinkMode={setLinkMode}
+        myNodeId={myNodeId}
+        setMyNodeId={setMyNodeId}
+        nodeList={nodeList}
         canUseMapbox={canUseMapbox}
         usingMapbox={usingMapbox}
       />

--- a/frontend/src/pages/map/MapLegend.tsx
+++ b/frontend/src/pages/map/MapLegend.tsx
@@ -1,4 +1,19 @@
-export function MapLegend() {
+import type { LinkMode } from "./types";
+
+export function MapLegend({
+  linkMode = "selected",
+  myNodeLabel,
+}: {
+  linkMode?: LinkMode;
+  myNodeLabel?: string;
+}) {
+  const linkHint =
+    linkMode === "all"
+      ? "Showing links for all nodes."
+      : linkMode === "mynode"
+        ? `Showing links for ${myNodeLabel || "My Node"}.`
+        : "Links shown when a node is selected.";
+
   return (
     <div
       id="legend"
@@ -40,7 +55,7 @@ export function MapLegend() {
         <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-tight">
           Online = seen in last 6 hours.
           <br />
-          Lines shown when a node is selected.
+          {linkHint}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/map/MapLegend.tsx
+++ b/frontend/src/pages/map/MapLegend.tsx
@@ -7,18 +7,40 @@ export function MapLegend() {
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
         Legend
       </div>
-      <div className="space-y-1 text-xs text-gray-600 dark:text-gray-300">
-        <div className="flex items-center justify-center gap-2">
-          <div className="w-4 h-1 bg-green-400 rounded-full" />
+      <div className="space-y-1.5 text-xs text-gray-600 dark:text-gray-300">
+        {/* Node symbols */}
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-[#32f032] border-2 border-white shadow-sm shrink-0" />
+          <span>Online Node</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-black/50 border-2 border-white shadow-sm shrink-0" />
+          <span>Offline Node</span>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
+
+        {/* Line symbols */}
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-[#66FF66] rounded-full shrink-0" />
           <span>Heard A Neighbor</span>
         </div>
-        <div className="flex items-center justify-center gap-2">
-          <div className="w-4 h-1 bg-blue-400 rounded-full" />
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-[#6666FF] rounded-full shrink-0" />
           <span>Heard By Neighbor</span>
         </div>
-        <div className="flex items-center justify-center gap-2">
-          <div className="w-4 h-1 bg-purple-400 rounded-full" />
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-[#FF66FF] rounded-full shrink-0" />
           <span>Mutual Connection</span>
+        </div>
+
+        {/* Threshold note */}
+        <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
+        <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-tight">
+          Online = seen in last 6 hours.
+          <br />
+          Lines shown when a node is selected.
         </div>
       </div>
     </div>

--- a/frontend/src/pages/map/MapSettingsPanel.tsx
+++ b/frontend/src/pages/map/MapSettingsPanel.tsx
@@ -1,8 +1,14 @@
-import type { Dispatch, RefObject, SetStateAction } from "react";
+import { type Dispatch, type RefObject, type SetStateAction, useMemo, useState } from "react";
 
 import type { OsmBasemap } from "../../maps/baseLayer";
 import { MapLegend } from "./MapLegend";
-import type { MapProvider } from "./types";
+import type { LinkMode, MapProvider } from "./types";
+
+interface NodeOption {
+  id: string;
+  shortname?: string;
+  longname?: string;
+}
 
 export function MapSettingsPanel({
   settingsPanelRef,
@@ -24,6 +30,14 @@ export function MapSettingsPanel({
 
   clusterEnabled,
   setClusterEnabled,
+
+  linkMode,
+  setLinkMode,
+
+  myNodeId,
+  setMyNodeId,
+
+  nodeList,
 
   canUseMapbox,
   usingMapbox,
@@ -48,9 +62,41 @@ export function MapSettingsPanel({
   clusterEnabled: boolean;
   setClusterEnabled: Dispatch<SetStateAction<boolean>>;
 
+  linkMode: LinkMode;
+  setLinkMode: Dispatch<SetStateAction<LinkMode>>;
+
+  myNodeId: string;
+  setMyNodeId: Dispatch<SetStateAction<string>>;
+
+  nodeList: NodeOption[];
+
   canUseMapbox: boolean;
   usingMapbox: boolean;
 }) {
+  const [nodeSearch, setNodeSearch] = useState("");
+
+  const filteredNodes = useMemo(() => {
+    if (!nodeSearch) return nodeList.slice(0, 50);
+    const q = nodeSearch.toLowerCase();
+    return nodeList
+      .filter(
+        (n) =>
+          n.id.toLowerCase().includes(q) ||
+          n.shortname?.toLowerCase().includes(q) ||
+          n.longname?.toLowerCase().includes(q)
+      )
+      .slice(0, 50);
+  }, [nodeList, nodeSearch]);
+
+  const myNodeLabel = useMemo(() => {
+    if (!myNodeId) return "";
+    const node = nodeList.find((n) => n.id === myNodeId);
+    return node?.shortname || node?.longname || myNodeId;
+  }, [myNodeId, nodeList]);
+
+  const selectClasses =
+    "w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100 focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400";
+
   return (
     <div className="fixed bottom-4 right-4 z-1100 min-w-56">
       {/* Toggle button - shows when closed */}
@@ -86,7 +132,7 @@ export function MapSettingsPanel({
       {settingsPanelOpen && (
         <div
           ref={settingsPanelRef}
-          className="mb-2 w-56 max-w-[calc(100vw-2rem)] rounded-xl shadow-lg border border-gray-200/70 dark:border-gray-700/70 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md"
+          className="mb-2 w-64 max-w-[calc(100vw-2rem)] max-h-[calc(100vh-8rem)] overflow-y-auto rounded-xl shadow-lg border border-gray-200/70 dark:border-gray-700/70 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md"
         >
           <div className="p-4">
             <div className="flex items-center justify-between mb-4">
@@ -128,7 +174,7 @@ export function MapSettingsPanel({
                 <select
                   id="provider-select"
                   aria-label="Map provider selection"
-                  className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100 focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400"
+                  className={selectClasses}
                   value={provider}
                   onChange={(e) => setProvider(e.target.value as MapProvider)}
                 >
@@ -152,7 +198,7 @@ export function MapSettingsPanel({
                   <select
                     id="mapbox-style-select"
                     aria-label="Mapbox map style selection"
-                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100 focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400"
+                    className={selectClasses}
                     value={mapboxStyle}
                     onChange={(e) => setMapboxStyle(e.target.value)}
                   >
@@ -174,7 +220,7 @@ export function MapSettingsPanel({
                   <select
                     id="osm-basemap-select"
                     aria-label="OpenStreetMap basemap selection"
-                    className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100 focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400"
+                    className={selectClasses}
                     value={osmBasemap}
                     onChange={(e) => setOsmBasemap(e.target.value as OsmBasemap)}
                   >
@@ -197,7 +243,7 @@ export function MapSettingsPanel({
                 <select
                   id="recent-days-select"
                   aria-label="Filter nodes by last seen timeframe"
-                  className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-gray-100 focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400"
+                  className={selectClasses}
                   value={recentDays}
                   onChange={(e) => setRecentDays(Number(e.target.value))}
                 >
@@ -209,6 +255,100 @@ export function MapSettingsPanel({
                   <option value={1}>1 day</option>
                 </select>
               </div>
+
+              {/* Neighbor Links */}
+              <div>
+                <label
+                  htmlFor="link-mode-select"
+                  className="text-xs font-medium uppercase tracking-wide text-gray-600 dark:text-gray-300 mb-2 block"
+                >
+                  Neighbor Links
+                </label>
+                <select
+                  id="link-mode-select"
+                  aria-label="Neighbor link display mode"
+                  className={selectClasses}
+                  value={linkMode}
+                  onChange={(e) => setLinkMode(e.target.value as LinkMode)}
+                >
+                  <option value="selected">Selected Node</option>
+                  <option value="all">All Nodes</option>
+                  <option value="mynode">My Node</option>
+                </select>
+              </div>
+
+              {/* My Node picker — shown when mode is "mynode" */}
+              {linkMode === "mynode" && (
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <label
+                      htmlFor="my-node-search"
+                      className="text-xs font-medium uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                    >
+                      My Node
+                      {myNodeLabel && (
+                        <span className="ml-1 normal-case font-normal text-gray-500 dark:text-gray-400">
+                          ({myNodeLabel})
+                        </span>
+                      )}
+                    </label>
+                    {myNodeId && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMyNodeId("");
+                          setLinkMode("selected");
+                        }}
+                        className="text-[10px] text-red-400 hover:text-red-300 transition-colors"
+                        aria-label="Clear My Node"
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                  <input
+                    id="my-node-search"
+                    type="text"
+                    placeholder="Search nodes..."
+                    className={selectClasses}
+                    value={nodeSearch}
+                    onChange={(e) => setNodeSearch(e.target.value)}
+                  />
+                  {nodeSearch && (
+                    <div className="mt-1 max-h-32 overflow-y-auto rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800">
+                      {filteredNodes.length === 0 && (
+                        <div className="px-3 py-2 text-xs text-gray-400">
+                          No nodes found
+                        </div>
+                      )}
+                      {filteredNodes.map((node) => (
+                        <button
+                          key={node.id}
+                          type="button"
+                          className="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 truncate"
+                          onClick={() => {
+                            setMyNodeId(node.id);
+                            setNodeSearch("");
+                          }}
+                        >
+                          <span className="font-medium">
+                            {node.shortname || node.id}
+                          </span>
+                          {node.longname && (
+                            <span className="ml-1 text-gray-500 dark:text-gray-400">
+                              {node.longname}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+                    Tip: right-click (or long-press) a node on the map to set it
+                    as My Node.
+                  </p>
+                </div>
+              )}
 
               {/* Clustering Toggle */}
               <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
@@ -251,7 +391,7 @@ export function MapSettingsPanel({
       )}
 
       {/* Legend */}
-      <MapLegend />
+      <MapLegend linkMode={linkMode} myNodeLabel={myNodeLabel} />
     </div>
   );
 }

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -153,3 +153,50 @@ export function buildMapboxLinkFeatureCollection(opts: {
 
   return { type: "FeatureCollection", features: linkFeatures };
 }
+
+/**
+ * Build link features for ALL nodes that have neighbor data.
+ * Deduplicates edges so A→B and B→A become a single "both" line.
+ */
+export function buildAllLinksFeatureCollection(
+  liveNodes: Record<string, IMapNode>,
+): FeatureCollection<GeoLineString, GeoJsonProperties> {
+  const linkFeatures: GeoFeature<GeoLineString, GeoJsonProperties>[] = [];
+
+  // Track edges we've already emitted (sorted key "idA|idB")
+  const seen = new Set<string>();
+
+  for (const [nodeId, node] of Object.entries(liveNodes)) {
+    if (!node.map_position || !node.neighbors?.length) continue;
+
+    for (const neighbor of node.neighbors) {
+      const other = liveNodes[neighbor.id];
+      if (!other?.map_position) continue;
+
+      const edgeKey = nodeId < neighbor.id
+        ? `${nodeId}|${neighbor.id}`
+        : `${neighbor.id}|${nodeId}`;
+
+      if (seen.has(edgeKey)) continue;
+      seen.add(edgeKey);
+
+      // Check if the reverse link also exists (mutual)
+      const reverseNeighbors = other.neighbors ?? [];
+      const isMutual = reverseNeighbors.some((n) => n.id === nodeId);
+
+      linkFeatures.push({
+        type: "Feature",
+        properties: { kind: isMutual ? "both" : "neighbor" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [node.map_position[0], node.map_position[1]],
+            [other.map_position[0], other.map_position[1]],
+          ],
+        },
+      });
+    }
+  }
+
+  return { type: "FeatureCollection", features: linkFeatures };
+}

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -5,6 +5,8 @@ export const LS_KEYS = {
   recentDays: "meshinfo.map.recentDays",
   clusterEnabled: "meshinfo.map.clusterEnabled",
   settingsPanelOpen: "meshinfo.map.settingsPanelOpen",
+  linkMode: "meshinfo.map.linkMode",
+  myNodeId: "meshinfo.map.myNodeId",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/types.ts
+++ b/frontend/src/pages/map/types.ts
@@ -3,6 +3,7 @@ import type { Coordinate } from "ol/coordinate";
 import type { INode } from "../../types";
 
 export type MapProvider = "osm" | "mapbox";
+export type LinkMode = "selected" | "all" | "mynode";
 
 export type IMapNode = INode & {
   online: boolean;


### PR DESCRIPTION
## Summary
- Add node symbols (online/offline) and online threshold note to the map legend, resolving the confusion around unlabeled green/gray dots (#83)
- Add "Neighbor Links" setting with three display modes: Selected Node (default/existing behavior), All Nodes (draws all known links at once), and My Node (persistently shows links for a saved node) (#83, #97)
- Add My Node selection via right-click (desktop) / long-press (mobile) on any map node, or via a searchable picker in settings, with localStorage persistence
- Legend dynamically updates to reflect the active link mode