### PR TITLE
fix: serve /v1/messages from PostgreSQL with search support

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -277,12 +277,23 @@ class API:
 
         @app.get("/v1/messages")
         async def messages(request: Request) -> JSONResponse:
-            # Messages and MQTT messages are not stored in Postgres, always use memory
+            search = request.query_params.get("q")
+            if self.read_from_postgres:
+                limit = int(request.query_params.get("limit", 1000))
+                limit = max(1, min(limit, 5000))
+                results = await self.data.pg_storage.query_mqtt_messages(
+                    limit=limit, search=search,
+                )
+                return jsonable_encoder(results)
             return jsonable_encoder(self.data.messages[:1000])
 
         @app.get("/v1/mqtt_messages")
         async def mqtt_messages(request: Request) -> JSONResponse:
-            # Messages and MQTT messages are not stored in Postgres, always use memory
+            if self.read_from_postgres:
+                limit = int(request.query_params.get("limit", 1000))
+                limit = max(1, min(limit, 5000))
+                results = await self.data.pg_storage.query_mqtt_messages(limit=limit)
+                return jsonable_encoder(results)
             return jsonable_encoder(self.data.mqtt_messages[:1000])
 
         @app.get("/v1/stats")

--- a/api/static_map.py
+++ b/api/static_map.py
@@ -96,7 +96,7 @@ def _render_map(tile_url: str, lat: float, lon: float, zoom: int, width: int, he
             url_template=tile_url,
             headers={"User-Agent": "MeshInfo/1.0"},
         )
-        marker = CircleMarker((lon, lat), color="red", width=8)
+        marker = CircleMarker((lon, lat), color="#45B3BA", width=8)
         m.add_marker(marker)
         image = m.render(zoom=zoom)
         buf = BytesIO()

--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -15,6 +15,7 @@ Moderator/Admin commands:
   /unbannode     — Remove ban
 """
 
+import asyncio
 import logging
 import re
 from typing import Optional
@@ -216,15 +217,21 @@ class AdminCommands(commands.Cog):
                     choices.append(app_commands.Choice(name=label, value=nid))
                     seen.add(nid)
 
-        # Supplement from DB if we have room
+        # Supplement from DB (with timeout to stay within Discord's 3s limit)
         if len(choices) < 25 and self.data.pg_storage:
             try:
-                results = await self.data.pg_storage.query_nodes_filtered(
-                    days_limit=None, shortname_filter=current,
+                results = await asyncio.wait_for(
+                    self.data.pg_storage.query_nodes_filtered(
+                        days_limit=None, shortname_filter=current,
+                    ),
+                    timeout=1.5,
                 )
                 if len(results) < 10:
-                    long_results = await self.data.pg_storage.query_nodes_filtered(
-                        days_limit=None, longname_filter=current,
+                    long_results = await asyncio.wait_for(
+                        self.data.pg_storage.query_nodes_filtered(
+                            days_limit=None, longname_filter=current,
+                        ),
+                        timeout=1.0,
                     )
                     results.update(long_results)
 

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import logging
 from typing import Optional
@@ -59,15 +60,21 @@ class MainCommands(commands.Cog):
                     choices.append(app_commands.Choice(name=label, value=nid))
                     seen.add(nid)
 
-        # Supplement from DB
+        # Supplement from DB (with timeout to stay within Discord's 3s limit)
         if len(choices) < 25 and self.data.pg_storage:
             try:
-                results = await self.data.pg_storage.query_nodes_filtered(
-                    days_limit=None, shortname_filter=current,
+                results = await asyncio.wait_for(
+                    self.data.pg_storage.query_nodes_filtered(
+                        days_limit=None, shortname_filter=current,
+                    ),
+                    timeout=1.5,
                 )
                 if len(results) < 10:
-                    long_results = await self.data.pg_storage.query_nodes_filtered(
-                        days_limit=None, longname_filter=current,
+                    long_results = await asyncio.wait_for(
+                        self.data.pg_storage.query_nodes_filtered(
+                            days_limit=None, longname_filter=current,
+                        ),
+                        timeout=1.0,
                     )
                     results.update(long_results)
 

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -71,6 +71,10 @@ def _node_linked_name(node: Optional[dict], node_id: str, base_url: str) -> str:
     name = _node_display_name(node, node_id)
     url = _node_url(base_url, node_id)
     if url:
+        # If longname is a URL, use shortname as link text instead
+        if name.startswith("http"):
+            short = _node_short_name(node, node_id)
+            return f"[{short}]({url})"
         return f"[{name}]({url})"
     return name
 

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -194,6 +194,7 @@ CREATE TABLE IF NOT EXISTS mqtt_messages (
 );
 
 CREATE INDEX IF NOT EXISTS idx_mqtt_messages_created_at ON mqtt_messages(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mqtt_messages_timestamp ON mqtt_messages(timestamp DESC);
 
 -- Neighbor snapshot history table (currently unused, for time-lapse update later on)
 CREATE TABLE IF NOT EXISTS node_neighborinfo_history (

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS nodes (
 
 CREATE INDEX IF NOT EXISTS idx_nodes_active ON nodes(active);
 CREATE INDEX IF NOT EXISTS idx_nodes_last_seen ON nodes(last_seen);
+CREATE INDEX IF NOT EXISTS idx_nodes_shortname_lower ON nodes(LOWER(shortname));
+CREATE INDEX IF NOT EXISTS idx_nodes_longname_lower ON nodes(LOWER(longname));
 
 -- Node positions table - stores ONLY the most recent position per node (latest-only)
 CREATE TABLE IF NOT EXISTS node_positions (

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -921,6 +921,55 @@ class PostgresStorage:
             if self.raise_on_write_error:
                 raise
 
+    async def query_mqtt_messages(self, limit: int = 1000, search: str | None = None) -> list:
+        """Query mqtt_messages from PostgreSQL, returning parsed message dicts.
+
+        Args:
+            limit: Max messages to return.
+            search: Optional search term to filter by topic or payload content.
+        """
+        if not self._ready("query_mqtt_messages"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                if search:
+                    rows = await conn.fetch(
+                        """SELECT topic, payload, qos, retain, timestamp, created_at
+                           FROM mqtt_messages
+                           WHERE topic ILIKE '%' || $1 || '%'
+                              OR payload ILIKE '%' || $1 || '%'
+                           ORDER BY created_at DESC LIMIT $2""",
+                        search, limit,
+                    )
+                else:
+                    rows = await conn.fetch(
+                        """SELECT topic, payload, qos, retain, timestamp, created_at
+                           FROM mqtt_messages
+                           ORDER BY created_at DESC LIMIT $1""",
+                        limit,
+                    )
+
+            results = []
+            for row in rows:
+                payload_text = row["payload"]
+                if payload_text:
+                    try:
+                        msg = json.loads(payload_text)
+                    except (json.JSONDecodeError, TypeError):
+                        msg = {"raw": payload_text}
+                else:
+                    msg = {}
+                # Ensure top-level fields are present
+                if "topic" not in msg:
+                    msg["topic"] = row["topic"]
+                if "timestamp" not in msg:
+                    msg["timestamp"] = row["timestamp"]
+                results.append(msg)
+            return results
+        except Exception as e:
+            logger.error("Failed to query mqtt_messages: %s", e)
+            return []
+
     # ============================================================================
     # READ OPERATIONS - Load data from PostgreSQL matching JSON structure
     # ============================================================================


### PR DESCRIPTION
## Summary

- `/v1/messages` and `/v1/mqtt_messages` now query PostgreSQL instead of the in-memory buffer when `read_from_postgres` is enabled
- Fixes packet ID links from Discord embeds not finding messages on the logs page (previously limited to last 1000 in-memory messages since restart)
- Server-side `?q=` search parameter filters by topic and payload content via `ILIKE`
- Configurable `?limit=` parameter (default 1000, max 5000)
- Added timestamp index on `mqtt_messages` table
- Falls back to in-memory data when PostgreSQL is not configured