### PR TITLE
feat: track node channel and add modem preset filtering

### DIFF
--- a/frontend/src/hooks/useNodesSearchParams.ts
+++ b/frontend/src/hooks/useNodesSearchParams.ts
@@ -32,6 +32,7 @@ function isDefaultParam(key: string, value: string) {
   if (key === "st") return (v as StatusKey) === DEFAULTS.st;
   if (key === "by") return (v as SortByKey) === DEFAULTS.by;
   if (key === "dir") return (v as SortDir) === DEFAULTS.dir;
+  if (key === "ch") return v === "";
 
   return false;
 }
@@ -55,6 +56,7 @@ export function useNodesSearchParams() {
   const urlDir = parseSortDir(rawDir) as SortDir;
 
   const urlNode = cleanNodeId(searchParams.get("node") ?? "");
+  const urlCh = (searchParams.get("ch") ?? "").trim();
 
   // Optional: canonicalize away defaults if someone links ?r=all&st=all&by=seen&dir=desc
   useEffect(() => {
@@ -78,6 +80,11 @@ export function useNodesSearchParams() {
       changed = true;
     }
 
+    if (next.has("ch") && !urlCh) {
+      next.delete("ch");
+      changed = true;
+    }
+
     // q/node canonicalization: delete if empty
     if (next.has("q") && !urlQ.trim()) {
       next.delete("q");
@@ -90,7 +97,7 @@ export function useNodesSearchParams() {
 
     if (changed) setSearchParams(next, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlRange, urlStatus, urlBy, urlDir, urlQ, urlNode]);
+  }, [urlRange, urlStatus, urlBy, urlDir, urlQ, urlNode, urlCh]);
 
   const setParam = (key: string, value?: string, mode: SetMode = "push") => {
     const next = new URLSearchParams(searchParams);
@@ -125,11 +132,12 @@ export function useNodesSearchParams() {
       urlStatus,
       urlBy,
       urlDir,
+      urlCh,
       urlNode,
       setParam,
       setParams,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- setParam/setParams are stable
-    [searchParams, urlQ, urlRange, urlStatus, urlBy, urlDir, urlNode]
+    [searchParams, urlQ, urlRange, urlStatus, urlBy, urlDir, urlCh, urlNode]
   );
 }

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -16,7 +16,7 @@ import { fromLonLat, transform } from "ol/proj";
 import { Vector } from "ol/source";
 import VectorSource from "ol/source/Vector";
 import { Circle, Fill, Stroke, Style } from "ol/style";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { env } from "../env";
@@ -107,6 +107,15 @@ export function Map() {
   const { data: rawNodes = {} } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
   const { data: rawTraceroutes = [] } = useGetTraceroutesQuery();
+
+  const resolveChannelLabel = useCallback(
+    (channelId: string | null | undefined): string | null => {
+      if (!channelId) return null;
+      const meta = (config as any)?.broker?.channels?.meta?.[channelId];
+      return meta?.label ? String(meta.label) : null;
+    },
+    [config],
+  );
 
   // ----- env capabilities
   const mapboxToken = env.MAPBOX_TOKEN;
@@ -882,6 +891,7 @@ export function Map() {
           displayName,
           elsewhereLinks: config?.mesh?.elsewhere_links,
           traceroutes: traceroutesRef.current,
+          channelLabel: resolveChannelLabel((node as any).last_channel),
         });
 
         setDetailsPanelContent({
@@ -1358,12 +1368,14 @@ export function Map() {
         gateway: node.gateway,
       };
 
+      const fullNode = nodes[node.id];
       const { html } = buildNodeDetailsHtml({
         node: nodeLike,
         liveNodes: nodes,
         displayName,
         elsewhereLinks: config?.mesh?.elsewhere_links,
         traceroutes: traceroutesRef.current,
+        channelLabel: resolveChannelLabel((fullNode as any)?.last_channel),
       });
 
       setDetailsPanelContent({

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -179,6 +179,7 @@ export const Nodes = () => {
     urlStatus,
     urlBy,
     urlDir,
+    urlCh,
     urlNode,
     setParam,
     setParams,
@@ -217,6 +218,31 @@ export const Nodes = () => {
     const bang = nodes?.[`!${serverNodeId}`];
     return bang ?? null;
   }, [nodes, serverNodeId]);
+
+  // Channel views from config
+  const channelViews = useMemo(() => {
+    const vraw = (config as any)?.broker?.channels?.views;
+    if (!Array.isArray(vraw) || vraw.length === 0) return [];
+    const out: { key: string; label: string; channelId: string }[] = [];
+    for (const v of vraw) {
+      const chans = Array.isArray(v?.channels) ? v.channels.map(String) : [];
+      if (chans.length !== 1) continue;
+      const channelId = chans[0];
+      const meta = (config as any)?.broker?.channels?.meta?.[channelId] ?? {};
+      const label = String(v?.label ?? meta?.label ?? `Channel ${channelId}`);
+      out.push({ key: channelId, label, channelId });
+    }
+    return out;
+  }, [config]);
+
+  // Resolve urlCh to a channel ID
+  const selectedChannelId = useMemo(() => {
+    if (!urlCh) return null;
+    for (const v of channelViews) {
+      if (urlCh === v.channelId || urlCh.toLowerCase() === v.label.toLowerCase()) return v.channelId;
+    }
+    return null;
+  }, [urlCh, channelViews]);
 
   // Range threshold clock: update infrequently (range cutoffs don't need 1s precision)
   const [rangeNowMs, setRangeNowMs] = useState(() => Date.now());
@@ -310,6 +336,10 @@ export const Nodes = () => {
     if (urlStatus === "online") items = items.filter((x) => x.online);
     if (urlStatus === "offline") items = items.filter((x) => !x.online);
 
+    if (selectedChannelId) {
+      items = items.filter((x) => (x.node as any)?.last_channel === selectedChannelId);
+    }
+
     const q = (urlQ ?? "").trim().toLowerCase();
     if (q) {
       items = items.filter((x) => {
@@ -355,7 +385,7 @@ export const Nodes = () => {
     });
 
     return items;
-  }, [allItems, rangeThresholdMs, urlStatus, urlQ, urlBy, urlDir]);
+  }, [allItems, rangeThresholdMs, urlStatus, selectedChannelId, urlQ, urlBy, urlDir]);
 
   // Selection (urlNode)
   const selectedId = useMemo(() => cleanNodeId(urlNode ?? ""), [urlNode]);
@@ -509,6 +539,7 @@ export const Nodes = () => {
         online: x.online ? "true" : "false",
         role: roleLabel(n?.role),
         hardware: hardwareLabel(n?.hardware),
+        last_channel: String(n?.last_channel ?? ""),
         last_seen: n?.last_seen ? new Date(n.last_seen).toISOString() : "",
         altitude_m: n?.position?.altitude ?? "",
         latitude: ll ? ll[1] : "",
@@ -562,11 +593,12 @@ export const Nodes = () => {
     let n = 0;
     if (urlRange !== "all") n += 1;
     if (urlStatus !== "all") n += 1;
+    if (selectedChannelId) n += 1;
     if ((urlQ ?? "").trim()) n += 1;
     if (urlBy !== "seen") n += 1;
     if (urlDir !== "desc") n += 1;
     return n;
-  }, [urlRange, urlStatus, urlQ, urlBy, urlDir]);
+  }, [urlRange, urlStatus, selectedChannelId, urlQ, urlBy, urlDir]);
 
   const hasFilters = activeFilterCount > 0;
 
@@ -576,6 +608,7 @@ export const Nodes = () => {
       [
         { key: "r", value: "all" },
         { key: "st", value: "all" },
+        { key: "ch", value: undefined },
         { key: "q", value: undefined },
         { key: "by", value: "seen" },
         { key: "dir", value: "desc" },
@@ -763,6 +796,63 @@ export const Nodes = () => {
             </div>
           </div>
 
+          {/* Channel preset pills */}
+          {channelViews.length > 1 && (
+            <div className="mt-3 flex gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
+              <button
+                type="button"
+                className={[
+                  "whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium border transition",
+                  !selectedChannelId
+                    ? "bg-indigo-600 text-white border-indigo-600 shadow-xs"
+                    : "bg-transparent text-gray-700 dark:text-gray-200 border-gray-300/60 dark:border-gray-600/60 hover:bg-gray-100/60 dark:hover:bg-gray-800/40",
+                ].join(" ")}
+                onClick={() => setParam("ch", undefined, "push")}
+              >
+                All
+                <span
+                  className={[
+                    "ml-2 rounded-full px-2 py-0.5 text-xs",
+                    !selectedChannelId
+                      ? "bg-white/20 text-white"
+                      : "bg-gray-200/70 dark:bg-gray-700/60 text-gray-700 dark:text-gray-200",
+                  ].join(" ")}
+                >
+                  {allItems.length}
+                </span>
+              </button>
+              {channelViews.map((v) => {
+                const active = selectedChannelId === v.channelId;
+                const count = allItems.filter((x) => (x.node as any)?.last_channel === v.channelId).length;
+                return (
+                  <button
+                    key={`ch-${v.key}`}
+                    type="button"
+                    className={[
+                      "whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium border transition",
+                      active
+                        ? "bg-indigo-600 text-white border-indigo-600 shadow-xs"
+                        : "bg-transparent text-gray-700 dark:text-gray-200 border-gray-300/60 dark:border-gray-600/60 hover:bg-gray-100/60 dark:hover:bg-gray-800/40",
+                    ].join(" ")}
+                    onClick={() => setParam("ch", v.channelId, "push")}
+                  >
+                    {v.label}
+                    <span
+                      className={[
+                        "ml-2 rounded-full px-2 py-0.5 text-xs",
+                        active
+                          ? "bg-white/20 text-white"
+                          : "bg-gray-200/70 dark:bg-gray-700/60 text-gray-700 dark:text-gray-200",
+                      ].join(" ")}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
           {/* Toolbar */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
             <div className="flex-1 min-w-0 lg:min-w-[260px]">
@@ -869,6 +959,14 @@ export const Nodes = () => {
               title="Click to reset status to All"
               onClick={() => setParam("st", "all", "push")} // deletes
             />
+            {channelViews.length > 1 && (
+              <StatusChip
+                label={selectedChannelId ? `Channel: ${channelViews.find((v) => v.channelId === selectedChannelId)?.label ?? selectedChannelId}` : "Channel: all"}
+                active={!!selectedChannelId}
+                title="Click to show all channels"
+                onClick={() => setParam("ch", undefined, "push")}
+              />
+            )}
             <StatusChip
               label={`Sort: ${urlBy}/${urlDir}`}
               active={urlBy !== "seen" || urlDir !== "desc"}

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -23,6 +23,7 @@ export function buildNodeDetailsHtml(opts: {
   displayName: string | null | undefined;
   elsewhereLinks?: ElsewhereLink[];
   traceroutes?: ITraceroutesResponse[];
+  channelLabel?: string | null;
 }): { html: string; heardBy: string[] } {
   const { node, liveNodes } = opts;
   const displayName = opts.displayName || "Unknown";
@@ -63,6 +64,7 @@ export function buildNodeDetailsHtml(opts: {
     `<b>Location</b> &nbsp;<span title="${escapeHtml(displayName)}" style="cursor:help;border-bottom:1px dotted currentColor">${escapeHtml(shortenLocation(displayName))}</span><br/>` +
     `<b>Status</b> &nbsp;${node.online ? "Online" : "Offline"}<br/>` +
     `<b>Last Seen</b> &nbsp;${escapeHtml(node.last_seen ?? "")}` +
+    (opts.channelLabel ? `<br/><b>Channel</b> &nbsp;${escapeHtml(opts.channelLabel)}` : "") +
     `</div>`;
 
   // Gateway

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -130,6 +130,7 @@ export interface INode {
   hardware: number | null;
   role?: NodeRole;
   gateway?: string | null;
+  last_channel?: string | null;
   position?: INodePosition;
   telemetry?: { [key: string]: number } | null;
   neighborinfo?: {

--- a/models/node.py
+++ b/models/node.py
@@ -14,6 +14,7 @@ class Node():
         'position': None,
         'telemetry': None,
         'gateway': None,
+        'last_channel': None,
         'active': False,
         'since': datetime.datetime.now(datetime.timezone.utc).astimezone() - datetime.datetime.now(datetime.timezone.utc).astimezone(),
         'last_seen': datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()
@@ -28,6 +29,7 @@ class Node():
       'position': None,
       'telemetry': None,
       'gateway': None,
+      'last_channel': None,
       'active': True,
       'since': datetime.datetime.now(datetime.timezone.utc).astimezone() - datetime.datetime.now(datetime.timezone.utc).astimezone(),
       'last_seen': datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()

--- a/mqtt.py
+++ b/mqtt.py
@@ -423,6 +423,9 @@ class MQTT:
         if msg.get('sender'):
             node['gateway'] = msg['sender']
 
+        if 'channel' in msg:
+            node['last_channel'] = str(msg['channel'])
+
         self.data.update_node(id, node)
 
         self.sort_nodes_by_shortname()
@@ -444,6 +447,9 @@ class MQTT:
             node['position'] = msg['payload'] if 'payload' in msg else None
             self.data.update_node(id, node)
             logger.debug("Node %s skeleton added with position", id)
+
+        if 'channel' in msg:
+            node['last_channel'] = str(msg['channel'])
 
         # Emit event for Discord bridge
         try:
@@ -486,6 +492,9 @@ class MQTT:
 
         if msg.get('sender'):
             node['gateway'] = msg['sender']
+
+        if 'channel' in msg:
+            node['last_channel'] = str(msg['channel'])
 
         self.data.update_node(id, node)
         logger.debug("Node %s updated with telemetry (variant=%s)", id, telemetry_type)
@@ -562,6 +571,7 @@ class MQTT:
         if node:
             if 'TC' in chat['text'] and 'BBS' in chat['text'] and 'Commands' in chat['text']:
                 node['tc2_bbs'] = True
+            node['last_channel'] = str(msg['channel'])
             self.data.update_node(node['id'], node)
 
         # Emit event for Discord bridge

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -268,6 +268,7 @@ ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS local_stats JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS health_metrics JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS host_metrics JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS traffic_management_stats JSONB;
+ALTER TABLE nodes ADD COLUMN IF NOT EXISTS last_channel VARCHAR(10);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Discord bridge tables

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -357,10 +357,14 @@ class PostgresStorage:
                     if role is None and role_raw not in (None, "", 0):
                         logger.debug("Invalid role %r for node %s; storing NULL", role_raw, node_id_norm)
 
+                    last_channel = node_data.get("last_channel")
+                    if last_channel is not None:
+                        last_channel = str(last_channel)
+
                     await conn.execute(
                         """
-                        INSERT INTO nodes (id, longname, shortname, hardware, role, active, tc2_bbs, gateway, last_seen, since_seconds)
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                        INSERT INTO nodes (id, longname, shortname, hardware, role, active, tc2_bbs, gateway, last_seen, since_seconds, last_channel)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                         ON CONFLICT (id) DO UPDATE SET
                             longname = EXCLUDED.longname,
                             shortname = EXCLUDED.shortname,
@@ -371,6 +375,7 @@ class PostgresStorage:
                             gateway = COALESCE(EXCLUDED.gateway, nodes.gateway),
                             last_seen = EXCLUDED.last_seen,
                             since_seconds = EXCLUDED.since_seconds,
+                            last_channel = COALESCE(EXCLUDED.last_channel, nodes.last_channel),
                             updated_at = NOW()
                         """,
                         node_id_norm,
@@ -383,6 +388,7 @@ class PostgresStorage:
                         self._normalize_node_id(node_data.get("gateway")),
                         last_seen_ts,
                         since_seconds,
+                        last_channel,
                     )
 
                     if node_data.get("position"):
@@ -1001,6 +1007,7 @@ class PostgresStorage:
                         "active": row["active"],
                         "tc2_bbs": row["tc2_bbs"],
                         "gateway": row["gateway"] if "gateway" in row.keys() else None,
+                        "last_channel": row["last_channel"] if "last_channel" in row.keys() else None,
                         "last_seen": row["last_seen"].isoformat() if row["last_seen"] else None,
                         "since": datetime.timedelta(seconds=row["since_seconds"]) if row["since_seconds"] else None,
                         "position": None,
@@ -1316,6 +1323,7 @@ class PostgresStorage:
                         "active": row["active"],
                         "tc2_bbs": row["tc2_bbs"] if "tc2_bbs" in row else False,
                         "gateway": row["gateway"] if "gateway" in row.keys() else None,
+                        "last_channel": row["last_channel"] if "last_channel" in row.keys() else None,
                         "last_seen": row["last_seen"].isoformat() if row["last_seen"] else None,
                         "since": datetime.timedelta(seconds=row["since_seconds"]) if row["since_seconds"] else None,
                         "position": None,


### PR DESCRIPTION
## Summary
- Track `last_channel` on node records from MQTT messages, enabling per-preset visibility across the app (closes #378)
- Add modem preset filter pills to the Nodes page, matching the Chat page's pill UI style
- Display channel preset label in the map details panel when a node is clicked
- Include `last_channel` in CSV/JSON node exports

## Changes

### Backend
- **postgres/sql/schema.sql** — Idempotent migration adding `last_channel VARCHAR(10)` to nodes table
- **models/node.py** — Added `last_channel` to default node templates
- **mqtt.py** — Updated `handle_nodeinfo`, `handle_position`, `handle_telemetry`, `handle_text` to capture `msg['channel']` onto the node record
- **storage/db/postgres.py** — `write_node` persists `last_channel` (COALESCE preserves existing value); both `query_nodes_filtered` mappings return it

### Frontend
- **types/index.ts** — Added `last_channel` to `INode` interface
- **useNodesSearchParams.ts** — Added `urlCh` / `ch` URL param support
- **Nodes.tsx** — Channel views from config, preset filter pills, filtering by `selectedChannelId`, StatusChip, filter count, clear, and `last_channel` in exports
- **map/detailsHtml.ts** — Optional `channelLabel` line in node details HTML
- **Map.tsx** — Resolves channel label from config and passes to details builder

## Notes
- Pills only render when 2+ channel views are configured (no UI change for single-channel installs)
- `last_channel` starts as NULL for existing nodes and populates as new MQTT messages arrive