### PR TITLE
feat: node packet history, log persistence, chat UX improvements, and gateway extraction

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -24,21 +24,26 @@ class API:
 
     @staticmethod
     def _parse_range(value: str | None) -> int | None:
-        """Convert a range string like '1h', '24h', '7d' to seconds. Returns None for 'all' or missing."""
-        if not value or value == "all":
+        """Convert a range string like '1h', '24h', '7d' to seconds. Returns None for 'all' or missing, defaults invalid values to 24h."""
+        DEFAULT_RANGE = 24 * 3600
+        if not value:
             return None
         v = value.strip().lower()
+        if v == "all":
+            return None
         if v.endswith("h"):
             try:
-                return int(v[:-1]) * 3600
+                hours = int(v[:-1])
+                return hours * 3600 if hours > 0 else DEFAULT_RANGE
             except ValueError:
-                return None
+                return DEFAULT_RANGE
         if v.endswith("d"):
             try:
-                return int(v[:-1]) * 86400
+                days = int(v[:-1])
+                return days * 86400 if days > 0 else DEFAULT_RANGE
             except ValueError:
-                return None
-        return None
+                return DEFAULT_RANGE
+        return DEFAULT_RANGE
 
     async def serve(self):
         @app.get("/")
@@ -239,9 +244,12 @@ class API:
                 node_id = int(id)
                 node_id = utils.convert_node_id_from_int_to_hex(node_id)
             except ValueError:
-                node_id = id
+                node_id = id.lstrip("!")
 
-            limit = int(request.query_params.get("limit", 50))
+            try:
+                limit = int(request.query_params.get("limit", 50))
+            except (TypeError, ValueError):
+                limit = 50
             limit = max(1, min(limit, 200))
 
             if self.read_from_postgres:

--- a/api/api.py
+++ b/api/api.py
@@ -215,6 +215,37 @@ class API:
                             texts.append(message)
                 return jsonable_encoder({ "texts": texts })
 
+        @app.get("/v1/nodes/{id}/packets")
+        async def node_packets(request: Request, id: str) -> JSONResponse:
+            try:
+                node_id = int(id)
+                node_id = utils.convert_node_id_from_int_to_hex(node_id)
+            except ValueError:
+                node_id = id
+
+            limit = int(request.query_params.get("limit", 50))
+            limit = max(1, min(limit, 200))
+
+            if self.read_from_postgres:
+                packets = await self.data.pg_storage.query_node_mqtt_messages(node_id, limit=limit)
+                return jsonable_encoder({"packets": packets})
+            else:
+                # In-memory fallback: filter mqtt_messages by from/to
+                packets = []
+                for msg in reversed(self.data.mqtt_messages):
+                    msg_from = msg.get("from")
+                    msg_to = msg.get("to")
+                    # Compare as hex string or int
+                    if isinstance(msg_from, int):
+                        msg_from = utils.convert_node_id_from_int_to_hex(msg_from)
+                    if isinstance(msg_to, int):
+                        msg_to = utils.convert_node_id_from_int_to_hex(msg_to)
+                    if msg_from == node_id or msg_to == node_id:
+                        packets.append(msg)
+                        if len(packets) >= limit:
+                            break
+                return jsonable_encoder({"packets": packets})
+
         @app.get("/v1/nodes/{id}/traceroutes")
         async def node_traceroutes(request: Request, id: str) -> JSONResponse:
             try:

--- a/api/api.py
+++ b/api/api.py
@@ -22,6 +22,24 @@ class API:
         self.data = data
         self.read_from_postgres = config.get('storage', {}).get('read_from') == 'postgres'
 
+    @staticmethod
+    def _parse_range(value: str | None) -> int | None:
+        """Convert a range string like '1h', '24h', '7d' to seconds. Returns None for 'all' or missing."""
+        if not value or value == "all":
+            return None
+        v = value.strip().lower()
+        if v.endswith("h"):
+            try:
+                return int(v[:-1]) * 3600
+            except ValueError:
+                return None
+        if v.endswith("d"):
+            try:
+                return int(v[:-1]) * 86400
+            except ValueError:
+                return None
+        return None
+
     async def serve(self):
         @app.get("/")
         async def root():
@@ -309,21 +327,25 @@ class API:
         @app.get("/v1/messages")
         async def messages(request: Request) -> JSONResponse:
             search = request.query_params.get("q")
+            range_seconds = self._parse_range(request.query_params.get("range"))
             if self.read_from_postgres:
-                limit = int(request.query_params.get("limit", 1000))
-                limit = max(1, min(limit, 5000))
+                limit = int(request.query_params.get("limit", 5000))
+                limit = max(1, min(limit, 50000))
                 results = await self.data.pg_storage.query_mqtt_messages(
-                    limit=limit, search=search,
+                    limit=limit, search=search, range_seconds=range_seconds,
                 )
                 return jsonable_encoder(results)
             return jsonable_encoder(self.data.messages[:1000])
 
         @app.get("/v1/mqtt_messages")
         async def mqtt_messages(request: Request) -> JSONResponse:
+            range_seconds = self._parse_range(request.query_params.get("range"))
             if self.read_from_postgres:
-                limit = int(request.query_params.get("limit", 1000))
-                limit = max(1, min(limit, 5000))
-                results = await self.data.pg_storage.query_mqtt_messages(limit=limit)
+                limit = int(request.query_params.get("limit", 5000))
+                limit = max(1, min(limit, 50000))
+                results = await self.data.pg_storage.query_mqtt_messages(
+                    limit=limit, range_seconds=range_seconds,
+                )
                 return jsonable_encoder(results)
             return jsonable_encoder(self.data.mqtt_messages[:1000])
 

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -473,6 +473,30 @@ export const Chat = () => {
   // Export menu
   const [exportOpen, setExportOpen] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  // Click outside sidebar panels to clear message selection
+  useEffect(() => {
+    if (!urlMsg) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const t = e.target as Node | null;
+      if (!t) return;
+      // Ignore clicks inside the sidebar (details/focus panels)
+      if (sidebarRef.current?.contains(t)) return;
+      // Ignore clicks inside mobile sheets
+      const sheet = (t as HTMLElement).closest?.("[data-mobile-sheet]");
+      if (sheet) return;
+      // Ignore clicks on interactive elements in the header/toolbar area
+      const interactive = (t as HTMLElement).closest?.(
+        "button, a, input, select, [role='button']"
+      );
+      if (interactive) return;
+
+      setParam("msg", undefined, "push");
+    };
+    window.addEventListener("mousedown", onMouseDown);
+    return () => window.removeEventListener("mousedown", onMouseDown);
+  }, [urlMsg, setParam]);
 
   // Search input
   const [qInput, setQInput] = useState(urlQ);
@@ -1663,6 +1687,13 @@ export const Chat = () => {
               title="Click to clear focus"
               onClick={() => clearFocus()}
             />
+
+            <StatusChip
+              label={urlMsg ? `Selected: ${urlMsg}` : "Selected: none"}
+              active={!!urlMsg}
+              title="Click to clear selection"
+              onClick={() => setParam("msg", undefined, "push")}
+            />
           </div>
 
           {urlNode ? (
@@ -1731,7 +1762,7 @@ export const Chat = () => {
             </div>
 
             {/* Desktop sidebar only */}
-            <div className="hidden lg:flex lg:col-span-1 flex-col gap-4 min-h-0 h-full">
+            <div ref={sidebarRef} className="hidden lg:flex lg:col-span-1 flex-col gap-4 min-h-0 h-full">
               <FocusPanel
                 urlNode={urlNode}
                 nodes={nodes}

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -262,26 +262,28 @@ function JsonBlock({ code }: { code: string }) {
 }
 
 export const Log = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlRange = (searchParams.get("r") as RangeKey) || DEFAULT_RANGE;
+
   const {
     data: rawMesh = [],
     fulfilledTimeStamp: meshUpdatedAt,
     isFetching: meshFetching,
     refetch: refetchMesh,
-  } = useGetMessagesQuery();
+  } = useGetMessagesQuery({ range: urlRange });
 
   const {
     data: rawMqtt = [],
     fulfilledTimeStamp: mqttUpdatedAt,
     isFetching: mqttFetching,
     refetch: refetchMqtt,
-  } = useGetMqttMessagesQuery();
+  } = useGetMqttMessagesQuery({ range: urlRange });
 
   const { data: config } = useGetConfigQuery();
 
   const dataUpdatedAt = Math.max(meshUpdatedAt ?? 0, mqttUpdatedAt ?? 0);
   const isFetching = meshFetching || mqttFetching;
-
-  const [searchParams, setSearchParams] = useSearchParams();
 
   // URL defaults to match UI defaults by omitting default params.
   const defaultViewKey = "all";
@@ -427,7 +429,6 @@ export const Log = () => {
     [views, selectedViewKey],
   );
 
-  const urlRange = (searchParams.get("r") as RangeKey) || DEFAULT_RANGE;
   const urlSort = (searchParams.get("s") as SortKey) || DEFAULT_SORT;
   const urlQ = searchParams.get("q") ?? "";
 
@@ -457,21 +458,6 @@ export const Log = () => {
     }
     window.prompt("Copy link:", url);
   }, []);
-
-  const nowSec = Math.floor(Date.now() / 1000);
-  const rangeThreshold = useMemo(() => {
-    switch (urlRange) {
-      case "1h":
-        return nowSec - 3600;
-      case "24h":
-        return nowSec - 86400;
-      case "7d":
-        return nowSec - 604800;
-      case "all":
-      default:
-        return undefined;
-    }
-  }, [nowSec, urlRange]);
 
   const preparedMesh: Prepared[] = useMemo(() => {
     return (rawMesh as any[]).map((m, idx) => {
@@ -592,10 +578,6 @@ export const Log = () => {
       items = items.filter((x) => x.preset === selectedViewKey);
     }
 
-    if (rangeThreshold) {
-      items = items.filter((x) => x.ts >= rangeThreshold);
-    }
-
     const q = urlQ.trim().toLowerCase();
     if (q) {
       items = items.filter((x) => x.searchText.includes(q));
@@ -606,7 +588,7 @@ export const Log = () => {
     });
 
     return items;
-  }, [baseRows, selectedViewKey, defaultViewKey, rangeThreshold, urlQ, urlSort]);
+  }, [baseRows, selectedViewKey, defaultViewKey, urlQ, urlSort]);
 
   // Export popover
   const [exportOpen, setExportOpen] = useState(false);

--- a/frontend/src/pages/chat/DetailsPanel.tsx
+++ b/frontend/src/pages/chat/DetailsPanel.tsx
@@ -190,6 +190,22 @@ export function DetailsPanel({
 
             <div>
               <div className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                Node
+              </div>
+              <div className="mt-2">
+                {String(selectedMessage.from ?? "") ? (
+                  <Link
+                    to={`/nodes/${String(selectedMessage.from)}`}
+                    className={`${baseBtn} ${defaultBtn} inline-block`}
+                  >
+                    Open from
+                  </Link>
+                ) : null}
+              </div>
+            </div>
+
+            <div>
+              <div className="text-sm font-medium text-gray-800 dark:text-gray-200">
                 Route
               </div>
 
@@ -267,7 +283,24 @@ export function DetailsPanel({
               </div>
             </div>
 
-            <div className="pt-2 flex flex-wrap gap-2">
+            <div>
+              <div className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                Packet
+              </div>
+              <div className="mt-2">
+                <Link
+                  to={`/logs?q=${String(selectedMessage.id)}`}
+                  className={`${baseBtn} ${defaultBtn} inline-block`}
+                  title="Search for this packet in logs"
+                >
+                  View in logs
+                </Link>
+              </div>
+            </div>
+
+            <hr className="border-gray-200 dark:border-gray-800" />
+
+            <div className="flex flex-wrap gap-2">
               <button
                 type="button"
                 className={[
@@ -330,14 +363,6 @@ export function DetailsPanel({
                 Focus to
               </button>
 
-              {String(selectedMessage.from ?? "") ? (
-                <Link
-                  to={`/nodes/${String(selectedMessage.from)}`}
-                  className={`${baseBtn} ${defaultBtn}`}
-                >
-                  Open from
-                </Link>
-              ) : null}
             </div>
           </div>
         )}

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -1,15 +1,16 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 
 import { Avatar } from "../../components/Avatar";
 import { HardwareImg } from "../../components/HardwareImg";
 import { Role } from "../../components/Role";
-import { useGetConfigQuery } from "../../slices/apiSlice";
+import { useGetConfigQuery, useGetNodePacketsQuery } from "../../slices/apiSlice";
 import { INode } from "../../types";
 import {
   convertNodeIdFromHexToInt,
 } from "../../utils/convertNodeId";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLinks";
+import { formatTimestamp } from "../../utils/formatTimestamp";
 import { calculateDistanceBetweenNodes } from "../../utils/getDistanceBetweenTwoNodes";
 import { NodeMap } from "../NodeMap";
 import {
@@ -95,6 +96,85 @@ function CopyLinkButton({ nodeId }: { nodeId: string }) {
     >
       {copied ? "Copied!" : "Copy link"}
     </button>
+  );
+}
+
+function RecentPackets({ nodeId }: { nodeId: string }) {
+  const { data, isFetching } = useGetNodePacketsQuery({ nodeId, limit: 50 });
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const packets = useMemo(() => data?.packets ?? [], [data]);
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Recent Packets
+          {packets.length > 0 && (
+            <span className="ml-1.5 text-xs font-normal text-gray-500 dark:text-gray-400">
+              ({packets.length})
+            </span>
+          )}
+        </div>
+        <Link
+          to={`/log?q=${nodeId}`}
+          className="text-xs underline hover:no-underline text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          View in logs
+        </Link>
+      </div>
+
+      {isFetching && packets.length === 0 ? (
+        <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          Loading...
+        </div>
+      ) : packets.length === 0 ? (
+        <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          No packets recorded for this node.
+        </div>
+      ) : (
+        <div className="mt-2 max-h-80 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-800">
+          {packets.map((pkt: any, i: number) => {
+            const key = `${pkt.id ?? i}-${pkt.timestamp ?? i}`;
+            const pktType = pkt.type ?? pkt.decoded?.portnum ?? "unknown";
+            const from = pkt.from ?? "?";
+            const to = pkt.to ?? "?";
+            const isExpanded = expanded === key;
+
+            return (
+              <button
+                key={key}
+                type="button"
+                className="w-full text-left px-1 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800/40 transition rounded"
+                onClick={() => setExpanded(isExpanded ? null : key)}
+              >
+                <div className="flex items-center gap-2 text-[11px]">
+                  <span className="text-gray-500 dark:text-gray-400 tabular-nums shrink-0">
+                    {formatTimestamp(pkt.timestamp, {
+                      year: undefined,
+                      month: undefined,
+                      day: undefined,
+                    })}
+                  </span>
+                  <span className="rounded bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 font-medium text-gray-700 dark:text-gray-300 shrink-0">
+                    {String(pktType)}
+                  </span>
+                  <span className="text-gray-400 dark:text-gray-500 truncate font-mono">
+                    {from} &rarr; {to}
+                  </span>
+                </div>
+
+                {isExpanded && (
+                  <pre className="mt-2 rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950/50 p-2 text-[10px] font-mono text-gray-700 dark:text-gray-300 overflow-x-auto whitespace-pre-wrap break-all">
+                    {JSON.stringify(pkt, null, 2)}
+                  </pre>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -318,6 +398,9 @@ export function NodeDetailsPanel({
               />
             </div>
           </div>
+
+          {/* Recent Packets */}
+          <RecentPackets nodeId={id} />
 
           {/* Map */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -8,6 +8,7 @@ import { useGetConfigQuery, useGetNodePacketsQuery } from "../../slices/apiSlice
 import { INode } from "../../types";
 import {
   convertNodeIdFromHexToInt,
+  convertNodeIdFromIntToHex,
 } from "../../utils/convertNodeId";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLinks";
 import { formatTimestamp } from "../../utils/formatTimestamp";
@@ -137,8 +138,12 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
           {packets.map((pkt: any, i: number) => {
             const key = `${pkt.id ?? i}-${pkt.timestamp ?? i}`;
             const pktType = pkt.type ?? pkt.decoded?.portnum ?? "unknown";
-            const from = String(pkt.from ?? "?");
-            const to = String(pkt.to ?? "?");
+            const from = typeof pkt.from === "number"
+              ? convertNodeIdFromIntToHex(pkt.from)
+              : String(pkt.from ?? "?").replace(/^!/, "");
+            const to = typeof pkt.to === "number"
+              ? convertNodeIdFromIntToHex(pkt.to)
+              : String(pkt.to ?? "?").replace(/^!/, "");
             const isSent = from === nodeId;
             const other = isSent ? to : from;
             const isExpanded = expanded === key;

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -107,13 +107,21 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
 
   return (
     <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">
-      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-        Recent Packets
-        {packets.length > 0 && (
-          <span className="ml-1.5 text-xs font-normal text-gray-500 dark:text-gray-400">
-            ({packets.length})
-          </span>
-        )}
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Recent Packets
+          {packets.length > 0 && (
+            <span className="ml-1.5 text-xs font-normal text-gray-500 dark:text-gray-400">
+              ({packets.length})
+            </span>
+          )}
+        </div>
+        <Link
+          to={`/logs?q=${nodeId}`}
+          className="text-xs underline hover:no-underline text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          View in logs
+        </Link>
       </div>
 
       {isFetching && packets.length === 0 ? (

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -107,21 +107,13 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
 
   return (
     <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">
-      <div className="flex items-center justify-between">
-        <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-          Recent Packets
-          {packets.length > 0 && (
-            <span className="ml-1.5 text-xs font-normal text-gray-500 dark:text-gray-400">
-              ({packets.length})
-            </span>
-          )}
-        </div>
-        <Link
-          to={`/log?q=${nodeId}`}
-          className="text-xs underline hover:no-underline text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
-        >
-          View in logs
-        </Link>
+      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+        Recent Packets
+        {packets.length > 0 && (
+          <span className="ml-1.5 text-xs font-normal text-gray-500 dark:text-gray-400">
+            ({packets.length})
+          </span>
+        )}
       </div>
 
       {isFetching && packets.length === 0 ? (
@@ -137,8 +129,10 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
           {packets.map((pkt: any, i: number) => {
             const key = `${pkt.id ?? i}-${pkt.timestamp ?? i}`;
             const pktType = pkt.type ?? pkt.decoded?.portnum ?? "unknown";
-            const from = pkt.from ?? "?";
-            const to = pkt.to ?? "?";
+            const from = String(pkt.from ?? "?");
+            const to = String(pkt.to ?? "?");
+            const isSent = from === nodeId;
+            const other = isSent ? to : from;
             const isExpanded = expanded === key;
 
             return (
@@ -160,7 +154,7 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
                     {String(pktType)}
                   </span>
                   <span className="text-gray-400 dark:text-gray-500 truncate font-mono">
-                    {from} &rarr; {to}
+                    {isSent ? "\u2192" : "\u2190"} {other}
                   </span>
                 </div>
 
@@ -399,9 +393,6 @@ export function NodeDetailsPanel({
             </div>
           </div>
 
-          {/* Recent Packets */}
-          <RecentPackets nodeId={id} />
-
           {/* Map */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">
             <div className="flex items-center justify-between">
@@ -427,6 +418,9 @@ export function NodeDetailsPanel({
               )}
             </div>
           </div>
+
+          {/* Recent Packets */}
+          <RecentPackets nodeId={id} />
 
           {/* Elsewhere */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -113,12 +113,30 @@ export const apiSlice = createApi({
       query: () => "traceroutes",
       providesTags: [{ type: "Traceroutes", id: "LIST" }],
     }),
-    getMessages: builder.query<IMessagesResponse[], void>({
-      query: () => "messages",
+    getMessages: builder.query<
+      IMessagesResponse[],
+      { range?: string } | void
+    >({
+      query: (params) => {
+        const sp = new URLSearchParams();
+        if (params && params.range && params.range !== "all")
+          sp.set("range", params.range);
+        const qs = sp.toString();
+        return qs ? `messages?${qs}` : "messages";
+      },
       providesTags: [{ type: "Messages", id: "LIST" }],
     }),
-    getMqttMessages: builder.query<IMqttMessagesResponse[], void>({
-      query: () => "mqtt_messages",
+    getMqttMessages: builder.query<
+      IMqttMessagesResponse[],
+      { range?: string } | void
+    >({
+      query: (params) => {
+        const sp = new URLSearchParams();
+        if (params && params.range && params.range !== "all")
+          sp.set("range", params.range);
+        const qs = sp.toString();
+        return qs ? `mqtt_messages?${qs}` : "mqtt_messages";
+      },
       providesTags: [{ type: "MqttMessages", id: "LIST" }],
     }),
     getNodePackets: builder.query<

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -121,6 +121,15 @@ export const apiSlice = createApi({
       query: () => "mqtt_messages",
       providesTags: [{ type: "MqttMessages", id: "LIST" }],
     }),
+    getNodePackets: builder.query<
+      { packets: IMqttMessagesResponse[] },
+      { nodeId: string; limit?: number }
+    >({
+      query: ({ nodeId, limit = 50 }) => `nodes/${nodeId}/packets?limit=${limit}`,
+      providesTags: (_result, _error, { nodeId }) => [
+        { type: "MqttMessages", id: nodeId },
+      ],
+    }),
   }),
 });
 
@@ -133,4 +142,5 @@ export const {
   useGetTraceroutesQuery,
   useGetMessagesQuery,
   useGetMqttMessagesQuery,
+  useGetNodePacketsQuery,
 } = apiSlice;

--- a/mqtt.py
+++ b/mqtt.py
@@ -82,6 +82,11 @@ class MQTT:
                     se.ParseFromString(msg.payload)
                     mp = se.packet
                     outs = json.loads(MessageToJson(mp, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
+                    # Extract gateway_id (the node that uplinked this packet to MQTT)
+                    if se.gateway_id:
+                        gw = se.gateway_id.replace('!', '')
+                        if len(gw) <= 8:
+                            outs['sender'] = gw
                     logger.debug("Decoded protobuf message: %s", outs)
                 except Exception as _:
                     pass
@@ -101,7 +106,10 @@ class MQTT:
                             data = mesh_pb2.Data()
                             data.ParseFromString(decrypted_bytes)
                             mp.decoded.CopyFrom(data)
+                            saved_sender = outs.get('sender')
                             outs = json.loads(MessageToJson(mp, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
+                            if saved_sender:
+                                outs['sender'] = saved_sender
                             break
                         except Exception as e:
                             logger.debug("Decryption failed: %s", e)
@@ -302,6 +310,12 @@ class MQTT:
                     j['topic'] = msg.topic.value
                     j["qos"] = getattr(msg, "qos", None)
                     j["retain"] = getattr(msg, "retain", None)
+
+                    # Extract gateway node from topic suffix (e.g. msh/US/2/json/LongFast/!67ea9400)
+                    if 'sender' not in j or not j.get('sender'):
+                        topic_parts = msg.topic.value.split('/')
+                        if topic_parts and topic_parts[-1].startswith('!'):
+                            j['sender'] = topic_parts[-1].replace('!', '')
 
                     await self.handle_log(j)
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -129,6 +129,12 @@ class MQTT:
                 outs["qos"] = getattr(msg, "qos", None)
                 outs["retain"] = getattr(msg, "retain", None)
 
+                # Fallback: extract gateway from topic suffix if gateway_id was empty
+                if not outs.get('sender'):
+                    topic_parts = msg.topic.value.split('/')
+                    if topic_parts and topic_parts[-1].startswith('!'):
+                        outs['sender'] = topic_parts[-1].replace('!', '')
+
                 # Calculate hops_away from hop_start and hop_limit
                 hop_start = outs.get("hop_start")
                 hop_limit = outs.get("hop_limit")

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -196,6 +196,12 @@ CREATE TABLE IF NOT EXISTS mqtt_messages (
 CREATE INDEX IF NOT EXISTS idx_mqtt_messages_created_at ON mqtt_messages(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_mqtt_messages_timestamp ON mqtt_messages(timestamp DESC);
 
+-- Node ID columns for filtered packet queries (managed via ensure_schema migrations)
+ALTER TABLE mqtt_messages ADD COLUMN IF NOT EXISTS from_node_id VARCHAR(8);
+ALTER TABLE mqtt_messages ADD COLUMN IF NOT EXISTS to_node_id VARCHAR(8);
+CREATE INDEX IF NOT EXISTS idx_mqtt_messages_from_node_id ON mqtt_messages(from_node_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mqtt_messages_to_node_id ON mqtt_messages(to_node_id, created_at DESC);
+
 -- Neighbor snapshot history table (currently unused, for time-lapse update later on)
 CREATE TABLE IF NOT EXISTS node_neighborinfo_history (
   id BIGSERIAL PRIMARY KEY,

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -161,19 +161,23 @@ class PostgresStorage:
                         v_from TEXT;
                         v_to TEXT;
                     BEGIN
-                        IF NEW.from_node_id IS NULL AND NEW.payload IS NOT NULL AND NEW.payload ~ '^\\s*\\{' THEN
+                        IF (NEW.from_node_id IS NULL OR NEW.to_node_id IS NULL) AND NEW.payload IS NOT NULL AND NEW.payload ~ '^\\s*\\{' THEN
                             BEGIN
                                 v_from := NEW.payload::jsonb ->> 'from';
                                 v_to   := NEW.payload::jsonb ->> 'to';
-                                IF v_from IS NOT NULL AND v_from ~ '^[0-9]+$' THEN
-                                    NEW.from_node_id := lpad(to_hex(v_from::bigint), 8, '0');
-                                ELSE
-                                    NEW.from_node_id := left(v_from, 8);
+                                IF NEW.from_node_id IS NULL AND v_from IS NOT NULL THEN
+                                    IF v_from ~ '^[0-9]+$' THEN
+                                        NEW.from_node_id := lpad(to_hex(v_from::bigint), 8, '0');
+                                    ELSE
+                                        NEW.from_node_id := left(regexp_replace(v_from, '^!', ''), 8);
+                                    END IF;
                                 END IF;
-                                IF v_to IS NOT NULL AND v_to ~ '^[0-9]+$' THEN
-                                    NEW.to_node_id := lpad(to_hex(v_to::bigint), 8, '0');
-                                ELSE
-                                    NEW.to_node_id := left(v_to, 8);
+                                IF NEW.to_node_id IS NULL AND v_to IS NOT NULL THEN
+                                    IF v_to ~ '^[0-9]+$' THEN
+                                        NEW.to_node_id := lpad(to_hex(v_to::bigint), 8, '0');
+                                    ELSE
+                                        NEW.to_node_id := left(regexp_replace(v_to, '^!', ''), 8);
+                                    END IF;
                                 END IF;
                             EXCEPTION WHEN OTHERS THEN
                                 NULL;
@@ -227,30 +231,17 @@ class PostgresStorage:
                             # Mark as processed with empty node IDs so we don't retry
                             updates.append((row["id"], "", ""))
                             continue
-                        raw_from = j.get("from")
-                        raw_to = j.get("to")
-                        fid = ""
-                        tid = ""
-                        if isinstance(raw_from, int):
-                            fid = f"{raw_from:08x}"
-                        elif isinstance(raw_from, str) and raw_from:
-                            fid = raw_from.replace("!", "")[:8]
-                        if isinstance(raw_to, int):
-                            tid = f"{raw_to:08x}"
-                        elif isinstance(raw_to, str) and raw_to:
-                            tid = raw_to.replace("!", "")[:8]
-                        updates.append((row["id"], fid or "", tid or ""))
+                        fid = self._normalize_node_id(j.get("from")) or ""
+                        tid = self._normalize_node_id(j.get("to")) or ""
+                        updates.append((row["id"], fid, tid))
                     if updates:
                         await conn.executemany("""
                             UPDATE mqtt_messages
                             SET from_node_id = $2, to_node_id = $3
                             WHERE id = $1
                         """, updates)
-                    result = f"UPDATE {len(updates)}"
-                    # result is e.g. "UPDATE 5000"
-                    count = int(result.split()[-1]) if result else 0
-                    total += count
-                    if count < BATCH:
+                    total += len(updates)
+                    if len(updates) < BATCH:
                         break
             if total > 0:
                 logger.info(f"MQTT node-ID backfill complete: {total} rows updated")
@@ -1022,16 +1013,8 @@ class PostgresStorage:
         from_node_id = None
         to_node_id = None
         if isinstance(mqtt_msg, dict):
-            raw_from = mqtt_msg.get("from")
-            raw_to = mqtt_msg.get("to")
-            if isinstance(raw_from, int):
-                from_node_id = f"{raw_from:08x}"
-            elif isinstance(raw_from, str) and raw_from:
-                from_node_id = raw_from.replace("!", "")[:8]
-            if isinstance(raw_to, int):
-                to_node_id = f"{raw_to:08x}"
-            elif isinstance(raw_to, str) and raw_to:
-                to_node_id = raw_to.replace("!", "")[:8]
+            from_node_id = self._normalize_node_id(mqtt_msg.get("from"))
+            to_node_id = self._normalize_node_id(mqtt_msg.get("to"))
 
         try:
             async with self.pool.acquire() as conn:
@@ -1126,6 +1109,7 @@ class PostgresStorage:
         """Query mqtt_messages for a specific node (as sender or recipient)."""
         if not self._ready("query_node_mqtt_messages"):
             return []
+        node_id = self._normalize_node_id(node_id) or node_id
         try:
             async with self.pool.acquire() as conn:
                 rows = await conn.fetch(

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -1053,33 +1053,53 @@ class PostgresStorage:
             if self.raise_on_write_error:
                 raise
 
-    async def query_mqtt_messages(self, limit: int = 1000, search: str | None = None) -> list:
+    async def query_mqtt_messages(
+        self,
+        limit: int = 1000,
+        search: str | None = None,
+        range_seconds: int | None = None,
+    ) -> list:
         """Query mqtt_messages from PostgreSQL, returning parsed message dicts.
 
         Args:
             limit: Max messages to return.
             search: Optional search term to filter by topic or payload content.
+            range_seconds: If provided, only include messages with
+                        timestamp >= (now_unix - range_seconds).
         """
         if not self._ready("query_mqtt_messages"):
             return []
         try:
+            import time
             async with self.pool.acquire() as conn:
+                conditions = []
+                params: list = []
+                idx = 1
+
+                if range_seconds is not None:
+                    threshold = int(time.time()) - range_seconds
+                    conditions.append(f"timestamp >= ${idx}")
+                    params.append(threshold)
+                    idx += 1
+
                 if search:
-                    rows = await conn.fetch(
-                        """SELECT topic, payload, qos, retain, timestamp, created_at
-                           FROM mqtt_messages
-                           WHERE topic ILIKE '%' || $1 || '%'
-                              OR payload ILIKE '%' || $1 || '%'
-                           ORDER BY created_at DESC LIMIT $2""",
-                        search, limit,
+                    conditions.append(
+                        f"(topic ILIKE '%' || ${idx} || '%'"
+                        f" OR payload ILIKE '%' || ${idx} || '%')"
                     )
-                else:
-                    rows = await conn.fetch(
-                        """SELECT topic, payload, qos, retain, timestamp, created_at
-                           FROM mqtt_messages
-                           ORDER BY created_at DESC LIMIT $1""",
-                        limit,
-                    )
+                    params.append(search)
+                    idx += 1
+
+                where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+                params.append(limit)
+
+                rows = await conn.fetch(
+                    f"""SELECT topic, payload, qos, retain, timestamp, created_at
+                        FROM mqtt_messages
+                        {where}
+                        ORDER BY created_at DESC LIMIT ${idx}""",
+                    *params,
+                )
 
             results = []
             for row in rows:

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -150,6 +150,115 @@ class PostgresStorage:
             if self.raise_on_write_error:
                 raise
 
+        # Mqtt node-ID trigger + backfill — run independently so a failure here
+        # does not prevent the core schema from being applied.
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.execute("""
+                    CREATE OR REPLACE FUNCTION mqtt_messages_extract_node_ids()
+                    RETURNS TRIGGER AS $fn$
+                    DECLARE
+                        v_from TEXT;
+                        v_to TEXT;
+                    BEGIN
+                        IF NEW.from_node_id IS NULL AND NEW.payload IS NOT NULL AND NEW.payload ~ '^\\s*\\{' THEN
+                            BEGIN
+                                v_from := NEW.payload::jsonb ->> 'from';
+                                v_to   := NEW.payload::jsonb ->> 'to';
+                                IF v_from IS NOT NULL AND v_from ~ '^[0-9]+$' THEN
+                                    NEW.from_node_id := lpad(to_hex(v_from::bigint), 8, '0');
+                                ELSE
+                                    NEW.from_node_id := left(v_from, 8);
+                                END IF;
+                                IF v_to IS NOT NULL AND v_to ~ '^[0-9]+$' THEN
+                                    NEW.to_node_id := lpad(to_hex(v_to::bigint), 8, '0');
+                                ELSE
+                                    NEW.to_node_id := left(v_to, 8);
+                                END IF;
+                            EXCEPTION WHEN OTHERS THEN
+                                NULL;
+                            END;
+                        END IF;
+                        RETURN NEW;
+                    END;
+                    $fn$ LANGUAGE plpgsql;
+                """)
+                await conn.execute("""
+                    DROP TRIGGER IF EXISTS trg_mqtt_messages_extract_node_ids ON mqtt_messages;
+                """)
+                await conn.execute("""
+                    CREATE TRIGGER trg_mqtt_messages_extract_node_ids
+                        BEFORE INSERT ON mqtt_messages
+                        FOR EACH ROW
+                        EXECUTE FUNCTION mqtt_messages_extract_node_ids();
+                """)
+                logger.info("MQTT node-ID trigger installed")
+        except Exception as e:
+            logger.warning(f"MQTT node-ID trigger setup skipped: {e}")
+
+        # Backfill existing rows in the background — don't block startup
+        import asyncio
+        asyncio.ensure_future(self._backfill_mqtt_node_ids())
+
+    async def _backfill_mqtt_node_ids(self):
+        """Backfill from_node_id/to_node_id for existing mqtt_messages rows in batches."""
+        BATCH = 5000
+        total = 0
+        try:
+            while True:
+                async with self.pool.acquire() as conn:
+                    await conn.execute("SET statement_timeout = '120s'")
+                    # Fetch candidate IDs and parse in Python to skip bad payloads
+                    rows = await conn.fetch("""
+                        SELECT id, payload
+                        FROM mqtt_messages
+                        WHERE from_node_id IS NULL
+                          AND payload IS NOT NULL
+                          AND payload ~ '^\\s*\\{'
+                        LIMIT $1
+                    """, BATCH)
+                    if not rows:
+                        break
+                    updates = []
+                    for row in rows:
+                        try:
+                            j = json.loads(row["payload"])
+                        except Exception:
+                            # Mark as processed with empty node IDs so we don't retry
+                            updates.append((row["id"], "", ""))
+                            continue
+                        raw_from = j.get("from")
+                        raw_to = j.get("to")
+                        fid = ""
+                        tid = ""
+                        if isinstance(raw_from, int):
+                            fid = f"{raw_from:08x}"
+                        elif isinstance(raw_from, str) and raw_from:
+                            fid = raw_from.replace("!", "")[:8]
+                        if isinstance(raw_to, int):
+                            tid = f"{raw_to:08x}"
+                        elif isinstance(raw_to, str) and raw_to:
+                            tid = raw_to.replace("!", "")[:8]
+                        updates.append((row["id"], fid or "", tid or ""))
+                    if updates:
+                        await conn.executemany("""
+                            UPDATE mqtt_messages
+                            SET from_node_id = $2, to_node_id = $3
+                            WHERE id = $1
+                        """, updates)
+                    result = f"UPDATE {len(updates)}"
+                    # result is e.g. "UPDATE 5000"
+                    count = int(result.split()[-1]) if result else 0
+                    total += count
+                    if count < BATCH:
+                        break
+            if total > 0:
+                logger.info(f"MQTT node-ID backfill complete: {total} rows updated")
+            else:
+                logger.info("MQTT node-ID backfill: nothing to do")
+        except Exception as e:
+            logger.warning(f"MQTT node-ID backfill failed after {total} rows: {type(e).__name__}: {e}")
+
     # --------------------------- readiness helper ---------------------------
 
     def _ready(self, op: str) -> bool:
@@ -909,18 +1018,35 @@ class PostgresStorage:
         except (TypeError, ValueError):
             ts_i = None
 
+        # Extract from/to node IDs for indexed filtering
+        from_node_id = None
+        to_node_id = None
+        if isinstance(mqtt_msg, dict):
+            raw_from = mqtt_msg.get("from")
+            raw_to = mqtt_msg.get("to")
+            if isinstance(raw_from, int):
+                from_node_id = f"{raw_from:08x}"
+            elif isinstance(raw_from, str) and raw_from:
+                from_node_id = raw_from.replace("!", "")[:8]
+            if isinstance(raw_to, int):
+                to_node_id = f"{raw_to:08x}"
+            elif isinstance(raw_to, str) and raw_to:
+                to_node_id = raw_to.replace("!", "")[:8]
+
         try:
             async with self.pool.acquire() as conn:
                 await conn.execute(
                     """
-                    INSERT INTO mqtt_messages (topic, payload, qos, retain, timestamp)
-                    VALUES ($1, $2, $3, $4, $5)
+                    INSERT INTO mqtt_messages (topic, payload, qos, retain, timestamp, from_node_id, to_node_id)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
                     """,
                     topic,
                     payload_text,
                     qos_i,
                     retain_b,
                     ts_i,
+                    from_node_id,
+                    to_node_id,
                 )
         except Exception as e:
             logger.error(f"Failed to write mqtt message to PostgreSQL: {e}")
@@ -974,6 +1100,40 @@ class PostgresStorage:
             return results
         except Exception as e:
             logger.error("Failed to query mqtt_messages: %s", e)
+            return []
+
+    async def query_node_mqtt_messages(self, node_id: str, limit: int = 50) -> list:
+        """Query mqtt_messages for a specific node (as sender or recipient)."""
+        if not self._ready("query_node_mqtt_messages"):
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """SELECT topic, payload, qos, retain, timestamp, created_at
+                       FROM mqtt_messages
+                       WHERE from_node_id = $1 OR to_node_id = $1
+                       ORDER BY created_at DESC LIMIT $2""",
+                    node_id, limit,
+                )
+
+            results = []
+            for row in rows:
+                payload_text = row["payload"]
+                if payload_text:
+                    try:
+                        msg = json.loads(payload_text)
+                    except (json.JSONDecodeError, TypeError):
+                        msg = {"raw": payload_text}
+                else:
+                    msg = {}
+                if "topic" not in msg:
+                    msg["topic"] = row["topic"]
+                if "timestamp" not in msg:
+                    msg["timestamp"] = row["timestamp"]
+                results.append(msg)
+            return results
+        except Exception as e:
+            logger.error("Failed to query node mqtt_messages: %s", e)
             return []
 
     # ============================================================================


### PR DESCRIPTION
## Summary

- **Recent Packets panel** on node details page — shows last 50 raw packets for a selected node with expandable JSON, powered by new indexed `from_node_id`/`to_node_id` columns on `mqtt_messages` and a new `GET /v1/nodes/{id}/packets` endpoint (closes #410)
- **Server-side log range filtering** — Logs page now queries Postgres with time range (`1h`/`24h`/`7d`/`all`) instead of fetching 1,000 rows and filtering client-side, enabling full historical log access
- **Gateway/sender extraction** — Extract `gateway_id` from protobuf `ServiceEnvelope` and MQTT topic suffix so chat messages show the actual relay gateway instead of "UNK" (closes #427)
- **Chat details panel** — reorganized into Text/Node/Route/Packet sections with "View in logs" link; added click-outside-to-deselect and "Selected" status chip
- **Schema migration** — adds `from_node_id`/`to_node_id` columns with indexes and a background backfill for existing rows; includes a DB trigger as fallback for node ID extraction
