### PR TITLE
fix: calculate hops_away from protobuf for correct gateway hop grouping in Discord bot

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -114,6 +114,15 @@ class MQTT:
                 outs["qos"] = getattr(msg, "qos", None)
                 outs["retain"] = getattr(msg, "retain", None)
 
+                # Calculate hops_away from hop_start and hop_limit
+                hop_start = outs.get("hop_start")
+                hop_limit = outs.get("hop_limit")
+                if hop_start is not None and hop_limit is not None:
+                    try:
+                        outs["hops_away"] = int(hop_start) - int(hop_limit)
+                    except (ValueError, TypeError):
+                        pass
+
                 if mp.decoded.portnum == portnums_pb2.TEXT_MESSAGE_APP:
                     payload_bytes = bytes(mp.decoded.payload)
                     try:


### PR DESCRIPTION
## Summary

- Fix gateway hop count calculation — `hops_away` was never being computed from the protobuf `hop_start` and `hop_limit` fields, causing all gateways to display as "Direct" regardless of actual hop count
- Calculation: `hops_away = hop_start - hop_limit` is now performed after protobuf decoding, before any message handlers are called
- Each gateway's individual hop count is now correctly preserved and displayed in Discord embeds grouped by hop level (Direct, 1 hop, 2 hops, etc.)

Closes #383 