### PR TITLE
fix(caddy): 404 missing assets instead of serving index.html

### DIFF
--- a/Caddyfile.frontend
+++ b/Caddyfile.frontend
@@ -2,6 +2,18 @@
 	encode gzip
 
 	root * /srv
-	try_files {path} /index.html
-	file_server
+
+	# Real assets 404 cleanly instead of falling through to index.html.
+	# Without this the SPA fallback returns HTML with 200, which CDNs (CF)
+	# then cache as a "successful" text/html response for the asset URL.
+	@assets path *.js *.css *.wasm *.map *.json *.png *.jpg *.jpeg *.svg *.webp *.ico *.woff *.woff2 *.ttf *.otf
+	handle @assets {
+		file_server
+	}
+
+	# SPA routes — fall back to index.html for client-side routing.
+	handle {
+		try_files {path} /index.html
+		file_server
+	}
 }


### PR DESCRIPTION
prevents issue where Cloudflare caches incorrect data