### PR TITLE
Map and node panel UX improvements (#437, #444, #445, #434)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -297,6 +297,7 @@ export function Map() {
 
   // Mapbox refs
   const mbMapRef = useRef<MbMap | null>(null);
+  const clusterDonutLayerRef = useRef<ClusterDonutLayer | null>(null);
   const mbSelectedIdRef = useRef<string | null>(null);
   const mbHandlersBoundRef = useRef(false);
   const mbCurrentStyleUrlRef = useRef<string | null>(null);
@@ -1984,6 +1985,23 @@ export function Map() {
     } catch {}
   }, [activeTool, showCoverageRays, coverageResult]);
 
+  // Dim cluster donuts/count once a tool reaches its result step (origin placed / link picked)
+  // so the raster + overlays read clearly.
+  useEffect(() => {
+    const dimmed = activeTool != null && toolStep === "result";
+    const alpha = dimmed ? 0.25 : 1;
+
+    clusterDonutLayerRef.current?.setAlpha(alpha);
+
+    const mb = mbMapRef.current;
+    if (mb && mb.getLayer("clusters-count")) {
+      try { mb.setPaintProperty("clusters-count", "text-opacity", alpha); } catch {}
+    }
+
+    const olCluster = olClusterSetupRef.current?.clusterLayer;
+    if (olCluster) olCluster.setOpacity(alpha);
+  }, [activeTool, toolStep]);
+
   // Sync coverage pin to origin (node pick or virtual placement)
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -3009,7 +3027,10 @@ export function Map() {
       }
 
       if (!map.getLayer("clusters-donuts")) {
-        map.addLayer(new ClusterDonutLayer());
+        const donutLayer = new ClusterDonutLayer();
+        map.addLayer(donutLayer);
+        clusterDonutLayerRef.current = donutLayer;
+        if (activeToolRef.current != null && toolStepRef.current === "result") donutLayer.setAlpha(0.25);
       }
 
       if (!map.getLayer("clusters-count")) {
@@ -3028,6 +3049,7 @@ export function Map() {
           },
           paint: {
             "text-color": "#ffffff",
+            "text-opacity": activeToolRef.current != null && toolStepRef.current === "result" ? 0.25 : 1,
           },
         });
       }
@@ -4006,6 +4028,9 @@ export function Map() {
 
     const clusterSetup = createOlClusterLayer(features);
     olClusterSetupRef.current = clusterSetup;
+    if (activeToolRef.current != null && toolStepRef.current === "result") {
+      clusterSetup.clusterLayer.setOpacity(0.25);
+    }
 
     // Add the appropriate layer based on cluster setting
     if (clusterEnabledRef.current) {

--- a/frontend/src/pages/map/MapDetailsPanel.tsx
+++ b/frontend/src/pages/map/MapDetailsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { roleTitles, type NodeRole } from "../../types";
+import { HardwareModel, roleTitles, type NodeRole } from "../../types";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLinks";
 import { ROLE_COLORS, DEFAULT_NODE_COLOR } from "./utils";
 import { calculateGeodesicDistance } from "./utils";
@@ -22,6 +22,13 @@ function formatLastSeen(raw: string | null | undefined): string {
     second: "2-digit",
     hour12: false,
   });
+}
+
+function formatHardwareLabel(model: number | null | undefined): string | null {
+  if (model == null) return null;
+  const name = HardwareModel[model as HardwareModel] as string | undefined;
+  if (!name) return null;
+  return name.replace(/_/g, " ").replace(/\bV(\d)/g, "v$1");
 }
 
 function shortenLocation(full: string): string {
@@ -222,6 +229,8 @@ export function MapDetailsPanel({
   const nodeIdInt = parseInt(node.id, 16);
   const elsewhereLinks = getElsewhereLinks(data.elsewhereLinks);
 
+  const hardwareLabel = formatHardwareLabel(liveNodes[node.id]?.hardware);
+
   const heardByRows = data.heardBy.map((nid) => {
     const nnode = liveNodes[nid];
     const neighbor = nnode?.neighbors?.find((n) => n.id === node.id);
@@ -339,6 +348,12 @@ export function MapDetailsPanel({
             {node.position[1].toFixed(5)}, {node.position[0].toFixed(5)}
           </div>
         </div>
+        {hardwareLabel && (
+          <div>
+            <div className="text-gray-500 text-[10px] uppercase tracking-wider">Hardware</div>
+            <div className="text-gray-300 truncate" title={hardwareLabel}>{hardwareLabel}</div>
+          </div>
+        )}
         {data.maxRangeKm != null && (
           <div>
             <div className="text-gray-500 text-[10px] uppercase tracking-wider">Max Range</div>

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -1,9 +1,40 @@
 import { useEffect, useState } from "react";
 import { ElevationProfile } from "./ElevationProfile";
-import { COMMON_ANTENNAS, COMMON_HARDWARE } from "./coverageAnalysis";
+import {
+  COMMON_ANTENNAS,
+  COMMON_HARDWARE,
+  effectiveSensitivityDbm,
+  MESHTASTIC_PRESETS,
+} from "./coverageAnalysis";
 import type { LoSResult } from "./losAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
+
+/** Modem preset assumed for link-budget readout in this panel.
+ *  LongFast = Meshtastic default mesh setting; -130 dBm typical SX1262 sensitivity. */
+const LOS_PRESET = MESHTASTIC_PRESETS.find((p) => p.id === "LongFast") ?? MESHTASTIC_PRESETS[1];
+
+/** One-direction link budget. Returns null if hw/ant lookups fail. */
+function dirLinkBudget(
+  txHwIdx: number,
+  txAntIdx: number,
+  rxHwIdx: number,
+  rxAntIdx: number,
+  itmLossDb: number,
+): { rssiDbm: number; marginDb: number; sensitivityDbm: number } | null {
+  const txHw = COMMON_HARDWARE[txHwIdx];
+  const txAnt = COMMON_ANTENNAS[txAntIdx];
+  const rxHw = COMMON_HARDWARE[rxHwIdx];
+  const rxAnt = COMMON_ANTENNAS[rxAntIdx];
+  if (!txHw || !txAnt || !rxHw || !rxAnt) return null;
+  const rssiDbm = txHw.txDbm + txAnt.dbi + rxAnt.dbi - itmLossDb;
+  const sensitivityDbm = effectiveSensitivityDbm(
+    LOS_PRESET.sensitivityDbm,
+    rxHw.chipset,
+    rxHw.sensitivityOffsetDb ?? 0,
+  );
+  return { rssiDbm, marginDb: rssiDbm - sensitivityDbm, sensitivityDbm };
+}
 
 /** Endpoint config column: hardware/antenna/height for one end of the LOS link. */
 function EndpointConfig({
@@ -243,6 +274,20 @@ export function MapLosPanel({
     red: "bg-red-400",
   }[statusColor];
 
+  // Link budget per direction (TX→RX = from→to and to→from). Both must work for a usable link.
+  const fwd = los.itmLossDb != null
+    ? dirLinkBudget(fromHwIdx, fromAntIdx, toHwIdx, toAntIdx, los.itmLossDb)
+    : null;
+  const rev = los.itmLossDb != null
+    ? dirLinkBudget(toHwIdx, toAntIdx, fromHwIdx, fromAntIdx, los.itmLossDb)
+    : null;
+  const worstMargin = fwd && rev ? Math.min(fwd.marginDb, rev.marginDb) : null;
+  const marginColor = worstMargin == null
+    ? ""
+    : worstMargin >= 10 ? "text-emerald-300"
+    : worstMargin >= 0 ? "text-yellow-300"
+    : "text-red-300";
+
   return (
     <div
       ref={sheet.sheetRef}
@@ -308,6 +353,23 @@ export function MapLosPanel({
                 </span>
               </>
             )}
+            {worstMargin != null && fwd && rev && (
+              <>
+                <span className="text-gray-600 mx-1">·</span>
+                <span
+                  className={`font-medium ${marginColor}`}
+                  title={
+                    `Link margin vs ${LOS_PRESET.label}.\n` +
+                    `${fromLabel} → ${toLabel}: RSSI ${Math.round(fwd.rssiDbm)} dBm, sens ${Math.round(fwd.sensitivityDbm)} dBm → ${fwd.marginDb >= 0 ? "+" : ""}${Math.round(fwd.marginDb)} dB\n` +
+                    `${toLabel} → ${fromLabel}: RSSI ${Math.round(rev.rssiDbm)} dBm, sens ${Math.round(rev.sensitivityDbm)} dBm → ${rev.marginDb >= 0 ? "+" : ""}${Math.round(rev.marginDb)} dB\n` +
+                    `Worst direction shown — both must be positive for a usable link.`
+                  }
+                >
+                  {worstMargin >= 0 ? "+" : ""}{Math.round(worstMargin)} dB
+                  <span className="text-gray-500 ml-1">margin</span>
+                </span>
+              </>
+            )}
           </span>
           {!los.losClear && (
             <span className="text-[10px] text-red-300">
@@ -338,6 +400,12 @@ export function MapLosPanel({
                   <strong>Path loss:</strong> Longley-Rice v1.4 (ITS) via WASM.
                   Assumes continental temperate climate, vertical polarization,
                   50 % reliability.
+                </div>
+              )}
+              {worstMargin != null && (
+                <div className="pt-1 border-t border-white/5">
+                  <strong>Link margin:</strong> RX − sensitivity vs <strong>{LOS_PRESET.label}</strong>{" "}
+                  ({LOS_PRESET.sensitivityDbm} dBm). Worst direction shown.
                 </div>
               )}
               <div className="pt-1 border-t border-white/5">

--- a/frontend/src/pages/map/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/clusterDonutLayer.ts
@@ -14,9 +14,11 @@ attribute float a_ratio;       // Online fraction, 0..1
 uniform mat4 u_matrix;
 uniform vec2 u_viewport;       // Framebuffer px
 uniform float u_dpr;           // devicePixelRatio
+uniform float u_alpha;         // Layer-wide opacity multiplier (0..1)
 
 varying vec2 v_uv;
 varying float v_ratio;
+varying float v_alpha;
 
 void main() {
   vec4 clip = u_matrix * vec4(a_pos, 1.0);
@@ -28,6 +30,7 @@ void main() {
   gl_Position = clip;
   v_uv = a_uv;
   v_ratio = a_ratio;
+  v_alpha = u_alpha;
 }
 `;
 
@@ -35,6 +38,7 @@ const FS = `
 precision highp float;
 varying vec2 v_uv;
 varying float v_ratio;
+varying float v_alpha;
 
 const float PI  = 3.14159265359;
 const float TAU = 6.28318530718;
@@ -85,7 +89,7 @@ void main() {
   float borderMask = smoothstep(OUTER_R - 0.015, OUTER_R - 0.005, d) * (1.0 - smoothstep(OUTER_R, OUTER_R + 0.01, d));
   color = mix(color, COL_BORDER, borderMask * 0.8);
 
-  gl_FragColor = color * outerMask;
+  gl_FragColor = color * outerMask * v_alpha;
 }
 `;
 
@@ -128,6 +132,8 @@ export class ClusterDonutLayer implements mapboxgl.CustomLayerInterface {
   private uMatrix: WebGLUniformLocation | null = null;
   private uViewport: WebGLUniformLocation | null = null;
   private uDpr: WebGLUniformLocation | null = null;
+  private uAlpha: WebGLUniformLocation | null = null;
+  private alpha = 1;
   private vertexCount = 0;
   /** Rebuild vertex buffer at the start of the next render() — rebuilding inside
    *  render() avoids stale features since sourcedata/moveend can fire before tiles re-render. */
@@ -160,6 +166,7 @@ export class ClusterDonutLayer implements mapboxgl.CustomLayerInterface {
     this.uMatrix = gl.getUniformLocation(program, "u_matrix");
     this.uViewport = gl.getUniformLocation(program, "u_viewport");
     this.uDpr = gl.getUniformLocation(program, "u_dpr");
+    this.uAlpha = gl.getUniformLocation(program, "u_alpha");
 
     this.buffer = gl.createBuffer();
 
@@ -206,6 +213,14 @@ export class ClusterDonutLayer implements mapboxgl.CustomLayerInterface {
     this.onMoveend = null;
     this.onIdle = null;
     this.onSourceData = null;
+  }
+
+  /** Layer-wide opacity multiplier (0..1). Used to dim donuts when an RF tool is active. */
+  setAlpha(alpha: number): void {
+    const a = Math.max(0, Math.min(1, alpha));
+    if (a === this.alpha) return;
+    this.alpha = a;
+    this.map?.triggerRepaint();
   }
 
   private rebuild(): void {
@@ -299,6 +314,7 @@ export class ClusterDonutLayer implements mapboxgl.CustomLayerInterface {
     gl.uniformMatrix4fv(this.uMatrix, false, matrix);
     gl.uniform2f(this.uViewport, gl.drawingBufferWidth, gl.drawingBufferHeight);
     gl.uniform1f(this.uDpr, window.devicePixelRatio || 1);
+    gl.uniform1f(this.uAlpha, this.alpha);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
     // per-vertex: pos.xyz (12) | uv (8) | pixelRadius (4) | ratio (4) = 28 B

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -100,11 +100,28 @@ function CopyLinkButton({ nodeId }: { nodeId: string }) {
   );
 }
 
-function RecentPackets({ nodeId }: { nodeId: string }) {
+function RecentPackets({
+  nodeId,
+  nodes,
+}: {
+  nodeId: string;
+  nodes: Record<string, INode>;
+}) {
   const { data, isFetching } = useGetNodePacketsQuery({ nodeId, limit: 50 });
   const [expanded, setExpanded] = useState<string | null>(null);
 
   const packets = useMemo(() => data?.packets ?? [], [data]);
+
+  const labelFor = (hex: string): string => {
+    const cleaned = hex.replace(/^!/, "");
+    const n = nodes[cleaned] ?? nodes[`!${cleaned}`];
+    return n?.shortname || n?.longname || cleaned;
+  };
+
+  const normHop = (h: any): string => {
+    if (typeof h === "number") return convertNodeIdFromIntToHex(h);
+    return String(h ?? "").replace(/^!/, "");
+  };
 
   return (
     <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">
@@ -148,6 +165,19 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
             const other = isSent ? to : from;
             const isExpanded = expanded === key;
 
+            let trForward: string[] | null = null;
+            let trBack: string[] | null = null;
+            if (pktType === "traceroute") {
+              const fwdHopsRaw: any[] = Array.isArray(pkt.route_ids) && pkt.route_ids.length > 0
+                ? pkt.route_ids
+                : Array.isArray(pkt.payload?.route) ? pkt.payload.route : [];
+              const backHopsRaw: any[] = Array.isArray(pkt.payload?.route_back) ? pkt.payload.route_back : [];
+              trForward = [from, ...fwdHopsRaw.map(normHop), to];
+              if (backHopsRaw.length > 0) {
+                trBack = [to, ...backHopsRaw.map(normHop), from];
+              }
+            }
+
             return (
               <button
                 key={key}
@@ -170,6 +200,30 @@ function RecentPackets({ nodeId }: { nodeId: string }) {
                     {isSent ? "\u2192" : "\u2190"} {other}
                   </span>
                 </div>
+
+                {trForward && (
+                  <div className="mt-1 ml-1 pl-2 border-l-2 border-indigo-500/30 text-[10px] space-y-0.5">
+                    <div className="text-gray-600 dark:text-gray-400 font-mono break-all">
+                      <span className="text-indigo-500/80 dark:text-indigo-400/80">\u2192</span>{" "}
+                      {trForward.map(labelFor).join(" \u2192 ")}
+                    </div>
+                    {trBack ? (
+                      <div className="text-gray-600 dark:text-gray-400 font-mono break-all">
+                        <span className="text-indigo-500/80 dark:text-indigo-400/80">\u2190</span>{" "}
+                        {trBack.map(labelFor).join(" \u2190 ")}
+                      </div>
+                    ) : (
+                      <div className="text-gray-500 dark:text-gray-500 italic">no return path</div>
+                    )}
+                    <Link
+                      to={`/traceroutes?range=all&sel=${encodeURIComponent(`pair:${from}|${to}`)}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="inline-block text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 underline hover:no-underline"
+                    >
+                      View on Traceroutes \u2192
+                    </Link>
+                  </div>
+                )}
 
                 {isExpanded && (
                   <pre className="mt-2 rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950/50 p-2 text-[10px] font-mono text-gray-700 dark:text-gray-300 overflow-x-auto whitespace-pre-wrap break-all">
@@ -433,7 +487,7 @@ export function NodeDetailsPanel({
           </div>
 
           {/* Recent Packets */}
-          <RecentPackets nodeId={id} />
+          <RecentPackets nodeId={id} nodes={nodes} />
 
           {/* Elsewhere */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-900/30 p-3 shadow-xs">


### PR DESCRIPTION
## Summary
- **#437** — Node tile on the map now shows a `Hardware` field next to Position, derived from the node's `hardware` model id.
- **#444** — Cluster donuts/count text dim to ~25% once an RF tool reaches its result step (Coverage/Scan/LoS/Traceroute), so the raster and overlays read clearly. Clusters stay full-opacity during pick steps so the user can still click an existing node as origin.
- **#445** — LoS panel now shows a per-direction **link margin** computed from the hw/antenna selectors, so changing those visibly updates the result. Path geometry/ITM loss are unchanged (those don't depend on TX power or antenna gain), so no extra DEM re-fetch is triggered.
- **#434** — `traceroute` rows in the node Recent Packets panel now render an inline path summary (`from → hop → ... → to`, with return path if present) and a `View on Traceroutes →` link that jumps straight to the matching pair (`?range=all&sel=pair:from|to`).
