### PR TITLE
fix(mqtt): persist position updates for existing nodes

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -468,15 +468,16 @@ class MQTT:
         id = msg['from']
         if id in self.data.nodes:
             node = self.data.nodes[id]
-            node['position'] = msg['payload'] if 'payload' in msg else None
         else:
             node = Node.default_node(id)
-            node['position'] = msg['payload'] if 'payload' in msg else None
-            self.data.update_node(id, node)
             logger.debug("Node %s skeleton added with position", id)
+
+        node['position'] = msg['payload'] if 'payload' in msg else None
 
         if 'channel' in msg:
             node['last_channel'] = str(msg['channel'])
+
+        self.data.update_node(id, node)
 
         # Emit event for Discord bridge
         try:


### PR DESCRIPTION
## Summary
- `handle_position` only called `update_node()` in the new-node branch; existing nodes mutated the in-memory dict and skipped persistence entirely.
- Effect: position-only beacons from known nodes never refreshed `last_seen`/`active`, never re-geocoded, and never wrote through to Postgres — in-memory state drifted from PG and reset on restart.
- Restructured to match `handle_nodeinfo`/`handle_telemetry`: branch picks the node ref, fields are mutated, single `update_node(id, node)` at the end.