### PR TITLE
Track gateway source, persist My Node banner, and update roles

### DIFF
--- a/frontend/src/components/Role.tsx
+++ b/frontend/src/components/Role.tsx
@@ -2,5 +2,5 @@ import { NodeRole, roleTitles } from "../types";
 
 export const Role = ({ role }: { role: NodeRole }) => {
   const roleInfo = roleTitles[role];
-  return <span title={roleInfo?.title}>{roleInfo?.abbreviation}</span>;
+  return <span title={roleInfo?.abbreviation}>{roleInfo?.title}</span>;
 };

--- a/frontend/src/components/Role.tsx
+++ b/frontend/src/components/Role.tsx
@@ -2,5 +2,5 @@ import { NodeRole, roleTitles } from "../types";
 
 export const Role = ({ role }: { role: NodeRole }) => {
   const roleInfo = roleTitles[role];
-  return <span title={roleInfo?.abbreviation}>{roleInfo?.title}</span>;
+  return <span title={roleInfo ? `${roleInfo.title}${roleInfo.abbreviation ? ` (${roleInfo.abbreviation})` : ""}` : undefined}>{roleInfo?.title}</span>;
 };

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -353,24 +353,12 @@ export function Map() {
     return () => timers.forEach(clearTimeout);
   }, [urlNodeId, flyToTarget, olMap, setSearchParams]);
 
-  /** Show a brief toast confirming "My Node" was set. */
-  function showMyNodeToast(name: string) {
-    const existing = document.getElementById("my-node-toast");
-    if (existing) existing.remove();
-
-    const toast = document.createElement("div");
-    toast.id = "my-node-toast";
-    toast.textContent = `My Node set to ${name}`;
-    toast.className =
-      "fixed top-4 left-1/2 -translate-x-1/2 z-[9999] px-4 py-2 rounded-lg shadow-lg " +
-      "bg-gray-900/95 text-white text-sm backdrop-blur-md border border-gray-700 " +
-      "transition-opacity duration-300";
-    document.body.appendChild(toast);
-    setTimeout(() => {
-      toast.style.opacity = "0";
-      setTimeout(() => toast.remove(), 300);
-    }, 2000);
-  }
+  // Derive "My Node" label from current state
+  const myNodeLabel = useMemo(() => {
+    if (!myNodeId) return null;
+    const n = nodes[myNodeId];
+    return n?.shortname || n?.longname || myNodeId;
+  }, [myNodeId, nodes]);
 
   /** Collect neighbor edge keys (for deduplication with traceroute links). */
   function collectNeighborEdgeKeys(liveNodes: Record<string, IMapNode>): Set<string> {
@@ -508,6 +496,7 @@ export function Map() {
     }
 
     mbSelectedIdRef.current = null;
+
 
     // Restore persistent links (all/mynode) or clear if mode is "selected"
     if (map) {
@@ -873,6 +862,7 @@ export function Map() {
 
         setSelected(id);
 
+
         const displayName = await reverseGeocode(node.map_position[0], node.map_position[1]);
 
         const nodeLike: NodeLike = {
@@ -1045,9 +1035,6 @@ export function Map() {
         const id = findNodeIdAtPoint(e.point);
         if (!id) return;
         e.preventDefault();
-        const node = nodesRef.current[id];
-        const name = node?.shortname || node?.longname || id;
-        showMyNodeToast(name);
         setMyNodeId(id);
         setLinkMode("mynode");
       });
@@ -1068,9 +1055,6 @@ export function Map() {
           if (!longPressPoint) return;
           const id = findNodeIdAtPoint(longPressPoint);
           if (!id) return;
-          const node = nodesRef.current[id];
-          const name = node?.shortname || node?.longname || id;
-          showMyNodeToast(name);
           setMyNodeId(id);
           setLinkMode("mynode");
           longPressPoint = null;
@@ -1132,6 +1116,7 @@ export function Map() {
 
       // Clear selection & overlays to avoid stale feature-state during style swap
       mbSelectedIdRef.current = null;
+  
       clearDetailsPanel();
       const linksSource = map.getSource("links") as MbGeoJSONSource | undefined;
       linksSource?.setData(emptyLineFeatureCollection());
@@ -1176,6 +1161,7 @@ export function Map() {
         } catch {}
 
         mbSelectedIdRef.current = null;
+    
 
         const linksSource = map.getSource("links") as MbGeoJSONSource | undefined;
         linksSource?.setData(emptyLineFeatureCollection());
@@ -1358,6 +1344,7 @@ export function Map() {
     const neighborLayers: VectorLayer<VectorSource<Feature>, Feature>[] = [];
 
     const handleNodeDetails = async (node: IFeatureNode) => {
+
       const displayName = await reverseGeocode(node.position[0], node.position[1]);
 
       const nodeLike: NodeLike = {
@@ -1455,8 +1442,6 @@ export function Map() {
       const node = findOlNodeAtPixel(pixel);
       if (!node) return;
       e.preventDefault();
-      const name = node.shortname || node.longname || node.id;
-      showMyNodeToast(name);
       setMyNodeId(node.id);
       setLinkMode("mynode");
     });
@@ -1476,8 +1461,6 @@ export function Map() {
         if (!olLongPressPixel) return;
         const node = findOlNodeAtPixel(olLongPressPixel);
         if (!node) return;
-        const name = node.shortname || node.longname || node.id;
-        showMyNodeToast(name);
         setMyNodeId(node.id);
         setLinkMode("mynode");
         olLongPressPixel = null;
@@ -1505,6 +1488,7 @@ export function Map() {
           select.getFeatures().clear();
           void handleNodeDetails(node);
         } else if (!map.hasFeatureAtPixel(event.pixel)) {
+      
           clearDetailsPanel();
         }
         return;
@@ -1512,6 +1496,7 @@ export function Map() {
 
       // Plain mode — original behavior
       if (map.hasFeatureAtPixel(event.pixel) !== true) {
+    
         clearDetailsPanel();
         return;
       }
@@ -1541,6 +1526,7 @@ export function Map() {
     const olKeydownHandler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         removeOlSpiderfy(map);
+    
         clearDetailsPanel();
       }
     };
@@ -1722,6 +1708,25 @@ export function Map() {
         canUseMapbox={canUseMapbox}
         usingMapbox={usingMapbox}
       />
+
+      {myNodeLabel && (
+        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-1060 px-4 py-2 rounded-lg shadow-lg bg-gray-900/95 text-white text-sm backdrop-blur-md border border-gray-700 flex items-center gap-3">
+          <span>My Node: <span className="font-semibold">{myNodeLabel}</span></span>
+          <button
+            type="button"
+            onClick={() => {
+              setMyNodeId("");
+              setLinkMode("selected");
+            }}
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="Clear My Node"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
 
       <MapDetailsPanel onClose={clearMapboxSelectionAndOverlays} />
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -417,6 +417,7 @@ export function Map() {
           online: Boolean(node.online),
           position: node.map_position,
           neighbors: node.neighbors,
+          gateway: node.gateway,
         };
         const heardBy = computeHeardByIds(liveNodes, id);
         const neighborFC = buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy });
@@ -882,6 +883,7 @@ export function Map() {
           online: Boolean(node.online),
           position: node.map_position,
           neighbors: node.neighbors,
+          gateway: node.gateway,
         };
 
         const { html, heardBy } = buildNodeDetailsHtml({
@@ -1322,6 +1324,7 @@ export function Map() {
             position: [node.map_position[0], node.map_position[1]] as Coordinate,
             online: node.online,
             neighbors: node.neighbors,
+            gateway: node.gateway,
           } satisfies IFeatureNode,
         });
 
@@ -1365,6 +1368,7 @@ export function Map() {
         online: Boolean(node.online),
         position: node.position,
         neighbors: node.neighbors,
+        gateway: node.gateway,
       };
 
       const { html } = buildNodeDetailsHtml({
@@ -1390,6 +1394,7 @@ export function Map() {
             position: [targetNode.map_position[0], targetNode.map_position[1]] as Coordinate,
             online: Boolean(targetNode.online),
             neighbors: targetNode.neighbors,
+            gateway: targetNode.gateway,
           });
         },
       });
@@ -1564,6 +1569,7 @@ export function Map() {
             position: [node.map_position[0], node.map_position[1]] as Coordinate,
             online: node.online,
             neighbors: node.neighbors,
+            gateway: node.gateway,
           } satisfies IFeatureNode,
         });
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -387,6 +387,7 @@ export function Map() {
           online: Boolean(node.online),
           position: node.map_position,
           neighbors: node.neighbors,
+          gateway: node.gateway,
         };
         const heardBy = computeHeardByIds(liveNodes, id);
         return buildMapboxLinkFeatureCollection({ node: nodeLike, liveNodes, heardBy });
@@ -834,6 +835,7 @@ export function Map() {
           online: Boolean(node.online),
           position: node.map_position,
           neighbors: node.neighbors,
+          gateway: node.gateway,
         };
 
         const { html, heardBy } = buildNodeDetailsHtml({
@@ -847,6 +849,7 @@ export function Map() {
           title: node.longname ?? "",
           subtitle: node.shortname ?? "",
           html,
+          onNodeSelect: (targetId) => void handleNodeClick(targetId),
         });
 
         // Draw links
@@ -1246,6 +1249,7 @@ export function Map() {
             position: [node.map_position[0], node.map_position[1]] as Coordinate,
             online: node.online,
             neighbors: node.neighbors,
+            gateway: node.gateway,
           } satisfies IFeatureNode,
         });
 
@@ -1289,6 +1293,7 @@ export function Map() {
         online: Boolean(node.online),
         position: node.position,
         neighbors: node.neighbors,
+        gateway: node.gateway,
       };
 
       const { html } = buildNodeDetailsHtml({
@@ -1302,6 +1307,20 @@ export function Map() {
         title: node.longname ?? "",
         subtitle: node.shortname ?? "",
         html,
+        onNodeSelect: (targetId) => {
+          const targetNode = nodes[targetId];
+          if (!targetNode?.map_position) return;
+          void handleNodeDetails({
+            id: targetId,
+            shortname: targetNode.shortname,
+            longname: targetNode.longname,
+            last_seen: targetNode.last_seen,
+            position: [targetNode.map_position[0], targetNode.map_position[1]] as Coordinate,
+            online: Boolean(targetNode.online),
+            neighbors: targetNode.neighbors,
+            gateway: targetNode.gateway,
+          });
+        },
       });
 
       // Draw neighbor lines
@@ -1474,6 +1493,7 @@ export function Map() {
             position: [node.map_position[0], node.map_position[1]] as Coordinate,
             online: node.online,
             neighbors: node.neighbors,
+            gateway: node.gateway,
           } satisfies IFeatureNode,
         });
 

--- a/frontend/src/pages/Node.tsx
+++ b/frontend/src/pages/Node.tsx
@@ -195,13 +195,17 @@ export const Node = () => {
                             case 6:
                               return "Sensor";
                             case 7:
-                              return "ATAK";
+                              return "TAK";
                             case 8:
                               return "Client Hidden";
                             case 9:
                               return "Lost and Found";
                             case 10:
-                              return "ATAK Tracker";
+                              return "TAK Tracker";
+                            case 11:
+                              return "Router Late";
+                            case 12:
+                              return "Client Base";
                             default:
                               return "Unknown";
                           }

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -926,6 +926,7 @@ export const Nodes = () => {
                     nodes={nodes as any}
                     serverNode={serverNode as any}
                     onClearSelection={clearSelection}
+                    onSelectNode={onSelect}
                   />
                 ) : (
                   <NodesOverviewPanel
@@ -1152,6 +1153,7 @@ export const Nodes = () => {
               clearSelection();
               setMobileSheet(null);
             }}
+            onSelectNode={onSelect}
           />
         ) : (
           <NodesOverviewPanel

--- a/frontend/src/pages/graph/graphUtils.ts
+++ b/frontend/src/pages/graph/graphUtils.ts
@@ -58,13 +58,15 @@ export type GraphEdge = {
 export const ROLE_COLORS: Record<string, string> = {
   "0": "#3b82f6", "1": "#64748b", "2": "#22c55e", "3": "#14b8a6",
   "4": "#f59e0b", "5": "#a855f7", "6": "#ec4899", "7": "#f97316",
-  "8": "#6b7280", "9": "#ef4444", "10": "#ea580c",
+  "8": "#6b7280", "9": "#ef4444", "10": "#ea580c", "11": "#10b981",
+  "12": "#0ea5e9",
 };
 
 export const ROLE_LABELS: Record<string, string> = {
   "0": "Client", "1": "Client Mute", "2": "Router", "3": "Router Client",
-  "4": "Repeater", "5": "Tracker", "6": "Sensor", "7": "ATAK",
-  "8": "Client Hidden", "9": "Lost & Found", "10": "ATAK Tracker",
+  "4": "Repeater", "5": "Tracker", "6": "Sensor", "7": "TAK",
+  "8": "Client Hidden", "9": "Lost & Found", "10": "TAK Tracker",
+  "11": "Router Late", "12": "Client Base",
 };
 
 export function roleColor(role: string | null | undefined): string {

--- a/frontend/src/pages/map/MapDetailsPanel.tsx
+++ b/frontend/src/pages/map/MapDetailsPanel.tsx
@@ -5,7 +5,7 @@ export function MapDetailsPanel({ onClose }: { onClose: () => void }) {
       className="hidden fixed top-2 right-2 z-1050
            w-[92vw] sm:w-80 max-w-[calc(100vw-1rem)]
            bg-white dark:bg-gray-900 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700
-           max-h-[60vh] sm:max-h-[calc(100vh-2rem)]
+           max-h-[60vh] sm:max-h-[calc(100vh-20rem)]
            overflow-hidden flex flex-col"
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">

--- a/frontend/src/pages/map/detailsDom.ts
+++ b/frontend/src/pages/map/detailsDom.ts
@@ -22,6 +22,7 @@ export function setDetailsPanelContent(opts: {
   title: string;
   subtitle: string;
   html: string;
+  onNodeSelect?: (nodeId: string) => void;
 }) {
   const { nodePanel, nodeTitle, nodeSubtitle, nodeContent } = getDetailsDom();
   if (!nodePanel || !nodeTitle || !nodeSubtitle || !nodeContent) return;
@@ -29,6 +30,18 @@ export function setDetailsPanelContent(opts: {
   nodeTitle.textContent = opts.title;
   nodeSubtitle.textContent = opts.subtitle;
   nodeContent.innerHTML = opts.html;
+
+  // Wire up clickable node links (data-select-node attributes)
+  if (opts.onNodeSelect) {
+    const handler = opts.onNodeSelect;
+    nodeContent.querySelectorAll<HTMLElement>("[data-select-node]").forEach((el) => {
+      el.addEventListener("click", (e) => {
+        e.preventDefault();
+        const id = el.getAttribute("data-select-node");
+        if (id) handler(id);
+      });
+    });
+  }
 
   nodePanel.classList.remove("hidden");
 }

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -69,11 +69,7 @@ export function buildNodeDetailsHtml(opts: {
   if (node.gateway) {
     const gwNode = liveNodes[node.gateway];
     const gwLabel = gwNode?.shortname || gwNode?.longname || node.gateway;
-    if (gwNode?.map_position) {
-      panel += `<b>Gateway</b> &nbsp;<a style="${linkStyle}" data-select-node="${escapeHtml(node.gateway)}">${escapeHtml(gwLabel)}</a><br/>`;
-    } else {
-      panel += `<b>Gateway</b> &nbsp;${escapeHtml(gwLabel)}<br/>`;
-    }
+    panel += `<b>Gateway</b> &nbsp;${nodeLink(node.gateway, gwLabel)}<br/>`;
   }
 
   // --- Neighbors Heard ---

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -32,6 +32,17 @@ export function buildNodeDetailsHtml(opts: {
     `<b>Status</b><br/>${node.online ? "Online" : "Offline"}<br/><br/>` +
     `<b>Last Seen</b><br/>${escapeHtml(node.last_seen ?? "")}<br/><br/>`;
 
+  // Gateway
+  if (node.gateway) {
+    const gwNode = liveNodes[node.gateway];
+    const gwLabel = gwNode?.shortname || gwNode?.longname || node.gateway;
+    if (gwNode?.map_position) {
+      panel += `<b>Gateway</b><br/><a style="color:#818cf8;cursor:pointer;text-decoration:none;" data-select-node="${escapeHtml(node.gateway)}">${escapeHtml(gwLabel)}</a><br/><br/>`;
+    } else {
+      panel += `<b>Gateway</b><br/>${escapeHtml(gwLabel)}<br/><br/>`;
+    }
+  }
+
   panel += "<b>Neighbors Heard</b><br/>";
   if ((node.neighbors?.length ?? 0) === 0) {
     panel += "None";

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -65,6 +65,17 @@ export function buildNodeDetailsHtml(opts: {
     `<b>Last Seen</b> &nbsp;${escapeHtml(node.last_seen ?? "")}` +
     `</div>`;
 
+  // Gateway
+  if (node.gateway) {
+    const gwNode = liveNodes[node.gateway];
+    const gwLabel = gwNode?.shortname || gwNode?.longname || node.gateway;
+    if (gwNode?.map_position) {
+      panel += `<b>Gateway</b> &nbsp;<a style="${linkStyle}" data-select-node="${escapeHtml(node.gateway)}">${escapeHtml(gwLabel)}</a><br/>`;
+    } else {
+      panel += `<b>Gateway</b> &nbsp;${escapeHtml(gwLabel)}<br/>`;
+    }
+  }
+
   // --- Neighbors Heard ---
   panel += "<b>Neighbors Heard</b>";
   if ((node.neighbors?.length ?? 0) === 0) {

--- a/frontend/src/pages/map/types.ts
+++ b/frontend/src/pages/map/types.ts
@@ -21,6 +21,7 @@ export type IFeatureNode = {
   shortname?: string;
   longname?: string;
   last_seen?: string;
+  gateway?: string | null;
   position: Coordinate; // [lon, lat]
   online: boolean;
   neighbors?: {
@@ -36,6 +37,7 @@ export type NodeLike = {
   shortname?: string;
   longname?: string;
   last_seen?: string;
+  gateway?: string | null;
   online: boolean;
   position: Coordinate; // [lon, lat]
   neighbors?: {

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -100,14 +100,16 @@ function CopyLinkButton({ nodeId }: { nodeId: string }) {
 
 export function NodeDetailsPanel({
   node,
-  nodes: _nodes,
+  nodes,
   serverNode,
   onClearSelection,
+  onSelectNode,
 }: {
   node: INode;
   nodes: Record<string, INode>;
   serverNode: INode | null;
   onClearSelection: () => void;
+  onSelectNode?: (id: string) => void;
 }) {
   const { data: config } = useGetConfigQuery();
   const n: any = node as any;
@@ -292,6 +294,27 @@ export function NodeDetailsPanel({
               <KV
                 k="Neighbors (count)"
                 v={n?.neighborinfo?.neighbors_count != null ? String(n.neighborinfo.neighbors_count) : "—"}
+              />
+              <KV
+                k="Gateway"
+                v={(() => {
+                  const gw = n?.gateway;
+                  if (!gw) return "—";
+                  const gwNode = nodes[gw];
+                  const label = gwNode?.shortname || gwNode?.longname || gw;
+                  if (onSelectNode) {
+                    return (
+                      <button
+                        type="button"
+                        className="underline hover:no-underline text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                        onClick={() => onSelectNode(gw)}
+                      >
+                        {label}
+                      </button>
+                    );
+                  }
+                  return label;
+                })()}
               />
             </div>
           </div>

--- a/frontend/src/pages/nodes/nodesUtils.ts
+++ b/frontend/src/pages/nodes/nodesUtils.ts
@@ -109,13 +109,17 @@ export function roleLabel(role: unknown) {
     case 6:
       return "Sensor";
     case 7:
-      return "ATAK";
+      return "TAK";
     case 8:
       return "Client Hidden";
     case 9:
       return "Lost and Found";
     case 10:
-      return "ATAK Tracker";
+      return "TAK Tracker";
+    case 11:
+      return "Router Late";
+    case 12:
+      return "Client Base";
     default:
       return "Unknown";
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -149,10 +149,12 @@ export enum NodeRole {
   REPEATER = 4,
   TRACKER = 5,
   SENSOR = 6,
-  ATAK = 7,
+  TAK = 7,
   CLIENT_HIDDEN = 8,
   LOST_AND_FOUND = 9,
-  ATAK_TRACKER = 10,
+  TAK_TRACKER = 10,
+  ROUTER_LATE = 11,
+  CLIENT_BASE = 12,
 }
 
 export const roleTitles: {
@@ -165,10 +167,12 @@ export const roleTitles: {
   [NodeRole.REPEATER]: { title: "Repeater", abbreviation: "RE" },
   [NodeRole.TRACKER]: { title: "Tracker", abbreviation: "T" },
   [NodeRole.SENSOR]: { title: "Sensor", abbreviation: "S" },
-  [NodeRole.ATAK]: { title: "ATAK", abbreviation: "A" },
+  [NodeRole.TAK]: { title: "TAK", abbreviation: "TAK" },
   [NodeRole.CLIENT_HIDDEN]: { title: "Client Hidden", abbreviation: "CH" },
   [NodeRole.LOST_AND_FOUND]: { title: "Lost and Found", abbreviation: "LF" },
-  [NodeRole.ATAK_TRACKER]: { title: "ATAK Tracker", abbreviation: "AT" },
+  [NodeRole.TAK_TRACKER]: { title: "TAK Tracker", abbreviation: "TT" },
+  [NodeRole.ROUTER_LATE]: { title: "Router Late", abbreviation: "RL" },
+  [NodeRole.CLIENT_BASE]: { title: "Client Base", abbreviation: "CB" },
 };
 
 export interface INeighbor {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -129,6 +129,7 @@ export interface INode {
   last_seen: string;
   hardware: number | null;
   role?: NodeRole;
+  gateway?: string | null;
   position?: INodePosition;
   telemetry?: { [key: string]: number } | null;
   neighborinfo?: {

--- a/models/node.py
+++ b/models/node.py
@@ -13,6 +13,7 @@ class Node():
         'shortname': 'ALL',
         'position': None,
         'telemetry': None,
+        'gateway': None,
         'active': False,
         'since': datetime.datetime.now(datetime.timezone.utc).astimezone() - datetime.datetime.now(datetime.timezone.utc).astimezone(),
         'last_seen': datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()

--- a/models/node.py
+++ b/models/node.py
@@ -26,6 +26,7 @@ class Node():
       'shortname': 'UNK',
       'position': None,
       'telemetry': None,
+      'gateway': None,
       'active': True,
       'since': datetime.datetime.now(datetime.timezone.utc).astimezone() - datetime.datetime.now(datetime.timezone.utc).astimezone(),
       'last_seen': datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()

--- a/mqtt.py
+++ b/mqtt.py
@@ -367,13 +367,13 @@ class MQTT:
         if id in self.data.nodes:
             node = self.data.nodes[id]
             node['neighborinfo'] = msg['payload']
-            self.data.update_node(id, node)
-            logger.debug("Node %s updated with neighborinfo", id)
         else:
             node = Node.default_node(id)
             node['neighborinfo'] = msg['payload']
-            self.data.update_node(id, node)
-            logger.debug("Node %s skeleton added with neighborinfo", id)
+        if msg.get('sender'):
+            node['gateway'] = msg['sender']
+        self.data.update_node(id, node)
+        logger.debug("Node %s updated with neighborinfo", id)
         await self.data.save()
 
     async def handle_nodeinfo(self, msg):
@@ -411,6 +411,9 @@ class MQTT:
         else:
             node['role'] = 0
 
+        if msg.get('sender'):
+            node['gateway'] = msg['sender']
+
         self.data.update_node(id, node)
 
         self.sort_nodes_by_shortname()
@@ -427,13 +430,13 @@ class MQTT:
         if id in self.data.nodes:
             node = self.data.nodes[id]
             node['position'] = msg['payload'] if 'payload' in msg else None
-            self.data.update_node(id, node)
-            logger.debug("Node %s updated with position", id)
         else:
             node = Node.default_node(id)
             node['position'] = msg['payload'] if 'payload' in msg else None
-            self.data.update_node(id, node)
-            logger.debug("Node %s skeleton added with position", id)
+        if msg.get('sender'):
+            node['gateway'] = msg['sender']
+        self.data.update_node(id, node)
+        logger.debug("Node %s updated with position", id)
         await self.data.save()
 
     async def handle_telemetry(self, msg):
@@ -462,6 +465,9 @@ class MQTT:
             # Merge: new fields overwrite, but fields not in this payload survive
             existing.update(payload)
             node['telemetry'] = existing
+
+        if msg.get('sender'):
+            node['gateway'] = msg['sender']
 
         self.data.update_node(id, node)
         logger.debug("Node %s updated with telemetry (variant=%s)", id, telemetry_type)

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     role INTEGER,
     active BOOLEAN DEFAULT TRUE,
     tc2_bbs BOOLEAN DEFAULT FALSE,
+    gateway VARCHAR(8),
     last_seen TIMESTAMP WITH TIME ZONE,
     since_seconds REAL,  -- Duration in seconds since last seen
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -380,7 +380,7 @@ class PostgresStorage:
                         role,
                         node_data.get("active", False),
                         node_data.get("tc2_bbs", False),
-                        node_data.get("gateway"),
+                        self._normalize_node_id(node_data.get("gateway")),
                         last_seen_ts,
                         since_seconds,
                     )

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -138,6 +138,12 @@ class PostgresStorage:
                 with open("postgres/sql/schema.sql", "r") as f:
                     schema_sql = f.read()
                 await conn.execute(schema_sql)
+
+                # Migrations — idempotent column additions for existing databases
+                await conn.execute("""
+                    ALTER TABLE nodes ADD COLUMN IF NOT EXISTS gateway VARCHAR(8);
+                """)
+
                 logger.info("PostgreSQL schema verified/created")
         except Exception as e:
             logger.error(f"Failed to ensure schema: {e}")
@@ -353,8 +359,8 @@ class PostgresStorage:
 
                     await conn.execute(
                         """
-                        INSERT INTO nodes (id, longname, shortname, hardware, role, active, tc2_bbs, last_seen, since_seconds)
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                        INSERT INTO nodes (id, longname, shortname, hardware, role, active, tc2_bbs, gateway, last_seen, since_seconds)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                         ON CONFLICT (id) DO UPDATE SET
                             longname = EXCLUDED.longname,
                             shortname = EXCLUDED.shortname,
@@ -362,6 +368,7 @@ class PostgresStorage:
                             role = EXCLUDED.role,
                             active = EXCLUDED.active,
                             tc2_bbs = EXCLUDED.tc2_bbs,
+                            gateway = COALESCE(EXCLUDED.gateway, nodes.gateway),
                             last_seen = EXCLUDED.last_seen,
                             since_seconds = EXCLUDED.since_seconds,
                             updated_at = NOW()
@@ -373,6 +380,7 @@ class PostgresStorage:
                         role,
                         node_data.get("active", False),
                         node_data.get("tc2_bbs", False),
+                        node_data.get("gateway"),
                         last_seen_ts,
                         since_seconds,
                     )
@@ -943,6 +951,7 @@ class PostgresStorage:
                         "role": row["role"],
                         "active": row["active"],
                         "tc2_bbs": row["tc2_bbs"],
+                        "gateway": row["gateway"] if "gateway" in row.keys() else None,
                         "last_seen": row["last_seen"].isoformat() if row["last_seen"] else None,
                         "since": datetime.timedelta(seconds=row["since_seconds"]) if row["since_seconds"] else None,
                         "position": None,
@@ -1256,6 +1265,7 @@ class PostgresStorage:
                         "role": row["role"],
                         "active": row["active"],
                         "tc2_bbs": row["tc2_bbs"] if "tc2_bbs" in row else False,
+                        "gateway": row["gateway"] if "gateway" in row.keys() else None,
                         "last_seen": row["last_seen"].isoformat() if row["last_seen"] else None,
                         "since": datetime.timedelta(seconds=row["since_seconds"]) if row["since_seconds"] else None,
                         "position": None,


### PR DESCRIPTION
## Summary

- Track which node relayed/gated each node's packets into meshinfo via the MQTT `sender` field ([Add node gateway source #96](link))
- Store `gateway` on the node model (in-memory and Postgres) — updated on every inbound message (neighborinfo, nodeinfo, position, telemetry)
- Add idempotent `ALTER TABLE nodes ADD COLUMN IF NOT EXISTS gateway` migration to `ensure_schema()` so existing databases auto-migrate on startup
- Display "Gateway" in the map detail panel with the gateway node's shortname, clickable to navigate to that node if it has a map position
- Display "Gateway" in the nodes page detail panel with the same clickable behavior
- Gateway field populates progressively as new MQTT messages arrive; existing nodes show it once they beacon after the update
- Cap map details panel height to prevent overlap with the legend/settings panel
- Replace ephemeral "My Node set to" toast with a persistent banner that stays visible while a My Node is active, with an X button to clear
- Update node roles to match current Meshtastic protobufs: rename ATAK → TAK, ATAK_TRACKER → TAK_TRACKER, add Router Late (11) and Client Base (12) (#367)
- Display full role titles (e.g. "Client Mute") instead of abbreviations ("CM") in the UI