### PR TITLE
feat(map): link upgrades — focus-on-hover, recency fade, hover card

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -75,6 +75,26 @@ html, body {
   border-top-color: rgba(0, 0, 0, 0.85);
 }
 
+/* Link hover card. Compound `.maplibregl-popup.map-link-tooltip` selector wins
+ *  over MapLibre's default popup styles. All four border-*-color slots set so
+ *  the tip stays dark at any anchor direction. */
+.maplibregl-popup.map-link-tooltip .maplibregl-popup-content {
+  background: rgba(0, 0, 0, 0.85);
+  color: white;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+  pointer-events: none;
+  box-shadow: none;
+}
+.maplibregl-popup.map-link-tooltip .maplibregl-popup-tip {
+  border-top-color: rgba(0, 0, 0, 0.85);
+  border-bottom-color: rgba(0, 0, 0, 0.85);
+  border-left-color: rgba(0, 0, 0, 0.85);
+  border-right-color: rgba(0, 0, 0, 0.85);
+}
+
 /* Top-right control stack: attribution + nav side by side */
 .maplibregl-ctrl-top-right {
   display: flex;

--- a/frontend/src/maps/mapStyle.ts
+++ b/frontend/src/maps/mapStyle.ts
@@ -127,19 +127,10 @@ export function buildMapStyle(opts: BuildStyleOptions): StyleSpecification {
   };
 }
 
-export function demSourceSpec(opts: BuildStyleOptions): RasterDEMSourceSpecification {
-  if (opts.provider === "mapbox" && opts.mapboxToken) {
-    return {
-      type: "raster-dem",
-      tiles: [
-        `https://api.mapbox.com/v4/mapbox.mapbox-terrain-dem-v1/{z}/{x}/{y}.pngraw?access_token=${opts.mapboxToken}`,
-      ],
-      tileSize: 512,
-      maxzoom: 14,
-      encoding: "mapbox",
-      attribution: ATTRIB_MAPBOX,
-    };
-  }
+/** Tilezen everywhere keeps the rendered terrain in lockstep with what the RF
+ *  tools (LoS / coverage / scan) feed into ITM. 3DEP 10 m in the US, SRTM 30 m
+ *  global, no token. */
+export function demSourceSpec(): RasterDEMSourceSpecification {
   return {
     type: "raster-dem",
     tiles: [
@@ -153,9 +144,9 @@ export function demSourceSpec(opts: BuildStyleOptions): RasterDEMSourceSpecifica
 }
 
 /** Idempotent — safe to re-call after style reloads. */
-export function ensureTerrain(map: MlMap, opts: BuildStyleOptions, exaggeration: number): void {
+export function ensureTerrain(map: MlMap, exaggeration: number): void {
   if (!map.getSource(TERRAIN_SOURCE_ID)) {
-    map.addSource(TERRAIN_SOURCE_ID, demSourceSpec(opts));
+    map.addSource(TERRAIN_SOURCE_ID, demSourceSpec());
   }
   map.setTerrain({ source: TERRAIN_SOURCE_ID, exaggeration });
   map.setSky(SKY_SPEC);

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -405,6 +405,8 @@ export function Map() {
   const [scanSummary, setScanSummary] = useState<ScanSummary | null>(null);
   const [isScanning, setIsScanning] = useState(false);
   const [scanHoverId, setScanHoverId] = useState<string | null>(null);
+  /** DEM tile source used for the last scan. */
+  const [scanDemSource, setScanDemSource] = useState<DemSource | null>(null);
   /** Monotonic request id — stale worker replies are dropped. */
   const coverageRequestIdRef = useRef(0);
   /** Lazily-created coverage worker pool; terminated on unmount. */
@@ -908,9 +910,6 @@ export function Map() {
   const isPickingNode = activeTool != null && toolStep !== "result";
   const terrain3DRef = useRef(terrain3D);
   const setDetailsDataRef = useRef(setDetailsData);
-  const providerRef = useRef(provider);
-  const mapboxStyleRef = useRef(mapboxStyle);
-  const osmBasemapRef = useRef(osmBasemap);
 
   useEffect(() => {
     nodesRef.current = nodes;
@@ -947,9 +946,6 @@ export function Map() {
   useEffect(() => {
     terrain3DRef.current = terrain3D;
   }, [terrain3D]);
-  useEffect(() => { providerRef.current = provider; }, [provider]);
-  useEffect(() => { mapboxStyleRef.current = mapboxStyle; }, [mapboxStyle]);
-  useEffect(() => { osmBasemapRef.current = osmBasemap; }, [osmBasemap]);
 
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -983,6 +979,7 @@ export function Map() {
     setCoverageProgress({ completed: 0, total: 0 });
     setCoverageDemSource(null);
     setLosDemSource(null);
+    setScanDemSource(null);
     setIsScanning(false);
 
     const mb = mbMapRef.current;
@@ -1382,13 +1379,14 @@ export function Map() {
           return;
         }
         const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
-        const { dem } = await buildDem({
+        const { dem, source: demSourceUsedForScan } = await buildDem({
           bounds: scanBounds,
           targetWidth: 1024,
           targetHeight: 1024,
           token: mapboxToken,
         });
         if (cancelled) return;
+        setScanDemSource(demSourceUsedForScan);
 
         // Override GPS altitude with terrain + configured AGL (matches coverage).
         // Falls back to GPS altitude if DEM sampling fails.
@@ -2906,11 +2904,7 @@ export function Map() {
       // Re-apply terrain if it was enabled (style.load wipes this)
       if (terrain3DRef.current) {
         try {
-          ensureTerrain(
-            map,
-            { provider: providerRef.current, mapboxToken, mapboxStyle: mapboxStyleRef.current, osmBasemap: osmBasemapRef.current },
-            terrainExaggeration,
-          );
+          ensureTerrain(map, terrainExaggeration);
         } catch (err) {
           console.warn("[Map] Terrain re-apply failed after style load:", err);
         }
@@ -3445,7 +3439,7 @@ export function Map() {
 
     try {
       if (terrain3D) {
-        ensureTerrain(map, { provider, mapboxToken, mapboxStyle, osmBasemap }, terrainExaggeration);
+        ensureTerrain(map, terrainExaggeration);
       } else {
         removeTerrain(map);
       }
@@ -3817,6 +3811,7 @@ export function Map() {
               : "Virtual location"
           }
           isScanning={isScanning}
+          demSource={scanDemSource}
           terrainNeeded={!terrain3D}
           onEnableTerrain={() => setTerrain3D(true)}
           onClose={resetTool}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -210,6 +210,9 @@ export function Map() {
 
   const mbMapRef = useRef<MlMap | null>(null);
   const clusterDonutLayerRef = useRef<ClusterDonutLayer | null>(null);
+  /** Currently hover-focused node id, or null. Drives focus-on-hover dimming
+   *  alongside the per-tool dim — the cluster layer applies whichever is dimmer. */
+  const focusedNodeIdRef = useRef<string | null>(null);
   // Sticky after first style.load — `isStyleLoaded()` momentarily lies post-removeSource.
   const styleEverLoadedRef = useRef(false);
   const mbSelectedIdRef = useRef<string | null>(null);
@@ -1849,11 +1852,14 @@ export function Map() {
     } catch {}
   }, [activeTool, showCoverageRays, coverageResult]);
 
-  // Dim cluster donuts/count once a tool reaches its result step (origin placed / link picked)
-  // so the raster + overlays read clearly.
-  useEffect(() => {
-    const dimmed = activeTool != null && toolStep === "result";
-    const alpha = dimmed ? 0.25 : 1;
+  /** Cluster donut + count text dim. Combines the tool-active dim (when an RF
+   *  tool is in result step, so the raster reads clearly) with focus-on-hover
+   *  dim (everything outside the hovered node's ego-network), taking whichever
+   *  is dimmer. Reads from refs so it's safe to call from any code path. */
+  const applyClusterDim = () => {
+    const toolDim = activeToolRef.current != null && toolStepRef.current === "result" ? 0.25 : 1;
+    const focusDim = focusedNodeIdRef.current != null ? 0.2 : 1;
+    const alpha = Math.min(toolDim, focusDim);
 
     clusterDonutLayerRef.current?.setAlpha(alpha);
 
@@ -1861,6 +1867,10 @@ export function Map() {
     if (mb && mb.getLayer("clusters-count")) {
       try { mb.setPaintProperty("clusters-count", "text-opacity", alpha); } catch {}
     }
+  };
+
+  useEffect(() => {
+    applyClusterDim();
   }, [activeTool, toolStep]);
 
   // Sync coverage pin to origin (node pick or virtual placement)
@@ -3068,7 +3078,7 @@ export function Map() {
         "links-dotted": 0.7,
       };
       const LINK_DIM_OPACITY = 0.1;
-      const NODE_DIM_OPACITY = 0.2;
+      // const NODE_DIM_OPACITY = 0.2;  // Re-enable with the disabled block in applyLinkFocus.
 
       const recencyExpr = ["coalesce", ["get", "recencyOpacity"], 1.0] as any;
 
@@ -3082,27 +3092,28 @@ export function Map() {
         ] as any;
       };
 
-      const nodeOpacityForFocus = (relatedIds: string[] | null) => {
-        if (!relatedIds || relatedIds.length === 0) return 1.0 as any;
-        return [
-          "case",
-          ["match", ["get", "id"], relatedIds, true, false],
-          1.0,
-          NODE_DIM_OPACITY,
-        ] as any;
-      };
-
-      const collectRelatedIds = (focusedId: string): string[] => {
-        const liveNodes = nodesRef.current;
-        const ids = new Set<string>([focusedId]);
-        const focusedNode = liveNodes[focusedId] ?? liveNodes[`!${focusedId}`];
-        for (const nb of focusedNode?.neighbors ?? []) ids.add(nb.id);
-        // heardBy: nodes whose neighbor list includes the focused node
-        for (const [otherId, other] of Object.entries(liveNodes)) {
-          if (other.neighbors?.some((n) => n.id === focusedId)) ids.add(otherId);
-        }
-        return [...ids];
-      };
+      // Node + cluster dimming helpers — kept for easy re-enable; see applyLinkFocus.
+      // const nodeOpacityForFocus = (relatedIds: string[] | null) => {
+      //   if (!relatedIds || relatedIds.length === 0) return 1.0 as any;
+      //   return [
+      //     "case",
+      //     ["match", ["get", "id"], relatedIds, true, false],
+      //     1.0,
+      //     NODE_DIM_OPACITY,
+      //   ] as any;
+      // };
+      //
+      // const collectRelatedIds = (focusedId: string): string[] => {
+      //   const liveNodes = nodesRef.current;
+      //   const ids = new Set<string>([focusedId]);
+      //   const focusedNode = liveNodes[focusedId] ?? liveNodes[`!${focusedId}`];
+      //   for (const nb of focusedNode?.neighbors ?? []) ids.add(nb.id);
+      //   // heardBy: nodes whose neighbor list includes the focused node
+      //   for (const [otherId, other] of Object.entries(liveNodes)) {
+      //     if (other.neighbors?.some((n) => n.id === focusedId)) ids.add(otherId);
+      //   }
+      //   return [...ids];
+      // };
 
       const applyLinkFocus = (focusedId: string | null) => {
         for (const [layerId, base] of Object.entries(LINK_LAYER_BASE_OPACITY)) {
@@ -3110,13 +3121,19 @@ export function Map() {
             try { map.setPaintProperty(layerId, "line-opacity", linkOpacityForFocus(base, focusedId)); } catch {}
           }
         }
-        const related = focusedId ? collectRelatedIds(focusedId) : null;
-        const nodeExpr = nodeOpacityForFocus(related);
-        for (const layerId of ["plain-nodes", "unclustered-nodes"]) {
-          if (map.getLayer(layerId)) {
-            try { map.setPaintProperty(layerId, "circle-opacity", nodeExpr); } catch {}
-          }
-        }
+
+        // Node + cluster dimming intentionally disabled — pure link focus reads
+        // cleanly without the ambient nodes/clusters fading away. Re-enable as
+        // a single block if we want full ego-network dimming back.
+        // focusedNodeIdRef.current = focusedId;
+        // const related = focusedId ? collectRelatedIds(focusedId) : null;
+        // const nodeExpr = nodeOpacityForFocus(related);
+        // for (const layerId of ["plain-nodes", "unclustered-nodes"]) {
+        //   if (map.getLayer(layerId)) {
+        //     try { map.setPaintProperty(layerId, "circle-opacity", nodeExpr); } catch {}
+        //   }
+        // }
+        // applyClusterDim();
       };
 
       const bindFocusHover = (layerId: string) => {

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -872,6 +872,7 @@ export function Map() {
             id: convertNodeIdFromIntToHex(neighbor.node_id),
             snr: neighbor.snr,
             distance: neighbor.distance ?? 0,
+            lastRxTime: neighbor.last_rx_time,
           })),
         },
       ])
@@ -2675,21 +2676,22 @@ export function Map() {
           -10, 1.5, 0, 3, 5, 5, 10, 7, 20, 9,
         ],
       ] as any;
+      // Color = SNR (link quality); kind is conveyed by line style. Traceroute
+      // keeps its orange — per-hop SNR isn't meaningful on an inferred path.
       const linkColor = [
         "case",
         ["==", ["get", "kind"], "traceroute"], "#F59E0B",
-        ["==", ["get", "snr"], null], [
-          "match", ["get", "kind"],
-          "neighbor", "#66FF66",
-          "heard_by", "#6666FF",
-          "both", "#FF66FF",
-          "#FFFFFF",
-        ],
+        ["==", ["get", "snr"], null], "#9ca3af",
         ["interpolate", ["linear"], ["get", "snr"],
           -10, "#FF4444", -5, "#FF6644", 0, "#FFAA00",
           2.5, "#FFDD00", 5, "#88DD00", 10, "#44CC44",
         ],
       ] as any;
+
+      // Initial line-opacity bakes recencyOpacity from the feature; focus-on-hover
+      // swaps these expressions in to dim non-connected links.
+      const linkOpacityInitial = (base: number) =>
+        ["*", base, ["coalesce", ["get", "recencyOpacity"], 1.0]] as any;
 
       // Neighbor + both links (solid; "both" uses curved arcs)
       if (!map.getLayer("links-solid")) {
@@ -2699,7 +2701,11 @@ export function Map() {
           source: "links",
           filter: ["in", ["get", "kind"], ["literal", ["neighbor", "both"]]],
           layout: { "line-join": "round", "line-cap": "round" },
-          paint: { "line-opacity": 0.9, "line-width": linkWidth, "line-color": linkColor },
+          paint: {
+            "line-opacity": linkOpacityInitial(0.9),
+            "line-width": linkWidth,
+            "line-color": linkColor,
+          },
         });
       }
 
@@ -2711,7 +2717,7 @@ export function Map() {
           filter: ["==", ["get", "kind"], "heard_by"],
           layout: { "line-join": "round", "line-cap": "round" },
           paint: {
-            "line-opacity": 0.7,
+            "line-opacity": linkOpacityInitial(0.7),
             "line-width": linkWidth,
             "line-color": linkColor,
             "line-dasharray": [4, 3],
@@ -2727,7 +2733,7 @@ export function Map() {
           filter: ["==", ["get", "kind"], "traceroute"],
           layout: { "line-join": "round", "line-cap": "round" },
           paint: {
-            "line-opacity": 0.7,
+            "line-opacity": linkOpacityInitial(0.7),
             "line-width": linkWidth,
             "line-color": linkColor,
             "line-dasharray": [1, 3],
@@ -3054,6 +3060,76 @@ export function Map() {
       bindHover("unclustered-nodes");
       bindHover("plain-nodes");
 
+      // Focus-on-hover: hovering a node highlights its ego-network (the node +
+      // its neighbors + nodes that heard it) and dims everything else.
+      const LINK_LAYER_BASE_OPACITY: Record<string, number> = {
+        "links-solid": 0.9,
+        "links-dashed": 0.7,
+        "links-dotted": 0.7,
+      };
+      const LINK_DIM_OPACITY = 0.1;
+      const NODE_DIM_OPACITY = 0.2;
+
+      const recencyExpr = ["coalesce", ["get", "recencyOpacity"], 1.0] as any;
+
+      const linkOpacityForFocus = (base: number, focusedId: string | null) => {
+        if (!focusedId) return ["*", base, recencyExpr] as any;
+        return [
+          "case",
+          ["any", ["==", ["get", "aId"], focusedId], ["==", ["get", "bId"], focusedId]],
+          ["*", base, recencyExpr],
+          ["*", LINK_DIM_OPACITY, recencyExpr],
+        ] as any;
+      };
+
+      const nodeOpacityForFocus = (relatedIds: string[] | null) => {
+        if (!relatedIds || relatedIds.length === 0) return 1.0 as any;
+        return [
+          "case",
+          ["match", ["get", "id"], relatedIds, true, false],
+          1.0,
+          NODE_DIM_OPACITY,
+        ] as any;
+      };
+
+      const collectRelatedIds = (focusedId: string): string[] => {
+        const liveNodes = nodesRef.current;
+        const ids = new Set<string>([focusedId]);
+        const focusedNode = liveNodes[focusedId] ?? liveNodes[`!${focusedId}`];
+        for (const nb of focusedNode?.neighbors ?? []) ids.add(nb.id);
+        // heardBy: nodes whose neighbor list includes the focused node
+        for (const [otherId, other] of Object.entries(liveNodes)) {
+          if (other.neighbors?.some((n) => n.id === focusedId)) ids.add(otherId);
+        }
+        return [...ids];
+      };
+
+      const applyLinkFocus = (focusedId: string | null) => {
+        for (const [layerId, base] of Object.entries(LINK_LAYER_BASE_OPACITY)) {
+          if (map.getLayer(layerId)) {
+            try { map.setPaintProperty(layerId, "line-opacity", linkOpacityForFocus(base, focusedId)); } catch {}
+          }
+        }
+        const related = focusedId ? collectRelatedIds(focusedId) : null;
+        const nodeExpr = nodeOpacityForFocus(related);
+        for (const layerId of ["plain-nodes", "unclustered-nodes"]) {
+          if (map.getLayer(layerId)) {
+            try { map.setPaintProperty(layerId, "circle-opacity", nodeExpr); } catch {}
+          }
+        }
+      };
+
+      const bindFocusHover = (layerId: string) => {
+        map.on("mouseenter", layerId, (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }) => {
+          const f = e.features?.[0];
+          const id = f?.properties?.id as string | undefined;
+          if (id) applyLinkFocus(id);
+        });
+        map.on("mouseleave", layerId, () => applyLinkFocus(null));
+      };
+      bindFocusHover("unclustered-nodes");
+      bindFocusHover("plain-nodes");
+
       // Cluster click — handler is on the invisible circle hit-test layer
       // ("clusters"), NOT the symbol donut layer. Circle hit-testing is reliable
       // geometry; symbol hit-testing is flaky with dynamic icon-size expressions.
@@ -3374,6 +3450,73 @@ export function Map() {
       for (const layerId of ["unclustered-nodes", "plain-nodes", SPIDERFY_LAYER_NODES]) {
         map.on("mouseenter", layerId, showTooltip);
         map.on("mouseleave", layerId, hideTooltip);
+      }
+
+      // --- Link hover card ---
+      const linkPopup = new maplibregl.Popup({
+        closeButton: false,
+        closeOnClick: false,
+        offset: 12,
+        className: "map-link-tooltip",
+      });
+
+      const KIND_LABEL: Record<string, string> = {
+        neighbor: "Neighbor",
+        heard_by: "Heard by",
+        both: "Mutual",
+        traceroute: "Traceroute",
+      };
+
+      const buildLinkPopupHtml = (p: Record<string, unknown>): string => {
+        const liveNodes = nodesRef.current;
+        const aId = String(p.aId ?? "");
+        const bId = String(p.bId ?? "");
+        const aShort = liveNodes[aId]?.shortname ?? aId.slice(0, 8);
+        const bShort = liveNodes[bId]?.shortname ?? bId.slice(0, 8);
+        const kind = String(p.kind ?? "");
+        const kindLabel = KIND_LABEL[kind] ?? kind;
+        const snrRaw = p.snr;
+        const snrStr = typeof snrRaw === "number" && Number.isFinite(snrRaw)
+          ? `${snrRaw.toFixed(1)} dB`
+          : "—";
+        const lastHeardMs = p.lastHeardMs;
+        const heardStr = typeof lastHeardMs === "number" && Number.isFinite(lastHeardMs)
+          ? relativeTime(new Date(lastHeardMs).toISOString())
+          : "—";
+
+        return (
+          `<div style="display:flex;align-items:center;gap:6px;font-size:11px">` +
+            `<strong>${escapeHtml(aShort)}</strong>` +
+            `<span style="opacity:0.6">↔</span>` +
+            `<strong>${escapeHtml(bShort)}</strong>` +
+          `</div>` +
+          `<div style="display:flex;justify-content:space-between;gap:12px;margin-top:4px;font-size:10px;opacity:0.85">` +
+            `<span>${escapeHtml(kindLabel)}</span>` +
+            `<span>SNR <strong>${snrStr}</strong></span>` +
+          `</div>` +
+          `<div style="font-size:10px;opacity:0.6;margin-top:2px">${escapeHtml(heardStr)}</div>`
+        );
+      };
+
+      const showLinkPopup = (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }) => {
+        const f = e.features?.[0];
+        if (!f) return;
+        linkPopup
+          .setLngLat(e.lngLat)
+          .setHTML(buildLinkPopupHtml(f.properties ?? {}))
+          .addTo(map);
+      };
+      const moveLinkPopup = (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }) => {
+        const f = e.features?.[0];
+        if (!f) return;
+        linkPopup.setLngLat(e.lngLat).setHTML(buildLinkPopupHtml(f.properties ?? {}));
+      };
+      const hideLinkPopup = () => linkPopup.remove();
+
+      for (const layerId of ["links-solid", "links-dashed", "links-dotted"]) {
+        map.on("mouseenter", layerId, showLinkPopup);
+        map.on("mousemove", layerId, moveLinkPopup);
+        map.on("mouseleave", layerId, hideLinkPopup);
       }
     };
 

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -25,12 +25,13 @@ export const COVERAGE_DETAIL_SIZE: Record<CoverageDetail, number> = {
   survey: 2048,
 };
 
-/** Per-Detail DEM tile cap. Higher = finer native zoom at smaller radii. */
+/** Per-Detail DEM tile cap. Higher = finer native zoom at smaller radii. Standard
+ *  matches the Tilezen LRU size so default-tier repeats hit cache 100%. */
 export const COVERAGE_DETAIL_MAX_TILES: Record<CoverageDetail, number> = {
   standard: 256,
-  high: 384,
-  ultra: 512,
-  survey: 768,
+  high: 512,
+  ultra: 768,
+  survey: 1024,
 };
 
 /** Info icon with hover tooltip. `align` picks the edge it anchors to. */

--- a/frontend/src/pages/map/MapLegend.tsx
+++ b/frontend/src/pages/map/MapLegend.tsx
@@ -53,21 +53,60 @@ export function MapLegend({
 
         <div className="border-t border-white/10 my-1" />
 
+        {/* Link color = SNR (quality). Kind is conveyed by line style below. */}
         <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 bg-[#66FF66] rounded-full shrink-0" />
+          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0">
+            <defs>
+              <linearGradient id="legend-snr-gradient" x1="0" x2="1" y1="0" y2="0">
+                <stop offset="0%" stopColor="#FF4444" />
+                <stop offset="50%" stopColor="#FFDD00" />
+                <stop offset="100%" stopColor="#44CC44" />
+              </linearGradient>
+            </defs>
+            <rect x="0" y="0" width="24" height="4" fill="url(#legend-snr-gradient)" />
+          </svg>
+          <span>Link quality (low → high SNR)</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-gray-400 rounded-full shrink-0" />
+          <span>SNR unknown</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0">
+            <line x1="0" y1="2" x2="24" y2="2" stroke="#cbd5e1" strokeWidth="2.5" strokeLinecap="round" />
+          </svg>
           <span>This node heard neighbor</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 bg-[#6666FF] rounded-full shrink-0" />
+          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0">
+            <line x1="0" y1="2" x2="24" y2="2" stroke="#cbd5e1" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="4 3" />
+          </svg>
           <span>Neighbor heard this node</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 bg-[#FF66FF] rounded-full shrink-0" />
+          <svg viewBox="0 0 24 8" preserveAspectRatio="none" className="w-4 h-2 shrink-0">
+            <path d="M 1 6 Q 12 -2 23 6" stroke="#cbd5e1" strokeWidth="2.5" fill="none" strokeLinecap="round" />
+          </svg>
           <span>Mutual link</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 bg-[#F59E0B] rounded-full shrink-0" />
-          <span>Traceroute link</span>
+          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0">
+            <line x1="0" y1="2" x2="24" y2="2" stroke="#F59E0B" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="1 3" />
+          </svg>
+          <span>Traceroute (inferred)</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0">
+            <defs>
+              <linearGradient id="legend-recency-fade" x1="0" x2="1" y1="0" y2="0">
+                <stop offset="0%" stopColor="#FFFFFF" stopOpacity="1.0" />
+                <stop offset="100%" stopColor="#FFFFFF" stopOpacity="0.2" />
+              </linearGradient>
+            </defs>
+            <rect x="0" y="0" width="24" height="4" fill="url(#legend-recency-fade)" />
+          </svg>
+          <span>Recency (recent → stale)</span>
         </div>
 
         <div className="border-t border-white/10 my-1" />

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { COMMON_ANTENNAS, COMMON_HARDWARE, ENVIRONMENTS, MESHTASTIC_PRESETS } from "./coverageAnalysis";
 import type { ScanClass, ScanResult,ScanSummary } from "./scanAnalysis";
+import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
 
 const CLASS_STYLES: Record<ScanClass, { bg: string; text: string; border: string; label: string }> = {
@@ -16,6 +17,7 @@ export function MapScanPanel({
   summary,
   originLabel,
   isScanning,
+  demSource,
   terrainNeeded,
   onEnableTerrain,
   onClose,
@@ -46,6 +48,8 @@ export function MapScanPanel({
   summary: ScanSummary | null;
   originLabel: string;
   isScanning: boolean;
+  /** null = scan hasn't run yet; otherwise the bulk DEM source actually used. */
+  demSource: DemSource | null;
   terrainNeeded?: boolean;
   onEnableTerrain?: () => void;
   onClose: () => void;
@@ -431,6 +435,15 @@ export function MapScanPanel({
                     );
                   })}
                 </div>
+              </div>
+
+              <div className="pt-2 border-t border-white/5 text-[10px] text-gray-500 leading-relaxed">
+                <span className="font-medium text-gray-400">Terrain data:</span>{" "}
+                {demSource === "tilezen"
+                  ? "Tilezen terrarium (USGS 3DEP / SRTM) via AWS Open Data"
+                  : demSource === "mapbox-terrain-rgb"
+                    ? "Mapbox terrain-rgb v1 (~30 m global, Tilezen fallback)"
+                    : "awaiting first scan…"}
               </div>
             </div>
           </details>

--- a/frontend/src/pages/map/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/clusterDonutLayer.ts
@@ -5,6 +5,8 @@
  */
 import maplibregl, { type CustomRenderMethodInput } from "maplibre-gl";
 
+import { MAP_STYLE_IDS } from "../../maps/mapStyle";
+
 const VS = `
 attribute vec3 a_pos;          // Mercator xyz (z = altitude → terrain-aware)
 attribute vec2 a_uv;           // Local corner [-1, 1] (+y = up)
@@ -138,6 +140,9 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
   /** Rebuild vertex buffer at the start of the next render() — rebuilding inside
    *  render() avoids stale features since sourcedata/moveend can fire before tiles re-render. */
   private dirty = true;
+  /** Cache of the last queryRenderedFeatures pass — render() rebuilds the GPU
+   *  buffer from this each frame with fresh terrain z when terrain is on. */
+  private lastClusters: { lng: number; lat: number; r: number; ratio: number }[] = [];
 
   private onMoveend: (() => void) | null = null;
   private onIdle: (() => void) | null = null;
@@ -184,11 +189,18 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     };
     this.onIdle = markDirty;
     this.onSourceData = (e) => {
-      if (e.sourceId !== "nodes_clustered") return;
-      // Hide stale donuts while tiles re-render after setData(); render() will rebuild.
-      this.vertexCount = 0;
-      this.dirty = true;
-      map.triggerRepaint();
+      if (e.sourceId === "nodes_clustered") {
+        // Hide stale donuts while tiles re-render after setData(); render() will rebuild.
+        this.vertexCount = 0;
+        this.dirty = true;
+        map.triggerRepaint();
+        return;
+      }
+      // Kick a repaint when DEM tiles arrive on an idle map; render's per-frame
+      // z-refresh picks up the new elevation. No dirty — cluster set is unchanged.
+      if (e.sourceId === MAP_STYLE_IDS.terrainSource) {
+        map.triggerRepaint();
+      }
     };
     map.on("moveend", this.onMoveend);
     map.on("idle", this.onIdle);
@@ -225,25 +237,18 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
 
   private rebuild(): void {
     const map = this.map;
-    const gl = this.gl;
-    if (!map || !gl || !this.buffer) return;
-    if (!map.getLayer("clusters")) { this.vertexCount = 0; return; }
+    if (!map) return;
+    if (!map.getLayer("clusters")) {
+      this.lastClusters = [];
+      this.vertexCount = 0;
+      return;
+    }
 
     const features = map.queryRenderedFeatures({ layers: ["clusters"] });
 
-    const terrainEnabled = !!map.getTerrain?.();
-    const elevationAt = (lng: number, lat: number): number => {
-      if (!terrainEnabled) return 0;
-      // Want exaggerated elevation here: mercatorMatrix doesn't scale terrain,
-      // so vertex z must already be in the same exaggerated space as the rendered mesh.
-      const e = map.queryTerrainElevation?.({ lng, lat });
-      return Number.isFinite(e) ? (e as number) : 0;
-    };
-
     // Dedupe by position — cluster_ids can flip across setData calls
     const seen = new Set<string>();
-    type Cluster = { x: number; y: number; z: number; r: number; ratio: number };
-    const clusters: Cluster[] = [];
+    const next: { lng: number; lat: number; r: number; ratio: number }[] = [];
 
     for (const f of features) {
       const coords = (f.geometry as any)?.coordinates;
@@ -260,22 +265,33 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
       const online = (f.properties?.onlineCount as number) ?? 0;
       const ratio = count > 0 ? online / count : 0;
 
-      const mc = maplibregl.MercatorCoordinate.fromLngLat({ lng, lat }, elevationAt(lng, lat));
-      clusters.push({
-        x: mc.x,
-        y: mc.y,
-        z: mc.z,
-        r: pixelRadiusForCount(count),
-        ratio,
-      });
+      next.push({ lng, lat, r: pixelRadiusForCount(count), ratio });
     }
 
-    if (clusters.length === 0) { this.vertexCount = 0; return; }
+    this.lastClusters = next;
+    this.uploadVerts();
+  }
+
+  /** Build verts from `lastClusters` with current terrain elevations and upload. */
+  private uploadVerts(): void {
+    const map = this.map;
+    const gl = this.gl;
+    if (!map || !gl || !this.buffer) return;
+    if (this.lastClusters.length === 0) { this.vertexCount = 0; return; }
+
+    const terrainEnabled = !!map.getTerrain?.();
+    const elevationAt = (lng: number, lat: number): number => {
+      if (!terrainEnabled) return 0;
+      // Want exaggerated elevation here: mercatorMatrix doesn't scale terrain,
+      // so vertex z must already be in the same exaggerated space as the rendered mesh.
+      const e = map.queryTerrainElevation?.({ lng, lat });
+      return Number.isFinite(e) ? (e as number) : 0;
+    };
 
     // 6 verts/cluster × 7 floats: x, y, z, ux, uy, r, ratio
     const floatsPerVertex = 7;
     const vertsPerCluster = 6;
-    const verts = new Float32Array(clusters.length * vertsPerCluster * floatsPerVertex);
+    const verts = new Float32Array(this.lastClusters.length * vertsPerCluster * floatsPerVertex);
 
     const corners: [number, number][] = [
       [-1,  1], [-1, -1], [ 1, -1],  // UL, LL, LR
@@ -283,11 +299,12 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     ];
 
     let i = 0;
-    for (const c of clusters) {
+    for (const c of this.lastClusters) {
+      const mc = maplibregl.MercatorCoordinate.fromLngLat({ lng: c.lng, lat: c.lat }, elevationAt(c.lng, c.lat));
       for (const [ux, uy] of corners) {
-        verts[i++] = c.x;
-        verts[i++] = c.y;
-        verts[i++] = c.z;
+        verts[i++] = mc.x;
+        verts[i++] = mc.y;
+        verts[i++] = mc.z;
         verts[i++] = ux;
         verts[i++] = uy;
         verts[i++] = c.r;
@@ -297,7 +314,7 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
 
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
     gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW);
-    this.vertexCount = clusters.length * vertsPerCluster;
+    this.vertexCount = this.lastClusters.length * vertsPerCluster;
   }
 
   render(gl: WebGLRenderingContext | WebGL2RenderingContext, options: CustomRenderMethodInput): void {
@@ -307,6 +324,10 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     if (this.dirty) {
       this.rebuild();
       this.dirty = false;
+    } else if (this.map?.getTerrain?.() && this.lastClusters.length > 0) {
+      // Symbol layer (cluster number labels) reprojects to terrain per-frame;
+      // donuts must too, or they drift relative to numbers in 3D-pitched view.
+      this.uploadVerts();
     }
 
     if (this.vertexCount === 0) return;

--- a/frontend/src/pages/map/linkFeatures.ts
+++ b/frontend/src/pages/map/linkFeatures.ts
@@ -6,7 +6,46 @@ import type {
 } from "geojson";
 
 import type { ITraceroutesResponse } from "../../types";
-import type { IMapNode, NodeLike } from "./types";
+import type { IMapNeighbor, IMapNode, NodeLike } from "./types";
+
+/** Time-since-heard → opacity multiplier. Stale links taper to 0.3 (still visible). */
+function recencyOpacityFromAgeMs(ageMs: number | null): number {
+  if (ageMs == null || !Number.isFinite(ageMs)) return 0.6;
+  const m = ageMs / 60_000;
+  if (m <= 15) return 1.0;
+  if (m <= 60) return 1.0 - ((m - 15) / 45) * 0.4;       // 1.0 → 0.6
+  if (m <= 360) return 0.6 - ((m - 60) / 300) * 0.3;     // 0.6 → 0.3
+  return 0.3;
+}
+
+/** Most recent edge activity (ms). Prefers per-direction `lastRxTime`; falls
+ *  back to the older of the two endpoints' `last_seen` when neither side has
+ *  rx-time data (typical for traceroute-inferred edges). */
+function edgeLastHeardMs(
+  forwardNeighbor: IMapNeighbor | undefined,
+  reverseNeighbor: IMapNeighbor | undefined,
+  fwdLastSeen: string | undefined,
+  revLastSeen: string | undefined,
+): number | null {
+  const fwdRx = forwardNeighbor?.lastRxTime;
+  const revRx = reverseNeighbor?.lastRxTime;
+  const rxMs: number[] = [];
+  if (typeof fwdRx === "number" && fwdRx > 0) rxMs.push(fwdRx * 1000);
+  if (typeof revRx === "number" && revRx > 0) rxMs.push(revRx * 1000);
+  if (rxMs.length > 0) return Math.max(...rxMs);
+
+  const seenMs: number[] = [];
+  if (fwdLastSeen) {
+    const t = new Date(fwdLastSeen).getTime();
+    if (Number.isFinite(t)) seenMs.push(t);
+  }
+  if (revLastSeen) {
+    const t = new Date(revLastSeen).getTime();
+    if (Number.isFinite(t)) seenMs.push(t);
+  }
+  if (seenMs.length > 0) return Math.min(...seenMs);
+  return null;
+}
 
 /** Curved arc between two points; offsetFactor 0 = straight line. */
 function arcCoordinates(
@@ -51,6 +90,8 @@ export function buildMapboxLinkFeatureCollection(opts: {
   const heardBySet = new Set(heardBy);
   const union = new Set<string>([...neighborSet, ...heardBySet]);
 
+  const nowMs = Date.now();
+
   union.forEach((otherId) => {
     const other = liveNodes[otherId];
     if (!other?.map_position) return;
@@ -60,16 +101,25 @@ export function buildMapboxLinkFeatureCollection(opts: {
     const kind = isNeighbor && isHeardBy ? "both" : isNeighbor ? "neighbor" : "heard_by";
 
     // Prefer this node's SNR; fall back to reverse
-    const fwdSnr = (node.neighbors ?? []).find((n) => n.id === otherId)?.snr;
-    const revSnr = (other.neighbors ?? []).find((n) => n.id === node.id)?.snr;
-    const snr = fwdSnr ?? revSnr ?? null;
+    const fwdEntry = (node.neighbors ?? []).find((n) => n.id === otherId);
+    const revEntry = (other.neighbors ?? []).find((n) => n.id === node.id);
+    const snr = fwdEntry?.snr ?? revEntry?.snr ?? null;
+    const lastHeardMs = edgeLastHeardMs(fwdEntry, revEntry, node.last_seen, other.last_seen);
+    const recencyOpacity = recencyOpacityFromAgeMs(lastHeardMs == null ? null : nowMs - lastHeardMs);
 
     const from: [number, number] = [node.position[0], node.position[1]];
     const to: [number, number] = [other.map_position[0], other.map_position[1]];
 
     linkFeatures.push({
       type: "Feature",
-      properties: { kind, snr },
+      properties: {
+        kind,
+        snr,
+        aId: node.id,
+        bId: otherId,
+        lastHeardMs,
+        recencyOpacity,
+      },
       geometry: {
         type: "LineString",
         coordinates: kind === "both" ? arcCoordinates(from, to) : [from, to],
@@ -85,8 +135,8 @@ export function buildAllLinksFeatureCollection(
   liveNodes: Record<string, IMapNode>,
 ): FeatureCollection<GeoLineString, GeoJsonProperties> {
   const linkFeatures: GeoFeature<GeoLineString, GeoJsonProperties>[] = [];
-
   const seen = new Set<string>(); // sorted "idA|idB"
+  const nowMs = Date.now();
 
   for (const [nodeId, node] of Object.entries(liveNodes)) {
     if (!node.map_position || !node.neighbors?.length) continue;
@@ -104,9 +154,10 @@ export function buildAllLinksFeatureCollection(
 
       const reverseNeighbors = other.neighbors ?? [];
       const isMutual = reverseNeighbors.some((n) => n.id === nodeId);
-
       const revEntry = reverseNeighbors.find((n) => n.id === nodeId);
       const snr = neighbor.snr ?? revEntry?.snr ?? null;
+      const lastHeardMs = edgeLastHeardMs(neighbor, revEntry, node.last_seen, other.last_seen);
+      const recencyOpacity = recencyOpacityFromAgeMs(lastHeardMs == null ? null : nowMs - lastHeardMs);
 
       const from: [number, number] = [node.map_position[0], node.map_position[1]];
       const to: [number, number] = [other.map_position[0], other.map_position[1]];
@@ -114,7 +165,14 @@ export function buildAllLinksFeatureCollection(
 
       linkFeatures.push({
         type: "Feature",
-        properties: { kind, snr },
+        properties: {
+          kind,
+          snr,
+          aId: nodeId,
+          bId: neighbor.id,
+          lastHeardMs,
+          recencyOpacity,
+        },
         geometry: {
           type: "LineString",
           coordinates: kind === "both" ? arcCoordinates(from, to) : [from, to],
@@ -176,9 +234,22 @@ export function buildTracerouteLinkFeatureCollection(
       const nodeB = liveNodes[kb] ?? liveNodes[`!${kb}`];
       if (!nodeA?.map_position || !nodeB?.map_position) continue;
 
+      // Traceroute lines have no per-link rx_time; fall back to whichever endpoint
+      // we last saw alive — gives recency fade something to bite on.
+      const lastHeardMs = edgeLastHeardMs(undefined, undefined, nodeA.last_seen, nodeB.last_seen);
+      const nowMs = Date.now();
+      const recencyOpacity = recencyOpacityFromAgeMs(lastHeardMs == null ? null : nowMs - lastHeardMs);
+
       linkFeatures.push({
         type: "Feature",
-        properties: { kind: "traceroute", snr: null },
+        properties: {
+          kind: "traceroute",
+          snr: null,
+          aId: ka,
+          bId: kb,
+          lastHeardMs,
+          recencyOpacity,
+        },
         geometry: {
           type: "LineString",
           coordinates: [

--- a/frontend/src/pages/map/types.ts
+++ b/frontend/src/pages/map/types.ts
@@ -8,14 +8,19 @@ export type Coordinate = [number, number];
 
 export type LinkMode = "selected" | "all" | "mynode";
 
+/** `lastRxTime` is `NeighborInfo.last_rx_time` from the protobuf — Unix epoch
+ *  seconds, NOT ms. Multiply by 1000 before comparing to `Date.now()`. */
+export interface IMapNeighbor {
+  id: string;
+  snr: number;
+  distance: number;
+  lastRxTime?: number;
+}
+
 export type IMapNode = INode & {
   online: boolean;
   map_position?: Coordinate; // [lon, lat]
-  neighbors?: {
-    id: string;
-    snr: number;
-    distance: number;
-  }[];
+  neighbors?: IMapNeighbor[];
 };
 
 export type IFeatureNode = {
@@ -26,11 +31,7 @@ export type IFeatureNode = {
   gateway?: string | null;
   position: Coordinate; // [lon, lat]
   online: boolean;
-  neighbors?: {
-    id: string;
-    snr: number;
-    distance: number;
-  }[];
+  neighbors?: IMapNeighbor[];
 };
 
 export type NodeLike = {
@@ -42,11 +43,7 @@ export type NodeLike = {
   online: boolean;
   position: Coordinate; // [lon, lat]
   role?: NodeRole;
-  neighbors?: {
-    id: string;
-    snr: number;
-    distance: number;
-  }[];
+  neighbors?: IMapNeighbor[];
 };
 
 export type NodeDetailsData = {

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
 
 import { Avatar } from "../../components/Avatar";
@@ -14,6 +14,7 @@ import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLin
 import { formatTimestamp } from "../../utils/formatTimestamp";
 import { calculateDistanceBetweenNodes } from "../../utils/getDistanceBetweenTwoNodes";
 import { NodeMap } from "../NodeMap";
+import { classifyAltitude, getGroundElevation } from "./groundElevation";
 import {
   cleanNodeId,
   getLatLon,
@@ -262,6 +263,23 @@ export function NodeDetailsPanel({
   const ll = getLatLon(node);
   const telem = getTelemetrySnapshot(node);
 
+  // ll is a fresh array each render; depend on its primitives instead.
+  const lng = ll?.[0] ?? null;
+  const lat = ll?.[1] ?? null;
+  const [groundM, setGroundM] = useState<number | null>(null);
+  useEffect(() => {
+    if (lng == null || lat == null || !id) { setGroundM(null); return; }
+    let cancelled = false;
+    void getGroundElevation(id, lng, lat).then((elev) => {
+      if (!cancelled) setGroundM(elev);
+    });
+    return () => { cancelled = true; };
+  }, [id, lng, lat]);
+  const altSanity = useMemo(
+    () => classifyAltitude(n?.position?.altitude, groundM),
+    [n?.position?.altitude, groundM],
+  );
+
   const distanceFromServer =
     serverNode && calculateDistanceBetweenNodes(serverNode as any, node as any) != null
       ? calculateDistanceBetweenNodes(serverNode as any, node as any)
@@ -393,9 +411,27 @@ export function NodeDetailsPanel({
               <KV
                 k="Altitude"
                 v={
-                  n?.position?.altitude != null
-                    ? `${n.position.altitude} m`
-                    : "Unknown"
+                  altSanity.reportedM != null ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <span>{altSanity.reportedM} m</span>
+                      {altSanity.suspectReason && (
+                        <span
+                          className="group relative inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md
+                            bg-amber-500/15 text-amber-600 dark:text-amber-400 border border-amber-500/30
+                            text-[10px] font-medium cursor-help"
+                          title={altSanity.suspectReason}
+                        >
+                          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                              d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+                          </svg>
+                          suspect
+                        </span>
+                      )}
+                    </span>
+                  ) : (
+                    "Unknown"
+                  )
                 }
               />
               <KV

--- a/frontend/src/pages/nodes/groundElevation.ts
+++ b/frontend/src/pages/nodes/groundElevation.ts
@@ -1,0 +1,76 @@
+import { env } from "../../env";
+import { fetchElevationAt } from "../map/terrainRgb";
+
+const cache = new Map<string, number | null>();
+const inflight = new Map<string, Promise<number | null>>();
+
+/** Cached Tilezen ground-elevation lookup keyed by node id. Reuses the LRU
+ *  inside fetchElevationAt; same lat/lng tile across nodes is shared. */
+export async function getGroundElevation(
+  nodeId: string,
+  lng: number,
+  lat: number,
+): Promise<number | null> {
+  if (cache.has(nodeId)) return cache.get(nodeId) ?? null;
+  const existing = inflight.get(nodeId);
+  if (existing) return existing;
+
+  const token = env.MAPBOX_TOKEN ?? "";
+  const p = fetchElevationAt(lng, lat, token)
+    .then((elev) => {
+      cache.set(nodeId, elev);
+      inflight.delete(nodeId);
+      return elev;
+    })
+    .catch(() => {
+      cache.set(nodeId, null);
+      inflight.delete(nodeId);
+      return null;
+    });
+  inflight.set(nodeId, p);
+  return p;
+}
+
+export interface AltitudeSanity {
+  reportedM: number | null;
+  groundM: number | null;
+  /** Human-readable explanation of the flag, or null when the reading looks fine. */
+  suspectReason: string | null;
+}
+
+/** Threshold (m) for flagging a reported altitude as inconsistent with terrain.
+ *  Tall masts and rooftop installs sit comfortably below 50 m AGL. */
+const ALT_DELTA_M = 50;
+
+export function classifyAltitude(
+  reported: number | null | undefined,
+  ground: number | null,
+): AltitudeSanity {
+  const r =
+    typeof reported === "number" && Number.isFinite(reported) ? reported : null;
+  if (r == null) {
+    return { reportedM: null, groundM: ground, suspectReason: null };
+  }
+
+  // 65535 is the Meshtastic "no altitude" sentinel from a uint16 overflow.
+  if (Math.round(r) === 65535) {
+    return {
+      reportedM: r,
+      groundM: ground,
+      suspectReason: "Reports 65535 m — firmware sentinel for missing altitude.",
+    };
+  }
+
+  if (ground != null) {
+    const delta = r - ground;
+    if (Math.abs(delta) > ALT_DELTA_M) {
+      return {
+        reportedM: r,
+        groundM: ground,
+        suspectReason: `Reports ${r.toFixed(0)} m; terrain here is ${ground.toFixed(0)} m (${delta >= 0 ? "+" : ""}${delta.toFixed(0)} m).`,
+      };
+    }
+  }
+
+  return { reportedM: r, groundM: ground, suspectReason: null };
+}


### PR DESCRIPTION
## Summary
- **Recency fade** — each link bakes a `recencyOpacity` factor from the most recent `last_rx_time` (NeighborInfo, both directions; falls back to `last_seen` for traceroute-inferred edges). Bands: <15 min full strength → 1 h taper to 0.6 → 6 h taper to 0.3.
- **Rich hover card** — `maplibregl.Popup` on all three link layers shows `A ↔ B`, kind (Neighbor / Heard by / Mutual / Traceroute), SNR, and relative last-heard. Follows cursor on `mousemove`.
- **Unified link color** — SNR gradient when known, gray when unknown. Drops the old kind-color fallback (green/blue/magenta), which read as "great link" when we just had no SNR data. Kind is now conveyed by line style only; traceroute keeps orange (per-hop SNR isn't meaningful on inferred paths).
- **Legend rebuilt** to match — SNR gradient bar, gray "unknown", line-style icons per kind, neutral white recency-fade swatch.

**Deferred:** SNR sparkline inside the hover card. Needs a backend endpoint that returns per-link SNR history (frontend fetches packets per node today, not per edge).