### PR TITLE
fix: improve gateway display layout, add metrics, and fix log level filtering for Discord integration

### DIFF
--- a/bot/cogs/admin_commands.py
+++ b/bot/cogs/admin_commands.py
@@ -240,10 +240,17 @@ class AdminCommands(commands.Cog):
                         break
                     if nid in seen:
                         continue
-                    display_name = node.get("longname") or node.get("shortname") or nid
-                    if display_name in ("Unknown", "UNK"):
-                        display_name = nid
-                    label = f"{display_name} (!{nid})"[:100]
+                    longname = node.get("longname", "")
+                    shortname = node.get("shortname", "")
+                    if longname and longname != "Unknown" and shortname and shortname != "UNK":
+                        label = f"{longname} [{shortname}] (!{nid})"
+                    elif longname and longname != "Unknown":
+                        label = f"{longname} (!{nid})"
+                    elif shortname and shortname != "UNK":
+                        label = f"{shortname} (!{nid})"
+                    else:
+                        label = f"!{nid}"
+                    label = label[:100]
                     choices.append(app_commands.Choice(name=label, value=nid))
                     seen.add(nid)
             except Exception:

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -114,7 +114,7 @@ def _format_gateway_info(msg: dict, nodes: dict, base_url: str) -> str:
     hops_away = msg.get("hops_away")
     hop_limit = msg.get("hop_limit")
     if hops_away is not None:
-        hop_str = "Direct" if hops_away == 0 else f"{hops_away} hop(s)"
+        hop_str = "Direct" if hops_away == 0 else f"{hops_away} hops"
         if hop_limit is not None:
             hop_str += f" (limit: {hop_limit})"
         parts.append(hop_str)
@@ -186,10 +186,27 @@ def build_text_embed(
     short_name = _node_short_name(node, from_id)
     text = chat.get("text", "")
 
-    # Build embed — color based on best gateway SNR
+    # Build embed — message text + gateway info in description (4096 char limit)
     node_link = _node_url(base_url, from_id)
+
+    # Build description: message text followed by gateway grouping
+    desc_parts = [text]
+
+    if gateway_entries and len(gateway_entries) > 0:
+        gw_text = _format_gateway_list(gateway_entries, nodes, base_url)
+        if gw_text:
+            desc_parts.append(gw_text)
+    else:
+        gw_info = _format_gateway_info(msg, nodes, base_url)
+        if gw_info:
+            desc_parts.append(gw_info)
+
+    description = "\n\n".join(desc_parts)
+    if len(description) > EMBED_DESC_LIMIT:
+        description = _safe_truncate(description, EMBED_DESC_LIMIT)
+
     embed = discord.Embed(
-        description=text[:EMBED_DESC_LIMIT],
+        description=description,
         color=_snr_color(gateway_entries, msg),
         timestamp=discord.utils.utcnow(),
     )
@@ -209,17 +226,12 @@ def build_text_embed(
     channel_label = _resolve_channel_name(channel, config)
     embed.add_field(name="Channel", value=channel_label, inline=True)
 
-    # Gateway info with linked names
+    # Hop limit and gateway count
     if gateway_entries and len(gateway_entries) > 0:
-        gw_text = _format_gateway_list(gateway_entries, nodes, base_url)
-        if gw_text:
-            gw_text = _safe_truncate(gw_text)
-            embed.add_field(name="Gateways", value=gw_text, inline=False)
-    else:
-        gw_info = _format_gateway_info(msg, nodes, base_url)
-        if gw_info:
-            gw_info = _safe_truncate(gw_info)
-            embed.add_field(name="Reception", value=gw_info, inline=False)
+        hop_limit = msg.get("hop_start") or msg.get("hop_limit")
+        if hop_limit is not None:
+            embed.add_field(name="Hop Limit", value=str(hop_limit), inline=True)
+        embed.add_field(name="Gateway Count", value=str(len(gateway_entries)), inline=True)
 
     # Owner mention
     if owner_id:
@@ -318,6 +330,7 @@ def _format_gateway_list(gateway_entries: list, nodes: dict, base_url: str) -> s
 
     Single gateway per hop group: full name with RSSI/SNR details.
     Multiple gateways per hop group: compact shortnames separated by |.
+    Hop groups are separated by blank lines for readability.
     """
     if not gateway_entries:
         return ""
@@ -330,17 +343,18 @@ def _format_gateway_list(gateway_entries: list, nodes: dict, base_url: str) -> s
             hops = 0
         by_hops.setdefault(hops, []).append(gw)
 
-    lines = []
+    sections = []
     for hops in sorted(by_hops.keys()):
+        lines = []
         if hops == 0:
             header = "**Direct**"
         else:
-            header = f"**{hops} hop(s)**"
+            header = f"**{hops} hops**"
         lines.append(header)
 
         gateways = by_hops[hops]
         if len(gateways) == 1:
-            # Single gateway — show full details
+            # Single gateway — show full details with SNR/RSSI
             gw = gateways[0]
             gw_id = gw.get("gateway_id", "unknown")
             gw_node = nodes.get(gw_id)
@@ -360,9 +374,10 @@ def _format_gateway_list(gateway_entries: list, nodes: dict, base_url: str) -> s
                 gw_id = gw.get("gateway_id", "unknown")
                 gw_node = nodes.get(gw_id)
                 names.append(_node_short_linked_name(gw_node, gw_id, base_url))
-            # Split into rows of ~10 to avoid line length issues
             for i in range(0, len(names), 10):
                 chunk = names[i:i + 10]
                 lines.append(" | ".join(chunk))
 
-    return "\n".join(lines)
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -186,27 +186,11 @@ def build_text_embed(
     short_name = _node_short_name(node, from_id)
     text = chat.get("text", "")
 
-    # Build embed — message text + gateway info in description (4096 char limit)
+    # Build embed — message text in description, gateway info added after fields
     node_link = _node_url(base_url, from_id)
 
-    # Build description: message text followed by gateway grouping
-    desc_parts = [text]
-
-    if gateway_entries and len(gateway_entries) > 0:
-        gw_text = _format_gateway_list(gateway_entries, nodes, base_url)
-        if gw_text:
-            desc_parts.append(gw_text)
-    else:
-        gw_info = _format_gateway_info(msg, nodes, base_url)
-        if gw_info:
-            desc_parts.append(gw_info)
-
-    description = "\n\n".join(desc_parts)
-    if len(description) > EMBED_DESC_LIMIT:
-        description = _safe_truncate(description, EMBED_DESC_LIMIT)
-
     embed = discord.Embed(
-        description=description,
+        description=text[:EMBED_DESC_LIMIT],
         color=_snr_color(gateway_entries, msg),
         timestamp=discord.utils.utcnow(),
     )
@@ -232,6 +216,24 @@ def build_text_embed(
         if hop_limit is not None:
             embed.add_field(name="Hop Limit", value=str(hop_limit), inline=True)
         embed.add_field(name="Gateway Count", value=str(len(gateway_entries)), inline=True)
+
+    # Gateway info — uses a field with 1024 limit, or description append for large lists
+    if gateway_entries and len(gateway_entries) > 0:
+        gw_text = _format_gateway_list(gateway_entries, nodes, base_url)
+        if gw_text:
+            if len(gw_text) <= EMBED_FIELD_VALUE_LIMIT:
+                embed.add_field(name="Gateways", value=gw_text, inline=False)
+            else:
+                # Large gateway list — append to description to use 4096 char limit
+                combined = embed.description + "\n\n" + gw_text
+                if len(combined) > EMBED_DESC_LIMIT:
+                    combined = _safe_truncate(combined, EMBED_DESC_LIMIT)
+                embed.description = combined
+    else:
+        gw_info = _format_gateway_info(msg, nodes, base_url)
+        if gw_info:
+            gw_info = _safe_truncate(gw_info)
+            embed.add_field(name="Gateways", value=gw_info, inline=False)
 
     # Owner mention
     if owner_id:

--- a/main.py
+++ b/main.py
@@ -42,6 +42,8 @@ class _DowngradeSuccessfulGetRequests(logging.Filter):
         ):
             record.levelno = logging.DEBUG
             record.levelname = "DEBUG"
+            # Suppress unless the logger is accepting DEBUG-level records
+            return record.levelno >= logging.getLogger("uvicorn.access").getEffectiveLevel()
         return True
 
 


### PR DESCRIPTION
## Summary

- Add Hop Limit and Gateway Count inline fields above gateway list 
- Gateway data overflows to embed description (4096 chars) when exceeding field limit (1024 chars), allowing 4x more gateways to display
- Rename "hop(s)" to "hops" throughout
- Add blank line spacing between hop groups for readability
- Add shortname to admin command autocomplete DB results
- Fix uvicorn access log filter to properly suppress successful GET requests at INFO level
