### PR TITLE
# fix(ci): pin WASM build stage to linux/amd64 for arm64 runner compat

### DIFF
--- a/Dockerfile.spa
+++ b/Dockerfile.spa
@@ -1,5 +1,7 @@
 # Compile NTIA ITM to WASM. Pinned to same emsdk as frontend/wasm/itm/Dockerfile.
-FROM emscripten/emsdk:3.1.65 AS wasm-build
+# --platform=linux/amd64: emsdk only publishes amd64; WASM output is arch-neutral
+# so QEMU-emulating this stage on arm64 runners is fine.
+FROM --platform=linux/amd64 emscripten/emsdk:3.1.65 AS wasm-build
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.spa.dev
+++ b/Dockerfile.spa.dev
@@ -1,5 +1,5 @@
 # Compile NTIA ITM to WASM (see Dockerfile.spa for details).
-FROM emscripten/emsdk:3.1.65 AS wasm-build
+FROM --platform=linux/amd64 emscripten/emsdk:3.1.65 AS wasm-build
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
The WASM multi-stage build added in the previous PR failed on the `linux/arm64` runner because `emscripten/emsdk:3.1.65` only publishes amd64 images. Without a platform pin, buildx pulled the amd64 image and tried to `exec` it on arm64 — `exec format error`.

## Fix
Pinned the `wasm-build` stage to `--platform=linux/amd64` in both `Dockerfile.spa` and `Dockerfile.spa.dev`. BuildKit emulates amd64 via QEMU on arm64 runners for that stage only.

## Impact
- **Runtime image is still native arm64** — only the WASM compile stage runs emulated.
- Only artifacts crossing the stage boundary are `itm.js` + `itm.d.ts` (plain text; the WASM bytecode inside is architecture-neutral).
- Arm64 build adds ~2–3 min (QEMU emulation of emcc compile). Amd64 build unchanged.
- Zero user-facing change.