### PR TITLE
feat: Discord mesh bridge with live forwarding, slash commands, leaderboard, and node watching

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,13 +1,13 @@
+import asyncio
 import datetime
 import logging
 import os
 from fastapi.encoders import jsonable_encoder
 import uvicorn
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 
-from fastapi.responses import Response
 from config import Config
 from api.static_map import generate_static_map
 import utils
@@ -325,7 +325,7 @@ class API:
             zoom = max(1, min(zoom, 18))
 
             try:
-                png_bytes = generate_static_map(lat, lon, self.config, zoom=zoom)
+                png_bytes = await asyncio.to_thread(generate_static_map, lat, lon, self.config, zoom=zoom)
                 return Response(
                     content=png_bytes,
                     media_type="image/png",

--- a/api/api.py
+++ b/api/api.py
@@ -315,13 +315,13 @@ class API:
             try:
                 lat = float(request.query_params.get("lat", 0))
                 lon = float(request.query_params.get("lon", 0))
+                zoom = int(request.query_params.get("zoom", 12))
             except (ValueError, TypeError):
-                return JSONResponse({"error": "Invalid lat/lon"}, status_code=400)
+                return JSONResponse({"error": "Invalid lat/lon/zoom"}, status_code=400)
 
             if lat == 0 and lon == 0:
                 return JSONResponse({"error": "lat and lon are required"}, status_code=400)
 
-            zoom = int(request.query_params.get("zoom", 12))
             zoom = max(1, min(zoom, 18))
 
             try:

--- a/api/api.py
+++ b/api/api.py
@@ -7,7 +7,9 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
+from fastapi.responses import Response
 from config import Config
+from api.static_map import generate_static_map
 import utils
 
 logger = logging.getLogger(__name__)
@@ -306,6 +308,32 @@ class API:
                         stats['active_nodes'] += 1
 
                 return jsonable_encoder({"stats": stats})
+
+        @app.get("/v1/static-map")
+        async def static_map(request: Request) -> Response:
+            """Generate a static map PNG image for given coordinates."""
+            try:
+                lat = float(request.query_params.get("lat", 0))
+                lon = float(request.query_params.get("lon", 0))
+            except (ValueError, TypeError):
+                return JSONResponse({"error": "Invalid lat/lon"}, status_code=400)
+
+            if lat == 0 and lon == 0:
+                return JSONResponse({"error": "lat and lon are required"}, status_code=400)
+
+            zoom = int(request.query_params.get("zoom", 12))
+            zoom = max(1, min(zoom, 18))
+
+            try:
+                png_bytes = generate_static_map(lat, lon, self.config, zoom=zoom)
+                return Response(
+                    content=png_bytes,
+                    media_type="image/png",
+                    headers={"Cache-Control": "public, max-age=3600"},
+                )
+            except Exception:
+                logger.exception("Failed to generate static map")
+                return JSONResponse({"error": "Map generation failed"}, status_code=500)
 
         @app.get("/v1/server/config")
         async def server_config(request: Request) -> JSONResponse:

--- a/api/static_map.py
+++ b/api/static_map.py
@@ -15,6 +15,7 @@ Results are cached to disk to avoid re-rendering for repeated requests.
 import hashlib
 import logging
 import os
+import tempfile
 import time
 from io import BytesIO
 from pathlib import Path
@@ -24,7 +25,7 @@ from staticmap import StaticMap, CircleMarker
 logger = logging.getLogger(__name__)
 
 # Cache settings
-CACHE_DIR = Path("/tmp/meshinfo-map-cache")
+CACHE_DIR = Path(tempfile.gettempdir()) / "meshinfo-map-cache"
 CACHE_MAX_AGE = 3600  # seconds (1 hour)
 
 # OSM tile URL

--- a/api/static_map.py
+++ b/api/static_map.py
@@ -1,0 +1,133 @@
+"""
+Self-hosted static map image generator.
+
+Renders a PNG map thumbnail by fetching tiles from OSM or Mapbox and
+compositing them locally. No external "static map API" — just tile
+fetching and image stitching via the `staticmap` library.
+
+Supports two tile providers:
+  - mapbox: Uses Mapbox raster tiles (requires access_token in config)
+  - osm:    Uses OpenStreetMap public tiles (no token needed, fallback)
+
+Results are cached to disk to avoid re-rendering for repeated requests.
+"""
+
+import hashlib
+import logging
+import os
+import time
+from io import BytesIO
+from pathlib import Path
+
+from staticmap import StaticMap, CircleMarker
+
+logger = logging.getLogger(__name__)
+
+# Cache settings
+CACHE_DIR = Path("/tmp/meshinfo-map-cache")
+CACHE_MAX_AGE = 3600  # seconds (1 hour)
+
+# OSM tile URL
+OSM_TILE_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+
+# Mapbox raster tile URL template (style and token injected at runtime)
+MAPBOX_TILE_URL = (
+    "https://api.mapbox.com/styles/v1/{style}/tiles/256/{{z}}/{{x}}/{{y}}@2x"
+    "?access_token={token}"
+)
+
+
+def _get_tile_url(config: dict) -> str:
+    """Determine the tile URL based on config, with Mapbox preferred."""
+    maps_cfg = (
+        config.get("integrations", {})
+        .get("discord", {})
+        .get("bridge", {})
+        .get("maps", {})
+    )
+    provider = maps_cfg.get("provider", "none")
+
+    if provider == "mapbox":
+        mb = maps_cfg.get("mapbox", {})
+        token = mb.get("access_token", "")
+        if token:
+            style = mb.get("style", "mapbox/dark-v11")
+            return MAPBOX_TILE_URL.format(style=style, token=token)
+        logger.warning("Mapbox configured but no access token; falling back to OSM tiles")
+
+    return OSM_TILE_URL
+
+
+def _cache_key(lat: float, lon: float, zoom: int, width: int, height: int, tile_url: str) -> str:
+    """Generate a cache key from parameters."""
+    # Round coords to ~100m precision to increase cache hits
+    lat_r = round(lat, 3)
+    lon_r = round(lon, 3)
+    raw = f"{lat_r},{lon_r},{zoom},{width},{height},{tile_url}"
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def _get_cached(cache_key: str) -> bytes | None:
+    """Return cached PNG bytes, or None if not cached/expired."""
+    path = CACHE_DIR / f"{cache_key}.png"
+    if not path.exists():
+        return None
+    age = time.time() - path.stat().st_mtime
+    if age > CACHE_MAX_AGE:
+        path.unlink(missing_ok=True)
+        return None
+    return path.read_bytes()
+
+
+def _set_cached(cache_key: str, data: bytes) -> None:
+    """Write PNG bytes to cache."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = CACHE_DIR / f"{cache_key}.png"
+    path.write_bytes(data)
+
+
+def generate_static_map(
+    lat: float,
+    lon: float,
+    config: dict,
+    zoom: int = 12,
+    width: int = 300,
+    height: int = 200,
+) -> bytes:
+    """
+    Generate a static map PNG image centered on the given coordinates.
+
+    Returns PNG bytes. Uses cache when available.
+    """
+    tile_url = _get_tile_url(config)
+    key = _cache_key(lat, lon, zoom, width, height, tile_url)
+
+    # Check cache
+    cached = _get_cached(key)
+    if cached:
+        return cached
+
+    # Generate map
+    m = StaticMap(
+        width,
+        height,
+        url_template=tile_url,
+        headers={"User-Agent": "MeshInfo/1.0"},
+    )
+
+    # Add a marker at the position
+    marker = CircleMarker((lon, lat), color="red", width=8)
+    m.add_marker(marker)
+
+    image = m.render(zoom=zoom)
+
+    # Convert to PNG bytes
+    buf = BytesIO()
+    image.save(buf, format="PNG")
+    png_bytes = buf.getvalue()
+
+    # Cache it
+    _set_cached(key, png_bytes)
+
+    logger.debug("Generated static map for %.4f, %.4f (zoom=%d, %dx%d)", lat, lon, zoom, width, height)
+    return png_bytes

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -244,6 +244,21 @@ class AdminCommands(commands.Cog):
 
         return choices
 
+    @staticmethod
+    def _make_display_name(node: Optional[dict]) -> Optional[str]:
+        """Build a display name like 'Modesto G2 Roof [NUTS]' from a node dict."""
+        if not node:
+            return None
+        longname = node.get("longname", "")
+        shortname = node.get("shortname", "")
+        if longname and longname != "Unknown" and shortname and shortname != "UNK":
+            return f"{longname} [{shortname}]"
+        if longname and longname != "Unknown":
+            return longname
+        if shortname and shortname != "UNK":
+            return shortname
+        return None
+
     async def _resolve_node_id(self, raw: str) -> tuple[Optional[str], Optional[str]]:
         """
         Resolve user input to a node hex ID.
@@ -262,8 +277,7 @@ class AdminCommands(commands.Cog):
                 # Look up name
                 node = self.data.nodes.get(nid)
                 if node:
-                    name = node.get("longname", node.get("shortname", ""))
-                    return nid, name if name not in ("Unknown", "UNK", "") else None
+                    return nid, self._make_display_name(node)
                 if self.data.pg_storage:
                     db_node = await self.data.pg_storage.query_node_by_id(nid)
                     if db_node:
@@ -295,8 +309,7 @@ class AdminCommands(commands.Cog):
         for node_id, node in self.data.nodes.items():
             if (str(node.get("shortname", "")).lower() == search_lower or
                     str(node.get("longname", "")).lower() == search_lower):
-                name = node.get("longname", node.get("shortname", ""))
-                return node_id, name if name not in ("Unknown", "UNK", "") else None
+                return node_id, self._make_display_name(node)
 
         # Try as shortname/longname in PostgreSQL
         if self.data.pg_storage:
@@ -382,11 +395,7 @@ class AdminCommands(commands.Cog):
             node = self.data.nodes.get(nid)
             if not node and self.data.pg_storage:
                 node = await self.data.pg_storage.query_node_by_id(nid)
-            name = None
-            if node:
-                n = node.get("longname", node.get("shortname", ""))
-                if n and n not in ("Unknown", "UNK"):
-                    name = n
+            name = self._make_display_name(node)
             lines.append(f"- {self._format_node_display(nid, name)}")
 
         # Build view with unlink buttons
@@ -448,11 +457,7 @@ class AdminCommands(commands.Cog):
             node = self.data.nodes.get(nid)
             if not node and self.data.pg_storage:
                 node = await self.data.pg_storage.query_node_by_id(nid)
-            name = None
-            if node:
-                n = node.get("longname", node.get("shortname", ""))
-                if n and n not in ("Unknown", "UNK"):
-                    name = n
+            name = self._make_display_name(node)
             lines.append(f"- {self._format_node_display(nid, name)}")
 
         view = _UnwatchView(self.data.pg_storage, nodes, str(interaction.user.id))
@@ -632,11 +637,7 @@ class AdminCommands(commands.Cog):
             node = self.data.nodes.get(nid)
             if not node and self.data.pg_storage:
                 node = await self.data.pg_storage.query_node_by_id(nid)
-            name = None
-            if node:
-                n = node.get("longname", node.get("shortname", ""))
-                if n and n not in ("Unknown", "UNK"):
-                    name = n
+            name = self._make_display_name(node)
             display = self._format_node_display(nid, name)
             added_by = t.get("added_by", "")
             added_str = f" (by <@{added_by}>)" if added_by else ""
@@ -669,11 +670,7 @@ class AdminCommands(commands.Cog):
             node = self.data.nodes.get(nid)
             if not node and self.data.pg_storage:
                 node = await self.data.pg_storage.query_node_by_id(nid)
-            name = None
-            if node:
-                n = node.get("longname", node.get("shortname", ""))
-                if n and n not in ("Unknown", "UNK"):
-                    name = n
+            name = self._make_display_name(node)
             display = self._format_node_display(nid, name)
             reason = b.get("reason", "")
             banned_by = b.get("banned_by", "")

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -83,6 +83,66 @@ class _UnlinkView(discord.ui.View):
             self.add_item(_UnlinkButton(pg_storage, nid, short_label))
 
 
+class _RemoveTrackerButton(discord.ui.Button):
+    """A button that removes tracking for a specific node."""
+
+    def __init__(self, pg_storage, node_id: str, label: str):
+        super().__init__(
+            style=discord.ButtonStyle.danger,
+            label=f"Remove {label}",
+            custom_id=f"rmtracker:{node_id}",
+        )
+        self.pg_storage = pg_storage
+        self.node_id = node_id
+
+    async def callback(self, interaction: discord.Interaction):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+        ok = await self.pg_storage.remove_tracker(self.node_id)
+        if ok:
+            await interaction.response.send_message(f"Removed tracking for `!{self.node_id}`.", ephemeral=True)
+        else:
+            await interaction.response.send_message(f"Node `!{self.node_id}` was not being tracked.", ephemeral=True)
+
+
+class _RemoveTrackerView(discord.ui.View):
+    def __init__(self, pg_storage, node_ids: list[str]):
+        super().__init__(timeout=120)
+        for nid in node_ids[:25]:
+            self.add_item(_RemoveTrackerButton(pg_storage, nid, nid[:8]))
+
+
+class _UnbanButton(discord.ui.Button):
+    """A button that unbans a specific node."""
+
+    def __init__(self, pg_storage, node_id: str, label: str):
+        super().__init__(
+            style=discord.ButtonStyle.success,
+            label=f"Unban {label}",
+            custom_id=f"unban:{node_id}",
+        )
+        self.pg_storage = pg_storage
+        self.node_id = node_id
+
+    async def callback(self, interaction: discord.Interaction):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+        ok = await self.pg_storage.unban_node(self.node_id)
+        if ok:
+            await interaction.response.send_message(f"Unbanned node `!{self.node_id}`.", ephemeral=True)
+        else:
+            await interaction.response.send_message(f"Node `!{self.node_id}` was not banned.", ephemeral=True)
+
+
+class _UnbanView(discord.ui.View):
+    def __init__(self, pg_storage, node_ids: list[str]):
+        super().__init__(timeout=120)
+        for nid in node_ids[:25]:
+            self.add_item(_UnbanButton(pg_storage, nid, nid[:8]))
+
+
 class AdminCommands(commands.Cog):
     """Slash commands for Discord bridge administration."""
 
@@ -357,3 +417,85 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(f"Node {display} has been unbanned.")
         else:
             await interaction.response.send_message(f"Node {display} was not banned.", ephemeral=True)
+
+    @app_commands.command(name="listtrackers", description="List all nodes being tracked for position updates")
+    async def list_trackers(self, interaction: discord.Interaction):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        trackers = await self.data.pg_storage.list_trackers()
+        if not trackers:
+            await interaction.response.send_message("No nodes are currently being tracked.", ephemeral=True)
+            return
+
+        lines = []
+        node_ids = []
+        for t in trackers:
+            nid = t["node_id"]
+            node_ids.append(nid)
+            track_type = t.get("track_type", "tracker")
+            label = "Balloon" if track_type == "balloon" else "Tracker"
+            # Resolve name
+            node = self.data.nodes.get(nid)
+            if not node and self.data.pg_storage:
+                node = await self.data.pg_storage.query_node_by_id(nid)
+            name = None
+            if node:
+                n = node.get("longname", node.get("shortname", ""))
+                if n and n not in ("Unknown", "UNK"):
+                    name = n
+            display = self._format_node_display(nid, name)
+            added_by = t.get("added_by", "")
+            added_str = f" (by <@{added_by}>)" if added_by else ""
+            lines.append(f"- [{label}] {display}{added_str}")
+
+        view = _RemoveTrackerView(self.data.pg_storage, node_ids)
+        await interaction.response.send_message(
+            f"**Tracked nodes ({len(trackers)}):**\n" + "\n".join(lines),
+            view=view,
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="listbans", description="List all nodes banned from the Discord bridge")
+    async def list_bans(self, interaction: discord.Interaction):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        bans = await self.data.pg_storage.list_bans()
+        if not bans:
+            await interaction.response.send_message("No nodes are currently banned.", ephemeral=True)
+            return
+
+        lines = []
+        node_ids = []
+        for b in bans:
+            nid = b["node_id"]
+            node_ids.append(nid)
+            # Resolve name
+            node = self.data.nodes.get(nid)
+            if not node and self.data.pg_storage:
+                node = await self.data.pg_storage.query_node_by_id(nid)
+            name = None
+            if node:
+                n = node.get("longname", node.get("shortname", ""))
+                if n and n not in ("Unknown", "UNK"):
+                    name = n
+            display = self._format_node_display(nid, name)
+            reason = b.get("reason", "")
+            banned_by = b.get("banned_by", "")
+            extra = []
+            if banned_by:
+                extra.append(f"by <@{banned_by}>")
+            if reason:
+                extra.append(f"reason: {reason}")
+            extra_str = f" ({', '.join(extra)})" if extra else ""
+            lines.append(f"- {display}{extra_str}")
+
+        view = _UnbanView(self.data.pg_storage, node_ids)
+        await interaction.response.send_message(
+            f"**Banned nodes ({len(bans)}):**\n" + "\n".join(lines),
+            view=view,
+            ephemeral=True,
+        )

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -83,6 +83,38 @@ class _UnlinkView(discord.ui.View):
             self.add_item(_UnlinkButton(pg_storage, nid, short_label))
 
 
+class _UnwatchButton(discord.ui.Button):
+    """A button that unwatches a specific node."""
+
+    def __init__(self, pg_storage, node_id: str, label: str, discord_user_id: str):
+        super().__init__(
+            style=discord.ButtonStyle.danger,
+            label=f"Unwatch {label}",
+            custom_id=f"unwatch:{node_id}",
+        )
+        self.pg_storage = pg_storage
+        self.node_id = node_id
+        self.discord_user_id = discord_user_id
+
+    async def callback(self, interaction: discord.Interaction):
+        ok = await self.pg_storage.unwatch_node(self.node_id, str(interaction.user.id))
+        if ok:
+            await interaction.response.send_message(
+                f"Stopped watching node `!{self.node_id}`.", ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                f"Node `!{self.node_id}` was not being watched.", ephemeral=True,
+            )
+
+
+class _UnwatchView(discord.ui.View):
+    def __init__(self, pg_storage, node_ids: list[str], discord_user_id: str):
+        super().__init__(timeout=120)
+        for nid in node_ids[:25]:
+            self.add_item(_UnwatchButton(pg_storage, nid, nid[:8], discord_user_id))
+
+
 class _RemoveTrackerButton(discord.ui.Button):
     """A button that removes tracking for a specific node."""
 
@@ -309,10 +341,14 @@ class AdminCommands(commands.Cog):
             )
             return
 
-        ok = await self.data.pg_storage.link_node(nid, str(interaction.user.id))
+        result = await self.data.pg_storage.link_node(nid, str(interaction.user.id))
         display = self._format_node_display(nid, name)
-        if ok:
+        if result == "ok":
             await interaction.response.send_message(f"Linked node {display} to your account.", ephemeral=True)
+        elif result == "already_yours":
+            await interaction.response.send_message(f"Node {display} is already linked to your account.", ephemeral=True)
+        elif result == "taken":
+            await interaction.response.send_message(f"Node {display} is already linked to another user.", ephemeral=True)
         else:
             await interaction.response.send_message("Failed to link node. Database may be unavailable.", ephemeral=True)
 
@@ -358,6 +394,71 @@ class AdminCommands(commands.Cog):
 
         await interaction.response.send_message(
             "**Your linked nodes:**\n" + "\n".join(lines),
+            view=view,
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="watchnode", description="Watch a node for online/offline alerts")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
+    async def watch_node(self, interaction: discord.Interaction, node_id: str):
+        nid, name = await self._resolve_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(
+                f"Could not find node `{node_id}`.", ephemeral=True,
+            )
+            return
+
+        result = await self.data.pg_storage.watch_node(nid, str(interaction.user.id))
+        display = self._format_node_display(nid, name)
+        if result == "ok":
+            await interaction.response.send_message(f"Now watching {display} for online/offline alerts.", ephemeral=True)
+        elif result == "already":
+            await interaction.response.send_message(f"You are already watching {display}.", ephemeral=True)
+        else:
+            await interaction.response.send_message("Failed to watch node. Database may be unavailable.", ephemeral=True)
+
+    @app_commands.command(name="unwatchnode", description="Stop watching a node for alerts")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
+    async def unwatch_node(self, interaction: discord.Interaction, node_id: str):
+        nid, name = await self._resolve_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(
+                f"Could not find node `{node_id}`.", ephemeral=True,
+            )
+            return
+
+        ok = await self.data.pg_storage.unwatch_node(nid, str(interaction.user.id))
+        display = self._format_node_display(nid, name)
+        if ok:
+            await interaction.response.send_message(f"Stopped watching {display}.", ephemeral=True)
+        else:
+            await interaction.response.send_message(f"You were not watching {display}.", ephemeral=True)
+
+    @app_commands.command(name="mywatchednodes", description="List all nodes you are watching for alerts")
+    async def my_watched_nodes(self, interaction: discord.Interaction):
+        nodes = await self.data.pg_storage.get_watched_nodes(str(interaction.user.id))
+        if not nodes:
+            await interaction.response.send_message("You are not watching any nodes.", ephemeral=True)
+            return
+
+        lines = []
+        for nid in nodes:
+            node = self.data.nodes.get(nid)
+            if not node and self.data.pg_storage:
+                node = await self.data.pg_storage.query_node_by_id(nid)
+            name = None
+            if node:
+                n = node.get("longname", node.get("shortname", ""))
+                if n and n not in ("Unknown", "UNK"):
+                    name = n
+            lines.append(f"- {self._format_node_display(nid, name)}")
+
+        view = _UnwatchView(self.data.pg_storage, nodes, str(interaction.user.id))
+
+        await interaction.response.send_message(
+            "**Your watched nodes:**\n" + "\n".join(lines),
             view=view,
             ephemeral=True,
         )

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -302,28 +302,35 @@ class AdminCommands(commands.Cog):
 
         # Try as shortname/longname in memory
         search_lower = raw.lower()
+        found_nid = None
         for node_id, node in self.data.nodes.items():
             if (str(node.get("shortname", "")).lower() == search_lower or
                     str(node.get("longname", "")).lower() == search_lower):
-                return node_id, self._make_display_name(node)
+                found_nid = node_id
+                break
 
         # Try as shortname/longname in PostgreSQL
-        if self.data.pg_storage:
+        if found_nid is None and self.data.pg_storage:
             results = await self.data.pg_storage.query_nodes_filtered(
                 days_limit=None, shortname_filter=search_lower,
             )
+            if not results:
+                results = await self.data.pg_storage.query_nodes_filtered(
+                    days_limit=None, longname_filter=search_lower,
+                )
             if results:
-                nid, node = next(iter(results.items()))
-                name = node.get("longname", node.get("shortname", ""))
-                return nid, name if name not in ("Unknown", "UNK", "") else None
+                found_nid = next(iter(results.keys()))
 
-            results = await self.data.pg_storage.query_nodes_filtered(
-                days_limit=None, longname_filter=search_lower,
-            )
-            if results:
-                nid, node = next(iter(results.items()))
-                name = node.get("longname", node.get("shortname", ""))
-                return nid, name if name not in ("Unknown", "UNK", "") else None
+        if found_nid:
+            # Get best display name (memory then DB)
+            node = self.data.nodes.get(found_nid)
+            name = self._make_display_name(node)
+            if self.data.pg_storage and (not name or "[" not in (name or "")):
+                db_node = await self.data.pg_storage.query_node_by_id(found_nid)
+                db_name = self._make_display_name(db_node)
+                if db_name and (not name or len(db_name) > len(name)):
+                    name = db_name
+            return found_nid, name
 
         return None, None
 

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -151,6 +151,60 @@ class AdminCommands(commands.Cog):
         self.config = config
         self.data = data
 
+    async def _node_autocomplete(
+        self, interaction: discord.Interaction, current: str,
+    ) -> list[app_commands.Choice[str]]:
+        """Shared autocomplete for node ID fields across all commands."""
+        current = current.strip().lower().replace("!", "")
+        if not current:
+            return []
+
+        choices: list[app_commands.Choice[str]] = []
+        seen: set[str] = set()
+
+        # Search in-memory nodes first (fast)
+        for nid, node in self.data.nodes.items():
+            if len(choices) >= 25:
+                break
+            short = str(node.get("shortname", "")).lower()
+            long = str(node.get("longname", "")).lower()
+            if current in nid or current in short or current in long:
+                display_name = node.get("longname") or node.get("shortname") or nid
+                if display_name in ("Unknown", "UNK"):
+                    display_name = nid
+                label = f"{display_name} (!{nid})"[:100]
+                if nid not in seen:
+                    choices.append(app_commands.Choice(name=label, value=nid))
+                    seen.add(nid)
+
+        # Supplement from DB if we have room
+        if len(choices) < 25 and self.data.pg_storage:
+            try:
+                results = await self.data.pg_storage.query_nodes_filtered(
+                    days_limit=None, shortname_filter=current,
+                )
+                if len(results) < 10:
+                    long_results = await self.data.pg_storage.query_nodes_filtered(
+                        days_limit=None, longname_filter=current,
+                    )
+                    results.update(long_results)
+
+                for nid, node in results.items():
+                    if len(choices) >= 25:
+                        break
+                    if nid in seen:
+                        continue
+                    display_name = node.get("longname") or node.get("shortname") or nid
+                    if display_name in ("Unknown", "UNK"):
+                        display_name = nid
+                    label = f"{display_name} (!{nid})"[:100]
+                    choices.append(app_commands.Choice(name=label, value=nid))
+                    seen.add(nid)
+            except Exception:
+                pass
+
+        return choices
+
     async def _resolve_node_id(self, raw: str) -> tuple[Optional[str], Optional[str]]:
         """
         Resolve user input to a node hex ID.
@@ -238,6 +292,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="linknode", description="Link a mesh node to your Discord account")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def link_node(self, interaction: discord.Interaction, node_id: str):
         nid, name = await self._resolve_node_id(node_id)
         if not nid:
@@ -256,6 +311,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="unlinknode", description="Unlink a mesh node from your Discord account")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def unlink_node(self, interaction: discord.Interaction, node_id: str):
         nid, name = await self._resolve_node_id(node_id)
         if not nid:
@@ -303,6 +359,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="addtracker", description="Enable position forwarding for a node")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def add_tracker(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
@@ -322,6 +379,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="removetracker", description="Disable position forwarding for a node")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def remove_tracker(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
@@ -341,6 +399,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="addballoon", description="Mark a node as a balloon for position tracking")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def add_balloon(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
@@ -360,6 +419,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="removeballoon", description="Remove balloon marking from a node")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def remove_balloon(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
@@ -379,6 +439,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="bannode", description="Ban a node from the Discord bridge")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name", reason="Reason for ban (optional)")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def ban_node(self, interaction: discord.Interaction, node_id: str, reason: str = ""):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
@@ -401,6 +462,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(name="unbannode", description="Unban a node from the Discord bridge")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
     async def unban_node(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -465,6 +465,28 @@ class AdminCommands(commands.Cog):
 
     # ─── Moderator Commands ──────────────────────────────────────────
 
+    @app_commands.command(name="forceunlink", description="Force unlink a node from any user (mod only)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
+    @app_commands.autocomplete(node_id=_node_autocomplete)
+    async def force_unlink(self, interaction: discord.Interaction, node_id: str):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid, name = await self._resolve_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
+            return
+
+        prev_owner = await self.data.pg_storage.force_unlink_node(nid)
+        display = self._format_node_display(nid, name)
+        if prev_owner:
+            await interaction.response.send_message(
+                f"Force unlinked {display} from <@{prev_owner}>.", ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(f"Node {display} was not linked to anyone.", ephemeral=True)
+
     @app_commands.command(name="addtracker", description="Enable position forwarding for a node")
     @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     @app_commands.autocomplete(node_id=_node_autocomplete)

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -274,35 +274,26 @@ class AdminCommands(commands.Cog):
             try:
                 id_int = int(search, 10)
                 nid = utils.convert_node_id_from_int_to_hex(id_int)
-                # Look up name
+                # Look up best display name (memory then DB)
                 node = self.data.nodes.get(nid)
-                if node:
-                    return nid, self._make_display_name(node)
-                if self.data.pg_storage:
+                name = self._make_display_name(node)
+                if not name and self.data.pg_storage:
                     db_node = await self.data.pg_storage.query_node_by_id(nid)
-                    if db_node:
-                        name = db_node.get("longname", db_node.get("shortname", ""))
-                        return nid, name if name not in ("Unknown", "UNK", "") else None
-                return nid, None
+                    name = self._make_display_name(db_node)
+                return nid, name
             except (ValueError, TypeError):
                 pass
 
         # Try as hex ID (contains a-f, or has ! prefix)
         nid = _normalize_node_id(raw)
         if nid:
-            # Verify it exists (optional — allow linking to unknown nodes)
+            # Try in-memory, then DB — pick the best display name
             node = self.data.nodes.get(nid)
-            if node:
-                name = node.get("longname", node.get("shortname", ""))
-                return nid, name if name not in ("Unknown", "UNK", "") else None
-            # Check DB
-            if self.data.pg_storage:
+            name = self._make_display_name(node)
+            if not name and self.data.pg_storage:
                 db_node = await self.data.pg_storage.query_node_by_id(nid)
-                if db_node:
-                    name = db_node.get("longname", db_node.get("shortname", ""))
-                    return nid, name if name not in ("Unknown", "UNK", "") else None
-            # Valid hex but not in DB — still allow it
-            return nid, None
+                name = self._make_display_name(db_node)
+            return nid, name
 
         # Try as shortname/longname in memory
         search_lower = raw.lower()

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -169,10 +169,17 @@ class AdminCommands(commands.Cog):
             short = str(node.get("shortname", "")).lower()
             long = str(node.get("longname", "")).lower()
             if current in nid or current in short or current in long:
-                display_name = node.get("longname") or node.get("shortname") or nid
-                if display_name in ("Unknown", "UNK"):
-                    display_name = nid
-                label = f"{display_name} (!{nid})"[:100]
+                longname = node.get("longname", "")
+                shortname = node.get("shortname", "")
+                if longname and longname != "Unknown" and shortname and shortname != "UNK":
+                    label = f"{longname} [{shortname}] (!{nid})"
+                elif longname and longname != "Unknown":
+                    label = f"{longname} (!{nid})"
+                elif shortname and shortname != "UNK":
+                    label = f"{shortname} (!{nid})"
+                else:
+                    label = f"!{nid}"
+                label = label[:100]
                 if nid not in seen:
                     choices.append(app_commands.Choice(name=label, value=nid))
                     seen.add(nid)

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -277,9 +277,11 @@ class AdminCommands(commands.Cog):
                 # Look up best display name (memory then DB)
                 node = self.data.nodes.get(nid)
                 name = self._make_display_name(node)
-                if not name and self.data.pg_storage:
+                if self.data.pg_storage and (not name or "[" not in (name or "")):
                     db_node = await self.data.pg_storage.query_node_by_id(nid)
-                    name = self._make_display_name(db_node)
+                    db_name = self._make_display_name(db_node)
+                    if db_name and (not name or len(db_name) > len(name)):
+                        name = db_name
                 return nid, name
             except (ValueError, TypeError):
                 pass
@@ -287,12 +289,15 @@ class AdminCommands(commands.Cog):
         # Try as hex ID (contains a-f, or has ! prefix)
         nid = _normalize_node_id(raw)
         if nid:
-            # Try in-memory, then DB — pick the best display name
+            # Try in-memory, then DB — pick the most complete display name
             node = self.data.nodes.get(nid)
             name = self._make_display_name(node)
-            if not name and self.data.pg_storage:
+            # If name is incomplete (missing shortname), try DB for a better version
+            if self.data.pg_storage and (not name or "[" not in (name or "")):
                 db_node = await self.data.pg_storage.query_node_by_id(nid)
-                name = self._make_display_name(db_node)
+                db_name = self._make_display_name(db_node)
+                if db_name and (not name or len(db_name) > len(name)):
+                    name = db_name
             return nid, name
 
         # Try as shortname/longname in memory

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -17,11 +17,13 @@ Moderator/Admin commands:
 
 import logging
 import re
+from typing import Optional
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
+import utils
 from memory_data_store import MemoryDataStore
 
 logger = logging.getLogger(__name__)
@@ -46,6 +48,41 @@ def _is_mod(interaction: discord.Interaction) -> bool:
     return perms.manage_messages or perms.administrator
 
 
+class _UnlinkButton(discord.ui.Button):
+    """A button that unlinks a specific node when clicked."""
+
+    def __init__(self, pg_storage, node_id: str, label: str):
+        super().__init__(
+            style=discord.ButtonStyle.danger,
+            label=f"Unlink {label}",
+            custom_id=f"unlink:{node_id}",
+        )
+        self.pg_storage = pg_storage
+        self.node_id = node_id
+
+    async def callback(self, interaction: discord.Interaction):
+        ok = await self.pg_storage.unlink_node(self.node_id, str(interaction.user.id))
+        if ok:
+            await interaction.response.send_message(
+                f"Unlinked node `!{self.node_id}`.", ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                f"Node `!{self.node_id}` was not linked to your account.", ephemeral=True,
+            )
+
+
+class _UnlinkView(discord.ui.View):
+    """A view containing unlink buttons for each linked node."""
+
+    def __init__(self, pg_storage, node_ids: list[str]):
+        super().__init__(timeout=120)
+        # Discord allows max 25 components, 5 per row
+        for nid in node_ids[:25]:
+            short_label = nid[:8]
+            self.add_item(_UnlinkButton(pg_storage, nid, short_label))
+
+
 class AdminCommands(commands.Cog):
     """Slash commands for Discord bridge administration."""
 
@@ -54,48 +91,114 @@ class AdminCommands(commands.Cog):
         self.config = config
         self.data = data
 
+    async def _resolve_node_id(self, raw: str) -> tuple[Optional[str], Optional[str]]:
+        """
+        Resolve user input to a node hex ID.
+
+        Accepts hex IDs, integer IDs, shortnames, and longnames.
+        Returns (hex_id, display_name) or (None, None) if not found.
+        """
+        raw = raw.strip()
+
+        # Try as hex ID
+        nid = _normalize_node_id(raw)
+        if nid:
+            # Verify it exists (optional — allow linking to unknown nodes)
+            node = self.data.nodes.get(nid)
+            if node:
+                name = node.get("longname", node.get("shortname", ""))
+                return nid, name if name not in ("Unknown", "UNK", "") else None
+            # Check DB
+            if self.data.pg_storage:
+                db_node = await self.data.pg_storage.query_node_by_id(nid)
+                if db_node:
+                    name = db_node.get("longname", db_node.get("shortname", ""))
+                    return nid, name if name not in ("Unknown", "UNK", "") else None
+            # Valid hex but not in DB — still allow it
+            return nid, None
+
+        # Try as integer ID
+        search = raw.replace("!", "").strip()
+        try:
+            id_int = int(search, 10)
+            nid = utils.convert_node_id_from_int_to_hex(id_int)
+            return nid, None
+        except (ValueError, TypeError):
+            pass
+
+        # Try as shortname/longname in memory
+        search_lower = raw.lower()
+        for node_id, node in self.data.nodes.items():
+            if (str(node.get("shortname", "")).lower() == search_lower or
+                    str(node.get("longname", "")).lower() == search_lower):
+                name = node.get("longname", node.get("shortname", ""))
+                return node_id, name if name not in ("Unknown", "UNK", "") else None
+
+        # Try as shortname/longname in PostgreSQL
+        if self.data.pg_storage:
+            results = await self.data.pg_storage.query_nodes_filtered(
+                days_limit=None, shortname_filter=search_lower,
+            )
+            if results:
+                nid, node = next(iter(results.items()))
+                name = node.get("longname", node.get("shortname", ""))
+                return nid, name if name not in ("Unknown", "UNK", "") else None
+
+            results = await self.data.pg_storage.query_nodes_filtered(
+                days_limit=None, longname_filter=search_lower,
+            )
+            if results:
+                nid, node = next(iter(results.items()))
+                name = node.get("longname", node.get("shortname", ""))
+                return nid, name if name not in ("Unknown", "UNK", "") else None
+
+        return None, None
+
+    def _format_node_display(self, nid: str, name: str | None) -> str:
+        """Format a node ID with linked name for display in responses."""
+        base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
+        if name and base_url:
+            return f"`!{nid}` ([{name}]({base_url}/nodes?node={nid}))"
+        elif name:
+            return f"`!{nid}` ({name})"
+        return f"`!{nid}`"
+
     # ─── User Commands ────────────────────────────────────────────────
 
     @app_commands.command(name="linknode", description="Link a mesh node to your Discord account")
-    @app_commands.describe(node_id="Mesh node ID (hex, e.g. !1a2b3c4d or 1a2b3c4d)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def link_node(self, interaction: discord.Interaction, node_id: str):
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
             await interaction.response.send_message(
-                f"Invalid node ID: `{node_id}`. Use 8 hex characters (e.g. `!1a2b3c4d`).",
+                f"Could not find node `{node_id}`. Try a hex ID, integer ID, short name, or long name.",
                 ephemeral=True,
             )
             return
 
         ok = await self.data.pg_storage.link_node(nid, str(interaction.user.id))
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(
-                f"Linked node `!{nid}` to your account.", ephemeral=True,
-            )
+            await interaction.response.send_message(f"Linked node {display} to your account.", ephemeral=True)
         else:
-            await interaction.response.send_message(
-                "Failed to link node. Database may be unavailable.", ephemeral=True,
-            )
+            await interaction.response.send_message("Failed to link node. Database may be unavailable.", ephemeral=True)
 
     @app_commands.command(name="unlinknode", description="Unlink a mesh node from your Discord account")
-    @app_commands.describe(node_id="Mesh node ID (hex)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def unlink_node(self, interaction: discord.Interaction, node_id: str):
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
             await interaction.response.send_message(
-                f"Invalid node ID: `{node_id}`.", ephemeral=True,
+                f"Could not find node `{node_id}`.", ephemeral=True,
             )
             return
 
         ok = await self.data.pg_storage.unlink_node(nid, str(interaction.user.id))
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(
-                f"Unlinked node `!{nid}` from your account.", ephemeral=True,
-            )
+            await interaction.response.send_message(f"Unlinked node {display} from your account.", ephemeral=True)
         else:
-            await interaction.response.send_message(
-                f"Node `!{nid}` was not linked to your account.", ephemeral=True,
-            )
+            await interaction.response.send_message(f"Node {display} was not linked to your account.", ephemeral=True)
 
     @app_commands.command(name="mylinkednodes", description="List all mesh nodes linked to your Discord account")
     async def my_linked_nodes(self, interaction: discord.Interaction):
@@ -104,109 +207,121 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message("You have no linked nodes.", ephemeral=True)
             return
 
-        lines = [f"- `!{nid}`" for nid in nodes]
-        # Resolve names where available
-        for i, nid in enumerate(nodes):
+        lines = []
+        for nid in nodes:
             node = self.data.nodes.get(nid)
+            if not node and self.data.pg_storage:
+                node = await self.data.pg_storage.query_node_by_id(nid)
+            name = None
             if node:
-                name = node.get("longname", node.get("shortname", ""))
-                if name and name not in ("Unknown", "UNK"):
-                    lines[i] = f"- `!{nid}` ({name})"
+                n = node.get("longname", node.get("shortname", ""))
+                if n and n not in ("Unknown", "UNK"):
+                    name = n
+            lines.append(f"- {self._format_node_display(nid, name)}")
+
+        # Build view with unlink buttons
+        view = _UnlinkView(self.data.pg_storage, nodes)
 
         await interaction.response.send_message(
             "**Your linked nodes:**\n" + "\n".join(lines),
+            view=view,
             ephemeral=True,
         )
 
     # ─── Moderator Commands ──────────────────────────────────────────
 
     @app_commands.command(name="addtracker", description="Enable position forwarding for a node")
-    @app_commands.describe(node_id="Mesh node ID (hex)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def add_tracker(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
             return
 
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
-            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
             return
 
         ok = await self.data.pg_storage.add_tracker(nid, "tracker", str(interaction.user.id))
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(f"Position tracking enabled for `!{nid}`.")
+            await interaction.response.send_message(f"Position tracking enabled for {display}.")
         else:
             await interaction.response.send_message("Failed to add tracker.", ephemeral=True)
 
     @app_commands.command(name="removetracker", description="Disable position forwarding for a node")
-    @app_commands.describe(node_id="Mesh node ID (hex)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def remove_tracker(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
             return
 
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
-            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
             return
 
         ok = await self.data.pg_storage.remove_tracker(nid)
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(f"Position tracking removed for `!{nid}`.")
+            await interaction.response.send_message(f"Position tracking removed for {display}.")
         else:
-            await interaction.response.send_message(f"Node `!{nid}` was not being tracked.", ephemeral=True)
+            await interaction.response.send_message(f"Node {display} was not being tracked.", ephemeral=True)
 
     @app_commands.command(name="addballoon", description="Mark a node as a balloon for position tracking")
-    @app_commands.describe(node_id="Mesh node ID (hex)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def add_balloon(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
             return
 
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
-            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
             return
 
         ok = await self.data.pg_storage.add_tracker(nid, "balloon", str(interaction.user.id))
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(f"Balloon tracking enabled for `!{nid}`.")
+            await interaction.response.send_message(f"Balloon tracking enabled for {display}.")
         else:
             await interaction.response.send_message("Failed to add balloon tracker.", ephemeral=True)
 
     @app_commands.command(name="removeballoon", description="Remove balloon marking from a node")
-    @app_commands.describe(node_id="Mesh node ID (hex)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def remove_balloon(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
             return
 
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
-            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
             return
 
         ok = await self.data.pg_storage.remove_tracker(nid)
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(f"Balloon tracking removed for `!{nid}`.")
+            await interaction.response.send_message(f"Balloon tracking removed for {display}.")
         else:
-            await interaction.response.send_message(f"Node `!{nid}` was not being tracked.", ephemeral=True)
+            await interaction.response.send_message(f"Node {display} was not being tracked.", ephemeral=True)
 
     @app_commands.command(name="bannode", description="Ban a node from the Discord bridge")
-    @app_commands.describe(node_id="Mesh node ID (hex)", reason="Reason for ban (optional)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name", reason="Reason for ban (optional)")
     async def ban_node(self, interaction: discord.Interaction, node_id: str, reason: str = ""):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
             return
 
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
-            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
             return
 
         ok = await self.data.pg_storage.ban_node(nid, str(interaction.user.id), reason)
+        display = self._format_node_display(nid, name)
         if ok:
-            msg = f"Node `!{nid}` has been banned from the Discord bridge."
+            msg = f"Node {display} has been banned from the Discord bridge."
             if reason:
                 msg += f" Reason: {reason}"
             await interaction.response.send_message(msg)
@@ -214,19 +329,20 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message("Failed to ban node.", ephemeral=True)
 
     @app_commands.command(name="unbannode", description="Unban a node from the Discord bridge")
-    @app_commands.describe(node_id="Mesh node ID (hex)")
+    @app_commands.describe(node_id="Node ID (hex), integer ID, short name, or long name")
     async def unban_node(self, interaction: discord.Interaction, node_id: str):
         if not _is_mod(interaction):
             await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
             return
 
-        nid = _normalize_node_id(node_id)
+        nid, name = await self._resolve_node_id(node_id)
         if not nid:
-            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            await interaction.response.send_message(f"Could not find node `{node_id}`.", ephemeral=True)
             return
 
         ok = await self.data.pg_storage.unban_node(nid)
+        display = self._format_node_display(nid, name)
         if ok:
-            await interaction.response.send_message(f"Node `!{nid}` has been unbanned.")
+            await interaction.response.send_message(f"Node {display} has been unbanned.")
         else:
-            await interaction.response.send_message(f"Node `!{nid}` was not banned.", ephemeral=True)
+            await interaction.response.send_message(f"Node {display} was not banned.", ephemeral=True)

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -99,8 +99,28 @@ class AdminCommands(commands.Cog):
         Returns (hex_id, display_name) or (None, None) if not found.
         """
         raw = raw.strip()
+        search = raw.replace("!", "").strip()
 
-        # Try as hex ID
+        # Try as integer ID first (digits-only input like "1234" should be decimal, not hex)
+        if search.isdigit():
+            try:
+                id_int = int(search, 10)
+                nid = utils.convert_node_id_from_int_to_hex(id_int)
+                # Look up name
+                node = self.data.nodes.get(nid)
+                if node:
+                    name = node.get("longname", node.get("shortname", ""))
+                    return nid, name if name not in ("Unknown", "UNK", "") else None
+                if self.data.pg_storage:
+                    db_node = await self.data.pg_storage.query_node_by_id(nid)
+                    if db_node:
+                        name = db_node.get("longname", db_node.get("shortname", ""))
+                        return nid, name if name not in ("Unknown", "UNK", "") else None
+                return nid, None
+            except (ValueError, TypeError):
+                pass
+
+        # Try as hex ID (contains a-f, or has ! prefix)
         nid = _normalize_node_id(raw)
         if nid:
             # Verify it exists (optional — allow linking to unknown nodes)
@@ -116,15 +136,6 @@ class AdminCommands(commands.Cog):
                     return nid, name if name not in ("Unknown", "UNK", "") else None
             # Valid hex but not in DB — still allow it
             return nid, None
-
-        # Try as integer ID
-        search = raw.replace("!", "").strip()
-        try:
-            id_int = int(search, 10)
-            nid = utils.convert_node_id_from_int_to_hex(id_int)
-            return nid, None
-        except (ValueError, TypeError):
-            pass
 
         # Try as shortname/longname in memory
         search_lower = raw.lower()

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -1,0 +1,232 @@
+"""
+Admin and user slash commands for the Discord bridge.
+
+User commands:
+  /linknode     — Associate a mesh node ID with your Discord account
+  /unlinknode   — Remove association
+  /mylinkednodes — List your linked nodes
+
+Moderator/Admin commands:
+  /addtracker    — Enable position forwarding for a node
+  /removetracker — Disable position forwarding
+  /addballoon    — Mark node as balloon (position forwarding)
+  /removeballoon — Remove balloon marking
+  /bannode       — Suppress all messages from a node
+  /unbannode     — Remove ban
+"""
+
+import logging
+import re
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from memory_data_store import MemoryDataStore
+
+logger = logging.getLogger(__name__)
+
+# Validate hex node IDs (8 hex chars, with or without ! prefix)
+_NODE_ID_RE = re.compile(r"^!?([0-9a-fA-F]{1,8})$")
+
+
+def _normalize_node_id(raw: str) -> str | None:
+    """Normalize a node ID to lowercase 8-char hex, or None if invalid."""
+    m = _NODE_ID_RE.match(raw.strip())
+    if not m:
+        return None
+    return m.group(1).lower().zfill(8)
+
+
+def _is_mod(interaction: discord.Interaction) -> bool:
+    """Check if the user has manage_messages permission (mod-level)."""
+    if not interaction.guild:
+        return False
+    perms = interaction.channel.permissions_for(interaction.user)
+    return perms.manage_messages or perms.administrator
+
+
+class AdminCommands(commands.Cog):
+    """Slash commands for Discord bridge administration."""
+
+    def __init__(self, bot: commands.Bot, config: dict, data: MemoryDataStore):
+        self.bot = bot
+        self.config = config
+        self.data = data
+
+    # ─── User Commands ────────────────────────────────────────────────
+
+    @app_commands.command(name="linknode", description="Link a mesh node to your Discord account")
+    @app_commands.describe(node_id="Mesh node ID (hex, e.g. !1a2b3c4d or 1a2b3c4d)")
+    async def link_node(self, interaction: discord.Interaction, node_id: str):
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(
+                f"Invalid node ID: `{node_id}`. Use 8 hex characters (e.g. `!1a2b3c4d`).",
+                ephemeral=True,
+            )
+            return
+
+        ok = await self.data.pg_storage.link_node(nid, str(interaction.user.id))
+        if ok:
+            await interaction.response.send_message(
+                f"Linked node `!{nid}` to your account.", ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "Failed to link node. Database may be unavailable.", ephemeral=True,
+            )
+
+    @app_commands.command(name="unlinknode", description="Unlink a mesh node from your Discord account")
+    @app_commands.describe(node_id="Mesh node ID (hex)")
+    async def unlink_node(self, interaction: discord.Interaction, node_id: str):
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(
+                f"Invalid node ID: `{node_id}`.", ephemeral=True,
+            )
+            return
+
+        ok = await self.data.pg_storage.unlink_node(nid, str(interaction.user.id))
+        if ok:
+            await interaction.response.send_message(
+                f"Unlinked node `!{nid}` from your account.", ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                f"Node `!{nid}` was not linked to your account.", ephemeral=True,
+            )
+
+    @app_commands.command(name="mylinkednodes", description="List all mesh nodes linked to your Discord account")
+    async def my_linked_nodes(self, interaction: discord.Interaction):
+        nodes = await self.data.pg_storage.get_linked_nodes(str(interaction.user.id))
+        if not nodes:
+            await interaction.response.send_message("You have no linked nodes.", ephemeral=True)
+            return
+
+        lines = [f"- `!{nid}`" for nid in nodes]
+        # Resolve names where available
+        for i, nid in enumerate(nodes):
+            node = self.data.nodes.get(nid)
+            if node:
+                name = node.get("longname", node.get("shortname", ""))
+                if name and name not in ("Unknown", "UNK"):
+                    lines[i] = f"- `!{nid}` ({name})"
+
+        await interaction.response.send_message(
+            "**Your linked nodes:**\n" + "\n".join(lines),
+            ephemeral=True,
+        )
+
+    # ─── Moderator Commands ──────────────────────────────────────────
+
+    @app_commands.command(name="addtracker", description="Enable position forwarding for a node")
+    @app_commands.describe(node_id="Mesh node ID (hex)")
+    async def add_tracker(self, interaction: discord.Interaction, node_id: str):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            return
+
+        ok = await self.data.pg_storage.add_tracker(nid, "tracker", str(interaction.user.id))
+        if ok:
+            await interaction.response.send_message(f"Position tracking enabled for `!{nid}`.")
+        else:
+            await interaction.response.send_message("Failed to add tracker.", ephemeral=True)
+
+    @app_commands.command(name="removetracker", description="Disable position forwarding for a node")
+    @app_commands.describe(node_id="Mesh node ID (hex)")
+    async def remove_tracker(self, interaction: discord.Interaction, node_id: str):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            return
+
+        ok = await self.data.pg_storage.remove_tracker(nid)
+        if ok:
+            await interaction.response.send_message(f"Position tracking removed for `!{nid}`.")
+        else:
+            await interaction.response.send_message(f"Node `!{nid}` was not being tracked.", ephemeral=True)
+
+    @app_commands.command(name="addballoon", description="Mark a node as a balloon for position tracking")
+    @app_commands.describe(node_id="Mesh node ID (hex)")
+    async def add_balloon(self, interaction: discord.Interaction, node_id: str):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            return
+
+        ok = await self.data.pg_storage.add_tracker(nid, "balloon", str(interaction.user.id))
+        if ok:
+            await interaction.response.send_message(f"Balloon tracking enabled for `!{nid}`.")
+        else:
+            await interaction.response.send_message("Failed to add balloon tracker.", ephemeral=True)
+
+    @app_commands.command(name="removeballoon", description="Remove balloon marking from a node")
+    @app_commands.describe(node_id="Mesh node ID (hex)")
+    async def remove_balloon(self, interaction: discord.Interaction, node_id: str):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            return
+
+        ok = await self.data.pg_storage.remove_tracker(nid)
+        if ok:
+            await interaction.response.send_message(f"Balloon tracking removed for `!{nid}`.")
+        else:
+            await interaction.response.send_message(f"Node `!{nid}` was not being tracked.", ephemeral=True)
+
+    @app_commands.command(name="bannode", description="Ban a node from the Discord bridge")
+    @app_commands.describe(node_id="Mesh node ID (hex)", reason="Reason for ban (optional)")
+    async def ban_node(self, interaction: discord.Interaction, node_id: str, reason: str = ""):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            return
+
+        ok = await self.data.pg_storage.ban_node(nid, str(interaction.user.id), reason)
+        if ok:
+            msg = f"Node `!{nid}` has been banned from the Discord bridge."
+            if reason:
+                msg += f" Reason: {reason}"
+            await interaction.response.send_message(msg)
+        else:
+            await interaction.response.send_message("Failed to ban node.", ephemeral=True)
+
+    @app_commands.command(name="unbannode", description="Unban a node from the Discord bridge")
+    @app_commands.describe(node_id="Mesh node ID (hex)")
+    async def unban_node(self, interaction: discord.Interaction, node_id: str):
+        if not _is_mod(interaction):
+            await interaction.response.send_message("You need Manage Messages permission.", ephemeral=True)
+            return
+
+        nid = _normalize_node_id(node_id)
+        if not nid:
+            await interaction.response.send_message(f"Invalid node ID: `{node_id}`.", ephemeral=True)
+            return
+
+        ok = await self.data.pg_storage.unban_node(nid)
+        if ok:
+            await interaction.response.send_message(f"Node `!{nid}` has been unbanned.")
+        else:
+            await interaction.response.send_message(f"Node `!{nid}` was not banned.", ephemeral=True)

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -44,10 +44,17 @@ class MainCommands(commands.Cog):
             short = str(node.get("shortname", "")).lower()
             long = str(node.get("longname", "")).lower()
             if current in nid or current in short or current in long:
-                display_name = node.get("longname") or node.get("shortname") or nid
-                if display_name in ("Unknown", "UNK"):
-                    display_name = nid
-                label = f"{display_name} (!{nid})"[:100]
+                longname = node.get("longname", "")
+                shortname = node.get("shortname", "")
+                if longname and longname != "Unknown" and shortname and shortname != "UNK":
+                    label = f"{longname} [{shortname}] (!{nid})"
+                elif longname and longname != "Unknown":
+                    label = f"{longname} (!{nid})"
+                elif shortname and shortname != "UNK":
+                    label = f"{shortname} (!{nid})"
+                else:
+                    label = f"!{nid}"
+                label = label[:100]
                 if nid not in seen:
                     choices.append(app_commands.Choice(name=label, value=nid))
                     seen.add(nid)
@@ -69,10 +76,17 @@ class MainCommands(commands.Cog):
                         break
                     if nid in seen:
                         continue
-                    display_name = node.get("longname") or node.get("shortname") or nid
-                    if display_name in ("Unknown", "UNK"):
-                        display_name = nid
-                    label = f"{display_name} (!{nid})"[:100]
+                    longname = node.get("longname", "")
+                    shortname = node.get("shortname", "")
+                    if longname and longname != "Unknown" and shortname and shortname != "UNK":
+                        label = f"{longname} [{shortname}] (!{nid})"
+                    elif longname and longname != "Unknown":
+                        label = f"{longname} (!{nid})"
+                    elif shortname and shortname != "UNK":
+                        label = f"{shortname} (!{nid})"
+                    else:
+                        label = f"!{nid}"
+                    label = label[:100]
                     choices.append(app_commands.Choice(name=label, value=nid))
                     seen.add(nid)
             except Exception:

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -89,7 +89,11 @@ class MainCommands(commands.Cog):
             # DB stores as string or int; normalize to int for enum lookup
             try:
                 hw_int = int(hardware_raw)
-                hardware = mesh_pb2.HardwareModel.Name(hw_int).replace("_", " ").title()
+                hw_name = mesh_pb2.HardwareModel.Name(hw_int)
+                if hw_name == "PRIVATE_HW":
+                    hardware = "Private"
+                else:
+                    hardware = hw_name.replace("_", " ").title()
             except (ValueError, TypeError):
                 hardware = str(hardware_raw)
         active = node.get('active', False)

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -84,13 +84,14 @@ class MainCommands(commands.Cog):
         shortname = node.get('shortname', 'UNK')
         longname = node.get('longname', 'Unknown')
         hardware_raw = node.get('hardware', None)
-        if hardware_raw is not None and isinstance(hardware_raw, int):
+        hardware = "Unknown"
+        if hardware_raw is not None:
+            # DB stores as string or int; normalize to int for enum lookup
             try:
-                hardware = mesh_pb2.HardwareModel.Name(hardware_raw).replace("_", " ").title()
-            except ValueError:
+                hw_int = int(hardware_raw)
+                hardware = mesh_pb2.HardwareModel.Name(hw_int).replace("_", " ").title()
+            except (ValueError, TypeError):
                 hardware = str(hardware_raw)
-        else:
-            hardware = str(hardware_raw) if hardware_raw else "Unknown"
         active = node.get('active', False)
         last_seen_raw = node.get('last_seen', None)
         if isinstance(last_seen_raw, str):

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -46,7 +46,7 @@ class MainCommands(commands.Cog):
             title=f"Node {node['shortname']}: {node['longname']}",
             url=f"{self.config['server']['base_url'].strip('/')}/node_{node['id']}.html",
             color=discord.Color.blue())
-        embed.set_thumbnail(url=f"https://api.dicebear.com/9.x/bottts-neutral/svg?seed={node['id']}")
+        embed.set_thumbnail(url=f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node['id']}")
         embed.add_field(name="ID (hex)", value=id_hex, inline=True)
         embed.add_field(name="ID (int)", value=id_int, inline=True)
         embed.add_field(name="Shortname", value=node['shortname'], inline=False)

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -396,11 +396,14 @@ class MainCommands(commands.Cog):
             inline=False,
         )
         embed.add_field(
-            name="Node Linking",
+            name="Node Linking & Watching",
             value=(
                 "`/linknode` \u2014 Link a mesh node to your Discord account\n"
                 "`/unlinknode` \u2014 Remove a node link\n"
-                "`/mylinkednodes` \u2014 See all your linked nodes"
+                "`/mylinkednodes` \u2014 See all your linked nodes\n"
+                "`/watchnode` \u2014 Get alerts when a node goes online/offline\n"
+                "`/unwatchnode` \u2014 Stop watching a node\n"
+                "`/mywatchednodes` \u2014 See all your watched nodes"
             ),
             inline=False,
         )

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -1,9 +1,14 @@
 import datetime
+import logging
 from zoneinfo import ZoneInfo
 from discord.ext import commands
 import discord
+from meshtastic import mesh_pb2
 
 import utils
+
+logger = logging.getLogger(__name__)
+
 
 class LookupFlags(commands.FlagConverter):
     node: str = commands.flag(description='Node')
@@ -16,78 +21,174 @@ class MainCommands(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        print('Discord: Logged in')
+        logger.info('Discord: Logged in')
 
-    @commands.hybrid_command(name="lookup", description="Look up a node by ID (int or hex) or short name")
+    @commands.hybrid_command(name="lookup", description="Look up a node by ID (int or hex), short name, or long name")
     async def lookup_node(self, ctx, *, flags: LookupFlags):
-        print(f"Discord: /lookup: Looking up {flags.node}")
+        logger.info("Discord: /lookup: Looking up %s", flags.node)
+        search = flags.node.strip().lower().replace("!", "")
+        node = None
+        id_hex = None
+
+        # Try parsing as integer node ID
         try:
-            id_int = int(flags.node, 10)
+            id_int = int(search, 10)
             id_hex = utils.convert_node_id_from_int_to_hex(id_int)
         except ValueError:
-            id_hex = flags.node
+            pass
 
-        if id_hex not in self.data.nodes:
-            for node_id, node in self.data.nodes.items():
-                if str(node['shortname']).lower() == flags.node.lower():
+        # Try parsing as hex node ID
+        if id_hex is None and all(c in '0123456789abcdef' for c in search) and len(search) <= 8:
+            id_hex = search.zfill(8)
+
+        # 1) Check in-memory first (fastest)
+        if id_hex and id_hex in self.data.nodes:
+            node = self.data.nodes[id_hex]
+        else:
+            # Search in-memory by shortname or longname
+            for node_id, n in self.data.nodes.items():
+                if (str(n.get('shortname', '')).lower() == search or
+                        str(n.get('longname', '')).lower() == search):
+                    node = n
                     id_hex = node_id
                     break
 
-        if id_hex not in self.data.nodes:
-            print(f"Discord: /lookup: Node {id_hex} not found.")
-            await ctx.send(f"Node {id_hex} not found.")
+        # 2) Fall back to PostgreSQL
+        if node is None and self.data.pg_storage:
+            # Try by ID first
+            if id_hex:
+                node = await self.data.pg_storage.query_node_by_id(id_hex)
+
+            # Try by shortname
+            if node is None:
+                results = await self.data.pg_storage.query_nodes_filtered(
+                    days_limit=None, shortname_filter=search,
+                )
+                if results:
+                    id_hex, node = next(iter(results.items()))
+
+            # Try by longname
+            if node is None:
+                results = await self.data.pg_storage.query_nodes_filtered(
+                    days_limit=None, longname_filter=search,
+                )
+                if results:
+                    id_hex, node = next(iter(results.items()))
+
+        if node is None:
+            await ctx.send(f"Node `{flags.node}` not found.")
             return
 
+        id_hex = node.get('id', id_hex) or id_hex
         id_int = utils.convert_node_id_from_hex_to_int(id_hex)
-        node = self.data.nodes[id_hex]
-        print(f"Discord: /lookup: Found {node['id']}")
+        shortname = node.get('shortname', 'UNK')
+        longname = node.get('longname', 'Unknown')
+        hardware_raw = node.get('hardware', None)
+        if hardware_raw is not None and isinstance(hardware_raw, int):
+            try:
+                hardware = mesh_pb2.HardwareModel.Name(hardware_raw).replace("_", " ").title()
+            except ValueError:
+                hardware = str(hardware_raw)
+        else:
+            hardware = str(hardware_raw) if hardware_raw else "Unknown"
+        active = node.get('active', False)
+        last_seen_raw = node.get('last_seen', None)
+        if isinstance(last_seen_raw, str):
+            try:
+                dt = datetime.datetime.fromisoformat(last_seen_raw)
+                tz = ZoneInfo(self.config['server']['timezone'])
+                last_seen = dt.astimezone(tz).strftime("%b %d, %Y %I:%M %p %Z")
+            except (ValueError, TypeError):
+                last_seen = last_seen_raw
+        elif isinstance(last_seen_raw, datetime.datetime):
+            tz = ZoneInfo(self.config['server']['timezone'])
+            last_seen = last_seen_raw.astimezone(tz).strftime("%b %d, %Y %I:%M %p %Z")
+        else:
+            last_seen = "Unknown"
+        role = node.get('role', 0)
 
+        logger.info("Discord: /lookup: Found %s (%s)", id_hex, longname)
+
+        base_url = self.config['server']['base_url'].strip('/')
         embed = discord.Embed(
-            title=f"Node {node['shortname']}: {node['longname']}",
-            url=f"{self.config['server']['base_url'].strip('/')}/node_{node['id']}.html",
-            color=discord.Color.blue())
-        embed.set_thumbnail(url=f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node['id']}")
-        embed.add_field(name="ID (hex)", value=id_hex, inline=True)
-        embed.add_field(name="ID (int)", value=id_int, inline=True)
-        embed.add_field(name="Shortname", value=node['shortname'], inline=False)
-        embed.add_field(name="Hardware", value=node['hardware'], inline=False)
-        embed.add_field(name="Last Seen", value=node['last_seen'], inline=False)
-        embed.add_field(name="Status", value=("Online" if node['active'] else "Offline"), inline=False)
+            title=f"{shortname}: {longname}",
+            url=f"{base_url}/node_{id_hex}.html",
+            color=discord.Color.green() if active else discord.Color.greyple())
+        embed.set_thumbnail(url=f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={id_hex}")
+        embed.add_field(name="ID (hex)", value=f"!{id_hex}", inline=True)
+        embed.add_field(name="ID (int)", value=str(id_int), inline=True)
+        embed.add_field(name="Status", value=("Online" if active else "Offline"), inline=True)
+        embed.add_field(name="Hardware", value=hardware, inline=True)
+        if role:
+            role_labels = {
+                0: "Client", 1: "Client Mute", 2: "Router", 3: "Router Client",
+                4: "Repeater", 5: "Tracker", 6: "Sensor", 7: "ATAK",
+                8: "Client Hidden", 9: "Lost and Found", 10: "ATAK Tracker",
+            }
+            embed.add_field(name="Role", value=role_labels.get(role, f"Role {role}"), inline=True)
+        embed.add_field(name="Last Seen", value=str(last_seen), inline=False)
+
+        # Position info if available
+        position = node.get('position', {})
+        if position and position.get('latitude_i') and position.get('longitude_i'):
+            lat = position['latitude_i'] / 1e7
+            lon = position['longitude_i'] / 1e7
+            embed.add_field(name="Position", value=f"{lat:.5f}, {lon:.5f}", inline=True)
+            if position.get('altitude'):
+                embed.add_field(name="Altitude", value=f"{position['altitude']}m", inline=True)
+
+        # Telemetry if available
+        telemetry = node.get('telemetry', {})
+        if telemetry:
+            telem_parts = []
+            if 'battery_level' in telemetry and telemetry['battery_level'] is not None:
+                telem_parts.append(f"Battery: {telemetry['battery_level']}%")
+            if 'voltage' in telemetry and telemetry['voltage'] is not None:
+                telem_parts.append(f"Voltage: {telemetry['voltage']:.2f}V")
+            if 'temperature' in telemetry and telemetry['temperature'] is not None:
+                telem_parts.append(f"Temp: {telemetry['temperature']:.1f}\u00b0C")
+            if telem_parts:
+                embed.add_field(name="Telemetry", value=" | ".join(telem_parts), inline=False)
+
+        embed.set_footer(text=f"Node: !{id_hex}")
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="mesh", description="Information about the mesh")
     async def mesh_info(self, ctx):
-        print(f"Discord: /mesh: Mesh info requested by {ctx.author}")
+        logger.info("Discord: /mesh: Mesh info requested by %s", ctx.author)
+
+        # Get node counts from PostgreSQL for accuracy
+        stats = {}
+        if self.data.pg_storage:
+            stats = await self.data.pg_storage.query_stats()
+
+        total_nodes = stats.get("total_nodes", len(self.data.nodes))
+        active_nodes = stats.get("active_nodes", len([n for n in self.data.nodes.values() if n.get('active')]))
+
+        base_url = self.config['server']['base_url'].strip('/')
         embed = discord.Embed(
-            title=f"Information about {self.config['mesh']['name']}",
-            url=self.config['server']['base_url'].strip('/'),
+            title=f"{self.config['mesh']['name']}",
+            url=base_url,
             color=discord.Color.blue())
-        embed.add_field(name="Name", value=self.config['mesh']['name'], inline=False)
-        embed.add_field(name="Shortname", value=self.config['mesh']['shortname'], inline=False)
-        embed.add_field(name="Description", value=self.config['mesh']['description'], inline=False)
-        embed.add_field(name="Official Website", value=self.config['mesh']['url'], inline=False)
+        embed.add_field(name="Description", value=self.config['mesh']['description'] or "N/A", inline=False)
         location = f"{self.config['mesh']['metro']}, {self.config['mesh']['region']}, {self.config['mesh']['country']}"
-        embed.add_field(name="Location", value=location, inline=False)
-        embed.add_field(name="Timezone", value=self.config['server']['timezone'], inline=False)
-        embed.add_field(name="Known Nodes", value=len(self.data.nodes), inline=True)
-        embed.add_field(name="Online Nodes", value=len([n for n in self.data.nodes.values() if n['active']]), inline=True)
+        embed.add_field(name="Location", value=location, inline=True)
+        embed.add_field(name="Timezone", value=self.config['server']['timezone'], inline=True)
+        if self.config['mesh'].get('url'):
+            embed.add_field(name="Website", value=self.config['mesh']['url'], inline=False)
+        embed.add_field(name="Total Nodes", value=str(total_nodes), inline=True)
+        embed.add_field(name="Online Nodes", value=str(active_nodes), inline=True)
         uptime = datetime.datetime.now().astimezone(ZoneInfo(self.config['server']['timezone'])) - self.config['server']['start_time']
-        embed.add_field(name="Server Uptime", value=f"{uptime.days}d {uptime.seconds // 3600}h {uptime.seconds // 60}m {uptime.seconds % 60}s", inline=False)
-        embed.add_field(name="Messages Since Server Startup", value=len(self.data.messages), inline=True)
+        embed.add_field(name="Server Uptime", value=f"{uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s", inline=False)
+        embed.set_footer(text=f"MeshInfo | {base_url}")
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="ping", description="Ping the bot")
     async def ping(self, ctx):
-        print(f"Discord: /ping: Pinged by {ctx.author}")
         await ctx.send(f'Pong! {round(self.bot.latency * 1000)}ms')
 
     @commands.hybrid_command(name="uptime", description="Uptime of MeshInfo instance")
     async def uptime(self, ctx):
-        print(f"Discord: /uptime: Uptime requested by {ctx.author}")
         now = datetime.datetime.now().astimezone(ZoneInfo(self.config['server']['timezone']))
-        print(now)
-        print(self.config['server']['start_time'])
         uptime = now - self.config['server']['start_time']
-        print(uptime)
-        print(f"{uptime.days}d {uptime.seconds // 3600}h {uptime.seconds // 60}m {uptime.seconds % 60}s")
-        await ctx.send(f'MeshInfo uptime: {uptime.days}d {uptime.seconds // 3600}h {uptime.seconds // 60}m {uptime.seconds % 60}s')
+        await ctx.send(f'MeshInfo uptime: {uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s')

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -410,6 +410,7 @@ class MainCommands(commands.Cog):
         embed.add_field(
             name="Moderator",
             value=(
+                "`/forceunlink` \u2014 Force unlink a node from any user\n"
                 "`/addtracker` / `/removetracker` \u2014 Manage position tracking\n"
                 "`/addballoon` / `/removeballoon` \u2014 Manage balloon tracking\n"
                 "`/bannode` / `/unbannode` \u2014 Manage bridge bans\n"

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -27,6 +27,10 @@ class MainCommands(commands.Cog):
     async def lookup_node(self, ctx, *, flags: LookupFlags):
         logger.info("Discord: /lookup: Looking up %s", flags.node)
         search = flags.node.strip().lower().replace("!", "")
+        if not search:
+            await ctx.send("Please provide a node ID or name to look up.")
+            return
+
         node = None
         id_hex = None
 

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -344,13 +344,14 @@ class MainCommands(commands.Cog):
                 lines.append(f"{medals[i]} {name} \u2014 **{days}** days")
             embed.add_field(name="\U0001f9be Iron Man", value="\n".join(lines), inline=False)
 
-        here_i_am = stats.get("here_i_am", [])
-        if here_i_am:
-            lines = []
-            for i, row in enumerate(here_i_am):
-                name = await resolve_name(row["node_id"])
-                lines.append(f"{medals[i]} {name} \u2014 **{row['count']}** updates")
-            embed.add_field(name="\U0001f4cd Here I Am", value="\n".join(lines), inline=False)
+        # Here I Am — disabled until position history table is added
+        # here_i_am = stats.get("here_i_am", [])
+        # if here_i_am:
+        #     lines = []
+        #     for i, row in enumerate(here_i_am):
+        #         name = await resolve_name(row["node_id"])
+        #         lines.append(f"{medals[i]} {name} \u2014 **{row['count']}** updates")
+        #     embed.add_field(name="\U0001f4cd Here I Am", value="\n".join(lines), inline=False)
 
         loudest = stats.get("loudest_signal", [])
         if loudest:

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -1,35 +1,92 @@
 import datetime
 import logging
+from typing import Optional
 from zoneinfo import ZoneInfo
-from discord.ext import commands
+
 import discord
+from discord import app_commands
+from discord.ext import commands
 from meshtastic import mesh_pb2
 
 import utils
+from memory_data_store import MemoryDataStore
 
 logger = logging.getLogger(__name__)
 
-
-class LookupFlags(commands.FlagConverter):
-    node: str = commands.flag(description='Node')
 
 class MainCommands(commands.Cog):
     def __init__(self, bot, config, data):
         self.bot = bot
         self.config = config
-        self.data = data
+        self.data: MemoryDataStore = data
 
     @commands.Cog.listener()
     async def on_ready(self):
         logger.info('Discord: Logged in')
 
-    @commands.hybrid_command(name="lookup", description="Look up a node by ID (int or hex), short name, or long name")
-    async def lookup_node(self, ctx, *, flags: LookupFlags):
-        logger.info("Discord: /lookup: Looking up %s", flags.node)
-        search = flags.node.strip().lower().replace("!", "")
+    # ─── Shared autocomplete ─────────────────────────────────────────
+
+    async def _node_autocomplete(
+        self, interaction: discord.Interaction, current: str,
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for node fields — searches hex ID, shortname, longname."""
+        current = current.strip().lower().replace("!", "")
+        if not current:
+            return []
+
+        choices: list[app_commands.Choice[str]] = []
+        seen: set[str] = set()
+
+        # Search in-memory nodes first
+        for nid, node in self.data.nodes.items():
+            if len(choices) >= 25:
+                break
+            short = str(node.get("shortname", "")).lower()
+            long = str(node.get("longname", "")).lower()
+            if current in nid or current in short or current in long:
+                display_name = node.get("longname") or node.get("shortname") or nid
+                if display_name in ("Unknown", "UNK"):
+                    display_name = nid
+                label = f"{display_name} (!{nid})"[:100]
+                if nid not in seen:
+                    choices.append(app_commands.Choice(name=label, value=nid))
+                    seen.add(nid)
+
+        # Supplement from DB
+        if len(choices) < 25 and self.data.pg_storage:
+            try:
+                results = await self.data.pg_storage.query_nodes_filtered(
+                    days_limit=None, shortname_filter=current,
+                )
+                if len(results) < 10:
+                    long_results = await self.data.pg_storage.query_nodes_filtered(
+                        days_limit=None, longname_filter=current,
+                    )
+                    results.update(long_results)
+
+                for nid, node in results.items():
+                    if len(choices) >= 25:
+                        break
+                    if nid in seen:
+                        continue
+                    display_name = node.get("longname") or node.get("shortname") or nid
+                    if display_name in ("Unknown", "UNK"):
+                        display_name = nid
+                    label = f"{display_name} (!{nid})"[:100]
+                    choices.append(app_commands.Choice(name=label, value=nid))
+                    seen.add(nid)
+            except Exception:
+                pass
+
+        return choices
+
+    # ─── Node resolution helper ──────────────────────────────────────
+
+    async def _resolve_node(self, search: str) -> tuple[Optional[str], Optional[dict]]:
+        """Resolve user input to (hex_id, node_dict). Returns (None, None) if not found."""
+        search = search.strip().lower().replace("!", "")
         if not search:
-            await ctx.send("Please provide a node ID or name to look up.")
-            return
+            return None, None
 
         node = None
         id_hex = None
@@ -45,11 +102,10 @@ class MainCommands(commands.Cog):
         if id_hex is None and all(c in '0123456789abcdef' for c in search) and len(search) <= 8:
             id_hex = search.zfill(8)
 
-        # 1) Check in-memory first (fastest)
+        # Check in-memory
         if id_hex and id_hex in self.data.nodes:
             node = self.data.nodes[id_hex]
         else:
-            # Search in-memory by shortname or longname
             for node_id, n in self.data.nodes.items():
                 if (str(n.get('shortname', '')).lower() == search or
                         str(n.get('longname', '')).lower() == search):
@@ -57,40 +113,43 @@ class MainCommands(commands.Cog):
                     id_hex = node_id
                     break
 
-        # 2) Fall back to PostgreSQL
+        # Fall back to PostgreSQL
         if node is None and self.data.pg_storage:
-            # Try by ID first
             if id_hex:
                 node = await self.data.pg_storage.query_node_by_id(id_hex)
-
-            # Try by shortname
             if node is None:
                 results = await self.data.pg_storage.query_nodes_filtered(
                     days_limit=None, shortname_filter=search,
                 )
+                if not results:
+                    results = await self.data.pg_storage.query_nodes_filtered(
+                        days_limit=None, longname_filter=search,
+                    )
                 if results:
                     id_hex, node = next(iter(results.items()))
 
-            # Try by longname
-            if node is None:
-                results = await self.data.pg_storage.query_nodes_filtered(
-                    days_limit=None, longname_filter=search,
-                )
-                if results:
-                    id_hex, node = next(iter(results.items()))
+        return id_hex, node
 
-        if node is None:
-            await ctx.send(f"Node `{flags.node}` not found.")
+    # ─── Commands ────────────────────────────────────────────────────
+
+    @app_commands.command(name="lookup", description="Look up a node by name, hex ID, or integer ID")
+    @app_commands.describe(node="Node name, hex ID, or integer ID")
+    @app_commands.autocomplete(node=_node_autocomplete)
+    async def lookup_node(self, interaction: discord.Interaction, node: str):
+        logger.info("Discord: /lookup: Looking up %s", node)
+        id_hex, node_data = await self._resolve_node(node)
+
+        if node_data is None:
+            await interaction.response.send_message(f"Node `{node}` not found.", ephemeral=True)
             return
 
-        id_hex = node.get('id', id_hex) or id_hex
+        id_hex = node_data.get('id', id_hex) or id_hex
         id_int = utils.convert_node_id_from_hex_to_int(id_hex)
-        shortname = node.get('shortname', 'UNK')
-        longname = node.get('longname', 'Unknown')
-        hardware_raw = node.get('hardware', None)
+        shortname = node_data.get('shortname', 'UNK')
+        longname = node_data.get('longname', 'Unknown')
+        hardware_raw = node_data.get('hardware', None)
         hardware = "Unknown"
         if hardware_raw is not None:
-            # DB stores as string or int; normalize to int for enum lookup
             try:
                 hw_int = int(hardware_raw)
                 hw_name = mesh_pb2.HardwareModel.Name(hw_int)
@@ -100,8 +159,8 @@ class MainCommands(commands.Cog):
                     hardware = hw_name.replace("_", " ").title()
             except (ValueError, TypeError):
                 hardware = str(hardware_raw)
-        active = node.get('active', False)
-        last_seen_raw = node.get('last_seen', None)
+        active = node_data.get('active', False)
+        last_seen_raw = node_data.get('last_seen', None)
         if isinstance(last_seen_raw, str):
             try:
                 dt = datetime.datetime.fromisoformat(last_seen_raw)
@@ -114,7 +173,7 @@ class MainCommands(commands.Cog):
             last_seen = last_seen_raw.astimezone(tz).strftime("%b %d, %Y %I:%M %p %Z")
         else:
             last_seen = "Unknown"
-        role = node.get('role', 0)
+        role = node_data.get('role', 0)
 
         logger.info("Discord: /lookup: Found %s (%s)", id_hex, longname)
 
@@ -137,8 +196,7 @@ class MainCommands(commands.Cog):
             embed.add_field(name="Role", value=role_labels.get(role, f"Role {role}"), inline=True)
         embed.add_field(name="Last Seen", value=str(last_seen), inline=False)
 
-        # Position info if available
-        position = node.get('position', {})
+        position = node_data.get('position', {})
         if position and position.get('latitude_i') and position.get('longitude_i'):
             lat = position['latitude_i'] / 1e7
             lon = position['longitude_i'] / 1e7
@@ -146,8 +204,7 @@ class MainCommands(commands.Cog):
             if position.get('altitude'):
                 embed.add_field(name="Altitude", value=f"{position['altitude']}m", inline=True)
 
-        # Telemetry if available
-        telemetry = node.get('telemetry', {})
+        telemetry = node_data.get('telemetry', {})
         if telemetry:
             telem_parts = []
             if 'battery_level' in telemetry and telemetry['battery_level'] is not None:
@@ -159,7 +216,6 @@ class MainCommands(commands.Cog):
             if telem_parts:
                 embed.add_field(name="Telemetry", value=" | ".join(telem_parts), inline=False)
 
-        # Elsewhere links from config
         elsewhere = self.config.get('mesh', {}).get('elsewhere_links', [])
         if elsewhere:
             link_parts = []
@@ -174,13 +230,12 @@ class MainCommands(commands.Cog):
                 embed.add_field(name="View Elsewhere", value=" | ".join(link_parts), inline=False)
 
         embed.set_footer(text=f"Node: !{id_hex}")
-        await ctx.send(embed=embed)
+        await interaction.response.send_message(embed=embed)
 
-    @commands.hybrid_command(name="mesh", description="Information about the mesh")
-    async def mesh_info(self, ctx):
-        logger.info("Discord: /mesh: Mesh info requested by %s", ctx.author)
+    @app_commands.command(name="mesh", description="Information about the mesh")
+    async def mesh_info(self, interaction: discord.Interaction):
+        logger.info("Discord: /mesh: Mesh info requested by %s", interaction.user)
 
-        # Get node counts from PostgreSQL for accuracy
         stats = {}
         if self.data.pg_storage:
             stats = await self.data.pg_storage.query_stats()
@@ -205,20 +260,21 @@ class MainCommands(commands.Cog):
         embed.add_field(name="Server Uptime", value=f"{uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s", inline=False)
         links = [f"[Dashboard]({base_url})", f"[Nodes]({base_url}/nodes)", f"[Chat]({base_url}/chat)", f"[Logs]({base_url}/logs)"]
         embed.add_field(name="Quick Links", value=" | ".join(links), inline=False)
-        await ctx.send(embed=embed)
+        await interaction.response.send_message(embed=embed)
 
-    @commands.hybrid_command(name="ping", description="Ping the bot")
-    async def ping(self, ctx):
-        await ctx.send(f'Pong! {round(self.bot.latency * 1000)}ms')
+    @app_commands.command(name="ping", description="Ping the bot")
+    async def ping(self, interaction: discord.Interaction):
+        await interaction.response.send_message(f'Pong! {round(self.bot.latency * 1000)}ms')
 
-    @commands.hybrid_command(name="uptime", description="Uptime of MeshInfo instance")
-    async def uptime(self, ctx):
+    @app_commands.command(name="uptime", description="Uptime of MeshInfo instance")
+    async def uptime(self, interaction: discord.Interaction):
         now = datetime.datetime.now().astimezone(ZoneInfo(self.config['server']['timezone']))
         uptime = now - self.config['server']['start_time']
-        await ctx.send(f'MeshInfo uptime: {uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s')
+        await interaction.response.send_message(f'MeshInfo uptime: {uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s')
 
-    @commands.hybrid_command(name="topnodes", description="Mesh leaderboard and achievements")
-    async def topnodes(self, ctx, timeframe: str = "24h"):
+    @app_commands.command(name="topnodes", description="Mesh leaderboard and achievements")
+    @app_commands.describe(timeframe="Time period: 24h (default) or 7d")
+    async def topnodes(self, interaction: discord.Interaction, timeframe: str = "24h"):
         if timeframe in ("7d", "7", "week"):
             hours = 168
             label = "7 Days"
@@ -227,22 +283,22 @@ class MainCommands(commands.Cog):
             label = "24 Hours"
 
         if not self.data.pg_storage:
-            await ctx.send("Database not available.")
+            await interaction.response.send_message("Database not available.", ephemeral=True)
             return
 
         stats = await self.data.pg_storage.query_top_nodes(hours=hours, limit=5)
         if not stats:
-            await ctx.send("No leaderboard data available yet.")
+            await interaction.response.send_message("No leaderboard data available yet.", ephemeral=True)
             return
 
         base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
 
         async def resolve_name(node_id: str) -> str:
-            node = self.data.nodes.get(node_id)
-            if not node and self.data.pg_storage:
-                node = await self.data.pg_storage.query_node_by_id(node_id)
-            if node:
-                name = node.get("longname") or node.get("shortname")
+            n = self.data.nodes.get(node_id)
+            if not n and self.data.pg_storage:
+                n = await self.data.pg_storage.query_node_by_id(node_id)
+            if n:
+                name = n.get("longname") or n.get("shortname")
                 if name and name not in ("Unknown", "UNK"):
                     if base_url:
                         return f"[{name}]({base_url}/nodes?node={node_id})"
@@ -303,10 +359,10 @@ class MainCommands(commands.Cog):
             embed.description = "Not enough data yet \u2014 check back later!"
 
         embed.set_footer(text=f"Timeframe: {label} | Use /topnodes 7d for weekly")
-        await ctx.send(embed=embed)
+        await interaction.response.send_message(embed=embed)
 
-    @commands.hybrid_command(name="meshinfo", description="Show all available bot commands")
-    async def meshinfo_help(self, ctx):
+    @app_commands.command(name="meshinfo", description="Show all available bot commands")
+    async def meshinfo_help(self, interaction: discord.Interaction):
         base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
         embed = discord.Embed(
             title="MeshInfo Bot Commands",
@@ -316,102 +372,61 @@ class MainCommands(commands.Cog):
         embed.add_field(
             name="General",
             value=(
-                "`/lookup` — Look up a node by name, hex ID, or integer ID\n"
-                "`/mesh` — View mesh network info and node counts\n"
-                "`/whereis` — Show a node's last known position on a map\n"
-                "`/topnodes` — Mesh leaderboard and achievements\n"
-                "`/ping` — Check bot latency\n"
-                "`/uptime` — MeshInfo server uptime\n"
-                "`/meshinfo` — This help message"
+                "`/lookup` \u2014 Look up a node by name, hex ID, or integer ID\n"
+                "`/mesh` \u2014 View mesh network info and node counts\n"
+                "`/whereis` \u2014 Show a node's last known position on a map\n"
+                "`/topnodes` \u2014 Mesh leaderboard and achievements\n"
+                "`/ping` \u2014 Check bot latency\n"
+                "`/uptime` \u2014 MeshInfo server uptime\n"
+                "`/meshinfo` \u2014 This help message"
             ),
             inline=False,
         )
         embed.add_field(
             name="Node Linking",
             value=(
-                "`/linknode` — Link a mesh node to your Discord account\n"
-                "`/unlinknode` — Remove a node link\n"
-                "`/mylinkednodes` — See all your linked nodes"
+                "`/linknode` \u2014 Link a mesh node to your Discord account\n"
+                "`/unlinknode` \u2014 Remove a node link\n"
+                "`/mylinkednodes` \u2014 See all your linked nodes"
             ),
             inline=False,
         )
         embed.add_field(
             name="Moderator",
             value=(
-                "`/addtracker` / `/removetracker` — Manage position tracking\n"
-                "`/addballoon` / `/removeballoon` — Manage balloon tracking\n"
-                "`/bannode` / `/unbannode` — Manage bridge bans\n"
-                "`/listtrackers` — View all tracked nodes\n"
-                "`/listbans` — View all banned nodes"
+                "`/addtracker` / `/removetracker` \u2014 Manage position tracking\n"
+                "`/addballoon` / `/removeballoon` \u2014 Manage balloon tracking\n"
+                "`/bannode` / `/unbannode` \u2014 Manage bridge bans\n"
+                "`/listtrackers` \u2014 View all tracked nodes\n"
+                "`/listbans` \u2014 View all banned nodes"
             ),
             inline=False,
         )
-        embed.set_footer(text="All node commands support autocomplete — start typing a name!")
-        await ctx.send(embed=embed, ephemeral=True)
+        embed.set_footer(text="All node commands support autocomplete \u2014 start typing a name!")
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
-    @commands.hybrid_command(name="whereis", description="Show a node's last known position")
-    async def whereis(self, ctx, *, flags: LookupFlags):
-        search = flags.node.strip().lower().replace("!", "")
-        if not search:
-            await ctx.send("Please provide a node ID or name.")
+    @app_commands.command(name="whereis", description="Show a node's last known position")
+    @app_commands.describe(node="Node name, hex ID, or integer ID")
+    @app_commands.autocomplete(node=_node_autocomplete)
+    async def whereis(self, interaction: discord.Interaction, node: str):
+        id_hex, node_data = await self._resolve_node(node)
+
+        if node_data is None:
+            await interaction.response.send_message(f"Node `{node}` not found.", ephemeral=True)
             return
 
-        node = None
-        id_hex = None
-
-        # Try parsing as integer node ID
-        try:
-            id_int = int(search, 10)
-            id_hex = utils.convert_node_id_from_int_to_hex(id_int)
-        except ValueError:
-            pass
-
-        # Try parsing as hex node ID
-        if id_hex is None and all(c in '0123456789abcdef' for c in search) and len(search) <= 8:
-            id_hex = search.zfill(8)
-
-        # Check in-memory
-        if id_hex and id_hex in self.data.nodes:
-            node = self.data.nodes[id_hex]
-        else:
-            for node_id, n in self.data.nodes.items():
-                if (str(n.get('shortname', '')).lower() == search or
-                        str(n.get('longname', '')).lower() == search):
-                    node = n
-                    id_hex = node_id
-                    break
-
-        # Fall back to PostgreSQL
-        if node is None and self.data.pg_storage:
-            if id_hex:
-                node = await self.data.pg_storage.query_node_by_id(id_hex)
-            if node is None:
-                results = await self.data.pg_storage.query_nodes_filtered(
-                    days_limit=None, shortname_filter=search,
-                )
-                if not results:
-                    results = await self.data.pg_storage.query_nodes_filtered(
-                        days_limit=None, longname_filter=search,
-                    )
-                if results:
-                    id_hex, node = next(iter(results.items()))
-
-        if node is None:
-            await ctx.send(f"Node `{flags.node}` not found.")
-            return
-
-        id_hex = node.get('id', id_hex) or id_hex
-        position = node.get('position', {})
+        id_hex = node_data.get('id', id_hex) or id_hex
+        position = node_data.get('position', {})
         if not position or not position.get('latitude_i') or not position.get('longitude_i'):
-            shortname = node.get('shortname', id_hex)
-            await ctx.send(f"No position data available for **{shortname}**.")
+            shortname = node_data.get('shortname', id_hex)
+            await interaction.response.send_message(f"No position data available for **{shortname}**.", ephemeral=True)
             return
 
         lat = position['latitude_i'] / 1e7
         lon = position['longitude_i'] / 1e7
         alt = position.get('altitude')
-        shortname = node.get('shortname', 'UNK')
-        longname = node.get('longname', 'Unknown')
+        shortname = node_data.get('shortname', 'UNK')
+        longname = node_data.get('longname', 'Unknown')
         base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
         map_link = f"{base_url}/map?node={id_hex}" if base_url else None
 
@@ -428,7 +443,6 @@ class MainCommands(commands.Cog):
         if alt is not None:
             embed.add_field(name="Altitude", value=f"{alt}m", inline=True)
 
-        # Map thumbnail
         maps_cfg = self.config.get("integrations", {}).get("discord", {}).get("bridge", {}).get("maps", {})
         provider = maps_cfg.get("provider", "none")
         if provider != "none" and base_url:
@@ -436,4 +450,4 @@ class MainCommands(commands.Cog):
             embed.set_image(url=thumbnail_url)
 
         embed.set_footer(text=f"Node: !{id_hex}")
-        await ctx.send(embed=embed)
+        await interaction.response.send_message(embed=embed)

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -113,7 +113,7 @@ class MainCommands(commands.Cog):
         base_url = self.config['server']['base_url'].strip('/')
         embed = discord.Embed(
             title=f"{shortname}: {longname}",
-            url=f"{base_url}/node_{id_hex}.html",
+            url=f"{base_url}/nodes?node={id_hex}",
             color=discord.Color.green() if active else discord.Color.greyple())
         embed.set_thumbnail(url=f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={id_hex}")
         embed.add_field(name="ID (hex)", value=f"!{id_hex}", inline=True)
@@ -150,6 +150,20 @@ class MainCommands(commands.Cog):
                 telem_parts.append(f"Temp: {telemetry['temperature']:.1f}\u00b0C")
             if telem_parts:
                 embed.add_field(name="Telemetry", value=" | ".join(telem_parts), inline=False)
+
+        # Elsewhere links from config
+        elsewhere = self.config.get('mesh', {}).get('elsewhere_links', [])
+        if elsewhere:
+            link_parts = []
+            for link in elsewhere:
+                name = link.get('name', '')
+                url = link.get('url', '')
+                if name and url:
+                    url = url.replace('{node_id_hex}', id_hex)
+                    url = url.replace('{node_id_int}', str(id_int))
+                    link_parts.append(f"[{name}]({url})")
+            if link_parts:
+                embed.add_field(name="View Elsewhere", value=" | ".join(link_parts), inline=False)
 
         embed.set_footer(text=f"Node: !{id_hex}")
         await ctx.send(embed=embed)

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 import discord
 from discord import app_commands
 from discord.ext import commands
-from meshtastic import mesh_pb2
+from meshtastic import mesh_pb2, config_pb2
 
 import utils
 from memory_data_store import MemoryDataStore
@@ -202,12 +202,11 @@ class MainCommands(commands.Cog):
         embed.add_field(name="Status", value=("Online" if active else "Offline"), inline=True)
         embed.add_field(name="Hardware", value=hardware, inline=True)
         if role:
-            role_labels = {
-                0: "Client", 1: "Client Mute", 2: "Router", 3: "Router Client",
-                4: "Repeater", 5: "Tracker", 6: "Sensor", 7: "ATAK",
-                8: "Client Hidden", 9: "Lost and Found", 10: "ATAK Tracker",
-            }
-            embed.add_field(name="Role", value=role_labels.get(role, f"Role {role}"), inline=True)
+            try:
+                role_name = config_pb2.Config.DeviceConfig.Role.Name(role).replace("_", " ").title()
+            except ValueError:
+                role_name = f"Role {role}"
+            embed.add_field(name="Role", value=role_name, inline=True)
         embed.add_field(name="Last Seen", value=str(last_seen), inline=False)
 
         position = node_data.get('position', {})

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -398,12 +398,14 @@ class MainCommands(commands.Cog):
         embed.add_field(
             name="Node Linking & Watching",
             value=(
-                "`/linknode` \u2014 Link a mesh node to your Discord account\n"
-                "`/unlinknode` \u2014 Remove a node link\n"
-                "`/mylinkednodes` \u2014 See all your linked nodes\n"
+                "*Only link nodes you own. Each node can have one owner.*\n"
+                "`/linknode` \u2014 Claim a node as yours\n"
+                "`/unlinknode` \u2014 Remove your claim\n"
+                "`/mylinkednodes` \u2014 See your linked nodes\n"
+                "*Watch any node for alerts \u2014 no ownership required.*\n"
                 "`/watchnode` \u2014 Get alerts when a node goes online/offline\n"
                 "`/unwatchnode` \u2014 Stop watching a node\n"
-                "`/mywatchednodes` \u2014 See all your watched nodes"
+                "`/mywatchednodes` \u2014 See your watched nodes"
             ),
             inline=False,
         )
@@ -416,6 +418,17 @@ class MainCommands(commands.Cog):
                 "`/bannode` / `/unbannode` \u2014 Manage bridge bans\n"
                 "`/listtrackers` \u2014 View all tracked nodes\n"
                 "`/listbans` \u2014 View all banned nodes"
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Signal Quality Colors",
+            value=(
+                "\U0001f7e2 **> 10 dB** Excellent\n"
+                "\U0001f535 **5\u201310 dB** Good\n"
+                "\U0001f7e1 **0\u20135 dB** Fair\n"
+                "\U0001f7e0 **-5\u20130 dB** Weak\n"
+                "\U0001f534 **< -5 dB** Poor"
             ),
             inline=False,
         )

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -216,3 +216,224 @@ class MainCommands(commands.Cog):
         now = datetime.datetime.now().astimezone(ZoneInfo(self.config['server']['timezone']))
         uptime = now - self.config['server']['start_time']
         await ctx.send(f'MeshInfo uptime: {uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s')
+
+    @commands.hybrid_command(name="topnodes", description="Mesh leaderboard and achievements")
+    async def topnodes(self, ctx, timeframe: str = "24h"):
+        if timeframe in ("7d", "7", "week"):
+            hours = 168
+            label = "7 Days"
+        else:
+            hours = 24
+            label = "24 Hours"
+
+        if not self.data.pg_storage:
+            await ctx.send("Database not available.")
+            return
+
+        stats = await self.data.pg_storage.query_top_nodes(hours=hours, limit=5)
+        if not stats:
+            await ctx.send("No leaderboard data available yet.")
+            return
+
+        base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
+
+        async def resolve_name(node_id: str) -> str:
+            node = self.data.nodes.get(node_id)
+            if not node and self.data.pg_storage:
+                node = await self.data.pg_storage.query_node_by_id(node_id)
+            if node:
+                name = node.get("longname") or node.get("shortname")
+                if name and name not in ("Unknown", "UNK"):
+                    if base_url:
+                        return f"[{name}]({base_url}/nodes?node={node_id})"
+                    return name
+            return f"!{node_id}"
+
+        embed = discord.Embed(
+            title=f"Mesh Leaderboard \u2014 {label}",
+            color=discord.Color.gold(),
+            timestamp=discord.utils.utcnow(),
+        )
+
+        medals = ["\U0001f947", "\U0001f948", "\U0001f949", "4.", "5."]
+
+        chatterbox = stats.get("chatterbox", [])
+        if chatterbox:
+            lines = []
+            for i, row in enumerate(chatterbox):
+                name = await resolve_name(row["node_id"])
+                lines.append(f"{medals[i]} {name} \u2014 **{row['count']}** msgs")
+            embed.add_field(name="\U0001f4ac Chatterbox", value="\n".join(lines), inline=False)
+
+        iron_man = stats.get("iron_man", [])
+        if iron_man:
+            lines = []
+            for i, row in enumerate(iron_man):
+                name = await resolve_name(row["node_id"])
+                secs = float(row["uptime_seconds"])
+                days = int(secs // 86400)
+                lines.append(f"{medals[i]} {name} \u2014 **{days}** days")
+            embed.add_field(name="\U0001f9be Iron Man", value="\n".join(lines), inline=False)
+
+        here_i_am = stats.get("here_i_am", [])
+        if here_i_am:
+            lines = []
+            for i, row in enumerate(here_i_am):
+                name = await resolve_name(row["node_id"])
+                lines.append(f"{medals[i]} {name} \u2014 **{row['count']}** updates")
+            embed.add_field(name="\U0001f4cd Here I Am", value="\n".join(lines), inline=False)
+
+        loudest = stats.get("loudest_signal", [])
+        if loudest:
+            lines = []
+            for i, row in enumerate(loudest):
+                name = await resolve_name(row["node_id"])
+                lines.append(f"{medals[i]} {name} \u2014 **{row['avg_snr']}** dB avg SNR")
+            embed.add_field(name="\U0001f4e1 Loudest Signal", value="\n".join(lines), inline=False)
+
+        gateway_mvp = stats.get("gateway_mvp", [])
+        if gateway_mvp:
+            lines = []
+            for i, row in enumerate(gateway_mvp):
+                name = await resolve_name(row["node_id"])
+                lines.append(f"{medals[i]} {name} \u2014 **{row['count']}** relayed")
+            embed.add_field(name="\U0001f310 Gateway MVP", value="\n".join(lines), inline=False)
+
+        if not any(stats.values()):
+            embed.description = "Not enough data yet \u2014 check back later!"
+
+        embed.set_footer(text=f"Timeframe: {label} | Use /topnodes 7d for weekly")
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(name="meshinfo", description="Show all available bot commands")
+    async def meshinfo_help(self, ctx):
+        base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
+        embed = discord.Embed(
+            title="MeshInfo Bot Commands",
+            url=base_url or None,
+            color=discord.Color.blue(),
+        )
+        embed.add_field(
+            name="General",
+            value=(
+                "`/lookup` — Look up a node by name, hex ID, or integer ID\n"
+                "`/mesh` — View mesh network info and node counts\n"
+                "`/whereis` — Show a node's last known position on a map\n"
+                "`/topnodes` — Mesh leaderboard and achievements\n"
+                "`/ping` — Check bot latency\n"
+                "`/uptime` — MeshInfo server uptime\n"
+                "`/meshinfo` — This help message"
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Node Linking",
+            value=(
+                "`/linknode` — Link a mesh node to your Discord account\n"
+                "`/unlinknode` — Remove a node link\n"
+                "`/mylinkednodes` — See all your linked nodes"
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Moderator",
+            value=(
+                "`/addtracker` / `/removetracker` — Manage position tracking\n"
+                "`/addballoon` / `/removeballoon` — Manage balloon tracking\n"
+                "`/bannode` / `/unbannode` — Manage bridge bans\n"
+                "`/listtrackers` — View all tracked nodes\n"
+                "`/listbans` — View all banned nodes"
+            ),
+            inline=False,
+        )
+        embed.set_footer(text="All node commands support autocomplete — start typing a name!")
+        await ctx.send(embed=embed, ephemeral=True)
+
+    @commands.hybrid_command(name="whereis", description="Show a node's last known position")
+    async def whereis(self, ctx, *, flags: LookupFlags):
+        search = flags.node.strip().lower().replace("!", "")
+        if not search:
+            await ctx.send("Please provide a node ID or name.")
+            return
+
+        node = None
+        id_hex = None
+
+        # Try parsing as integer node ID
+        try:
+            id_int = int(search, 10)
+            id_hex = utils.convert_node_id_from_int_to_hex(id_int)
+        except ValueError:
+            pass
+
+        # Try parsing as hex node ID
+        if id_hex is None and all(c in '0123456789abcdef' for c in search) and len(search) <= 8:
+            id_hex = search.zfill(8)
+
+        # Check in-memory
+        if id_hex and id_hex in self.data.nodes:
+            node = self.data.nodes[id_hex]
+        else:
+            for node_id, n in self.data.nodes.items():
+                if (str(n.get('shortname', '')).lower() == search or
+                        str(n.get('longname', '')).lower() == search):
+                    node = n
+                    id_hex = node_id
+                    break
+
+        # Fall back to PostgreSQL
+        if node is None and self.data.pg_storage:
+            if id_hex:
+                node = await self.data.pg_storage.query_node_by_id(id_hex)
+            if node is None:
+                results = await self.data.pg_storage.query_nodes_filtered(
+                    days_limit=None, shortname_filter=search,
+                )
+                if not results:
+                    results = await self.data.pg_storage.query_nodes_filtered(
+                        days_limit=None, longname_filter=search,
+                    )
+                if results:
+                    id_hex, node = next(iter(results.items()))
+
+        if node is None:
+            await ctx.send(f"Node `{flags.node}` not found.")
+            return
+
+        id_hex = node.get('id', id_hex) or id_hex
+        position = node.get('position', {})
+        if not position or not position.get('latitude_i') or not position.get('longitude_i'):
+            shortname = node.get('shortname', id_hex)
+            await ctx.send(f"No position data available for **{shortname}**.")
+            return
+
+        lat = position['latitude_i'] / 1e7
+        lon = position['longitude_i'] / 1e7
+        alt = position.get('altitude')
+        shortname = node.get('shortname', 'UNK')
+        longname = node.get('longname', 'Unknown')
+        base_url = self.config.get('server', {}).get('base_url', '').rstrip('/')
+        map_link = f"{base_url}/map?node={id_hex}" if base_url else None
+
+        embed = discord.Embed(
+            title=f"{longname} [{shortname}]",
+            url=map_link,
+            color=discord.Color.blue(),
+        )
+        avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={id_hex}"
+        embed.set_author(name="Last Known Position", icon_url=avatar_url)
+
+        coord_text = f"[{lat:.6f}, {lon:.6f}]({map_link})" if map_link else f"{lat:.6f}, {lon:.6f}"
+        embed.add_field(name="Position", value=coord_text, inline=True)
+        if alt is not None:
+            embed.add_field(name="Altitude", value=f"{alt}m", inline=True)
+
+        # Map thumbnail
+        maps_cfg = self.config.get("integrations", {}).get("discord", {}).get("bridge", {}).get("maps", {})
+        provider = maps_cfg.get("provider", "none")
+        if provider != "none" and base_url:
+            thumbnail_url = f"{base_url}/v1/static-map?lat={lat:.6f}&lon={lon:.6f}&zoom=12"
+            embed.set_image(url=thumbnail_url)
+
+        embed.set_footer(text=f"Node: !{id_hex}")
+        await ctx.send(embed=embed)

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -195,11 +195,12 @@ class MainCommands(commands.Cog):
         embed.add_field(name="Timezone", value=self.config['server']['timezone'], inline=True)
         if self.config['mesh'].get('url'):
             embed.add_field(name="Website", value=self.config['mesh']['url'], inline=False)
-        embed.add_field(name="Total Nodes", value=str(total_nodes), inline=True)
-        embed.add_field(name="Online Nodes", value=str(active_nodes), inline=True)
+        embed.add_field(name="Total Nodes", value=f"[{total_nodes}]({base_url}/nodes)", inline=True)
+        embed.add_field(name="Online Nodes", value=f"[{active_nodes}]({base_url}/nodes?status=online)", inline=True)
         uptime = datetime.datetime.now().astimezone(ZoneInfo(self.config['server']['timezone'])) - self.config['server']['start_time']
         embed.add_field(name="Server Uptime", value=f"{uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds % 3600) // 60}m {uptime.seconds % 60}s", inline=False)
-        embed.set_footer(text=f"MeshInfo | {base_url}")
+        links = [f"[Dashboard]({base_url})", f"[Nodes]({base_url}/nodes)", f"[Chat]({base_url}/chat)", f"[Logs]({base_url}/logs)"]
+        embed.add_field(name="Quick Links", value=" | ".join(links), inline=False)
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(name="ping", description="Ping the bot")

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -99,12 +99,18 @@ class MeshBridge(commands.Cog):
         self._node_cache: dict[str, Optional[dict]] = {}
         self._node_cache_max = 1000
 
+        # Status alert channel (first text channel mapped, or configurable)
+        self._alert_channel_id = bridge_cfg.get("alert_channel")
+        # Track last known status per linked node: node_id -> bool (active)
+        self._node_status: dict[str, bool] = {}
+
     @commands.Cog.listener()
     async def on_ready(self):
         if self.bridge_enabled:
             logger.info("Discord: MeshBridge enabled — starting event consumer and flush loop")
             self._consume_task = asyncio.create_task(self._consume_events())
             self._flush_loop.start()
+            self._status_check_loop.start()
         else:
             logger.info("Discord: MeshBridge disabled in config")
 
@@ -113,6 +119,8 @@ class MeshBridge(commands.Cog):
             self._consume_task.cancel()
         if self._flush_loop.is_running():
             self._flush_loop.cancel()
+        if self._status_check_loop.is_running():
+            self._status_check_loop.cancel()
 
     # ─── Node name resolution ────────────────────────────────────────
 
@@ -460,6 +468,89 @@ class MeshBridge(commands.Cog):
             pending.discord_message = sent
         except Exception:
             logger.exception("MeshBridge: Failed to send position to channel %s", discord_channel_id)
+
+    # ─── Node status alerts ────────────────────────────────────────
+
+    @tasks.loop(minutes=5)
+    async def _status_check_loop(self):
+        """Check linked nodes for online/offline status changes."""
+        if not self.data.pg_storage:
+            return
+
+        # Determine alert channel
+        alert_channel_id = self._alert_channel_id
+        if not alert_channel_id:
+            # Fall back to first mapped text channel
+            if self.channel_map:
+                alert_channel_id = next(iter(self.channel_map.values()))
+        if not alert_channel_id:
+            return
+
+        channel = self.bot.get_channel(int(alert_channel_id))
+        if not channel:
+            try:
+                channel = await self.bot.fetch_channel(int(alert_channel_id))
+            except Exception:
+                return
+
+        try:
+            links = await self.data.pg_storage.get_all_linked_nodes()
+        except Exception:
+            return
+
+        if not links:
+            return
+
+        base_url = self.config.get("server", {}).get("base_url", "").rstrip("/")
+
+        for link in links:
+            node_id = link["node_id"]
+            discord_user_id = link["discord_user_id"]
+
+            # Get current status from DB
+            node = await self._resolve_node(node_id)
+            if not node:
+                continue
+
+            current_active = bool(node.get("active", False))
+            prev_active = self._node_status.get(node_id)
+
+            # Store current status
+            self._node_status[node_id] = current_active
+
+            # Skip on first run (no previous state to compare)
+            if prev_active is None:
+                continue
+
+            # Status changed
+            if current_active != prev_active:
+                display_name = self._get_display_name(node, node_id)
+                node_url = f"{base_url}/nodes?node={node_id}" if base_url else ""
+
+                if current_active:
+                    embed = discord.Embed(
+                        description=f"**{display_name}** is now **online**",
+                        color=discord.Color.from_rgb(87, 187, 138),
+                    )
+                else:
+                    embed = discord.Embed(
+                        description=f"**{display_name}** has gone **offline**",
+                        color=discord.Color.from_rgb(194, 108, 108),
+                    )
+
+                if node_url:
+                    embed.description = f"[{display_name}]({node_url}) {'is now **online**' if current_active else 'has gone **offline**'}"
+
+                embed.set_footer(text=f"Node: !{node_id} | Owner: <@{discord_user_id}>")
+
+                try:
+                    await channel.send(embed=embed)
+                except Exception:
+                    logger.debug("MeshBridge: Failed to send status alert for %s", node_id)
+
+    @_status_check_loop.before_loop
+    async def _before_status_check(self):
+        await self.bot.wait_until_ready()
 
     # ─── Helpers ─────────────────────────────────────────────────────
 

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -3,8 +3,8 @@ MeshBridge cog — live mesh-to-Discord message bridge.
 
 Consumes events from MemoryDataStore.discord_event_queue, aggregates gateway
 reports for the same packet over a configurable window (default 5s), then
-posts or edits a Discord embed. This gives the "growing gateway list" UX
-from RATM 2.0 without needing Redis.
+posts or edits a Discord embed via webhook. Each mesh node appears as a
+unique "sender" with its own name and avatar in Discord.
 """
 
 import asyncio
@@ -19,6 +19,8 @@ from bot.embeds import build_text_embed, build_position_embed
 from memory_data_store import MemoryDataStore
 
 logger = logging.getLogger(__name__)
+
+WEBHOOK_NAME = "MeshInfo Bridge"
 
 
 class _PendingPacket:
@@ -90,6 +92,13 @@ class MeshBridge(commands.Cog):
         self._reply_cache: dict[int, discord.Message] = {}
         self._reply_cache_max = 500
 
+        # Webhook cache: discord_channel_id -> discord.Webhook
+        self._webhooks: dict[int, discord.Webhook] = {}
+
+        # Node info cache from DB: node_id -> node dict (avoids repeated queries)
+        self._node_cache: dict[str, Optional[dict]] = {}
+        self._node_cache_max = 1000
+
     @commands.Cog.listener()
     async def on_ready(self):
         if self.bridge_enabled:
@@ -104,6 +113,74 @@ class MeshBridge(commands.Cog):
             self._consume_task.cancel()
         if self._flush_loop.is_running():
             self._flush_loop.cancel()
+
+    # ─── Node name resolution ────────────────────────────────────────
+
+    async def _resolve_node(self, node_id: str) -> Optional[dict]:
+        """Look up a node by ID, checking in-memory first then PostgreSQL."""
+        # In-memory (live data from this session)
+        node = self.data.nodes.get(node_id)
+        if node and node.get("longname", "Unknown") != "Unknown":
+            return node
+
+        # Local cache (avoids repeated DB hits for the same node)
+        if node_id in self._node_cache:
+            return self._node_cache[node_id]
+
+        # PostgreSQL
+        if self.data.pg_storage:
+            try:
+                db_node = await self.data.pg_storage.query_node_by_id(node_id)
+                if db_node:
+                    self._node_cache[node_id] = db_node
+                    # Evict old cache entries
+                    if len(self._node_cache) > self._node_cache_max:
+                        oldest = next(iter(self._node_cache))
+                        self._node_cache.pop(oldest, None)
+                    return db_node
+            except Exception:
+                logger.debug("MeshBridge: DB lookup failed for node %s", node_id)
+
+        # Return whatever we have from memory (might be a skeleton)
+        self._node_cache[node_id] = node
+        return node
+
+    async def _build_enriched_nodes(self, node_ids: list[str]) -> dict:
+        """Build a nodes dict enriched with DB data for all referenced node IDs."""
+        enriched = {}
+        for nid in node_ids:
+            node = await self._resolve_node(nid)
+            if node:
+                enriched[nid] = node
+        return enriched
+
+    # ─── Webhook management ──────────────────────────────────────────
+
+    async def _get_webhook(self, channel: discord.TextChannel) -> Optional[discord.Webhook]:
+        """Get or create a webhook for the given channel."""
+        if channel.id in self._webhooks:
+            return self._webhooks[channel.id]
+
+        try:
+            # Look for an existing MeshInfo webhook
+            webhooks = await channel.webhooks()
+            for wh in webhooks:
+                if wh.name == WEBHOOK_NAME:
+                    self._webhooks[channel.id] = wh
+                    return wh
+
+            # Create one
+            wh = await channel.create_webhook(name=WEBHOOK_NAME)
+            self._webhooks[channel.id] = wh
+            return wh
+        except discord.Forbidden:
+            logger.warning("MeshBridge: No permission to manage webhooks in #%s — falling back to bot messages", channel.name)
+            return None
+        except Exception:
+            logger.exception("MeshBridge: Failed to get/create webhook for #%s", channel.name)
+            return None
+
+    # ─── Event consumption ───────────────────────────────────────────
 
     async def _consume_events(self):
         """Read events from the queue and aggregate into pending packets."""
@@ -207,6 +284,19 @@ class MeshBridge(commands.Cog):
         if text.startswith("seq ") and text[4:].isdigit():
             return
 
+        # Resolve all referenced node IDs from DB
+        all_node_ids = [from_id]
+        for gw in pending.gateways:
+            gw_id = gw.get("gateway_id", "")
+            if gw_id:
+                all_node_ids.append(gw_id)
+        enriched_nodes = await self._build_enriched_nodes(all_node_ids)
+
+        # Get sender info for webhook
+        sender_node = enriched_nodes.get(from_id)
+        sender_name = self._get_display_name(sender_node, from_id)
+        avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={from_id}"
+
         # Get node owner
         owner_id = await self.data.pg_storage.get_node_owner(from_id)
 
@@ -214,44 +304,66 @@ class MeshBridge(commands.Cog):
         embed = build_text_embed(
             msg=msg,
             chat=chat,
-            nodes=self.data.nodes,
+            nodes=enriched_nodes,
             base_url=base_url,
             config=self.config,
             owner_id=owner_id,
             gateway_entries=pending.gateways,
         )
 
-        # Reply threading: if this mesh message has a reply_id, find the Discord message
-        reply_to = None
-        reply_id = msg.get("decoded", {}).get("reply_id") if isinstance(msg.get("decoded"), dict) else None
-        if reply_id and reply_id in self._reply_cache:
-            reply_to = self._reply_cache[reply_id]
+        # Try webhook first (makes each node look like a unique sender)
+        webhook = await self._get_webhook(channel)
 
-        if pending.discord_message:
-            # Edit existing message with updated gateway info
+        if pending.discord_message and webhook:
+            # Edit existing webhook message
             try:
-                await pending.discord_message.edit(embed=embed)
+                await webhook.edit_message(
+                    pending.discord_message.id,
+                    embed=embed,
+                )
+                return
             except Exception:
-                logger.warning("MeshBridge: Failed to edit message, posting new")
+                logger.debug("MeshBridge: Failed to edit webhook message, posting new")
                 pending.discord_message = None
 
-        if not pending.discord_message:
-            kwargs = {"embed": embed}
-            if reply_to:
-                kwargs["reference"] = reply_to
+        if not pending.discord_message and webhook:
             try:
-                sent = await channel.send(**kwargs)
+                sent = await webhook.send(
+                    embed=embed,
+                    username=sender_name,
+                    avatar_url=avatar_url,
+                    wait=True,
+                )
                 pending.discord_message = sent
-                # Cache for reply threading
                 packet_id = msg.get("id")
                 if packet_id:
                     self._reply_cache[packet_id] = sent
-                    # Evict old entries
                     if len(self._reply_cache) > self._reply_cache_max:
                         oldest_key = next(iter(self._reply_cache))
                         self._reply_cache.pop(oldest_key, None)
+                return
             except Exception:
-                logger.exception("MeshBridge: Failed to send text message to channel %s", discord_channel_id)
+                logger.exception("MeshBridge: Webhook send failed, falling back to bot message")
+
+        # Fallback: send as bot
+        if pending.discord_message:
+            try:
+                await pending.discord_message.edit(embed=embed)
+                return
+            except Exception:
+                pending.discord_message = None
+
+        try:
+            sent = await channel.send(embed=embed)
+            pending.discord_message = sent
+            packet_id = msg.get("id")
+            if packet_id:
+                self._reply_cache[packet_id] = sent
+                if len(self._reply_cache) > self._reply_cache_max:
+                    oldest_key = next(iter(self._reply_cache))
+                    self._reply_cache.pop(oldest_key, None)
+        except Exception:
+            logger.exception("MeshBridge: Failed to send text message to channel %s", discord_channel_id)
 
     async def _post_position(self, pending: _PendingPacket):
         """Post or update a position embed for a tracked node."""
@@ -265,7 +377,6 @@ class MeshBridge(commands.Cog):
         channel_hash = str(msg.get("channel", "0"))
         discord_channel_id = self.position_channel_map.get(channel_hash)
         if not discord_channel_id:
-            # Fall back to text channel map
             discord_channel_id = self.channel_map.get(channel_hash)
         if not discord_channel_id:
             return
@@ -278,9 +389,20 @@ class MeshBridge(commands.Cog):
                 logger.warning("MeshBridge: Cannot find Discord channel %s", discord_channel_id)
                 return
 
-        # Check ban
         if await self.data.pg_storage.is_node_banned(node_id):
             return
+
+        # Resolve node IDs from DB
+        all_node_ids = [node_id]
+        for gw in pending.gateways:
+            gw_id = gw.get("gateway_id", "")
+            if gw_id:
+                all_node_ids.append(gw_id)
+        enriched_nodes = await self._build_enriched_nodes(all_node_ids)
+
+        sender_node = enriched_nodes.get(node_id)
+        sender_name = self._get_display_name(sender_node, node_id)
+        avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node_id}"
 
         track_type = await self.data.pg_storage.get_tracker_type(node_id) or "tracker"
         owner_id = await self.data.pg_storage.get_node_owner(node_id)
@@ -289,22 +411,61 @@ class MeshBridge(commands.Cog):
         embed = build_position_embed(
             msg=msg,
             node_id=node_id,
-            nodes=self.data.nodes,
+            nodes=enriched_nodes,
             base_url=base_url,
             track_type=track_type,
             owner_id=owner_id,
             gateway_entries=pending.gateways,
         )
 
-        if pending.discord_message:
+        webhook = await self._get_webhook(channel)
+
+        if pending.discord_message and webhook:
             try:
-                await pending.discord_message.edit(embed=embed)
+                await webhook.edit_message(pending.discord_message.id, embed=embed)
+                return
             except Exception:
                 pending.discord_message = None
 
-        if not pending.discord_message:
+        if not pending.discord_message and webhook:
             try:
-                sent = await channel.send(embed=embed)
+                sent = await webhook.send(
+                    embed=embed,
+                    username=sender_name,
+                    avatar_url=avatar_url,
+                    wait=True,
+                )
                 pending.discord_message = sent
+                return
             except Exception:
-                logger.exception("MeshBridge: Failed to send position to channel %s", discord_channel_id)
+                logger.exception("MeshBridge: Webhook send failed for position, falling back")
+
+        # Fallback
+        if pending.discord_message:
+            try:
+                await pending.discord_message.edit(embed=embed)
+                return
+            except Exception:
+                pending.discord_message = None
+
+        try:
+            sent = await channel.send(embed=embed)
+            pending.discord_message = sent
+        except Exception:
+            logger.exception("MeshBridge: Failed to send position to channel %s", discord_channel_id)
+
+    # ─── Helpers ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_display_name(node: Optional[dict], node_id: str) -> str:
+        """Get a display name for a node, suitable for webhook username."""
+        if node:
+            longname = node.get("longname", "")
+            shortname = node.get("shortname", "")
+            if longname and longname != "Unknown":
+                if shortname and shortname != "UNK":
+                    return f"{longname} [{shortname}]"
+                return longname
+            if shortname and shortname != "UNK":
+                return shortname
+        return f"!{node_id}"

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -503,10 +503,14 @@ class MeshBridge(commands.Cog):
 
         base_url = self.config.get("server", {}).get("base_url", "").rstrip("/")
 
+        # Group watchers by node to avoid duplicate alerts
+        node_watchers: dict[str, list[str]] = {}
         for link in links:
-            node_id = link["node_id"]
-            discord_user_id = link["discord_user_id"]
+            nid = link["node_id"]
+            uid = link["discord_user_id"]
+            node_watchers.setdefault(nid, []).append(uid)
 
+        for node_id, watcher_ids in node_watchers.items():
             # Get current status from DB
             node = await self._resolve_node(node_id)
             if not node:
@@ -527,6 +531,8 @@ class MeshBridge(commands.Cog):
                 display_name = self._get_display_name(node, node_id)
                 node_url = f"{base_url}/nodes?node={node_id}" if base_url else ""
 
+                mentions = " ".join(f"<@{uid}>" for uid in watcher_ids)
+
                 if current_active:
                     embed = discord.Embed(
                         description=f"**{display_name}** is now **online**",
@@ -541,10 +547,10 @@ class MeshBridge(commands.Cog):
                 if node_url:
                     embed.description = f"[{display_name}]({node_url}) {'is now **online**' if current_active else 'has gone **offline**'}"
 
-                embed.set_footer(text=f"Node: !{node_id} | Owner: <@{discord_user_id}>")
+                embed.set_footer(text=f"Node: !{node_id}")
 
                 try:
-                    await channel.send(embed=embed)
+                    await channel.send(content=mentions, embed=embed)
                 except Exception:
                     logger.debug("MeshBridge: Failed to send status alert for %s", node_id)
 

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -216,6 +216,7 @@ class MeshBridge(commands.Cog):
             chat=chat,
             nodes=self.data.nodes,
             base_url=base_url,
+            config=self.config,
             owner_id=owner_id,
             gateway_entries=pending.gateways,
         )

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -156,10 +156,15 @@ class MeshBridge(commands.Cog):
 
     # ─── Webhook management ──────────────────────────────────────────
 
+    _WEBHOOK_UNAVAILABLE = object()  # sentinel for channels where webhooks are forbidden
+
     async def _get_webhook(self, channel: discord.TextChannel) -> Optional[discord.Webhook]:
         """Get or create a webhook for the given channel."""
-        if channel.id in self._webhooks:
-            return self._webhooks[channel.id]
+        cached = self._webhooks.get(channel.id)
+        if cached is self._WEBHOOK_UNAVAILABLE:
+            return None  # already know webhooks are forbidden here
+        if cached is not None:
+            return cached
 
         try:
             # Look for an existing MeshInfo webhook
@@ -175,6 +180,7 @@ class MeshBridge(commands.Cog):
             return wh
         except discord.Forbidden:
             logger.warning("MeshBridge: No permission to manage webhooks in #%s — falling back to bot messages", channel.name)
+            self._webhooks[channel.id] = self._WEBHOOK_UNAVAILABLE
             return None
         except Exception:
             logger.exception("MeshBridge: Failed to get/create webhook for #%s", channel.name)
@@ -227,7 +233,7 @@ class MeshBridge(commands.Cog):
         now = time.monotonic()
         keys_to_remove = []
 
-        for key, pending in self._pending.items():
+        for key, pending in list(self._pending.items()):
             age = now - pending.first_seen
             if age >= self.aggregate_seconds and pending.dirty:
                 try:

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -1,0 +1,309 @@
+"""
+MeshBridge cog — live mesh-to-Discord message bridge.
+
+Consumes events from MemoryDataStore.discord_event_queue, aggregates gateway
+reports for the same packet over a configurable window (default 5s), then
+posts or edits a Discord embed. This gives the "growing gateway list" UX
+from RATM 2.0 without needing Redis.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import discord
+from discord.ext import commands, tasks
+
+from bot.embeds import build_text_embed, build_position_embed
+from memory_data_store import MemoryDataStore
+
+logger = logging.getLogger(__name__)
+
+
+class _PendingPacket:
+    """Tracks a packet that is accumulating gateway reports before posting."""
+
+    __slots__ = (
+        "event_type",
+        "msg",
+        "chat",
+        "node_id",
+        "gateways",
+        "first_seen",
+        "discord_message",
+        "dirty",
+    )
+
+    def __init__(self, event_type: str, msg: dict, chat: Optional[dict] = None, node_id: Optional[str] = None):
+        self.event_type = event_type
+        self.msg = msg
+        self.chat = chat
+        self.node_id = node_id
+        self.gateways: list[dict] = []
+        self.first_seen: float = time.monotonic()
+        self.discord_message: Optional[discord.Message] = None
+        self.dirty: bool = True
+
+    def add_gateway(self, msg: dict):
+        """Add a gateway report for this packet."""
+        topic = msg.get("topic", "")
+        topic_parts = topic.split("/")
+        gw_id = ""
+        if topic_parts and topic_parts[-1].startswith("!"):
+            gw_id = topic_parts[-1].replace("!", "")
+
+        entry = {
+            "gateway_id": gw_id,
+            "rssi": msg.get("rssi"),
+            "snr": msg.get("snr"),
+            "hops_away": msg.get("hops_away"),
+            "topic": topic,
+        }
+
+        # Deduplicate by gateway_id
+        for existing in self.gateways:
+            if existing["gateway_id"] == gw_id and gw_id:
+                return
+        self.gateways.append(entry)
+        self.dirty = True
+
+
+class MeshBridge(commands.Cog):
+    """Bridges live mesh traffic into Discord channels."""
+
+    def __init__(self, bot: commands.Bot, config: dict, data: MemoryDataStore):
+        self.bot = bot
+        self.config = config
+        self.data = data
+
+        bridge_cfg = config.get("integrations", {}).get("discord", {}).get("bridge", {})
+        self.bridge_enabled = bridge_cfg.get("enabled", False)
+        self.aggregate_seconds = bridge_cfg.get("aggregate_seconds", 5)
+        self.channel_map: dict[str, str] = bridge_cfg.get("channels", {})
+        self.position_channel_map: dict[str, str] = bridge_cfg.get("position_channels", {})
+
+        # packet_key -> _PendingPacket
+        self._pending: dict[str, _PendingPacket] = {}
+        # Cache of recently sent Discord message IDs for reply threading
+        # mesh_packet_id -> discord.Message
+        self._reply_cache: dict[int, discord.Message] = {}
+        self._reply_cache_max = 500
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        if self.bridge_enabled:
+            logger.info("Discord: MeshBridge enabled — starting event consumer and flush loop")
+            self._consume_task = asyncio.create_task(self._consume_events())
+            self._flush_loop.start()
+        else:
+            logger.info("Discord: MeshBridge disabled in config")
+
+    def cog_unload(self):
+        if hasattr(self, "_consume_task"):
+            self._consume_task.cancel()
+        if self._flush_loop.is_running():
+            self._flush_loop.cancel()
+
+    async def _consume_events(self):
+        """Read events from the queue and aggregate into pending packets."""
+        while True:
+            try:
+                event = await self.data.discord_event_queue.get()
+                await self._handle_event(event)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("MeshBridge: Error consuming event")
+
+    async def _handle_event(self, event: dict):
+        """Process a single event from the MQTT pipeline."""
+        event_type = event.get("type")
+        msg = event.get("msg", {})
+
+        packet_id = msg.get("id")
+        from_id = msg.get("from", "")
+        if not packet_id or not from_id:
+            return
+
+        key = f"{packet_id}:{from_id}"
+
+        if key in self._pending:
+            # Additional gateway for an already-seen packet
+            self._pending[key].add_gateway(msg)
+        else:
+            if event_type == "text":
+                chat = event.get("chat", {})
+                pending = _PendingPacket("text", msg, chat=chat)
+            elif event_type == "position":
+                node_id = event.get("node_id", from_id)
+                pending = _PendingPacket("position", msg, node_id=node_id)
+            else:
+                return
+
+            pending.add_gateway(msg)
+            self._pending[key] = pending
+
+    @tasks.loop(seconds=1)
+    async def _flush_loop(self):
+        """Periodically flush pending packets that have aged past the aggregation window."""
+        now = time.monotonic()
+        keys_to_remove = []
+
+        for key, pending in self._pending.items():
+            age = now - pending.first_seen
+            if age >= self.aggregate_seconds and pending.dirty:
+                try:
+                    await self._post_or_update(pending)
+                    pending.dirty = False
+                except Exception:
+                    logger.exception("MeshBridge: Error posting packet %s", key)
+
+            # Clean up old entries (keep for 60s for late gateways, then discard)
+            if age > 60:
+                keys_to_remove.append(key)
+
+        for key in keys_to_remove:
+            self._pending.pop(key, None)
+
+    @_flush_loop.before_loop
+    async def _before_flush_loop(self):
+        await self.bot.wait_until_ready()
+
+    async def _post_or_update(self, pending: _PendingPacket):
+        """Post a new embed or edit an existing one with updated gateway info."""
+        if pending.event_type == "text":
+            await self._post_text(pending)
+        elif pending.event_type == "position":
+            await self._post_position(pending)
+
+    async def _post_text(self, pending: _PendingPacket):
+        """Post or update a text message embed."""
+        chat = pending.chat or {}
+        msg = pending.msg
+        channel_hash = str(chat.get("channel", "0"))
+
+        discord_channel_id = self.channel_map.get(channel_hash)
+        if not discord_channel_id:
+            return
+
+        channel = self.bot.get_channel(int(discord_channel_id))
+        if not channel:
+            try:
+                channel = await self.bot.fetch_channel(int(discord_channel_id))
+            except Exception:
+                logger.warning("MeshBridge: Cannot find Discord channel %s", discord_channel_id)
+                return
+
+        from_id = chat.get("from", msg.get("from", ""))
+
+        # Check if node is banned
+        if await self.data.pg_storage.is_node_banned(from_id):
+            logger.debug("MeshBridge: Skipping banned node %s", from_id)
+            return
+
+        # Filter out test messages
+        text = chat.get("text", "")
+        if text.startswith("seq ") and text[4:].isdigit():
+            return
+
+        # Get node owner
+        owner_id = await self.data.pg_storage.get_node_owner(from_id)
+
+        base_url = self.config.get("server", {}).get("base_url", "")
+        embed = build_text_embed(
+            msg=msg,
+            chat=chat,
+            nodes=self.data.nodes,
+            base_url=base_url,
+            owner_id=owner_id,
+            gateway_entries=pending.gateways,
+        )
+
+        # Reply threading: if this mesh message has a reply_id, find the Discord message
+        reply_to = None
+        reply_id = msg.get("decoded", {}).get("reply_id") if isinstance(msg.get("decoded"), dict) else None
+        if reply_id and reply_id in self._reply_cache:
+            reply_to = self._reply_cache[reply_id]
+
+        if pending.discord_message:
+            # Edit existing message with updated gateway info
+            try:
+                await pending.discord_message.edit(embed=embed)
+            except Exception:
+                logger.warning("MeshBridge: Failed to edit message, posting new")
+                pending.discord_message = None
+
+        if not pending.discord_message:
+            kwargs = {"embed": embed}
+            if reply_to:
+                kwargs["reference"] = reply_to
+            try:
+                sent = await channel.send(**kwargs)
+                pending.discord_message = sent
+                # Cache for reply threading
+                packet_id = msg.get("id")
+                if packet_id:
+                    self._reply_cache[packet_id] = sent
+                    # Evict old entries
+                    if len(self._reply_cache) > self._reply_cache_max:
+                        oldest_key = next(iter(self._reply_cache))
+                        self._reply_cache.pop(oldest_key, None)
+            except Exception:
+                logger.exception("MeshBridge: Failed to send text message to channel %s", discord_channel_id)
+
+    async def _post_position(self, pending: _PendingPacket):
+        """Post or update a position embed for a tracked node."""
+        msg = pending.msg
+        node_id = pending.node_id or msg.get("from", "")
+
+        # Only post for tracked nodes
+        if not await self.data.pg_storage.is_node_tracked(node_id):
+            return
+
+        channel_hash = str(msg.get("channel", "0"))
+        discord_channel_id = self.position_channel_map.get(channel_hash)
+        if not discord_channel_id:
+            # Fall back to text channel map
+            discord_channel_id = self.channel_map.get(channel_hash)
+        if not discord_channel_id:
+            return
+
+        channel = self.bot.get_channel(int(discord_channel_id))
+        if not channel:
+            try:
+                channel = await self.bot.fetch_channel(int(discord_channel_id))
+            except Exception:
+                logger.warning("MeshBridge: Cannot find Discord channel %s", discord_channel_id)
+                return
+
+        # Check ban
+        if await self.data.pg_storage.is_node_banned(node_id):
+            return
+
+        track_type = await self.data.pg_storage.get_tracker_type(node_id) or "tracker"
+        owner_id = await self.data.pg_storage.get_node_owner(node_id)
+
+        base_url = self.config.get("server", {}).get("base_url", "")
+        embed = build_position_embed(
+            msg=msg,
+            node_id=node_id,
+            nodes=self.data.nodes,
+            base_url=base_url,
+            track_type=track_type,
+            owner_id=owner_id,
+            gateway_entries=pending.gateways,
+        )
+
+        if pending.discord_message:
+            try:
+                await pending.discord_message.edit(embed=embed)
+            except Exception:
+                pending.discord_message = None
+
+        if not pending.discord_message:
+            try:
+                sent = await channel.send(embed=embed)
+                pending.discord_message = sent
+            except Exception:
+                logger.exception("MeshBridge: Failed to send position to channel %s", discord_channel_id)

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -494,7 +494,7 @@ class MeshBridge(commands.Cog):
                 return
 
         try:
-            links = await self.data.pg_storage.get_all_linked_nodes()
+            links = await self.data.pg_storage.get_all_watched_nodes()
         except Exception:
             return
 

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -419,6 +419,7 @@ class MeshBridge(commands.Cog):
             node_id=node_id,
             nodes=enriched_nodes,
             base_url=base_url,
+            config=self.config,
             track_type=track_type,
             owner_id=owner_id,
             gateway_entries=pending.gateways,

--- a/bot/discord.py
+++ b/bot/discord.py
@@ -5,6 +5,8 @@ from discord.ext import commands
 import discord
 from dotenv import load_dotenv
 from bot.cogs.main_commands import MainCommands
+from bot.cogs.admin_commands import AdminCommands
+from bot.cogs.mesh_bridge import MeshBridge
 from memory_data_store import MemoryDataStore
 
 logger = logging.getLogger(__name__)
@@ -42,6 +44,8 @@ class DiscordBot(commands.Bot):
     async def start_server(self):
         logger.info("Starting Discord Bot")
         await self.add_cog(MainCommands(self, self.config, self.data))
+        await self.add_cog(AdminCommands(self, self.config, self.data))
+        await self.add_cog(MeshBridge(self, self.config, self.data))
         await self.start(self.config['integrations']['discord']['token'])
         logger.info("Discord Bot Done!")
 

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -133,10 +133,12 @@ def build_text_embed(
     avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={from_id}"
     embed.set_author(name=f"{display_name} [{short_name}]", url=node_link, icon_url=avatar_url)
 
-    # Packet info fields
+    # Packet info fields — linked to logs search
     packet_id = msg.get("id")
     if packet_id:
-        embed.add_field(name="Packet ID", value=str(packet_id), inline=True)
+        logs_url = f"{base_url.rstrip('/')}/logs?q={packet_id}" if base_url else None
+        pid_display = f"[{packet_id}]({logs_url})" if logs_url else str(packet_id)
+        embed.add_field(name="Packet ID", value=pid_display, inline=True)
 
     channel = str(chat.get("channel", "0"))
     channel_label = _resolve_channel_name(channel, config)

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -20,8 +20,41 @@ EMBED_TOTAL_LIMIT = 6000
 EMBED_DESC_LIMIT = 4096
 EMBED_FIELD_VALUE_LIMIT = 1024
 
-# Static map API for position embeds
-MAP_API_URL = "https://api.smerty.org/staticmap"
+# OpenStreetMap static map (free, no token)
+OSM_STATIC_MAP_URL = "https://staticmap.openstreetmap.de/staticmap.php"
+
+
+def _map_thumbnail_url(lat: float, lon: float, maps_cfg: dict) -> str | None:
+    """Build a static map thumbnail URL based on the configured provider."""
+    provider = maps_cfg.get("provider", "none")
+
+    if provider == "osm":
+        return (
+            f"{OSM_STATIC_MAP_URL}"
+            f"?center={lat},{lon}&zoom=12&size=300x200"
+            f"&markers={lat},{lon},red-pushpin"
+        )
+
+    if provider == "mapbox":
+        mb = maps_cfg.get("mapbox", {})
+        token = mb.get("access_token", "")
+        if not token:
+            return None
+        style = mb.get("style", "mapbox/dark-v11")
+        return (
+            f"https://api.mapbox.com/styles/v1/{style}/static"
+            f"/pin-s+ff0000({lon},{lat})/{lon},{lat},12,0/300x200@2x"
+            f"?access_token={token}"
+        )
+
+    return None  # "none" — no thumbnail
+
+
+def _map_link_url(base_url: str, node_id: str) -> str | None:
+    """Build a clickable link to the node on the MeshInfo map page."""
+    if not base_url:
+        return None
+    return f"{base_url.rstrip('/')}/map?node={node_id}"
 
 
 def _node_url(base_url: str, node_id: str) -> str | None:
@@ -173,6 +206,7 @@ def build_position_embed(
     node_id: str,
     nodes: dict,
     base_url: str,
+    config: dict,
     track_type: str = "tracker",
     owner_id: Optional[str] = None,
     gateway_entries: Optional[list] = None,
@@ -186,10 +220,11 @@ def build_position_embed(
     payload = msg.get("payload", {})
 
     label = "Balloon" if track_type == "balloon" else "Tracker"
+    map_link = _map_link_url(base_url, node_id)
     node_link = _node_url(base_url, node_id)
     embed = discord.Embed(
         title=f"{label} Position Update",
-        url=node_link,
+        url=map_link or node_link,
         color=discord.Color.orange() if track_type == "balloon" else discord.Color.blue(),
         timestamp=discord.utils.utcnow(),
     )
@@ -202,17 +237,22 @@ def build_position_embed(
     lon_i = payload.get("longitude_i")
     alt = payload.get("altitude")
 
+    maps_cfg = config.get("integrations", {}).get("discord", {}).get("bridge", {}).get("maps", {})
+
     if lat_i is not None and lon_i is not None:
         lat = lat_i / 1e7
         lon = lon_i / 1e7
-        embed.add_field(name="Latitude", value=f"{lat:.6f}", inline=True)
-        embed.add_field(name="Longitude", value=f"{lon:.6f}", inline=True)
+
+        # Clickable coordinates linking to MeshInfo map
+        coord_text = f"[{lat:.6f}, {lon:.6f}]({map_link})" if map_link else f"{lat:.6f}, {lon:.6f}"
+        embed.add_field(name="Position", value=coord_text, inline=True)
         if alt is not None:
             embed.add_field(name="Altitude", value=f"{alt}m", inline=True)
 
-        # Static map thumbnail
-        map_url = f"{MAP_API_URL}?center={lat},{lon}&zoom=12&size=300x200&markers={lat},{lon}"
-        embed.set_thumbnail(url=map_url)
+        # Static map thumbnail (configurable provider)
+        thumbnail_url = _map_thumbnail_url(lat, lon, maps_cfg)
+        if thumbnail_url:
+            embed.set_thumbnail(url=thumbnail_url)
 
     # Gateway info with linked names
     if gateway_entries and len(gateway_entries) > 0:

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -207,7 +207,6 @@ def build_text_embed(
     if owner_id:
         embed.add_field(name="Owner", value=f"<@{owner_id}>", inline=True)
 
-    # Footer with link-friendly node ID
     embed.set_footer(text=f"Node: !{from_id}")
 
     return embed

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -20,34 +20,17 @@ EMBED_TOTAL_LIMIT = 6000
 EMBED_DESC_LIMIT = 4096
 EMBED_FIELD_VALUE_LIMIT = 1024
 
-# OpenStreetMap static map (free, no token)
-OSM_STATIC_MAP_URL = "https://staticmap.openstreetmap.de/staticmap.php"
+def _map_thumbnail_url(lat: float, lon: float, base_url: str, maps_cfg: dict) -> str | None:
+    """Build a self-hosted static map thumbnail URL.
 
-
-def _map_thumbnail_url(lat: float, lon: float, maps_cfg: dict) -> str | None:
-    """Build a static map thumbnail URL based on the configured provider."""
+    Points to the MeshInfo /v1/static-map endpoint, which renders tiles
+    from OSM or Mapbox server-side. Returns None if provider is "none".
+    """
     provider = maps_cfg.get("provider", "none")
+    if provider == "none" or not base_url:
+        return None
 
-    if provider == "osm":
-        return (
-            f"{OSM_STATIC_MAP_URL}"
-            f"?center={lat},{lon}&zoom=12&size=300x200"
-            f"&markers={lat},{lon},red-pushpin"
-        )
-
-    if provider == "mapbox":
-        mb = maps_cfg.get("mapbox", {})
-        token = mb.get("access_token", "")
-        if not token:
-            return None
-        style = mb.get("style", "mapbox/dark-v11")
-        return (
-            f"https://api.mapbox.com/styles/v1/{style}/static"
-            f"/pin-s+ff0000({lon},{lat})/{lon},{lat},12,0/300x200@2x"
-            f"?access_token={token}"
-        )
-
-    return None  # "none" — no thumbnail
+    return f"{base_url.rstrip('/')}/v1/static-map?lat={lat:.6f}&lon={lon:.6f}&zoom=12"
 
 
 def _map_link_url(base_url: str, node_id: str) -> str | None:
@@ -249,8 +232,8 @@ def build_position_embed(
         if alt is not None:
             embed.add_field(name="Altitude", value=f"{alt}m", inline=True)
 
-        # Static map thumbnail (configurable provider)
-        thumbnail_url = _map_thumbnail_url(lat, lon, maps_cfg)
+        # Static map thumbnail (self-hosted, provider from config)
+        thumbnail_url = _map_thumbnail_url(lat, lon, base_url, maps_cfg)
         if thumbnail_url:
             embed.set_thumbnail(url=thumbnail_url)
 

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -1,0 +1,262 @@
+"""
+Rich Discord embed builders for Meshtastic mesh messages.
+
+Inspired by RATM 2.0's presentation layer — gateway grouping by hop count,
+SNR/RSSI display, static map thumbnails for position packets, and reply
+threading support.
+"""
+
+import logging
+from typing import Optional
+
+import discord
+
+import utils
+
+logger = logging.getLogger(__name__)
+
+# Discord embed limits
+EMBED_TOTAL_LIMIT = 6000
+EMBED_DESC_LIMIT = 4096
+EMBED_FIELD_VALUE_LIMIT = 1024
+
+# Static map API for position embeds
+MAP_API_URL = "https://api.smerty.org/staticmap"
+
+
+def _node_display_name(node: Optional[dict], node_id: str) -> str:
+    """Return a human-readable name for a node, falling back to hex ID."""
+    if node:
+        longname = node.get("longname", "")
+        shortname = node.get("shortname", "")
+        if longname and longname != "Unknown":
+            return longname
+        if shortname and shortname != "UNK":
+            return shortname
+    return f"!{node_id}"
+
+
+def _node_short_name(node: Optional[dict], node_id: str) -> str:
+    """Return the short name for a node."""
+    if node and node.get("shortname") and node["shortname"] != "UNK":
+        return node["shortname"]
+    return node_id[:4]
+
+
+def _format_gateway_info(msg: dict, nodes: dict) -> str:
+    """Format gateway/reception info from the message metadata."""
+    parts = []
+
+    # SNR/RSSI from the receiving gateway
+    snr = msg.get("snr")
+    rssi = msg.get("rssi")
+    if snr is not None or rssi is not None:
+        signal_parts = []
+        if rssi is not None:
+            signal_parts.append(f"RSSI: {rssi} dBm")
+        if snr is not None:
+            signal_parts.append(f"SNR: {snr} dB")
+        parts.append(" | ".join(signal_parts))
+
+    # Hop info
+    hops_away = msg.get("hops_away")
+    hop_limit = msg.get("hop_limit")
+    if hops_away is not None:
+        hop_str = "Direct" if hops_away == 0 else f"{hops_away} hop(s)"
+        if hop_limit is not None:
+            hop_str += f" (limit: {hop_limit})"
+        parts.append(hop_str)
+
+    # Gateway node
+    topic = msg.get("topic", "")
+    if topic:
+        # Extract gateway ID from topic: msh/region/2/e/LongFast/!gateway_id
+        topic_parts = topic.split("/")
+        if topic_parts and topic_parts[-1].startswith("!"):
+            gw_id = topic_parts[-1].replace("!", "")
+            gw_node = nodes.get(gw_id)
+            gw_name = _node_display_name(gw_node, gw_id)
+            parts.append(f"Gateway: {gw_name}")
+
+    return "\n".join(parts) if parts else ""
+
+
+def build_text_embed(
+    msg: dict,
+    chat: dict,
+    nodes: dict,
+    base_url: str,
+    owner_id: Optional[str] = None,
+    gateway_entries: Optional[list] = None,
+) -> discord.Embed:
+    """
+    Build a rich embed for a text message from the mesh.
+
+    Args:
+        msg: The raw MQTT message dict.
+        chat: The processed chat dict with 'text', 'from', 'channel', etc.
+        nodes: The current nodes dict from MemoryDataStore.
+        base_url: The MeshInfo base URL for linking.
+        owner_id: Discord user ID linked to the sender node, or None.
+        gateway_entries: List of gateway info dicts for aggregated display.
+    """
+    from_id = chat.get("from", msg.get("from", "unknown"))
+    node = nodes.get(from_id)
+    display_name = _node_display_name(node, from_id)
+    short_name = _node_short_name(node, from_id)
+    text = chat.get("text", "")
+
+    # Build embed
+    embed = discord.Embed(
+        description=text[:EMBED_DESC_LIMIT],
+        color=discord.Color.green(),
+        timestamp=discord.utils.utcnow(),
+    )
+
+    # Author = sender node
+    node_url = f"{base_url.rstrip('/')}/node_{from_id}.html" if base_url else None
+    avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/svg?seed={from_id}"
+    embed.set_author(name=f"{display_name} [{short_name}]", url=node_url, icon_url=avatar_url)
+
+    # Packet info fields
+    packet_id = msg.get("id")
+    if packet_id:
+        embed.add_field(name="Packet ID", value=str(packet_id), inline=True)
+
+    channel = chat.get("channel", "0")
+    embed.add_field(name="Channel", value=str(channel), inline=True)
+
+    # Gateway info
+    if gateway_entries and len(gateway_entries) > 0:
+        gw_text = _format_gateway_list(gateway_entries, nodes)
+        if gw_text:
+            # Truncate if needed
+            if len(gw_text) > EMBED_FIELD_VALUE_LIMIT:
+                gw_text = gw_text[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
+            embed.add_field(name="Gateways", value=gw_text, inline=False)
+    else:
+        # Single gateway from the original message
+        gw_info = _format_gateway_info(msg, nodes)
+        if gw_info:
+            if len(gw_info) > EMBED_FIELD_VALUE_LIMIT:
+                gw_info = gw_info[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
+            embed.add_field(name="Reception", value=gw_info, inline=False)
+
+    # Owner mention
+    if owner_id:
+        embed.add_field(name="Owner", value=f"<@{owner_id}>", inline=True)
+
+    # Footer
+    embed.set_footer(text=f"Node: !{from_id}")
+
+    return embed
+
+
+def build_position_embed(
+    msg: dict,
+    node_id: str,
+    nodes: dict,
+    base_url: str,
+    track_type: str = "tracker",
+    owner_id: Optional[str] = None,
+    gateway_entries: Optional[list] = None,
+) -> discord.Embed:
+    """
+    Build a rich embed for a position update from a tracked node.
+    """
+    node = nodes.get(node_id)
+    display_name = _node_display_name(node, node_id)
+    short_name = _node_short_name(node, node_id)
+    payload = msg.get("payload", {})
+
+    label = "Balloon" if track_type == "balloon" else "Tracker"
+    embed = discord.Embed(
+        title=f"{label} Position Update",
+        color=discord.Color.orange() if track_type == "balloon" else discord.Color.blue(),
+        timestamp=discord.utils.utcnow(),
+    )
+
+    node_url = f"{base_url.rstrip('/')}/node_{node_id}.html" if base_url else None
+    avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/svg?seed={node_id}"
+    embed.set_author(name=f"{display_name} [{short_name}]", url=node_url, icon_url=avatar_url)
+
+    # Position fields
+    lat_i = payload.get("latitude_i")
+    lon_i = payload.get("longitude_i")
+    alt = payload.get("altitude")
+
+    if lat_i is not None and lon_i is not None:
+        lat = lat_i / 1e7
+        lon = lon_i / 1e7
+        embed.add_field(name="Latitude", value=f"{lat:.6f}", inline=True)
+        embed.add_field(name="Longitude", value=f"{lon:.6f}", inline=True)
+        if alt is not None:
+            embed.add_field(name="Altitude", value=f"{alt}m", inline=True)
+
+        # Static map thumbnail
+        map_url = f"{MAP_API_URL}?center={lat},{lon}&zoom=12&size=300x200&markers={lat},{lon}"
+        embed.set_thumbnail(url=map_url)
+
+    # Gateway info
+    if gateway_entries and len(gateway_entries) > 0:
+        gw_text = _format_gateway_list(gateway_entries, nodes)
+        if gw_text:
+            if len(gw_text) > EMBED_FIELD_VALUE_LIMIT:
+                gw_text = gw_text[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
+            embed.add_field(name="Gateways", value=gw_text, inline=False)
+    else:
+        gw_info = _format_gateway_info(msg, nodes)
+        if gw_info:
+            if len(gw_info) > EMBED_FIELD_VALUE_LIMIT:
+                gw_info = gw_info[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
+            embed.add_field(name="Reception", value=gw_info, inline=False)
+
+    if owner_id:
+        embed.add_field(name="Owner", value=f"<@{owner_id}>", inline=True)
+
+    embed.set_footer(text=f"Node: !{node_id}")
+
+    return embed
+
+
+def _format_gateway_list(gateway_entries: list, nodes: dict) -> str:
+    """
+    Format a list of gateway reception reports grouped by hop count.
+
+    Each entry is a dict with keys: gateway_id, rssi, snr, hops_away, topic.
+    """
+    if not gateway_entries:
+        return ""
+
+    # Group by hops
+    by_hops: dict[int, list] = {}
+    for gw in gateway_entries:
+        hops = gw.get("hops_away", -1)
+        if hops is None:
+            hops = -1
+        by_hops.setdefault(hops, []).append(gw)
+
+    lines = []
+    for hops in sorted(by_hops.keys()):
+        if hops == 0:
+            header = "**Direct**"
+        elif hops == -1:
+            header = "**Unknown hops**"
+        else:
+            header = f"**{hops} hop(s)**"
+        lines.append(header)
+
+        for gw in by_hops[hops]:
+            gw_id = gw.get("gateway_id", "unknown")
+            gw_node = nodes.get(gw_id)
+            gw_name = _node_display_name(gw_node, gw_id)
+            parts = [f"  {gw_name}"]
+            rssi = gw.get("rssi")
+            snr = gw.get("snr")
+            if rssi is not None:
+                parts.append(f"RSSI: {rssi}")
+            if snr is not None:
+                parts.append(f"SNR: {snr}")
+            lines.append(" | ".join(parts))
+
+    return "\n".join(lines)

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -24,6 +24,13 @@ EMBED_FIELD_VALUE_LIMIT = 1024
 MAP_API_URL = "https://api.smerty.org/staticmap"
 
 
+def _node_url(base_url: str, node_id: str) -> str | None:
+    """Build a deep link URL to a node's detail page."""
+    if not base_url:
+        return None
+    return f"{base_url.rstrip('/')}/nodes?node={node_id}"
+
+
 def _node_display_name(node: Optional[dict], node_id: str) -> str:
     """Return a human-readable name for a node, falling back to hex ID."""
     if node:
@@ -43,7 +50,16 @@ def _node_short_name(node: Optional[dict], node_id: str) -> str:
     return node_id[:4]
 
 
-def _format_gateway_info(msg: dict, nodes: dict) -> str:
+def _node_linked_name(node: Optional[dict], node_id: str, base_url: str) -> str:
+    """Return a markdown-linked node name, e.g. [NodeName](https://...)."""
+    name = _node_display_name(node, node_id)
+    url = _node_url(base_url, node_id)
+    if url:
+        return f"[{name}]({url})"
+    return name
+
+
+def _format_gateway_info(msg: dict, nodes: dict, base_url: str) -> str:
     """Format gateway/reception info from the message metadata."""
     parts = []
 
@@ -70,12 +86,11 @@ def _format_gateway_info(msg: dict, nodes: dict) -> str:
     # Gateway node
     topic = msg.get("topic", "")
     if topic:
-        # Extract gateway ID from topic: msh/region/2/e/LongFast/!gateway_id
         topic_parts = topic.split("/")
         if topic_parts and topic_parts[-1].startswith("!"):
             gw_id = topic_parts[-1].replace("!", "")
             gw_node = nodes.get(gw_id)
-            gw_name = _node_display_name(gw_node, gw_id)
+            gw_name = _node_linked_name(gw_node, gw_id, base_url)
             parts.append(f"Gateway: {gw_name}")
 
     return "\n".join(parts) if parts else ""
@@ -99,14 +114,6 @@ def build_text_embed(
 ) -> discord.Embed:
     """
     Build a rich embed for a text message from the mesh.
-
-    Args:
-        msg: The raw MQTT message dict.
-        chat: The processed chat dict with 'text', 'from', 'channel', etc.
-        nodes: The current nodes dict from MemoryDataStore.
-        base_url: The MeshInfo base URL for linking.
-        owner_id: Discord user ID linked to the sender node, or None.
-        gateway_entries: List of gateway info dicts for aggregated display.
     """
     from_id = chat.get("from", msg.get("from", "unknown"))
     node = nodes.get(from_id)
@@ -114,17 +121,17 @@ def build_text_embed(
     short_name = _node_short_name(node, from_id)
     text = chat.get("text", "")
 
-    # Build embed
+    # Build embed — title links to the sender's node page
+    node_link = _node_url(base_url, from_id)
     embed = discord.Embed(
         description=text[:EMBED_DESC_LIMIT],
         color=discord.Color.green(),
         timestamp=discord.utils.utcnow(),
     )
 
-    # Author = sender node
-    node_url = f"{base_url.rstrip('/')}/node_{from_id}.html" if base_url else None
+    # Author = sender node (linked to node page)
     avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={from_id}"
-    embed.set_author(name=f"{display_name} [{short_name}]", url=node_url, icon_url=avatar_url)
+    embed.set_author(name=f"{display_name} [{short_name}]", url=node_link, icon_url=avatar_url)
 
     # Packet info fields
     packet_id = msg.get("id")
@@ -135,17 +142,15 @@ def build_text_embed(
     channel_label = _resolve_channel_name(channel, config)
     embed.add_field(name="Channel", value=channel_label, inline=True)
 
-    # Gateway info
+    # Gateway info with linked names
     if gateway_entries and len(gateway_entries) > 0:
-        gw_text = _format_gateway_list(gateway_entries, nodes)
+        gw_text = _format_gateway_list(gateway_entries, nodes, base_url)
         if gw_text:
-            # Truncate if needed
             if len(gw_text) > EMBED_FIELD_VALUE_LIMIT:
                 gw_text = gw_text[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
             embed.add_field(name="Gateways", value=gw_text, inline=False)
     else:
-        # Single gateway from the original message
-        gw_info = _format_gateway_info(msg, nodes)
+        gw_info = _format_gateway_info(msg, nodes, base_url)
         if gw_info:
             if len(gw_info) > EMBED_FIELD_VALUE_LIMIT:
                 gw_info = gw_info[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
@@ -155,7 +160,7 @@ def build_text_embed(
     if owner_id:
         embed.add_field(name="Owner", value=f"<@{owner_id}>", inline=True)
 
-    # Footer
+    # Footer with link-friendly node ID
     embed.set_footer(text=f"Node: !{from_id}")
 
     return embed
@@ -179,15 +184,16 @@ def build_position_embed(
     payload = msg.get("payload", {})
 
     label = "Balloon" if track_type == "balloon" else "Tracker"
+    node_link = _node_url(base_url, node_id)
     embed = discord.Embed(
         title=f"{label} Position Update",
+        url=node_link,
         color=discord.Color.orange() if track_type == "balloon" else discord.Color.blue(),
         timestamp=discord.utils.utcnow(),
     )
 
-    node_url = f"{base_url.rstrip('/')}/node_{node_id}.html" if base_url else None
     avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node_id}"
-    embed.set_author(name=f"{display_name} [{short_name}]", url=node_url, icon_url=avatar_url)
+    embed.set_author(name=f"{display_name} [{short_name}]", url=node_link, icon_url=avatar_url)
 
     # Position fields
     lat_i = payload.get("latitude_i")
@@ -206,15 +212,15 @@ def build_position_embed(
         map_url = f"{MAP_API_URL}?center={lat},{lon}&zoom=12&size=300x200&markers={lat},{lon}"
         embed.set_thumbnail(url=map_url)
 
-    # Gateway info
+    # Gateway info with linked names
     if gateway_entries and len(gateway_entries) > 0:
-        gw_text = _format_gateway_list(gateway_entries, nodes)
+        gw_text = _format_gateway_list(gateway_entries, nodes, base_url)
         if gw_text:
             if len(gw_text) > EMBED_FIELD_VALUE_LIMIT:
                 gw_text = gw_text[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
             embed.add_field(name="Gateways", value=gw_text, inline=False)
     else:
-        gw_info = _format_gateway_info(msg, nodes)
+        gw_info = _format_gateway_info(msg, nodes, base_url)
         if gw_info:
             if len(gw_info) > EMBED_FIELD_VALUE_LIMIT:
                 gw_info = gw_info[: EMBED_FIELD_VALUE_LIMIT - 3] + "..."
@@ -228,11 +234,10 @@ def build_position_embed(
     return embed
 
 
-def _format_gateway_list(gateway_entries: list, nodes: dict) -> str:
+def _format_gateway_list(gateway_entries: list, nodes: dict, base_url: str) -> str:
     """
     Format a list of gateway reception reports grouped by hop count.
-
-    Each entry is a dict with keys: gateway_id, rssi, snr, hops_away, topic.
+    Gateway names are markdown-linked to their MeshInfo node pages.
     """
     if not gateway_entries:
         return ""
@@ -256,7 +261,7 @@ def _format_gateway_list(gateway_entries: list, nodes: dict) -> str:
         for gw in by_hops[hops]:
             gw_id = gw.get("gateway_id", "unknown")
             gw_node = nodes.get(gw_id)
-            gw_name = _node_display_name(gw_node, gw_id)
+            gw_name = _node_linked_name(gw_node, gw_id, base_url)
             parts = [f"  {gw_name}"]
             rssi = gw.get("rssi")
             snr = gw.get("snr")

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -81,11 +81,19 @@ def _format_gateway_info(msg: dict, nodes: dict) -> str:
     return "\n".join(parts) if parts else ""
 
 
+def _resolve_channel_name(channel_hash: str, config: dict) -> str:
+    """Resolve a channel hash to its label from config, or return the hash."""
+    meta = config.get("broker", {}).get("channels", {}).get("meta", {})
+    channel_meta = meta.get(channel_hash, {})
+    return channel_meta.get("label", f"Channel {channel_hash}")
+
+
 def build_text_embed(
     msg: dict,
     chat: dict,
     nodes: dict,
     base_url: str,
+    config: dict,
     owner_id: Optional[str] = None,
     gateway_entries: Optional[list] = None,
 ) -> discord.Embed:
@@ -115,7 +123,7 @@ def build_text_embed(
 
     # Author = sender node
     node_url = f"{base_url.rstrip('/')}/node_{from_id}.html" if base_url else None
-    avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/svg?seed={from_id}"
+    avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={from_id}"
     embed.set_author(name=f"{display_name} [{short_name}]", url=node_url, icon_url=avatar_url)
 
     # Packet info fields
@@ -123,8 +131,9 @@ def build_text_embed(
     if packet_id:
         embed.add_field(name="Packet ID", value=str(packet_id), inline=True)
 
-    channel = chat.get("channel", "0")
-    embed.add_field(name="Channel", value=str(channel), inline=True)
+    channel = str(chat.get("channel", "0"))
+    channel_label = _resolve_channel_name(channel, config)
+    embed.add_field(name="Channel", value=channel_label, inline=True)
 
     # Gateway info
     if gateway_entries and len(gateway_entries) > 0:
@@ -177,7 +186,7 @@ def build_position_embed(
     )
 
     node_url = f"{base_url.rstrip('/')}/node_{node_id}.html" if base_url else None
-    avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/svg?seed={node_id}"
+    avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node_id}"
     embed.set_author(name=f"{display_name} [{short_name}]", url=node_url, icon_url=avatar_url)
 
     # Position fields
@@ -228,20 +237,18 @@ def _format_gateway_list(gateway_entries: list, nodes: dict) -> str:
     if not gateway_entries:
         return ""
 
-    # Group by hops
+    # Group by hops — treat None/missing as 0 (direct)
     by_hops: dict[int, list] = {}
     for gw in gateway_entries:
-        hops = gw.get("hops_away", -1)
+        hops = gw.get("hops_away")
         if hops is None:
-            hops = -1
+            hops = 0
         by_hops.setdefault(hops, []).append(gw)
 
     lines = []
     for hops in sorted(by_hops.keys()):
         if hops == 0:
             header = "**Direct**"
-        elif hops == -1:
-            header = "**Unknown hops**"
         else:
             header = f"**{hops} hop(s)**"
         lines.append(header)

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -112,6 +112,35 @@ def _format_gateway_info(msg: dict, nodes: dict, base_url: str) -> str:
     return "\n".join(parts) if parts else ""
 
 
+def _snr_color(gateway_entries: Optional[list], msg: dict) -> discord.Color:
+    """Return a soft embed color based on best gateway SNR."""
+    best_snr = None
+
+    if gateway_entries:
+        for gw in gateway_entries:
+            snr = gw.get("snr")
+            if snr is not None:
+                if best_snr is None or snr > best_snr:
+                    best_snr = snr
+    else:
+        snr = msg.get("snr")
+        if snr is not None:
+            best_snr = snr
+
+    if best_snr is None:
+        return discord.Color.from_rgb(134, 148, 159)  # soft grey — no data
+
+    if best_snr > 10:
+        return discord.Color.from_rgb(87, 187, 138)    # soft green — excellent
+    if best_snr > 5:
+        return discord.Color.from_rgb(69, 179, 186)    # teal — good
+    if best_snr > 0:
+        return discord.Color.from_rgb(219, 196, 104)   # soft yellow — fair
+    if best_snr > -5:
+        return discord.Color.from_rgb(217, 158, 87)    # soft orange — weak
+    return discord.Color.from_rgb(194, 108, 108)       # muted red — poor
+
+
 def _resolve_channel_name(channel_hash: str, config: dict) -> str:
     """Resolve a channel hash to its label from config, or return the hash."""
     meta = config.get("broker", {}).get("channels", {}).get("meta", {})
@@ -137,11 +166,11 @@ def build_text_embed(
     short_name = _node_short_name(node, from_id)
     text = chat.get("text", "")
 
-    # Build embed — title links to the sender's node page
+    # Build embed — color based on best gateway SNR
     node_link = _node_url(base_url, from_id)
     embed = discord.Embed(
         description=text[:EMBED_DESC_LIMIT],
-        color=discord.Color.green(),
+        color=_snr_color(gateway_entries, msg),
         timestamp=discord.utils.utcnow(),
     )
 

--- a/config.py
+++ b/config.py
@@ -94,6 +94,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "enabled": False,
             "token": "",
             "guild": "",
+            "bridge": {
+                "enabled": False,
+                "aggregate_seconds": 5,
+                "channels": {},
+                "position_channels": {},
+            },
         },
         "geocoding": {
             "enabled": False,
@@ -350,6 +356,14 @@ def validate(config: dict) -> list[str]:
         guild = discord_cfg.get("guild") or ""
         if not guild or "REPLACE_WITH" in str(guild):
             warn("Discord is enabled but guild ID is missing or still a placeholder.")
+
+        bridge_cfg = discord_cfg.get("bridge", {})
+        if bridge_cfg.get("enabled"):
+            check(_validate_type(config, "integrations.discord.bridge.aggregate_seconds", (int, float)))
+            check(_validate_type(config, "integrations.discord.bridge.channels", dict))
+            check(_validate_type(config, "integrations.discord.bridge.position_channels", dict))
+            if not bridge_cfg.get("channels"):
+                warn("Discord bridge is enabled but no channel mappings are configured. No messages will be forwarded.")
 
     check(_validate_type(config, "integrations.geocoding", dict))
     geocoding_cfg = _get_nested(config, "integrations", "geocoding") or {}

--- a/config.py
+++ b/config.py
@@ -99,6 +99,13 @@ DEFAULT_CONFIG: dict[str, Any] = {
                 "aggregate_seconds": 5,
                 "channels": {},
                 "position_channels": {},
+                "maps": {
+                    "provider": "none",
+                    "mapbox": {
+                        "access_token": "",
+                        "style": "mapbox/dark-v11",
+                    },
+                },
             },
         },
         "geocoding": {
@@ -365,6 +372,18 @@ def validate(config: dict) -> list[str]:
             if not bridge_cfg.get("channels"):
                 warn("Discord bridge is enabled but no channel mappings are configured. No messages will be forwarded.")
 
+            maps_cfg = bridge_cfg.get("maps", {})
+            maps_provider = maps_cfg.get("provider", "none")
+            check(_validate_one_of(config, "integrations.discord.bridge.maps.provider", ["none", "osm", "mapbox"]))
+            if maps_provider == "mapbox":
+                mapbox_token = maps_cfg.get("mapbox", {}).get("access_token", "")
+                if not mapbox_token or "REPLACE_WITH" in str(mapbox_token):
+                    warn(
+                        "Discord bridge maps provider is 'mapbox' but no access token is configured. "
+                        "Position embeds will not include map thumbnails. "
+                        "Set access_token under [integrations.discord.bridge.maps.mapbox] in your config.toml."
+                    )
+
     check(_validate_type(config, "integrations.geocoding", dict))
     geocoding_cfg = _get_nested(config, "integrations", "geocoding") or {}
     if geocoding_cfg.get("enabled"):
@@ -558,6 +577,7 @@ class Config:
             ("broker", "password"),
             ("broker", "username"),
             ("integrations", "discord", "token"),
+            ("integrations", "discord", "bridge", "maps", "mapbox", "access_token"),
             ("integrations", "geocoding", "geocode.maps.co", "api_key"),
             ("storage", "postgres", "password"),
             ("storage", "postgres", "username"),

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -279,13 +279,15 @@ aggregate_seconds = 5  # seconds to wait for additional gateways before posting
 # "8" = "1234567890123456791"    # LongFast positions -> #position-tracking
 
 # Static map thumbnails for position tracking embeds.
-# Generates a map image when a tracked node sends a position update.
+# Renders map images server-side by fetching tiles and compositing them locally.
+# No external "static map API" — just tile fetching from OSM or Mapbox.
 # The clickable link always points to your MeshInfo map page.
+# If mapbox is configured with a valid token, it is preferred; otherwise falls back to OSM.
 [integrations.discord.bridge.maps]
 provider = "none"  # "none", "osm", "mapbox"
                    # none    = no thumbnail, just a clickable link to your map
-                   # osm     = free OpenStreetMap tiles (no token needed)
-                   # mapbox  = Mapbox Static Images API (requires access token)
+                   # osm     = OpenStreetMap tiles rendered server-side (no token needed)
+                   # mapbox  = Mapbox tiles rendered server-side (requires access token)
 
 # Mapbox configuration (only used when provider = "mapbox")
 [integrations.discord.bridge.maps.mapbox]

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -265,6 +265,7 @@ guild = "REPLACE_WITH_GUILD_ID"
 [integrations.discord.bridge]
 enabled = false
 aggregate_seconds = 5  # seconds to wait for additional gateways before posting
+# alert_channel = "1234567890123456789"  # Channel for node online/offline alerts (linked nodes only)
 
 # Map Meshtastic channel hashes to Discord channel IDs for text messages.
 # Key = Meshtastic channel hash (from broker.channels.display), value = Discord channel ID.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -278,6 +278,24 @@ aggregate_seconds = 5  # seconds to wait for additional gateways before posting
 [integrations.discord.bridge.position_channels]
 # "8" = "1234567890123456791"    # LongFast positions -> #position-tracking
 
+# Static map thumbnails for position tracking embeds.
+# Generates a map image when a tracked node sends a position update.
+# The clickable link always points to your MeshInfo map page.
+[integrations.discord.bridge.maps]
+provider = "none"  # "none", "osm", "mapbox"
+                   # none    = no thumbnail, just a clickable link to your map
+                   # osm     = free OpenStreetMap tiles (no token needed)
+                   # mapbox  = Mapbox Static Images API (requires access token)
+
+# Mapbox configuration (only used when provider = "mapbox")
+[integrations.discord.bridge.maps.mapbox]
+access_token = ""
+style = "mapbox/dark-v11"
+# style = "mapbox/streets-v12"
+# style = "mapbox/satellite-streets-v12"
+# style = "mapbox/outdoors-v12"
+# style = "mapbox/light-v11"
+
 # ─────────────────────────────────────────────────────────────────────────────
 # UI Customization — Optional
 # External tools and node detail links shown in the web UI.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -254,11 +254,29 @@ provider = "geocode.maps.co"
 [integrations.geocoding."geocode.maps.co"]
 api_key = "REPLACE_WITH_API_KEY"
 
-# Discord bot for mesh notifications
+# Discord bot for mesh notifications and live mesh bridge
 [integrations.discord]
 enabled = false
 token = "REPLACE_WITH_TOKEN"
 guild = "REPLACE_WITH_GUILD_ID"
+
+# Live mesh-to-Discord bridge
+# Forwards mesh text messages and position updates into Discord channels.
+[integrations.discord.bridge]
+enabled = false
+aggregate_seconds = 5  # seconds to wait for additional gateways before posting
+
+# Map Meshtastic channel hashes to Discord channel IDs for text messages.
+# Key = Meshtastic channel hash (from broker.channels.display), value = Discord channel ID.
+# Messages on unmapped channels are ignored.
+[integrations.discord.bridge.channels]
+# "8" = "1234567890123456789"    # LongFast -> #longfast
+# "31" = "1234567890123456790"   # MediumFast -> #mediumfast
+
+# Map Meshtastic channel hashes to Discord channel IDs for position updates.
+# Only nodes flagged as "trackers" via /addtracker will have positions forwarded.
+[integrations.discord.bridge.position_channels]
+# "8" = "1234567890123456791"    # LongFast positions -> #position-tracking
 
 # ─────────────────────────────────────────────────────────────────────────────
 # UI Customization — Optional

--- a/memory_data_store.py
+++ b/memory_data_store.py
@@ -35,7 +35,8 @@ class MemoryDataStore:
     self.traceroutes_by_node: dict = {}
 
     # Event queue for Discord bridge (MQTT -> Discord)
-    self.discord_event_queue: asyncio.Queue = asyncio.Queue()
+    # Bounded to prevent unbounded memory growth if the consumer is slow/stopped.
+    self.discord_event_queue: asyncio.Queue = asyncio.Queue(maxsize=1000)
 
     # Initialize Postgres storage
     self.pg_storage = PostgresStorage(config)

--- a/memory_data_store.py
+++ b/memory_data_store.py
@@ -34,6 +34,9 @@ class MemoryDataStore:
     self.traceroutes: list = []
     self.traceroutes_by_node: dict = {}
 
+    # Event queue for Discord bridge (MQTT -> Discord)
+    self.discord_event_queue: asyncio.Queue = asyncio.Queue()
+
     # Initialize Postgres storage
     self.pg_storage = PostgresStorage(config)
 

--- a/memory_data_store.py
+++ b/memory_data_store.py
@@ -65,7 +65,7 @@ class MemoryDataStore:
 
       # Skip common non-copyable runtime objects
       try:
-        if isinstance(v, (asyncio.Lock, asyncio.Event, asyncio.Task, logging.Logger)):
+        if isinstance(v, (asyncio.Lock, asyncio.Event, asyncio.Task, asyncio.Queue, logging.Logger)):
           setattr(result, k, v)
           continue
       except Exception as exc:

--- a/mqtt.py
+++ b/mqtt.py
@@ -442,8 +442,8 @@ class MQTT:
                 'msg': msg,
                 'node_id': id,
             })
-        except Exception:
-            pass
+        except asyncio.QueueFull:
+            pass  # Drop event if consumer is behind
 
         await self.data.save()
 
@@ -558,8 +558,8 @@ class MQTT:
                 'msg': msg,
                 'chat': chat,
             })
-        except Exception:
-            pass
+        except asyncio.QueueFull:
+            pass  # Drop event if consumer is behind
 
         await self.data.save()
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -434,6 +434,17 @@ class MQTT:
             node['position'] = msg['payload'] if 'payload' in msg else None
             self.data.update_node(id, node)
             logger.debug("Node %s skeleton added with position", id)
+
+        # Emit event for Discord bridge
+        try:
+            self.data.discord_event_queue.put_nowait({
+                'type': 'position',
+                'msg': msg,
+                'node_id': id,
+            })
+        except Exception:
+            pass
+
         await self.data.save()
 
     async def handle_telemetry(self, msg):
@@ -539,6 +550,16 @@ class MQTT:
             if 'TC' in chat['text'] and 'BBS' in chat['text'] and 'Commands' in chat['text']:
                 node['tc2_bbs'] = True
             self.data.update_node(node['id'], node)
+
+        # Emit event for Discord bridge
+        try:
+            self.data.discord_event_queue.put_nowait({
+                'type': 'text',
+                'msg': msg,
+                'chat': chat,
+            })
+        except Exception:
+            pass
 
         await self.data.save()
 

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -290,6 +290,18 @@ CREATE TABLE IF NOT EXISTS discord_banned_nodes (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Watched nodes (online/offline alerts sent to Discord)
+CREATE TABLE IF NOT EXISTS discord_watched_nodes (
+    id SERIAL PRIMARY KEY,
+    node_id VARCHAR(8) NOT NULL,
+    discord_user_id VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT discord_watched_nodes_unique UNIQUE (node_id, discord_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discord_watched_nodes_node_id ON discord_watched_nodes(node_id);
+CREATE INDEX IF NOT EXISTS idx_discord_watched_nodes_discord_user_id ON discord_watched_nodes(discord_user_id);
+
 -- Tracked nodes (position updates forwarded to Discord)
 CREATE TABLE IF NOT EXISTS discord_tracked_nodes (
     node_id VARCHAR(8) PRIMARY KEY,

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -264,3 +264,35 @@ ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS local_stats JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS health_metrics JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS host_metrics JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS traffic_management_stats JSONB;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Discord bridge tables
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Links between mesh nodes and Discord users
+CREATE TABLE IF NOT EXISTS discord_node_links (
+    id SERIAL PRIMARY KEY,
+    node_id VARCHAR(8) NOT NULL,
+    discord_user_id VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT discord_node_links_unique UNIQUE (node_id, discord_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discord_node_links_node_id ON discord_node_links(node_id);
+CREATE INDEX IF NOT EXISTS idx_discord_node_links_discord_user_id ON discord_node_links(discord_user_id);
+
+-- Banned nodes (messages suppressed from Discord bridge)
+CREATE TABLE IF NOT EXISTS discord_banned_nodes (
+    node_id VARCHAR(8) PRIMARY KEY,
+    banned_by VARCHAR(20),  -- Discord user ID who banned
+    reason TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Tracked nodes (position updates forwarded to Discord)
+CREATE TABLE IF NOT EXISTS discord_tracked_nodes (
+    node_id VARCHAR(8) PRIMARY KEY,
+    track_type VARCHAR(20) NOT NULL DEFAULT 'tracker',  -- 'tracker' or 'balloon'
+    added_by VARCHAR(20),  -- Discord user ID who added
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -275,7 +275,7 @@ CREATE TABLE IF NOT EXISTS discord_node_links (
     node_id VARCHAR(8) NOT NULL,
     discord_user_id VARCHAR(20) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    CONSTRAINT discord_node_links_unique UNIQUE (node_id, discord_user_id)
+    CONSTRAINT discord_node_links_unique UNIQUE (node_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_discord_node_links_node_id ON discord_node_links(node_id);

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ cryptography
 protobuf
 uvicorn
 asyncpg
+staticmap
+Pillow

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1737,22 +1737,35 @@ class PostgresStorage:
     # Discord bridge helpers
     # ───────────────────────────────────────────────────────────────────
 
-    async def link_node(self, node_id: str, discord_user_id: str) -> bool:
-        """Link a mesh node to a Discord user. Returns True on success."""
+    async def link_node(self, node_id: str, discord_user_id: str) -> str:
+        """Link a mesh node to a Discord user.
+
+        Returns:
+            "ok" on success,
+            "already_yours" if already linked to this user,
+            "taken" if linked to another user,
+            "error" on failure.
+        """
         if not self._ready("link_node"):
-            return False
+            return "error"
         try:
             async with self.pool.acquire() as conn:
+                existing = await conn.fetchval(
+                    "SELECT discord_user_id FROM discord_node_links WHERE node_id = $1",
+                    node_id,
+                )
+                if existing == discord_user_id:
+                    return "already_yours"
+                if existing is not None:
+                    return "taken"
                 await conn.execute(
-                    """INSERT INTO discord_node_links (node_id, discord_user_id)
-                       VALUES ($1, $2)
-                       ON CONFLICT (node_id) DO UPDATE SET discord_user_id = $2""",
+                    "INSERT INTO discord_node_links (node_id, discord_user_id) VALUES ($1, $2)",
                     node_id, discord_user_id,
                 )
-            return True
+            return "ok"
         except Exception as e:
             logger.error("Failed to link node %s to Discord user %s: %s", node_id, discord_user_id, e)
-            return False
+            return "error"
 
     async def unlink_node(self, node_id: str, discord_user_id: str) -> bool:
         """Unlink a mesh node from a Discord user. Returns True if a row was deleted."""
@@ -1782,6 +1795,71 @@ class PostgresStorage:
             return [r["node_id"] for r in rows]
         except Exception as e:
             logger.error("Failed to get linked nodes for Discord user %s: %s", discord_user_id, e)
+            return []
+
+    async def watch_node(self, node_id: str, discord_user_id: str) -> str:
+        """Watch a node for online/offline alerts. Returns 'ok', 'already', or 'error'."""
+        if not self._ready("watch_node"):
+            return "error"
+        try:
+            async with self.pool.acquire() as conn:
+                existing = await conn.fetchval(
+                    "SELECT 1 FROM discord_watched_nodes WHERE node_id = $1 AND discord_user_id = $2",
+                    node_id, discord_user_id,
+                )
+                if existing:
+                    return "already"
+                await conn.execute(
+                    "INSERT INTO discord_watched_nodes (node_id, discord_user_id) VALUES ($1, $2)",
+                    node_id, discord_user_id,
+                )
+            return "ok"
+        except Exception as e:
+            logger.error("Failed to watch node %s for user %s: %s", node_id, discord_user_id, e)
+            return "error"
+
+    async def unwatch_node(self, node_id: str, discord_user_id: str) -> bool:
+        """Stop watching a node. Returns True if a row was deleted."""
+        if not self._ready("unwatch_node"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM discord_watched_nodes WHERE node_id = $1 AND discord_user_id = $2",
+                    node_id, discord_user_id,
+                )
+            return result == "DELETE 1"
+        except Exception as e:
+            logger.error("Failed to unwatch node %s for user %s: %s", node_id, discord_user_id, e)
+            return False
+
+    async def get_watched_nodes(self, discord_user_id: str) -> list[str]:
+        """Return all node IDs watched by a Discord user."""
+        if not self._ready("get_watched_nodes"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT node_id FROM discord_watched_nodes WHERE discord_user_id = $1",
+                    discord_user_id,
+                )
+            return [r["node_id"] for r in rows]
+        except Exception as e:
+            logger.error("Failed to get watched nodes for user %s: %s", discord_user_id, e)
+            return []
+
+    async def get_all_watched_nodes(self) -> list[dict]:
+        """Return all watch entries: [{node_id, discord_user_id}, ...]."""
+        if not self._ready("get_all_watched_nodes"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT node_id, discord_user_id FROM discord_watched_nodes",
+                )
+                return [dict(r) for r in rows]
+        except Exception as e:
+            logger.error("Failed to get all watched nodes: %s", e)
             return []
 
     async def get_all_linked_nodes(self) -> list[dict]:

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1901,3 +1901,31 @@ class PostgresStorage:
         except Exception as e:
             logger.error("Failed to get tracker type for node %s: %s", node_id, e)
             return None
+
+    async def list_trackers(self) -> list[dict]:
+        """List all tracked nodes with their type and who added them."""
+        if not self._ready("list_trackers"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT node_id, track_type, added_by, created_at FROM discord_tracked_nodes ORDER BY created_at",
+                )
+                return [dict(row) for row in rows]
+        except Exception as e:
+            logger.error("Failed to list trackers: %s", e)
+            return []
+
+    async def list_bans(self) -> list[dict]:
+        """List all banned nodes with reason and who banned them."""
+        if not self._ready("list_bans"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT node_id, banned_by, reason, created_at FROM discord_banned_nodes ORDER BY created_at",
+                )
+                return [dict(row) for row in rows]
+        except Exception as e:
+            logger.error("Failed to list bans: %s", e)
+            return []

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1736,7 +1736,7 @@ class PostgresStorage:
                 await conn.execute(
                     """INSERT INTO discord_node_links (node_id, discord_user_id)
                        VALUES ($1, $2)
-                       ON CONFLICT (node_id, discord_user_id) DO NOTHING""",
+                       ON CONFLICT (node_id) DO UPDATE SET discord_user_id = $2""",
                     node_id, discord_user_id,
                 )
             return True

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -2073,13 +2073,13 @@ class PostgresStorage:
                 )
                 results["iron_man"] = [dict(r) for r in rows]
 
-                # Here I Am — most position updates (nodes with most recent position changes)
+                # Here I Am — nodes with known positions (most telemetry activity)
                 rows = await conn.fetch(
-                    """SELECT np.node_id, COUNT(t.*) AS count
-                       FROM node_positions np
-                       JOIN telemetry t ON t.from_node_id = np.node_id
+                    """SELECT t.from_node_id AS node_id, COUNT(*) AS count
+                       FROM telemetry t
                        WHERE t.created_at >= NOW() - $1::interval
-                       GROUP BY np.node_id ORDER BY count DESC LIMIT $2""",
+                         AND t.from_node_id IN (SELECT node_id FROM node_positions)
+                       GROUP BY t.from_node_id ORDER BY count DESC LIMIT $2""",
                     interval, limit,
                 )
                 results["here_i_am"] = [dict(r) for r in rows]

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1782,6 +1782,26 @@ class PostgresStorage:
             logger.error("Failed to unlink node %s from Discord user %s: %s", node_id, discord_user_id, e)
             return False
 
+    async def force_unlink_node(self, node_id: str) -> Optional[str]:
+        """Force unlink a node regardless of owner. Returns the previous owner's Discord ID, or None."""
+        if not self._ready("force_unlink_node"):
+            return None
+        try:
+            async with self.pool.acquire() as conn:
+                owner = await conn.fetchval(
+                    "SELECT discord_user_id FROM discord_node_links WHERE node_id = $1",
+                    node_id,
+                )
+                if owner:
+                    await conn.execute(
+                        "DELETE FROM discord_node_links WHERE node_id = $1",
+                        node_id,
+                    )
+                return owner
+        except Exception as e:
+            logger.error("Failed to force unlink node %s: %s", node_id, e)
+            return None
+
     async def get_linked_nodes(self, discord_user_id: str) -> List[str]:
         """Return all node IDs linked to a Discord user."""
         if not self._ready("get_linked_nodes"):

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -2073,16 +2073,12 @@ class PostgresStorage:
                 )
                 results["iron_man"] = [dict(r) for r in rows]
 
-                # Here I Am — nodes with known positions (most telemetry activity)
-                rows = await conn.fetch(
-                    """SELECT t.from_node_id AS node_id, COUNT(*) AS count
-                       FROM telemetry t
-                       WHERE t.created_at >= NOW() - $1::interval
-                         AND t.from_node_id IN (SELECT node_id FROM node_positions)
-                       GROUP BY t.from_node_id ORDER BY count DESC LIMIT $2""",
-                    interval, limit,
-                )
-                results["here_i_am"] = [dict(r) for r in rows]
+                # Here I Am — disabled: requires position history table (not yet implemented)
+                # When a position_history table is added, uncomment and query:
+                #   SELECT from_node_id AS node_id, COUNT(*) AS count
+                #   FROM position_history
+                #   WHERE created_at >= NOW() - interval
+                #   GROUP BY from_node_id ORDER BY count DESC
 
                 # Loudest Signal — best average SNR
                 rows = await conn.fetch(

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1784,6 +1784,20 @@ class PostgresStorage:
             logger.error("Failed to get linked nodes for Discord user %s: %s", discord_user_id, e)
             return []
 
+    async def get_all_linked_nodes(self) -> list[dict]:
+        """Return all node links: [{node_id, discord_user_id}, ...]."""
+        if not self._ready("get_all_linked_nodes"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT node_id, discord_user_id FROM discord_node_links",
+                )
+                return [dict(r) for r in rows]
+        except Exception as e:
+            logger.error("Failed to get all linked nodes: %s", e)
+            return []
+
     async def get_node_owner(self, node_id: str) -> Optional[str]:
         """Return the Discord user ID linked to a node, or None."""
         if not self._ready("get_node_owner"):
@@ -1929,3 +1943,74 @@ class PostgresStorage:
         except Exception as e:
             logger.error("Failed to list bans: %s", e)
             return []
+
+    async def query_top_nodes(self, hours: int = 24, limit: int = 5) -> dict:
+        """Query leaderboard stats for the mesh. Returns dict of categories."""
+        if not self._ready("query_top_nodes"):
+            return {}
+
+        interval = f"{hours} hours"
+        results = {}
+
+        try:
+            async with self.pool.acquire() as conn:
+                # Chatterbox — most messages sent
+                rows = await conn.fetch(
+                    """SELECT from_node_id AS node_id, COUNT(*) AS count
+                       FROM chat_messages
+                       WHERE created_at >= NOW() - $1::interval
+                       GROUP BY from_node_id ORDER BY count DESC LIMIT $2""",
+                    interval, limit,
+                )
+                results["chatterbox"] = [dict(r) for r in rows]
+
+                # Iron Man — longest uptime (active nodes with oldest created_at)
+                rows = await conn.fetch(
+                    """SELECT id AS node_id,
+                              EXTRACT(EPOCH FROM (NOW() - created_at)) AS uptime_seconds
+                       FROM nodes
+                       WHERE active = TRUE AND created_at IS NOT NULL
+                       ORDER BY created_at ASC LIMIT $1""",
+                    limit,
+                )
+                results["iron_man"] = [dict(r) for r in rows]
+
+                # Here I Am — most position updates (nodes with most recent position changes)
+                rows = await conn.fetch(
+                    """SELECT np.node_id, COUNT(t.*) AS count
+                       FROM node_positions np
+                       JOIN telemetry t ON t.from_node_id = np.node_id
+                       WHERE t.created_at >= NOW() - $1::interval
+                       GROUP BY np.node_id ORDER BY count DESC LIMIT $2""",
+                    interval, limit,
+                )
+                results["here_i_am"] = [dict(r) for r in rows]
+
+                # Loudest Signal — best average SNR
+                rows = await conn.fetch(
+                    """SELECT from_node_id AS node_id, ROUND(AVG(snr)::numeric, 1) AS avg_snr
+                       FROM chat_messages
+                       WHERE created_at >= NOW() - $1::interval AND snr IS NOT NULL
+                       GROUP BY from_node_id
+                       HAVING COUNT(*) >= 3
+                       ORDER BY avg_snr DESC LIMIT $2""",
+                    interval, limit,
+                )
+                results["loudest_signal"] = [dict(r) for r in rows]
+
+                # Gateway MVP — most messages relayed (nodes appearing as sender_node_id)
+                rows = await conn.fetch(
+                    """SELECT sender_node_id AS node_id, COUNT(*) AS count
+                       FROM chat_messages
+                       WHERE created_at >= NOW() - $1::interval
+                         AND sender_node_id IS NOT NULL
+                         AND sender_node_id != from_node_id
+                       GROUP BY sender_node_id ORDER BY count DESC LIMIT $2""",
+                    interval, limit,
+                )
+                results["gateway_mvp"] = [dict(r) for r in rows]
+
+        except Exception as e:
+            logger.error("Failed to query top nodes: %s", e)
+
+        return results

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1721,3 +1721,172 @@ class PostgresStorage:
         except Exception as e:
             logger.error(f"Failed to query stats from PostgreSQL: {e}")
             return {}
+
+    # ───────────────────────────────────────────────────────────────────
+    # Discord bridge helpers
+    # ───────────────────────────────────────────────────────────────────
+
+    async def link_node(self, node_id: str, discord_user_id: str) -> bool:
+        """Link a mesh node to a Discord user. Returns True on success."""
+        if not self._ready("link_node"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.execute(
+                    """INSERT INTO discord_node_links (node_id, discord_user_id)
+                       VALUES ($1, $2)
+                       ON CONFLICT (node_id, discord_user_id) DO NOTHING""",
+                    node_id, discord_user_id,
+                )
+            return True
+        except Exception as e:
+            logger.error("Failed to link node %s to Discord user %s: %s", node_id, discord_user_id, e)
+            return False
+
+    async def unlink_node(self, node_id: str, discord_user_id: str) -> bool:
+        """Unlink a mesh node from a Discord user. Returns True if a row was deleted."""
+        if not self._ready("unlink_node"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM discord_node_links WHERE node_id = $1 AND discord_user_id = $2",
+                    node_id, discord_user_id,
+                )
+            return result == "DELETE 1"
+        except Exception as e:
+            logger.error("Failed to unlink node %s from Discord user %s: %s", node_id, discord_user_id, e)
+            return False
+
+    async def get_linked_nodes(self, discord_user_id: str) -> List[str]:
+        """Return all node IDs linked to a Discord user."""
+        if not self._ready("get_linked_nodes"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT node_id FROM discord_node_links WHERE discord_user_id = $1",
+                    discord_user_id,
+                )
+            return [r["node_id"] for r in rows]
+        except Exception as e:
+            logger.error("Failed to get linked nodes for Discord user %s: %s", discord_user_id, e)
+            return []
+
+    async def get_node_owner(self, node_id: str) -> Optional[str]:
+        """Return the Discord user ID linked to a node, or None."""
+        if not self._ready("get_node_owner"):
+            return None
+        try:
+            async with self.pool.acquire() as conn:
+                return await conn.fetchval(
+                    "SELECT discord_user_id FROM discord_node_links WHERE node_id = $1 LIMIT 1",
+                    node_id,
+                )
+        except Exception as e:
+            logger.error("Failed to get owner of node %s: %s", node_id, e)
+            return None
+
+    async def ban_node(self, node_id: str, banned_by: str, reason: str = "") -> bool:
+        """Ban a node from the Discord bridge."""
+        if not self._ready("ban_node"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.execute(
+                    """INSERT INTO discord_banned_nodes (node_id, banned_by, reason)
+                       VALUES ($1, $2, $3)
+                       ON CONFLICT (node_id) DO UPDATE SET banned_by = $2, reason = $3""",
+                    node_id, banned_by, reason,
+                )
+            return True
+        except Exception as e:
+            logger.error("Failed to ban node %s: %s", node_id, e)
+            return False
+
+    async def unban_node(self, node_id: str) -> bool:
+        """Unban a node from the Discord bridge."""
+        if not self._ready("unban_node"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM discord_banned_nodes WHERE node_id = $1", node_id,
+                )
+            return result == "DELETE 1"
+        except Exception as e:
+            logger.error("Failed to unban node %s: %s", node_id, e)
+            return False
+
+    async def is_node_banned(self, node_id: str) -> bool:
+        """Check if a node is banned."""
+        if not self._ready("is_node_banned"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                return await conn.fetchval(
+                    "SELECT EXISTS(SELECT 1 FROM discord_banned_nodes WHERE node_id = $1)",
+                    node_id,
+                ) or False
+        except Exception as e:
+            logger.error("Failed to check ban for node %s: %s", node_id, e)
+            return False
+
+    async def add_tracker(self, node_id: str, track_type: str, added_by: str) -> bool:
+        """Add a node to position tracking."""
+        if not self._ready("add_tracker"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.execute(
+                    """INSERT INTO discord_tracked_nodes (node_id, track_type, added_by)
+                       VALUES ($1, $2, $3)
+                       ON CONFLICT (node_id) DO UPDATE SET track_type = $2, added_by = $3""",
+                    node_id, track_type, added_by,
+                )
+            return True
+        except Exception as e:
+            logger.error("Failed to add tracker for node %s: %s", node_id, e)
+            return False
+
+    async def remove_tracker(self, node_id: str) -> bool:
+        """Remove a node from position tracking."""
+        if not self._ready("remove_tracker"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM discord_tracked_nodes WHERE node_id = $1", node_id,
+                )
+            return result == "DELETE 1"
+        except Exception as e:
+            logger.error("Failed to remove tracker for node %s: %s", node_id, e)
+            return False
+
+    async def is_node_tracked(self, node_id: str) -> bool:
+        """Check if a node has position tracking enabled."""
+        if not self._ready("is_node_tracked"):
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                return await conn.fetchval(
+                    "SELECT EXISTS(SELECT 1 FROM discord_tracked_nodes WHERE node_id = $1)",
+                    node_id,
+                ) or False
+        except Exception as e:
+            logger.error("Failed to check tracker for node %s: %s", node_id, e)
+            return False
+
+    async def get_tracker_type(self, node_id: str) -> Optional[str]:
+        """Return the tracker type for a node, or None if not tracked."""
+        if not self._ready("get_tracker_type"):
+            return None
+        try:
+            async with self.pool.acquire() as conn:
+                return await conn.fetchval(
+                    "SELECT track_type FROM discord_tracked_nodes WHERE node_id = $1",
+                    node_id,
+                )
+        except Exception as e:
+            logger.error("Failed to get tracker type for node %s: %s", node_id, e)
+            return None

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1241,9 +1241,10 @@ class PostgresStorage:
 
                 where_clause = " AND ".join(where_parts) if where_parts else "TRUE"
 
-                # Query nodes
+                # Query nodes — most recently seen first so name collisions
+                # return the active node rather than a stale duplicate
                 nodes = {}
-                query = f"SELECT * FROM nodes WHERE {where_clause}"
+                query = f"SELECT * FROM nodes WHERE {where_clause} ORDER BY last_seen DESC NULLS LAST"
                 rows = await conn.fetch(query, *params)
 
                 for row in rows:


### PR DESCRIPTION
## Summary

- Live mesh-to-Discord message bridge via webhooks — each mesh node appears as a unique sender with its own name and avatar
- Packet aggregation (5s window) with edit-in-place as additional gateways report
- Signal quality colors — embed color reflects best gateway SNR (green → teal → yellow → orange → red)
- Gateway SNR/RSSI display grouped by hop count with deep links to node pages
- Self-hosted static map endpoint (`/v1/static-map`) — renders OSM or Mapbox tiles server-side with disk caching, no external static map API dependency
- Configurable map providers (`none`, `osm`, `mapbox`) with Mapbox preferred when token is valid, OSM fallback
- 19 slash commands (all pure `app_commands` with autocomplete on node fields):
  - **General:** `/lookup`, `/mesh`, `/whereis`, `/topnodes`, `/ping`, `/uptime`, `/meshinfo`
  - **Node linking:** `/linknode`, `/unlinknode`, `/mylinkednodes` — one owner per node, clear conflict messaging
  - **Node watching:** `/watchnode`, `/unwatchnode`, `/mywatchednodes` — multiple users can watch the same node
  - **Moderator:** `/forceunlink`, `/addtracker`, `/removetracker`, `/addballoon`, `/removeballoon`, `/bannode`, `/unbannode`, `/listtrackers`, `/listbans`
- `/topnodes` leaderboard with 4 achievement categories: Chatterbox, Iron Man, Loudest Signal, Gateway MVP (24h and 7d timeframes)
- `/whereis` shows last known position with map thumbnail
- `/meshinfo` ephemeral help command with grouped command reference
- `/listtrackers` and `/listbans` are mod-only with inline action buttons (remove/unban)
- `/forceunlink` allows mods to remove another user's node claim
- Node linking and watching are independent — linking claims ownership (one per node), watching opts into online/offline alerts (many per node)
- Node online/offline alerts for watched nodes — posts to channel when a watched node changes status
- All commands accept hex ID, integer ID, shortname, or longname with DB-backed resolution and live autocomplete
- Enhanced `/lookup` — searches PostgreSQL, shows hardware, role (resolved from protobuf enum), telemetry, position, and elsewhere links
- Enhanced `/mesh` — pulls stats from DB with quick links to Dashboard, Nodes, Chat, Logs
- Deep links throughout: packet IDs link to logs, gateway names link to node pages, position coordinates link to MeshInfo map, elsewhere links in lookups
- 4 new DB tables: `discord_node_links`, `discord_banned_nodes`, `discord_tracked_nodes`, `discord_watched_nodes`
- All persistent data exists in PostgreSQL, packet aggregation is ephemeral in-memory
- Bounded event queue with backpressure to prevent unbounded memory growth
- Async-wrapped static map generation to avoid blocking the event loop
