### PR TITLE
Add traceroute-inferred links to map and detail panel

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -886,6 +886,7 @@ export function Map() {
           liveNodes,
           displayName,
           elsewhereLinks: config?.mesh?.elsewhere_links,
+          traceroutes: traceroutesRef.current,
         });
 
         setDetailsPanelContent({
@@ -1367,6 +1368,7 @@ export function Map() {
         liveNodes: nodes,
         displayName,
         elsewhereLinks: config?.mesh?.elsewhere_links,
+        traceroutes: traceroutesRef.current,
       });
 
       setDetailsPanelContent({

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -22,10 +22,10 @@ import { useSearchParams } from "react-router";
 import { env } from "../env";
 import { createBaseTileLayer, type OsmBasemap } from "../maps/baseLayer";
 import { reverseGeocode } from "../maps/geocoder";
-import { useGetConfigQuery, useGetNodesQuery } from "../slices/apiSlice";
+import { useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
 import { clearDetailsPanel, getDetailsDom, setDetailsPanelContent } from "./map/detailsDom";
-import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildNodeDetailsHtml, computeHeardByIds } from "./map/detailsHtml";
+import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildNodeDetailsHtml, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId } from "./map/detailsHtml";
 import { MapDetailsPanel } from "./map/MapDetailsPanel";
 import { MapSettingsPanel } from "./map/MapSettingsPanel";
 import { LS_KEYS, readJson, toMapboxStyleUrl, writeJson } from "./map/storage";
@@ -106,6 +106,7 @@ export function Map() {
 
   const { data: rawNodes = {} } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
+  const { data: rawTraceroutes = [] } = useGetTraceroutesQuery();
 
   // ----- env capabilities
   const mapboxToken = env.MAPBOX_TOKEN;
@@ -254,6 +255,7 @@ export function Map() {
   // Refs to avoid stale closures (Mapbox handlers)
   // ----------------------------
   const nodesRef = useRef(nodes);
+  const traceroutesRef = useRef(rawTraceroutes);
   const recentDaysRef = useRef(recentDays);
   const clusterEnabledRef = useRef(clusterEnabled);
   const linkModeRef = useRef(linkMode);
@@ -262,6 +264,10 @@ export function Map() {
   useEffect(() => {
     nodesRef.current = nodes;
   }, [nodes]);
+
+  useEffect(() => {
+    traceroutesRef.current = rawTraceroutes;
+  }, [rawTraceroutes]);
 
   useEffect(() => {
     recentDaysRef.current = recentDays;
@@ -366,13 +372,34 @@ export function Map() {
     }, 2000);
   }
 
-  /** Compute the persistent link GeoJSON for the current linkMode (all/mynode). */
+  /** Collect neighbor edge keys (for deduplication with traceroute links). */
+  function collectNeighborEdgeKeys(liveNodes: Record<string, IMapNode>): Set<string> {
+    const keys = new Set<string>();
+    for (const [nodeId, node] of Object.entries(liveNodes)) {
+      if (!node.neighbors?.length) continue;
+      for (const nb of node.neighbors) {
+        const a = nodeId < nb.id ? nodeId : nb.id;
+        const b = nodeId < nb.id ? nb.id : nodeId;
+        keys.add(`${a}|${b}`);
+      }
+    }
+    return keys;
+  }
+
+  /** Compute the persistent link GeoJSON for the current linkMode (all/mynode), including traceroute-inferred links. */
   function computePersistentLinks() {
     const mode = linkModeRef.current;
     const liveNodes = nodesRef.current;
+    const traceroutes = traceroutesRef.current;
 
     if (mode === "all") {
-      return buildAllLinksFeatureCollection(liveNodes);
+      const neighborFC = buildAllLinksFeatureCollection(liveNodes);
+      const neighborKeys = collectNeighborEdgeKeys(liveNodes);
+      const tracerouteFC = buildTracerouteLinkFeatureCollection(traceroutes, liveNodes, neighborKeys);
+      return {
+        type: "FeatureCollection" as const,
+        features: [...neighborFC.features, ...tracerouteFC.features],
+      };
     }
 
     if (mode === "mynode") {
@@ -389,7 +416,23 @@ export function Map() {
           neighbors: node.neighbors,
         };
         const heardBy = computeHeardByIds(liveNodes, id);
-        return buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy });
+        const neighborFC = buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy });
+        // For "mynode", also include traceroute links involving this node
+        const tracerouteFC = buildTracerouteLinkFeatureCollection(
+          traceroutes.filter((tr) => {
+            const norm = normNodeId(id);
+            const from = normNodeId(tr.from);
+            const to = normNodeId(tr.to);
+            if (from === norm || to === norm) return true;
+            const hops = (tr.route_ids ?? tr.route ?? []).map((r: string) => normNodeId(r));
+            return hops.includes(norm);
+          }),
+          liveNodes,
+        );
+        return {
+          type: "FeatureCollection" as const,
+          features: [...neighborFC.features, ...tracerouteFC.features],
+        };
       }
     }
 
@@ -678,6 +721,8 @@ export function Map() {
               "#6666FF",
               "both",
               "#FF66FF",
+              "traceroute",
+              "#F59E0B",
               "#FFFFFF",
             ],
           },
@@ -849,9 +894,35 @@ export function Map() {
           html,
         });
 
-        // Draw links
+        // Draw links (neighbor + traceroute)
+        const neighborFC = buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy });
+        const tracerouteFC = buildTracerouteLinkFeatureCollection(
+          traceroutesRef.current.filter((tr) => {
+            const norm = normNodeId(id);
+            const from = normNodeId(tr.from);
+            const to = normNodeId(tr.to);
+            if (from === norm || to === norm) return true;
+            const hops = (tr.route_ids ?? tr.route ?? []).map((r: string) => normNodeId(r));
+            return hops.includes(norm);
+          }),
+          liveNodes,
+        );
+        const mergedFC = {
+          type: "FeatureCollection" as const,
+          features: [...neighborFC.features, ...tracerouteFC.features],
+        };
+
         const linksSource = map.getSource("links") as MbGeoJSONSource | undefined;
-        linksSource?.setData(buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy }));
+        if (linkModeRef.current === "selected") {
+          linksSource?.setData(mergedFC);
+        } else {
+          // In all/mynode mode, merge with persistent links
+          const persistent = computePersistentLinks();
+          linksSource?.setData({
+            type: "FeatureCollection",
+            features: [...persistent.features, ...mergedFC.features],
+          });
+        }
       };
 
       // Cursor behaviors (both render modes)
@@ -1126,7 +1197,7 @@ export function Map() {
       refreshMapboxLinks();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [linkMode, myNodeId, nodes, provider]);
+  }, [linkMode, myNodeId, nodes, rawTraceroutes, provider]);
 
   // ----------------------------
   // OpenLayers: init (OSM path)
@@ -1581,7 +1652,7 @@ export function Map() {
     if (!olMap) return;
     refreshOlPersistentLinks(olMap);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [linkMode, myNodeId, nodes, provider, olMap]);
+  }, [linkMode, myNodeId, nodes, rawTraceroutes, provider, olMap]);
 
   // ----------------------------
   // Settings panel UI

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -378,8 +378,11 @@ export function Map() {
     for (const [nodeId, node] of Object.entries(liveNodes)) {
       if (!node.neighbors?.length) continue;
       for (const nb of node.neighbors) {
-        const a = nodeId < nb.id ? nodeId : nb.id;
-        const b = nodeId < nb.id ? nb.id : nodeId;
+        const normA = normNodeId(nodeId);
+        const normB = normNodeId(nb.id);
+        if (!normA || !normB || normA === normB) continue;
+        const a = normA < normB ? normA : normB;
+        const b = normA < normB ? normB : normA;
         keys.add(`${a}|${b}`);
       }
     }
@@ -448,7 +451,7 @@ export function Map() {
       );
       const line = new Feature({ geometry: new LineString(coords) });
       const kind = f.properties?.kind ?? "neighbor";
-      const color = kind === "both" ? "#FF66FF" : kind === "heard_by" ? "#6666FF" : "#66FF66";
+      const color = kind === "traceroute" ? "#F59E0B" : kind === "both" ? "#FF66FF" : kind === "heard_by" ? "#6666FF" : "#66FF66";
       line.setStyle(
         new Style({
           stroke: new Stroke({ color, width: 4 }),

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -893,6 +893,7 @@ export function Map() {
           title: node.longname ?? "",
           subtitle: node.shortname ?? "",
           html,
+          onNodeSelect: (targetId) => void handleNodeClick(targetId),
         });
 
         // Draw links (neighbor + traceroute)
@@ -1375,6 +1376,19 @@ export function Map() {
         title: node.longname ?? "",
         subtitle: node.shortname ?? "",
         html,
+        onNodeSelect: (targetId) => {
+          const targetNode = nodes[targetId];
+          if (!targetNode?.map_position) return;
+          void handleNodeDetails({
+            id: targetId,
+            shortname: targetNode.shortname,
+            longname: targetNode.longname,
+            last_seen: targetNode.last_seen,
+            position: [targetNode.map_position[0], targetNode.map_position[1]] as Coordinate,
+            online: Boolean(targetNode.online),
+            neighbors: targetNode.neighbors,
+          });
+        },
       });
 
       // Draw neighbor lines

--- a/frontend/src/pages/map/MapLegend.tsx
+++ b/frontend/src/pages/map/MapLegend.tsx
@@ -49,6 +49,10 @@ export function MapLegend({
           <div className="w-4 h-0.5 bg-[#FF66FF] rounded-full shrink-0" />
           <span>Mutual Connection</span>
         </div>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-[#F59E0B] rounded-full shrink-0" />
+          <span>Traceroute Link</span>
+        </div>
 
         {/* Threshold note */}
         <div className="border-t border-gray-200 dark:border-gray-700 my-1" />

--- a/frontend/src/pages/map/detailsDom.ts
+++ b/frontend/src/pages/map/detailsDom.ts
@@ -22,6 +22,7 @@ export function setDetailsPanelContent(opts: {
   title: string;
   subtitle: string;
   html: string;
+  onNodeSelect?: (nodeId: string) => void;
 }) {
   const { nodePanel, nodeTitle, nodeSubtitle, nodeContent } = getDetailsDom();
   if (!nodePanel || !nodeTitle || !nodeSubtitle || !nodeContent) return;
@@ -29,6 +30,18 @@ export function setDetailsPanelContent(opts: {
   nodeTitle.textContent = opts.title;
   nodeSubtitle.textContent = opts.subtitle;
   nodeContent.innerHTML = opts.html;
+
+  // Wire up clickable node links (data-select-node attributes)
+  if (opts.onNodeSelect) {
+    const handler = opts.onNodeSelect;
+    nodeContent.querySelectorAll<HTMLElement>("[data-select-node]").forEach((el) => {
+      el.addEventListener("click", (e) => {
+        e.preventDefault();
+        const id = el.getAttribute("data-select-node");
+        if (id) handler(id);
+      });
+    });
+  }
 
   nodePanel.classList.remove("hidden");
 }

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -35,7 +35,7 @@ export function buildNodeDetailsHtml(opts: {
   const nodeLink = (id: string, label: string) => {
     const target = liveNodes[id];
     if (target?.map_position) {
-      return `<a style="${linkStyle}" data-select-node="${escapeHtml(id)}">${escapeHtml(label)}</a>`;
+      return `<button type="button" style="${linkStyle}" data-select-node="${escapeHtml(id)}">${escapeHtml(label)}</button>`;
     }
     return escapeHtml(label);
   };

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -7,6 +7,7 @@ import type {
 
 import type { ElsewhereLink } from "../../types/config";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLinks";
+import type { ITraceroutesResponse } from "../../types";
 import type { IMapNode, NodeLike } from "./types";
 import { calculateGeodesicDistance, escapeHtml } from "./utils";
 
@@ -192,6 +193,79 @@ export function buildAllLinksFeatureCollection(
           coordinates: [
             [node.map_position[0], node.map_position[1]],
             [other.map_position[0], other.map_position[1]],
+          ],
+        },
+      });
+    }
+  }
+
+  return { type: "FeatureCollection", features: linkFeatures };
+}
+
+/** Normalize a node ID (int or hex string) to lowercase hex. */
+export function normNodeId(raw: unknown): string {
+  if (raw == null) return "";
+  if (typeof raw === "number") {
+    if (!Number.isFinite(raw) || raw <= 0) return "";
+    return (raw >>> 0).toString(16).toLowerCase();
+  }
+  let s = String(raw).trim();
+  if (/^\d+$/.test(s) && s.length > 6) {
+    const n = parseInt(s, 10);
+    if (Number.isFinite(n) && n > 0) return (n >>> 0).toString(16).toLowerCase();
+  }
+  if (s.startsWith("!")) s = s.slice(1);
+  if (s.startsWith("0x") || s.startsWith("0X")) s = s.slice(2);
+  return s.toLowerCase();
+}
+
+/**
+ * Build link features inferred from traceroute hops.
+ * Each consecutive pair in a traceroute path (from → hop1 → hop2 → to)
+ * is treated as a link. Deduplicates and only includes edges where both
+ * nodes have map positions.
+ */
+export function buildTracerouteLinkFeatureCollection(
+  traceroutes: ITraceroutesResponse[],
+  liveNodes: Record<string, IMapNode>,
+  neighborEdgeKeys?: Set<string>,
+): FeatureCollection<GeoLineString, GeoJsonProperties> {
+  const linkFeatures: GeoFeature<GeoLineString, GeoJsonProperties>[] = [];
+  const seen = new Set<string>();
+
+  for (const tr of traceroutes) {
+    const from = normNodeId(tr?.from);
+    const to = normNodeId(tr?.to);
+    const route: string[] = (tr?.route ?? tr?.payload?.route ?? [])
+      .map(normNodeId)
+      .filter(Boolean);
+    const path = [from, ...route, to].filter(Boolean);
+
+    for (let i = 0; i < path.length - 1; i++) {
+      const a = path[i], b = path[i + 1];
+      if (!a || !b || a === b) continue;
+
+      const ka = a < b ? a : b;
+      const kb = a < b ? b : a;
+      const edgeKey = `${ka}|${kb}`;
+
+      // Skip if we already emitted this edge or if a neighbor edge covers it
+      if (seen.has(edgeKey)) continue;
+      if (neighborEdgeKeys?.has(edgeKey)) continue;
+      seen.add(edgeKey);
+
+      const nodeA = liveNodes[ka] ?? liveNodes[`!${ka}`];
+      const nodeB = liveNodes[kb] ?? liveNodes[`!${kb}`];
+      if (!nodeA?.map_position || !nodeB?.map_position) continue;
+
+      linkFeatures.push({
+        type: "Feature",
+        properties: { kind: "traceroute" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [nodeA.map_position[0], nodeA.map_position[1]],
+            [nodeB.map_position[0], nodeB.map_position[1]],
           ],
         },
       });

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -22,60 +22,67 @@ export function buildNodeDetailsHtml(opts: {
   liveNodes: Record<string, IMapNode>;
   displayName: string | null | undefined;
   elsewhereLinks?: ElsewhereLink[];
+  traceroutes?: ITraceroutesResponse[];
 }): { html: string; heardBy: string[] } {
   const { node, liveNodes } = opts;
   const displayName = opts.displayName || "Unknown";
+  const tblClass = "border border-gray-300 dark:border-gray-600";
+  const thStyle = "font-weight:600;padding:2px 4px;";
+  const tdStyle = "padding:2px 4px;";
 
   let panel =
-    `<b>${escapeHtml(node.longname ?? "")}</b><br/>${escapeHtml(node.shortname ?? "")} / ${escapeHtml(node.id)}<br/><br/>` +
-    `<b>Position</b><br/>LAT: ${escapeHtml(node.position[1].toString())}<br/>LON: ${escapeHtml(node.position[0].toString())}<br/><br/>` +
-    `<b>Location</b><br/>${escapeHtml(displayName)}<br/><br/>` +
-    `<b>Status</b><br/>${node.online ? "Online" : "Offline"}<br/><br/>` +
-    `<b>Last Seen</b><br/>${escapeHtml(node.last_seen ?? "")}<br/><br/>`;
+    `<b>${escapeHtml(node.longname ?? "")}</b><br/>` +
+    `<span style="opacity:.7">${escapeHtml(node.shortname ?? "")} / ${escapeHtml(node.id)}</span><br/>` +
+    `<div style="margin:6px 0">` +
+    `<b>Position</b> &nbsp;${escapeHtml(node.position[1].toFixed(6))}, ${escapeHtml(node.position[0].toFixed(6))}<br/>` +
+    `<b>Location</b> &nbsp;${escapeHtml(displayName)}<br/>` +
+    `<b>Status</b> &nbsp;${node.online ? "Online" : "Offline"}<br/>` +
+    `<b>Last Seen</b> &nbsp;${escapeHtml(node.last_seen ?? "")}` +
+    `</div>`;
 
-  panel += "<b>Neighbors Heard</b><br/>";
+  // --- Neighbors Heard ---
+  panel += "<b>Neighbors Heard</b>";
   if ((node.neighbors?.length ?? 0) === 0) {
-    panel += "None";
+    panel += " &mdash; <span style='opacity:.5'>None</span>";
   } else {
-    panel += "<table border=1 cellpadding=2 cellspacing=0 width=100% class='border border-gray-300'>";
-    panel += "<tr><th width=33% align=left>Node</th><th width=33% align=center>SNR</th><th width=33% align=right>Distance</th></tr>";
+    panel += `<table border=0 cellpadding=0 cellspacing=0 width=100% class='${tblClass}' style='margin:2px 0 0'>`;
+    panel += `<tr><th style="${thStyle}" align=left>Node</th><th style="${thStyle}" align=center>SNR</th><th style="${thStyle}" align=right>Distance</th></tr>`;
 
     panel += (node.neighbors ?? [])
       .map((neighbor) => {
         const nnode = liveNodes[neighbor.id];
         if (!nnode) {
-          return `<tr><td class="text-gray-600">UNK</td><td align=center>${neighbor.snr}</td><td></td></tr>`;
+          return `<tr><td style="${tdStyle}" class="text-gray-600">UNK</td><td style="${tdStyle}" align=center>${neighbor.snr}</td><td style="${tdStyle}"></td></tr>`;
         }
 
         let distance;
         if (nnode.map_position) {
           distance = calculateGeodesicDistance(
-            node.position[1],
-            node.position[0],
-            nnode.map_position[1],
-            nnode.map_position[0]
+            node.position[1], node.position[0],
+            nnode.map_position[1], nnode.map_position[0]
           );
         }
 
-        return `<tr><td align=left>${escapeHtml(nnode.shortname ?? "")}</td><td align=center>${neighbor.snr}</td><td align=right>${
-          distance ? distance.toFixed(2) : "unk"
-        } km</td></tr>`;
+        return `<tr><td style="${tdStyle}" align=left>${escapeHtml(nnode.shortname ?? "")}</td><td style="${tdStyle}" align=center>${neighbor.snr}</td><td style="${tdStyle}" align=right>${
+          distance ? distance.toFixed(2) + " km" : ""
+        }</td></tr>`;
       })
       .join("");
 
     panel += "</table>";
   }
 
-  panel += "<br/><br/>";
+  panel += "<br/>";
 
-  panel += "<b>Heard By Neighbors</b><br/>";
+  // --- Heard By Neighbors ---
   const heardBy = computeHeardByIds(liveNodes, node.id);
+  panel += "<b>Heard By Neighbors</b>";
 
   if (heardBy.length === 0) {
-    panel += "None<br/>";
+    panel += " &mdash; <span style='opacity:.5'>None</span>";
   } else {
-    panel += "<table border=1 cellpadding=2 cellspacing=0 width=100% class='border border-gray-300'>";
-    panel += "<tr><th width=33% align=left>Node</th><th width=33% align=center>SNR</th><th width=33% align=right>Distance</th></tr>";
+    panel += `<table border=0 cellpadding=0 cellspacing=0 width=100% class='${tblClass}' style='margin:2px 0 0'>`;
+    panel += `<tr><th style="${thStyle}" align=left>Node</th><th style="${thStyle}" align=center>SNR</th><th style="${thStyle}" align=right>Distance</th></tr>`;
 
     panel += heardBy
       .map((nid) => {
@@ -83,30 +90,73 @@ export function buildNodeDetailsHtml(opts: {
         const neighbor = nnode?.neighbors?.find((n) => n.id === node.id);
 
         if (!nnode) {
-          return `<tr><td class="text-gray-600">UNK</td><td align=center>${neighbor?.snr}</td><td></td></tr>`;
+          return `<tr><td style="${tdStyle}" class="text-gray-600">UNK</td><td style="${tdStyle}" align=center>${neighbor?.snr}</td><td style="${tdStyle}"></td></tr>`;
         }
 
         let distance;
         if (nnode.map_position) {
           distance = calculateGeodesicDistance(
-            node.position[1],
-            node.position[0],
-            nnode.map_position[1],
-            nnode.map_position[0]
+            node.position[1], node.position[0],
+            nnode.map_position[1], nnode.map_position[0]
           );
         }
 
-        return `<tr><td align=left>${escapeHtml(nnode.shortname ?? "")}</td><td align=center>${neighbor?.snr}</td><td align=right>${
-          distance ? distance.toFixed(2) : "unk"
-        } km</td></tr>`;
+        return `<tr><td style="${tdStyle}" align=left>${escapeHtml(nnode.shortname ?? "")}</td><td style="${tdStyle}" align=center>${neighbor?.snr}</td><td style="${tdStyle}" align=right>${
+          distance ? distance.toFixed(2) + " km" : ""
+        }</td></tr>`;
       })
       .join("");
 
     panel += "</table>";
   }
 
-  panel += "<br/><br/>";
+  panel += "<br/>";
 
+  // --- Traceroute Links ---
+  const traceroutes = opts.traceroutes ?? [];
+  const normId = normNodeId(node.id);
+  // Find all nodes this node connects to via traceroute hops
+  const trLinkCounts = new Map<string, number>();
+  for (const tr of traceroutes) {
+    const from = normNodeId(tr.from);
+    const to = normNodeId(tr.to);
+    const hops = (tr.route_ids ?? tr.route ?? []).map((r: string) => normNodeId(r));
+    const path = [from, ...hops, to].filter(Boolean);
+    const idx = path.indexOf(normId);
+    if (idx === -1) continue;
+    // Adjacent nodes in the path are direct links
+    if (idx > 0) {
+      const prev = path[idx - 1];
+      trLinkCounts.set(prev, (trLinkCounts.get(prev) ?? 0) + 1);
+    }
+    if (idx < path.length - 1) {
+      const next = path[idx + 1];
+      trLinkCounts.set(next, (trLinkCounts.get(next) ?? 0) + 1);
+    }
+  }
+
+  panel += "<b>Traceroute Links</b>";
+
+  if (trLinkCounts.size === 0) {
+    panel += " &mdash; <span style='opacity:.5'>None</span>";
+  } else {
+    // Sort by count descending
+    const sorted = [...trLinkCounts.entries()].sort((a, b) => b[1] - a[1]);
+    panel += `<table border=0 cellpadding=0 cellspacing=0 width=100% class='${tblClass}' style='margin:2px 0 0'>`;
+    panel += `<tr><th style="${thStyle}" align=left>Node</th><th style="${thStyle}" align=right>Routes</th></tr>`;
+
+    for (const [linkedId, count] of sorted) {
+      const linkedNode = liveNodes[linkedId];
+      const label = linkedNode?.shortname ? escapeHtml(linkedNode.shortname) : escapeHtml(linkedId);
+      panel += `<tr><td style="${tdStyle}" align=left>${label}</td><td style="${tdStyle}" align=right>${count}</td></tr>`;
+    }
+
+    panel += "</table>";
+  }
+
+  panel += "<br/>";
+
+  // --- Elsewhere ---
   panel += "<b>Elsewhere</b><br/>";
   const nodeIdInt = parseInt(node.id, 16);
   const links = getElsewhereLinks(opts.elsewhereLinks);

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -171,9 +171,10 @@ export function buildNodeDetailsHtml(opts: {
     panel += `<tr><th style="${thStyle}" align=left>Node</th><th style="${thStyle}" align=right>Routes</th></tr>`;
 
     for (const [linkedId, count] of sorted) {
-      const linkedNode = liveNodes[linkedId];
+      const lookupId = liveNodes[linkedId] ? linkedId : liveNodes[`!${linkedId}`] ? `!${linkedId}` : linkedId;
+      const linkedNode = liveNodes[lookupId];
       const label = linkedNode?.shortname ?? linkedId;
-      panel += `<tr><td style="${tdStyle}" align=left>${nodeLink(linkedId, label)}</td><td style="${tdStyle}" align=right>${count}</td></tr>`;
+      panel += `<tr><td style="${tdStyle}" align=left>${nodeLink(lookupId, label)}</td><td style="${tdStyle}" align=right>${count}</td></tr>`;
     }
 
     panel += "</table>";
@@ -311,7 +312,7 @@ export function buildTracerouteLinkFeatureCollection(
   for (const tr of traceroutes) {
     const from = normNodeId(tr?.from);
     const to = normNodeId(tr?.to);
-    const route: string[] = (tr?.route ?? tr?.payload?.route ?? [])
+    const route: string[] = (tr?.route_ids ?? tr?.route ?? tr?.payload?.route ?? [])
       .map(normNodeId)
       .filter(Boolean);
     const path = [from, ...route, to].filter(Boolean);

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -29,13 +29,38 @@ export function buildNodeDetailsHtml(opts: {
   const tblClass = "border border-gray-300 dark:border-gray-600";
   const thStyle = "font-weight:600;padding:2px 4px;";
   const tdStyle = "padding:2px 4px;";
+  const linkStyle = "color:#818cf8;cursor:pointer;text-decoration:none;";
+
+  /** Render a node name — clickable if it has a map position, plain text otherwise. */
+  const nodeLink = (id: string, label: string) => {
+    const target = liveNodes[id];
+    if (target?.map_position) {
+      return `<a style="${linkStyle}" data-select-node="${escapeHtml(id)}">${escapeHtml(label)}</a>`;
+    }
+    return escapeHtml(label);
+  };
+
+  /** Shorten a geocoded address to ~city, state. */
+  function shortenLocation(full: string): string {
+    // Typical format: "123 Street, City, State ZIP, Country"
+    const parts = full.split(",").map((s) => s.trim());
+    if (parts.length >= 3) {
+      // Take city (2nd-to-last-1) and state+zip (2nd-to-last), drop street and country
+      const city = parts[parts.length - 3];
+      const stateZip = parts[parts.length - 2];
+      // Strip ZIP from state
+      const state = stateZip.replace(/\s+\d{5}(-\d{4})?$/, "");
+      return `${city}, ${state}`;
+    }
+    return full;
+  }
 
   let panel =
     `<b>${escapeHtml(node.longname ?? "")}</b><br/>` +
     `<span style="opacity:.7">${escapeHtml(node.shortname ?? "")} / ${escapeHtml(node.id)}</span><br/>` +
     `<div style="margin:6px 0">` +
     `<b>Position</b> &nbsp;${escapeHtml(node.position[1].toFixed(6))}, ${escapeHtml(node.position[0].toFixed(6))}<br/>` +
-    `<b>Location</b> &nbsp;${escapeHtml(displayName)}<br/>` +
+    `<b>Location</b> &nbsp;<span title="${escapeHtml(displayName)}" style="cursor:help;border-bottom:1px dotted currentColor">${escapeHtml(shortenLocation(displayName))}</span><br/>` +
     `<b>Status</b> &nbsp;${node.online ? "Online" : "Offline"}<br/>` +
     `<b>Last Seen</b> &nbsp;${escapeHtml(node.last_seen ?? "")}` +
     `</div>`;
@@ -63,7 +88,7 @@ export function buildNodeDetailsHtml(opts: {
           );
         }
 
-        return `<tr><td style="${tdStyle}" align=left>${escapeHtml(nnode.shortname ?? "")}</td><td style="${tdStyle}" align=center>${neighbor.snr}</td><td style="${tdStyle}" align=right>${
+        return `<tr><td style="${tdStyle}" align=left>${nodeLink(neighbor.id, nnode.shortname ?? neighbor.id)}</td><td style="${tdStyle}" align=center>${neighbor.snr}</td><td style="${tdStyle}" align=right>${
           distance ? distance.toFixed(2) + " km" : ""
         }</td></tr>`;
       })
@@ -101,7 +126,7 @@ export function buildNodeDetailsHtml(opts: {
           );
         }
 
-        return `<tr><td style="${tdStyle}" align=left>${escapeHtml(nnode.shortname ?? "")}</td><td style="${tdStyle}" align=center>${neighbor?.snr}</td><td style="${tdStyle}" align=right>${
+        return `<tr><td style="${tdStyle}" align=left>${nodeLink(nid, nnode.shortname ?? nid)}</td><td style="${tdStyle}" align=center>${neighbor?.snr}</td><td style="${tdStyle}" align=right>${
           distance ? distance.toFixed(2) + " km" : ""
         }</td></tr>`;
       })
@@ -147,8 +172,8 @@ export function buildNodeDetailsHtml(opts: {
 
     for (const [linkedId, count] of sorted) {
       const linkedNode = liveNodes[linkedId];
-      const label = linkedNode?.shortname ? escapeHtml(linkedNode.shortname) : escapeHtml(linkedId);
-      panel += `<tr><td style="${tdStyle}" align=left>${label}</td><td style="${tdStyle}" align=right>${count}</td></tr>`;
+      const label = linkedNode?.shortname ?? linkedId;
+      panel += `<tr><td style="${tdStyle}" align=left>${nodeLink(linkedId, label)}</td><td style="${tdStyle}" align=right>${count}</td></tr>`;
     }
 
     panel += "</table>";


### PR DESCRIPTION
## Summary
- Infer mesh topology links from traceroute hop data, supplementing the largely defunct NeighborInfo module (disabled/MQTT-only since Meshtastic firmware 2.5.13)
- Draw traceroute-inferred links on the map in amber (#F59E0B), distinct from green/blue/purple neighbor links, across all three link display modes (Selected Node, All Nodes, My Node)
- Deduplicate traceroute edges against existing neighbor edges so neighbor data takes priority when both exist
- Add "Traceroute Links" section to the node details panel showing adjacent nodes and route counts
- Compact the details panel layout: single-line position/status fields, shortened location (city, state) with full address on hover
- Make node names in all detail panel tables (Neighbors Heard, Heard By, Traceroute Links) clickable to navigate to that node on the map — only styled as links when the target node has a map position