### PR TITLE
fix(build): compile ITM WASM in Dockerfile.spa(.dev) and ship it via public/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
 caddy
 output
 postgres
+# Host node_modules would clobber the container install and drop .bin shims.
+frontend/node_modules
+# Regenerated inside the wasm-build stage.
+frontend/wasm/itm/vendor
+frontend/wasm/itm/dist
+frontend/wasm/itm/fixtures

--- a/Dockerfile.spa
+++ b/Dockerfile.spa
@@ -1,3 +1,13 @@
+# Compile NTIA ITM to WASM. Pinned to same emsdk as frontend/wasm/itm/Dockerfile.
+FROM emscripten/emsdk:3.1.65 AS wasm-build
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /itm
+COPY frontend/wasm/itm/fetch-vendor.sh frontend/wasm/itm/build.sh frontend/wasm/itm/shim.h ./
+RUN chmod +x fetch-vendor.sh build.sh && ./fetch-vendor.sh && ./build.sh
+
 FROM node:25.9.0-alpine AS build
 
 LABEL org.opencontainers.image.source="https://github.com/MeshAddicts/meshinfo"
@@ -18,6 +28,12 @@ COPY frontend/.yarn ./.yarn
 RUN yarn install --immutable
 
 COPY frontend/ ./
+
+# .d.ts for tsc; .js goes to public/ because the worker's @vite-ignore'd
+# import expects /generated/itm/itm.js at a fixed URL.
+COPY --from=wasm-build /itm/dist/itm.d.ts ./src/generated/itm/itm.d.ts
+RUN mkdir -p ./public/generated/itm
+COPY --from=wasm-build /itm/dist/itm.js ./public/generated/itm/itm.js
 
 RUN yarn build --base=/
 

--- a/Dockerfile.spa.dev
+++ b/Dockerfile.spa.dev
@@ -1,3 +1,13 @@
+# Compile NTIA ITM to WASM (see Dockerfile.spa for details).
+FROM emscripten/emsdk:3.1.65 AS wasm-build
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /itm
+COPY frontend/wasm/itm/fetch-vendor.sh frontend/wasm/itm/build.sh frontend/wasm/itm/shim.h ./
+RUN chmod +x fetch-vendor.sh build.sh && ./fetch-vendor.sh && ./build.sh
+
 # trunk-ignore-all(checkov/CKV_DOCKER_3)
 FROM node:25.9.0-alpine
 
@@ -5,6 +15,12 @@ LABEL org.opencontainers.image.source="https://github.com/MeshAddicts/meshinfo"
 LABEL org.opencontainers.image.description="Realtime web UI to run against a Meshtastic regional or private mesh network."
 
 COPY . .
+
+# src/ copy for vite dev's module resolution; public/ copy mirrors prod.
+COPY --from=wasm-build /itm/dist/itm.js /frontend/src/generated/itm/itm.js
+COPY --from=wasm-build /itm/dist/itm.d.ts /frontend/src/generated/itm/itm.d.ts
+RUN mkdir -p /frontend/public/generated/itm
+COPY --from=wasm-build /itm/dist/itm.js /frontend/public/generated/itm/itm.js
 
 WORKDIR /frontend
 


### PR DESCRIPTION
# fix(build): compile ITM WASM in Docker, ship via public/

## Summary
The Coverage tool was broken on the published `ghcr.io/meshaddicts/meshinfo-spa:latest` image because the ITM WebAssembly module was never built during CI. Two issues:

1. `Dockerfile.spa` ran `yarn build` but never `yarn build:wasm`, so the placeholder `itm.js` shipped to production.
2. Even with a real `itm.js` in `src/generated/itm/`, the `@vite-ignore` on the dynamic import in [itm.ts](frontend/src/pages/map/itm.ts) means Vite doesn't bundle or copy the file — it must exist at a fixed URL (`/generated/itm/itm.js`).

## Fix
- **Dockerfile.spa / Dockerfile.spa.dev** — new `wasm-build` stage (`emscripten/emsdk:3.1.65`) compiles NTIA ITM v1.4 to WASM, then copies `itm.d.ts` into `src/generated/itm/` (for tsc) and `itm.js` into `public/generated/itm/` (Vite serves `public/` verbatim to `dist/`, matching the worker's expected URL).
- **.dockerignore** — excludes `frontend/node_modules` and the WASM stage's intermediate dirs.

## Impact
- First clean build adds ~3–5 min (emsdk pull + source clone + compile); subsequent builds are cached.
- No frontend code changes.
- Fixes Coverage / LOS / Scan tools for everyone deploying from the published image.