### PR TITLE
fix: nodes list UX, chat auto-poll, topnodes channel scoping, and timestamp fixes

### DIFF
--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -356,7 +356,21 @@ class MainCommands(commands.Cog):
 
         await interaction.response.defer()
 
-        stats = await self.data.pg_storage.query_top_nodes(hours=hours, limit=5)
+        # Determine mesh channel from Discord channel via bridge config
+        mesh_channel = None
+        channel_label = None
+        bridge_cfg = self.config.get('discord', {}).get('bridge', {})
+        bridge_channels = bridge_cfg.get('channels', {})
+        discord_ch_id = str(interaction.channel_id)
+        for mesh_ch, disc_ch in bridge_channels.items():
+            if str(disc_ch) == discord_ch_id:
+                mesh_channel = mesh_ch
+                # Resolve a friendly label from channel meta
+                meta = self.config.get('broker', {}).get('channels', {}).get('meta', {}).get(mesh_ch, {})
+                channel_label = meta.get('label') or f"Channel {mesh_ch}"
+                break
+
+        stats = await self.data.pg_storage.query_top_nodes(hours=hours, limit=5, channel_id=mesh_channel)
         if not stats:
             await interaction.followup.send("No leaderboard data available yet.", ephemeral=True)
             return
@@ -375,8 +389,11 @@ class MainCommands(commands.Cog):
                     return name
             return f"!{node_id}"
 
+        title = f"Mesh Leaderboard \u2014 {label}"
+        if channel_label:
+            title += f" \u2014 {channel_label}"
         embed = discord.Embed(
-            title=f"Mesh Leaderboard \u2014 {label}",
+            title=title,
             color=discord.Color.gold(),
             timestamp=discord.utils.utcnow(),
         )

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -343,6 +343,8 @@ class MainCommands(commands.Cog):
     @app_commands.command(name="topnodes", description="Mesh leaderboard and achievements")
     @app_commands.describe(timeframe="Time period: 24h (default) or 7d")
     async def topnodes(self, interaction: discord.Interaction, timeframe: str = "24h"):
+        await interaction.response.defer()
+
         if timeframe in ("7d", "7", "week"):
             hours = 168
             label = "7 Days"
@@ -351,15 +353,13 @@ class MainCommands(commands.Cog):
             label = "24 Hours"
 
         if not self.data.pg_storage:
-            await interaction.response.send_message("Database not available.", ephemeral=True)
+            await interaction.followup.send("Database not available.", ephemeral=True)
             return
-
-        await interaction.response.defer()
 
         # Determine mesh channel from Discord channel via bridge config
         mesh_channel = None
         channel_label = None
-        bridge_cfg = self.config.get('discord', {}).get('bridge', {})
+        bridge_cfg = self.config.get('integrations', {}).get('discord', {}).get('bridge', {})
         bridge_channels = bridge_cfg.get('channels', {})
         discord_ch_id = str(interaction.channel_id)
         for mesh_ch, disc_ch in bridge_channels.items():
@@ -446,7 +446,11 @@ class MainCommands(commands.Cog):
         if not any(stats.values()):
             embed.description = "Not enough data yet \u2014 check back later!"
 
-        embed.set_footer(text=f"Timeframe: {label} | Use /topnodes 7d for weekly")
+        footer_parts = [f"Timeframe: {label}"]
+        if mesh_channel:
+            footer_parts.append(f"Channel: {mesh_channel}")
+        footer_parts.append("Use /topnodes 7d for weekly")
+        embed.set_footer(text=" | ".join(footer_parts))
         await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="meshinfo", description="Show all available bot commands")

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -238,6 +238,9 @@ export const Chat = () => {
     return "0";
   }, [config, rawCh]);
 
+  // Live / auto-follow toggle (declared before query so polling can reference it)
+  const [liveEnabled, setLiveEnabled] = useState(true);
+
   // ── 5. Chat query (fires with resolved channel + range) ──
   const chatQueryParams = useMemo(() => {
     const params: { channel?: string; range?: string } = {};
@@ -251,7 +254,12 @@ export const Chat = () => {
     fulfilledTimeStamp: dataUpdatedAt,
     isFetching,
     refetch,
-  } = useGetChatsQuery(chatQueryParams);
+  } = useGetChatsQuery(chatQueryParams, {
+    pollingInterval: liveEnabled ? 5000 : 0,
+    skipPollingIfUnfocused: true,
+    refetchOnReconnect: liveEnabled,
+    refetchOnFocus: liveEnabled,
+  });
 
   // ── 6. Stable chat ref (prevents skeleton flash on filter change) ──
   const prevChatRef = useRef(chat);
@@ -447,9 +455,6 @@ export const Chat = () => {
       setMobileSheet("details");
     }
   }, [urlMsg, isLgUp]);
-
-  // Live / auto-follow toggle
-  const [liveEnabled, setLiveEnabled] = useState(true);
 
   // Follow state reported by MessageList so header can reflect "Paused" even when liveEnabled=true
   const [followState, setFollowState] = useState<{

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -628,6 +628,28 @@ export const Nodes = () => {
     setParam("node", undefined, "push");
   }, [setParam]);
 
+  // Click-outside: clear selection when clicking in the page background
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const detailsPanelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!selectedId) return;
+
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node | null;
+      if (!t) return;
+      if (listContainerRef.current?.contains(t)) return;
+      if (detailsPanelRef.current?.contains(t)) return;
+      // Don't clear if clicking on header/toolbar controls
+      const el = e.target as HTMLElement;
+      if (el.closest?.("[data-no-clear-selection]")) return;
+      clearSelection();
+    };
+
+    window.addEventListener("mousedown", onDown);
+    return () => window.removeEventListener("mousedown", onDown);
+  }, [selectedId, clearSelection]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -669,7 +691,7 @@ export const Nodes = () => {
   return (
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header */}
-      <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
+      <div data-no-clear-selection className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
         <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
@@ -1002,13 +1024,14 @@ export const Nodes = () => {
         <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0">
             {/* Left: list */}
-            <div className="lg:col-span-2 min-h-0 flex flex-col h-full">
+            <div ref={listContainerRef} className="lg:col-span-2 min-h-0 flex flex-col h-full">
               <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
                 <NodesList
                   items={filteredItems}
                   selectedId={selectedId}
                   flashId={flashNodeId}
                   scrollToId={scrollToId}
+                  liveEnabled={liveEnabled}
                   onSelect={onSelect}
                   onAtTopChange={onAtTopChange}
                   totalSeen={Object.keys(nodes as any).length}
@@ -1017,7 +1040,7 @@ export const Nodes = () => {
             </div>
 
             {/* Right: overview or details (desktop only) */}
-            <div className="hidden lg:flex lg:col-span-1 flex-col min-h-0 h-full overflow-y-auto">
+            <div ref={detailsPanelRef} className="hidden lg:flex lg:col-span-1 flex-col min-h-0 h-full overflow-y-auto">
               <div className="min-h-0">
                 {selectedNode ? (
                   <NodeDetailsPanel

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -526,10 +526,12 @@ export const Nodes = () => {
   const livePillTitle = useMemo(() => {
     if (!liveEnabled)
       return "Live mode is off. Auto-refresh is disabled (no polling / focus / reconnect). Click to enable.";
+    if (selectedId)
+      return "List paused while a node is selected. Clear selection to resume.";
     if (!listAtTop)
       return "Auto-refresh paused while scrolled. Scroll to top or click to resume.";
     return "Live mode is on. Auto-refresh polls every 5 seconds (paused when tab is unfocused). Click to disable.";
-  }, [liveEnabled, listAtTop]);
+  }, [liveEnabled, selectedId, listAtTop]);
 
   // Export rows
   const exportRows = useMemo(() => {

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -431,18 +431,23 @@ export const Nodes = () => {
     if (selectedId && selectedId !== prev) setMobileSheet("details");
   }, [selectedId, isLgUp]);
 
-  // Scroll-to + flash: driven by selectedId changes
+  // Scroll-to + flash: only auto-scroll for deep links, not interactive clicks
   const [scrollToId, setScrollToId] = useState<string>("");
   const [flashNodeId, setFlashNodeId] = useState<string>("");
-  const prevSelectedRef = useRef<string>("");
+  const isInitialLoadRef = useRef(true);
 
-  // Trigger scroll when selection changes
+  // On mount: if there's a selectedId from the URL, mark it for scroll
   useEffect(() => {
-    const prev = prevSelectedRef.current;
-    prevSelectedRef.current = selectedId;
-    if (!selectedId || selectedId === prev) return;
-    setScrollToId(selectedId);
-    setFlashNodeId(selectedId);
+    if (isInitialLoadRef.current && selectedId) {
+      setScrollToId(selectedId);
+      setFlashNodeId(selectedId);
+    }
+    isInitialLoadRef.current = false;
+  }, [selectedId]);
+
+  // Clear scrollToId when selection is cleared (so freeze can release)
+  useEffect(() => {
+    if (!selectedId) setScrollToId("");
   }, [selectedId]);
 
   // Separate effect to clear flash — not affected by StrictMode double-invoke
@@ -507,9 +512,10 @@ export const Nodes = () => {
   // Header live pill
   const liveUiMode = useMemo(() => {
     if (!liveEnabled) return "off" as const;
+    if (selectedId) return "paused" as const;
     if (!listAtTop) return "paused" as const;
     return "live" as const;
-  }, [liveEnabled, listAtTop]);
+  }, [liveEnabled, selectedId, listAtTop]);
 
   const livePillText = useMemo(() => {
     if (liveUiMode === "live") return "Live";
@@ -1033,6 +1039,7 @@ export const Nodes = () => {
                   scrollToId={scrollToId}
                   liveEnabled={liveEnabled}
                   onSelect={onSelect}
+                  onClearSelection={clearSelection}
                   onAtTopChange={onAtTopChange}
                   totalSeen={Object.keys(nodes as any).length}
                 />

--- a/frontend/src/pages/map/detailsHtml.ts
+++ b/frontend/src/pages/map/detailsHtml.ts
@@ -17,6 +17,21 @@ export function computeHeardByIds(liveNodes: Record<string, IMapNode>, targetId:
   );
 }
 
+function formatLastSeen(raw: string | null | undefined): string {
+  if (!raw) return "Unknown";
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
 export function buildNodeDetailsHtml(opts: {
   node: NodeLike;
   liveNodes: Record<string, IMapNode>;
@@ -63,7 +78,7 @@ export function buildNodeDetailsHtml(opts: {
     `<b>Position</b> &nbsp;${escapeHtml(node.position[1].toFixed(6))}, ${escapeHtml(node.position[0].toFixed(6))}<br/>` +
     `<b>Location</b> &nbsp;<span title="${escapeHtml(displayName)}" style="cursor:help;border-bottom:1px dotted currentColor">${escapeHtml(shortenLocation(displayName))}</span><br/>` +
     `<b>Status</b> &nbsp;${node.online ? "Online" : "Offline"}<br/>` +
-    `<b>Last Seen</b> &nbsp;${escapeHtml(node.last_seen ?? "")}` +
+    `<b>Last Seen</b> &nbsp;${escapeHtml(formatLastSeen(node.last_seen))}` +
     (opts.channelLabel ? `<br/><b>Channel</b> &nbsp;${escapeHtml(opts.channelLabel)}` : "") +
     `</div>`;
 

--- a/frontend/src/pages/nodes/NodesList.tsx
+++ b/frontend/src/pages/nodes/NodesList.tsx
@@ -89,12 +89,14 @@ export function NodesList({
   const shouldFreeze = liveEnabled && items.length > 0 && (!atTop || !!selectedId);
   const frozenRef = useRef<NodeListItem[] | null>(null);
 
-  // Capture/release frozen snapshot
-  if (shouldFreeze) {
-    if (!frozenRef.current) frozenRef.current = items;
-  } else {
-    frozenRef.current = null;
-  }
+  // Capture/release frozen snapshot after commit (not during render)
+  useEffect(() => {
+    if (shouldFreeze) {
+      if (!frozenRef.current) frozenRef.current = items;
+    } else {
+      frozenRef.current = null;
+    }
+  }, [shouldFreeze, items]);
 
   const displayItems = useMemo(
     () => frozenRef.current ?? items,
@@ -122,13 +124,15 @@ export function NodesList({
   const scrollDoneRef = useRef<string>("");
   const pendingScrollRef = useRef<string>("");
 
-  // Update pending scroll target
-  if (scrollToId && scrollToId !== scrollDoneRef.current) {
-    pendingScrollRef.current = scrollToId;
-  } else if (!scrollToId) {
-    pendingScrollRef.current = "";
-    scrollDoneRef.current = "";
-  }
+  // Update pending scroll target after commit
+  useEffect(() => {
+    if (scrollToId && scrollToId !== scrollDoneRef.current) {
+      pendingScrollRef.current = scrollToId;
+    } else if (!scrollToId) {
+      pendingScrollRef.current = "";
+      scrollDoneRef.current = "";
+    }
+  }, [scrollToId]);
 
   useEffect(() => {
     const target = pendingScrollRef.current;

--- a/frontend/src/pages/nodes/NodesList.tsx
+++ b/frontend/src/pages/nodes/NodesList.tsx
@@ -39,6 +39,7 @@ export function NodesList({
   selectedId,
   flashId,
   scrollToId,
+  liveEnabled = true,
   onSelect,
   onAtTopChange,
   totalSeen,
@@ -48,6 +49,7 @@ export function NodesList({
   flashId?: string;
   /** When set, the list scrolls to this node id and clears via onScrollComplete */
   scrollToId?: string;
+  liveEnabled?: boolean;
   onSelect: (id: string) => void;
   onAtTopChange?: (atTop: boolean) => void;
   totalSeen: number;
@@ -79,16 +81,51 @@ export function NodesList({
     [],
   );
 
-  // Scroll-to-node: retry until Virtuoso is ready
-  // Scroll-to-node when scrollToId is set.
+  // Freeze the item list when scrolled away from top to prevent
+  // re-sorting from jumping the user's scroll position.
+  const frozenRef = useRef<NodeListItem[] | null>(null);
+  const displayItems = (() => {
+    if (liveEnabled && !atTop) {
+      // Paused: capture snapshot on first frame, keep it stable
+      if (!frozenRef.current) frozenRef.current = items;
+      return frozenRef.current;
+    }
+    // Live at top, or live disabled: show latest, clear snapshot
+    frozenRef.current = null;
+    return items;
+  })();
+
+  // Track new items arriving while paused
+  const [newCount, setNewCount] = useState(0);
+
+  useEffect(() => {
+    if (!liveEnabled || atTop) {
+      setNewCount(0);
+      return;
+    }
+    // While paused, diff live items against frozen snapshot
+    if (frozenRef.current) {
+      const frozenIds = new Set(frozenRef.current.map((x) => x.id));
+      const added = items.filter((x) => !frozenIds.has(x.id)).length;
+      setNewCount(added);
+    }
+  }, [items, atTop, liveEnabled]);
+
+  // Scroll-to-node: retry until Virtuoso is ready.
   // Re-runs when items change (e.g. data finishes loading after mount).
   const scrollDoneRef = useRef<string>("");
+  // Reset scroll tracking when the target changes
+  useEffect(() => {
+    if (scrollToId !== scrollDoneRef.current) {
+      scrollDoneRef.current = "";
+    }
+  }, [scrollToId]);
+
   useEffect(() => {
     if (!scrollToId) return;
-    // Already scrolled for this id — skip
     if (scrollDoneRef.current === scrollToId) return;
 
-    const idx = items.findIndex((x) => x.id === scrollToId);
+    const idx = displayItems.findIndex((x) => x.id === scrollToId);
     if (idx < 0) return; // node not in list yet — will re-run when items updates
 
     const doScroll = () => {
@@ -106,7 +143,7 @@ export function NodesList({
     doScroll();
     const timers = [50, 200, 500, 1000].map((d) => setTimeout(doScroll, d));
     return () => timers.forEach(clearTimeout);
-  }, [scrollToId, items]);
+  }, [scrollToId, displayItems]);
 
   // Jump to top (used by "Back to live" externally via ref isn't needed —
   // we expose it through a simpler pattern: parent sets scrollToId="" or
@@ -116,7 +153,7 @@ export function NodesList({
     <div className="relative rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden shadow-xs flex flex-col min-h-0 flex-1">
       <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/40 flex items-center justify-between">
         <div className="text-sm text-gray-800 dark:text-gray-200">
-          <span className="font-semibold">{items.length}</span> shown{" "}
+          <span className="font-semibold">{displayItems.length}</span> shown{" "}
           <span className="text-gray-500 dark:text-gray-400">
             (out of {totalSeen} seen)
           </span>
@@ -144,7 +181,7 @@ export function NodesList({
                 });
               }}
             >
-              Back to top <span className="ml-1 opacity-80">&uarr;</span>
+              Back to top{newCount > 0 && ` (${newCount} new)`} <span className="ml-1 opacity-80">&uarr;</span>
             </button>
           </div>
         )}
@@ -152,7 +189,7 @@ export function NodesList({
         <Virtuoso
           ref={virtuosoRef}
           style={{ flex: 1, minHeight: 0, height: "100%" }}
-          data={items}
+          data={displayItems}
           computeItemKey={(_index, item) => item.id}
           overscan={600}
           rangeChanged={handleRangeChanged}

--- a/frontend/src/pages/nodes/NodesList.tsx
+++ b/frontend/src/pages/nodes/NodesList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 
 import { Avatar } from "../../components/Avatar";
@@ -41,6 +41,7 @@ export function NodesList({
   scrollToId,
   liveEnabled = true,
   onSelect,
+  onClearSelection,
   onAtTopChange,
   totalSeen,
 }: {
@@ -51,6 +52,7 @@ export function NodesList({
   scrollToId?: string;
   liveEnabled?: boolean;
   onSelect: (id: string) => void;
+  onClearSelection?: () => void;
   onAtTopChange?: (atTop: boolean) => void;
   totalSeen: number;
 }) {
@@ -81,69 +83,83 @@ export function NodesList({
     [],
   );
 
-  // Freeze the item list when scrolled away from top to prevent
-  // re-sorting from jumping the user's scroll position.
+  // Freeze the item list when scrolled away from top OR a node is selected,
+  // to prevent re-sorting from jumping the user's scroll position.
+  // Don't freeze until we have data (avoids freezing an empty list on deep links).
+  const shouldFreeze = liveEnabled && items.length > 0 && (!atTop || !!selectedId);
   const frozenRef = useRef<NodeListItem[] | null>(null);
-  const displayItems = (() => {
-    if (liveEnabled && !atTop) {
-      // Paused: capture snapshot on first frame, keep it stable
-      if (!frozenRef.current) frozenRef.current = items;
-      return frozenRef.current;
-    }
-    // Live at top, or live disabled: show latest, clear snapshot
+
+  // Capture/release frozen snapshot
+  if (shouldFreeze) {
+    if (!frozenRef.current) frozenRef.current = items;
+  } else {
     frozenRef.current = null;
-    return items;
-  })();
+  }
+
+  const displayItems = useMemo(
+    () => frozenRef.current ?? items,
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally re-evaluate when freeze state or items change
+    [shouldFreeze, items],
+  );
 
   // Track new items arriving while paused
   const [newCount, setNewCount] = useState(0);
 
   useEffect(() => {
-    if (!liveEnabled || atTop) {
+    if (!shouldFreeze) {
       setNewCount(0);
       return;
     }
-    // While paused, diff live items against frozen snapshot
+    // While frozen, diff live items against frozen snapshot
     if (frozenRef.current) {
       const frozenIds = new Set(frozenRef.current.map((x) => x.id));
       const added = items.filter((x) => !frozenIds.has(x.id)).length;
       setNewCount(added);
     }
-  }, [items, atTop, liveEnabled]);
+  }, [items, shouldFreeze]);
 
-  // Scroll-to-node: retry until Virtuoso is ready.
-  // Re-runs when items change (e.g. data finishes loading after mount).
+  // Scroll-to-node: track pending scroll and attempt on every render + timers
   const scrollDoneRef = useRef<string>("");
-  // Reset scroll tracking when the target changes
-  useEffect(() => {
-    if (scrollToId !== scrollDoneRef.current) {
-      scrollDoneRef.current = "";
-    }
-  }, [scrollToId]);
+  const pendingScrollRef = useRef<string>("");
+
+  // Update pending scroll target
+  if (scrollToId && scrollToId !== scrollDoneRef.current) {
+    pendingScrollRef.current = scrollToId;
+  } else if (!scrollToId) {
+    pendingScrollRef.current = "";
+    scrollDoneRef.current = "";
+  }
 
   useEffect(() => {
-    if (!scrollToId) return;
-    if (scrollDoneRef.current === scrollToId) return;
+    const target = pendingScrollRef.current;
+    if (!target || scrollDoneRef.current === target) return;
 
-    const idx = displayItems.findIndex((x) => x.id === scrollToId);
-    if (idx < 0) return; // node not in list yet — will re-run when items updates
+    const idx = displayItems.findIndex((x) => x.id === target);
+    if (idx < 0) return;
 
-    const doScroll = () => {
-      if (scrollDoneRef.current === scrollToId) return;
-      if (!virtuosoRef.current) return;
-      scrollDoneRef.current = scrollToId;
-      virtuosoRef.current.scrollToIndex({
-        index: idx,
-        align: "center",
-        behavior: "smooth",
-      });
+    scrollDoneRef.current = target;
+    pendingScrollRef.current = "";
+
+    // Use Virtuoso scrollToIndex to get the item rendered, then
+    // fall back to native DOM scrollIntoView for reliability.
+    const scrollViaDOM = () => {
+      const el = document.querySelector(`[data-node-id="${target}"]`);
+      if (el) {
+        el.scrollIntoView({ block: "center", behavior: "smooth" });
+        return true;
+      }
+      return false;
     };
 
-    // Try immediately, plus retries for Virtuoso readiness
-    doScroll();
-    const timers = [50, 200, 500, 1000].map((d) => setTimeout(doScroll, d));
+    // First: tell Virtuoso to render the area around the target index
+    virtuosoRef.current?.scrollToIndex({ index: idx, align: "center", behavior: "auto" });
+
+    // Then: use DOM scrollIntoView as the reliable fallback
+    const timers = [100, 300, 600, 1200, 2500].map((delay) =>
+      setTimeout(() => scrollViaDOM(), delay),
+    );
     return () => timers.forEach(clearTimeout);
-  }, [scrollToId, displayItems]);
+  }); // Run on every render — cheap because it short-circuits immediately when done
 
   // Jump to top (used by "Back to live" externally via ref isn't needed —
   // we expose it through a simpler pattern: parent sets scrollToId="" or
@@ -174,6 +190,8 @@ export function NodesList({
                 bg-gray-900 text-white border-gray-900 hover:bg-gray-800
                 dark:bg-gray-100 dark:text-gray-900 dark:border-gray-100 dark:hover:bg-gray-200"
               onClick={() => {
+                onClearSelection?.();
+                frozenRef.current = null;
                 virtuosoRef.current?.scrollToIndex({
                   index: 0,
                   align: "start",
@@ -208,6 +226,7 @@ export function NodesList({
             return (
               <button
                 type="button"
+                data-node-id={item.id}
                 onClick={() => onSelect(item.id)}
                 className={[
                   "w-full text-left px-4 py-3 border-b border-gray-200 dark:border-gray-800 transition",

--- a/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
+++ b/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
@@ -229,10 +229,7 @@ export function TracerouteDetailsPanel({
 
             {lastEvent ? (
               <div className="text-[11px] text-gray-500 mt-1 tabular-nums">
-                Latest: {formatTimestamp(lastEvent.timestamp) || "Unknown"} •{" "}
-                {safeTsMs(lastEvent.timestamp)
-                  ? new Date(safeTsMs(lastEvent.timestamp)).toISOString()
-                  : "—"}
+                Latest: {formatTimestamp(lastEvent.timestamp) || "Unknown"}
               </div>
             ) : null}
           </div>
@@ -463,16 +460,9 @@ export function TracerouteDetailsPanel({
                             {occurrences.map((e) => (
                               <div
                                 key={`occ-${e.__idx}`}
-                                className="flex items-center justify-between gap-3 text-xs"
+                                className="text-xs text-gray-700 dark:text-gray-200"
                               >
-                                <span className="text-gray-700 dark:text-gray-200">
-                                  {formatTimestamp(e.timestamp) || "Unknown"}
-                                </span>
-                                <span className="text-gray-500 tabular-nums">
-                                  {safeTsMs(e.timestamp)
-                                    ? new Date(safeTsMs(e.timestamp)).toISOString()
-                                    : "—"}
-                                </span>
+                                {formatTimestamp(e.timestamp) || "Unknown"}
                               </div>
                             ))}
                           </div>

--- a/mqtt.py
+++ b/mqtt.py
@@ -109,7 +109,14 @@ class MQTT:
 
                 outs['rssi'] = mp.rx_rssi
                 outs['snr'] = mp.rx_snr
-                outs['timestamp'] = mp.rx_time
+                # Clamp rx_time to current time if node clock is ahead
+                rx_time = mp.rx_time
+                now_epoch = int(time.time())
+                if rx_time and rx_time > now_epoch + 300:  # 5 min tolerance
+                    node_id = utils.convert_node_id_from_int_to_hex(getattr(mp, "from", 0))
+                    logger.warning("Node %s has future clock: rx_time=%s (%.0f min ahead), clamping to now", node_id, rx_time, (rx_time - now_epoch) / 60)
+                    rx_time = now_epoch
+                outs['timestamp'] = rx_time
                 outs['topic'] = msg.topic.value
                 outs["qos"] = getattr(msg, "qos", None)
                 outs["retain"] = getattr(msg, "retain", None)

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -2099,9 +2099,10 @@ class PostgresStorage:
             logger.error("Failed to list bans: %s", e)
             return []
 
-    async def query_top_nodes(self, hours: int = 24, limit: int = 5, channel_id: str = None) -> dict:
+    async def query_top_nodes(self, hours: int = 24, limit: int = 5, channel_id: Optional[str] = None) -> dict:
         """Query leaderboard stats for the mesh. Returns dict of categories.
-        If channel_id is provided, chat-based stats are scoped to that channel."""
+        If channel_id is provided, chat-based stats are scoped to that channel,
+        and node-based categories (such as iron_man) are scoped via nodes.last_channel."""
         if not self._ready("query_top_nodes"):
             return {}
 

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -2099,8 +2099,9 @@ class PostgresStorage:
             logger.error("Failed to list bans: %s", e)
             return []
 
-    async def query_top_nodes(self, hours: int = 24, limit: int = 5) -> dict:
-        """Query leaderboard stats for the mesh. Returns dict of categories."""
+    async def query_top_nodes(self, hours: int = 24, limit: int = 5, channel_id: str = None) -> dict:
+        """Query leaderboard stats for the mesh. Returns dict of categories.
+        If channel_id is provided, chat-based stats are scoped to that channel."""
         if not self._ready("query_top_nodes"):
             return {}
 
@@ -2108,52 +2109,69 @@ class PostgresStorage:
         cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=hours)
         results = {}
 
+        # Build optional channel filter for chat_messages queries
+        ch_filter = ""
+        ch_params: list = []
+        if channel_id is not None:
+            ch_filter = " AND channel_id = $3"
+            ch_params = [channel_id]
+
         try:
             async with self.pool.acquire() as conn:
                 # Chatterbox — most messages sent
                 rows = await conn.fetch(
-                    """SELECT from_node_id AS node_id, COUNT(*) AS count
+                    f"""SELECT from_node_id AS node_id, COUNT(*) AS count
                        FROM chat_messages
-                       WHERE created_at >= $1
+                       WHERE created_at >= $1{ch_filter}
                        GROUP BY from_node_id ORDER BY count DESC LIMIT $2""",
-                    cutoff, limit,
+                    cutoff, limit, *ch_params,
                 )
                 results["chatterbox"] = [dict(r) for r in rows]
 
                 # Iron Man — longest uptime (active nodes with oldest created_at)
-                rows = await conn.fetch(
-                    """SELECT id AS node_id,
-                              EXTRACT(EPOCH FROM (NOW() - created_at)) AS uptime_seconds
-                       FROM nodes
-                       WHERE active = TRUE AND created_at IS NOT NULL
-                       ORDER BY created_at ASC LIMIT $1""",
-                    limit,
-                )
+                if channel_id is not None:
+                    rows = await conn.fetch(
+                        """SELECT id AS node_id,
+                                  EXTRACT(EPOCH FROM (NOW() - created_at)) AS uptime_seconds
+                           FROM nodes
+                           WHERE active = TRUE AND created_at IS NOT NULL AND last_channel = $2
+                           ORDER BY created_at ASC LIMIT $1""",
+                        limit, channel_id,
+                    )
+                else:
+                    rows = await conn.fetch(
+                        """SELECT id AS node_id,
+                                  EXTRACT(EPOCH FROM (NOW() - created_at)) AS uptime_seconds
+                           FROM nodes
+                           WHERE active = TRUE AND created_at IS NOT NULL
+                           ORDER BY created_at ASC LIMIT $1""",
+                        limit,
+                    )
                 results["iron_man"] = [dict(r) for r in rows]
 
                 # Here I Am — disabled: requires position history table (not yet implemented)
 
                 # Loudest Signal — best average SNR
                 rows = await conn.fetch(
-                    """SELECT from_node_id AS node_id, ROUND(AVG(snr)::numeric, 1) AS avg_snr
+                    f"""SELECT from_node_id AS node_id, ROUND(AVG(snr)::numeric, 1) AS avg_snr
                        FROM chat_messages
-                       WHERE created_at >= $1 AND snr IS NOT NULL
+                       WHERE created_at >= $1 AND snr IS NOT NULL{ch_filter}
                        GROUP BY from_node_id
                        HAVING COUNT(*) >= 3
                        ORDER BY avg_snr DESC LIMIT $2""",
-                    cutoff, limit,
+                    cutoff, limit, *ch_params,
                 )
                 results["loudest_signal"] = [dict(r) for r in rows]
 
                 # Gateway MVP — most messages relayed (nodes appearing as sender_node_id)
                 rows = await conn.fetch(
-                    """SELECT sender_node_id AS node_id, COUNT(*) AS count
+                    f"""SELECT sender_node_id AS node_id, COUNT(*) AS count
                        FROM chat_messages
                        WHERE created_at >= $1
                          AND sender_node_id IS NOT NULL
-                         AND sender_node_id != from_node_id
+                         AND sender_node_id != from_node_id{ch_filter}
                        GROUP BY sender_node_id ORDER BY count DESC LIMIT $2""",
-                    cutoff, limit,
+                    cutoff, limit, *ch_params,
                 )
                 results["gateway_mvp"] = [dict(r) for r in rows]
 


### PR DESCRIPTION
## Summary
- Stabilize nodes list scroll position during live 5s polling — freeze displayed items when scrolled away or a node is selected, with new-item count badge (closes #419)
- Click outside the node list/details panel clears selection
- Deep link to a node (`?node=xyz`) auto-scrolls to and highlights the selected node
- Enable auto-polling for chat messages when live mode is active (closes #420)
- Scope `/topnodes` leaderboard to the mesh channel when run in a mapped Discord channel (closes #423)
- Fix timestamps showing raw UTC/ISO on map details panel and traceroutes details — now formats to local time (closes #422)
- Clamp future node clock timestamps on MQTT ingestion with warning log

## Changes

### Frontend
- **NodesList.tsx** — Frozen snapshot when paused/selected, `displayItems` via useMemo, new-item counter, "Back to top (N new)" button clears selection, native DOM `scrollIntoView` fallback for deep link scroll
- **Nodes.tsx** — Click-outside handler with refs, deep link scroll initialization, `liveUiMode` shows "paused" when node selected, `scrollToId` cleared on deselect
- **useNodesSearchParams.ts** — `urlCh` channel param support
- **Chat.tsx** — Added `pollingInterval: 5000` with `skipPollingIfUnfocused` when live enabled
- **map/detailsHtml.ts** — Format `last_seen` to local time via `toLocaleString()` instead of raw ISO string
- **TracerouteDetailsPanel.tsx** — Removed raw `.toISOString()` UTC displays

### Backend
- **mqtt.py** — Clamp `rx_time` to current time when node clock is >5 min ahead, log warning with node ID and drift
- **bot/cogs/main_commands.py** — `/topnodes` reverse-looks up Discord channel → mesh channel hash via bridge config, filters Chatterbox/Loudest Signal/Gateway MVP/Iron Man queries by channel; `defer()` moved to first line
- **storage/db/postgres.py** — `query_top_nodes` accepts optional `channel_id` filter for chat-based and node-based stats