### PR TITLE
feat(coverage): per-pixel clutter model from NLCD land cover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ config.json
 config.toml
 
 .claude/
+docs/
 
 .pnp.*
 .yarn/*

--- a/Dockerfile.landcover
+++ b/Dockerfile.landcover
@@ -1,0 +1,13 @@
+# One-shot bake image. Run via `docker compose --profile bake run --rm landcover-bake`.
+# Kept separate from the prod image to keep that image lean. rasterio ships GDAL
+# wheels on PyPI, so no system GDAL install is needed.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY scripts/requirements-landcover.txt scripts/
+RUN pip install --no-cache-dir -r scripts/requirements-landcover.txt
+
+COPY scripts/landcover_tiles.py scripts/
+
+CMD ["python", "scripts/landcover_tiles.py"]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,13 @@ See [config.toml.sample](config.toml.sample) for all options with inline documen
 
 For PostgreSQL-specific details, see [POSTGRES.md](POSTGRES.md).
 
-For the Coverage and Scan tools' propagation model (ITM + ITU-R clutter), see [RF-MODEL.md](RF-MODEL.md). Operators wanting per-pixel land-cover-aware predictions also need to bake NLCD tiles once via [scripts/README-landcover.md](scripts/README-landcover.md).
+For the Coverage and Scan tools' propagation model (ITM + ITU-R clutter), see [RF-MODEL.md](RF-MODEL.md). To enable per-pixel land-cover-aware predictions, run the one-shot tile bake:
+
+```sh
+docker compose --profile bake run --rm landcover-bake
+```
+
+The bake auto-downloads NLCD from MRLC, extracts, and writes tiles to `output/landcover/`. ~15–90 min one-time, no manual download. See [scripts/README-landcover.md](scripts/README-landcover.md) for sub-region or offline options.
 
 ### Caddy / Reverse Proxy
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ See a live instance at [Central Valley Mesh](https://meshinfo.cvme.sh).
 ## Features
 
 - **Interactive Map** -- Node positions on OpenStreetMap or Mapbox with hardware icons
+- **RF Coverage / Best Neighbors** -- Per-pixel RF coverage prediction using ITM (Longley-Rice) over real terrain plus per-pixel ITU-R clutter loss from USGS land cover. See [RF-MODEL.md](RF-MODEL.md).
 - **Chat** -- View and search mesh text messages across channels, with CSV/JSON export
 - **Node Explorer** -- Browse all nodes with filtering by status, hardware, role, and more
 - **Network Graph** -- Visualize mesh topology with adjacency heatmaps and arc diagrams
@@ -108,6 +109,8 @@ The main configuration file is `config.toml`. Key sections:
 See [config.toml.sample](config.toml.sample) for all options with inline documentation.
 
 For PostgreSQL-specific details, see [POSTGRES.md](POSTGRES.md).
+
+For the Coverage and Scan tools' propagation model (ITM + ITU-R clutter), see [RF-MODEL.md](RF-MODEL.md). Operators wanting per-pixel land-cover-aware predictions also need to bake NLCD tiles once via [scripts/README-landcover.md](scripts/README-landcover.md).
 
 ### Caddy / Reverse Proxy
 

--- a/RF-MODEL.md
+++ b/RF-MODEL.md
@@ -1,0 +1,165 @@
+# MeshInfo Coverage / Scan RF Model
+
+This is the propagation model behind the **Coverage** and **Best Neighbors (Scan)** tools on the map. It predicts how far a given Meshtastic node can reach in a specific terrain — the output is the colored coverage bubble around an origin pin and the per-target reach classification in the scan tool.
+
+## Executive summary
+
+For each receiver pixel (or scan target), MeshInfo computes:
+
+```
+RSSI = TX_power + TX_gain + RX_gain
+       − path_loss_ITM        ← terrain diffraction (Longley-Rice)
+       − clutter_loss         ← buildings + vegetation (ITU-R)
+       − cable_loss
+margin = RSSI − sensitivity − fade_margin
+```
+
+Pixels with positive margin are reachable; pixels with margin ≥ 15 dB are reliable. The model is **terrain-aware** (real elevation everywhere) and **per-pixel land-cover-aware** (real building / forest classification at every sample). It's calibrated to ITU-R recommendations, not invented numbers.
+
+## The three components
+
+### 1. Path loss — ITM / Longley-Rice (ITU-R P.526 family)
+
+The Irregular Terrain Model is the industry standard for predicting how a radio wave bends, diffracts, and scatters over real terrain. MeshInfo runs the canonical ITM v1.4 implementation as WebAssembly per pixel, sampling real elevations from USGS 3DEP / Tilezen along each propagation path.
+
+ITM models terrain diffraction over **bare earth** and produces a basic transmission loss in dB. It does not model anything above the ground — no buildings, no trees, no rooftops. That's where the next two components come in.
+
+### 2. Endpoint clutter loss — ITU-R P.452-17 §4.5.4
+
+Each end of the path (TX and RX) has a height-gain correction based on:
+
+- The **antenna's height above local terrain** (h)
+- The **nominal clutter height** at that location (hₐ — e.g. 20 m for evergreen forest, 25 m for dense urban)
+- The **nominal distance** from antenna to the clutter (dₖ — typically 20–100 m)
+- **Frequency** (915 MHz for US Meshtastic)
+
+The formula:
+
+```
+A_h = 10.25 · F_fc · exp(−d_k) · {1 − tanh[6 · (h/h_a − 0.625)]} − 0.33   [dB]
+```
+
+At 915 MHz, F_fc ≈ 1. The shape: **antenna inside clutter ≈ 19 dB loss; antenna above clutter ≈ 0 dB**, smooth transition through h ≈ 0.625 · hₐ.
+
+Worked examples:
+
+| Class | hₐ | dₖ | h | Aₕ |
+|---|---|---|---|---|
+| Dense urban | 25 m | 0.02 km | 2 m (handheld) | 19.7 dB |
+| Dense urban | 25 m | 0.02 km | 30 m (tower) | ≈ 0 dB |
+| Suburban | 9 m | 0.025 km | 2 m | 19.5 dB |
+| Suburban | 9 m | 0.025 km | 10 m | ≈ 0 dB |
+| Evergreen forest | 20 m | 0.05 km | 2 m | 19.1 dB |
+| Evergreen forest | 20 m | 0.05 km | 25 m | ≈ 0 dB |
+| Open water | — | — | any | 0 dB |
+
+This explains why a handheld inside trees barely gets a kilometer, but the same node 5 m above the canopy reaches 30+ km — the model captures both regimes correctly.
+
+### 3. Path-traversed vegetation — ITU-R P.833-9 §4.1 (modified exponential decay)
+
+For path segments that pass *through* foliage (between the endpoint zones), the model accumulates additional attenuation:
+
+```
+L = A · {1 − exp[−γ · d / A]}   [dB]
+```
+
+Where `γ` is the per-metre specific attenuation (dB/m) and `A` is the saturation ceiling (dB) for the class. Properties:
+
+- Linear in distance for short grazes (10 m of evergreen → ~6 dB)
+- Saturates for long penetration (1000 m of evergreen → ~27 dB, doesn't grow further)
+
+Per-class accumulation: a path crossing 200 m of deciduous forest then 200 m of evergreen forest computes both losses separately and sums them.
+
+### Avoiding double-counting
+
+P.452 endpoint clutter handles "antenna immersed in nearby clutter" (within ~50 m). P.833 path-integration handles "ray traveling through canopy beyond that zone." MeshInfo skips the first/last `dₖ` km of profile from MED accumulation so the same metre of clutter isn't counted twice.
+
+## Where the land cover comes from
+
+The per-pixel classification uses **USGS NLCD** (National Land Cover Database) — public domain, 30 m native resolution, 16 standard classes for CONUS, well-validated by EPA / USGS / MRLC.
+
+Classes the model uses:
+
+| ID | Class | Penetrable? |
+|---|---|---|
+| 11 | Open Water | — |
+| 12 | Perennial Ice/Snow | — |
+| 21 | Developed, Open Space | — |
+| 22 | Developed, Low Intensity | — |
+| 23 | Developed, Medium Intensity | — |
+| 24 | Developed, High Intensity | — |
+| 31 | Barren Land | — |
+| 41 | Deciduous Forest | yes |
+| 42 | Evergreen Forest | yes |
+| 43 | Mixed Forest | yes |
+| 52 | Shrub/Scrub | yes |
+| 71 | Grassland/Herbaceous | — |
+| 81 | Pasture/Hay | — |
+| 82 | Cultivated Crops | yes |
+| 90 | Woody Wetlands | yes |
+| 95 | Emergent Herbaceous Wetlands | yes |
+
+The full per-class P.452 (hₐ, dₖ) and P.833 (γ, A) parameters are visible in the **class legend** popover inside the Coverage and Scan settings panels — click "Show class legend" to see the dB at 2 m AGL for every class.
+
+Outside the United States (or anywhere the NLCD bake doesn't cover), the model falls back to **Mixed Forest** as a conservative default for every pixel. Future work tracks adding ESA WorldCover as a global fallback.
+
+## Setup — running the bake
+
+NLCD data is not bundled with MeshInfo (it's ~2 GB). Operators run a one-shot bake script after deploying:
+
+```bash
+pip install -r scripts/requirements-landcover.txt
+# Download NLCD source from MRLC and extract, then:
+python scripts/landcover_tiles.py --source /path/to/nlcd_*.tif --out output/landcover
+```
+
+CONUS at full resolution takes 15–90 min depending on CPU. Tiles are bind-mounted into the meshinfo container automatically, no extra config needed.
+
+**Full operator runbook:** [scripts/README-landcover.md](scripts/README-landcover.md)
+
+Once tiles exist, the API mounts them at `/tiles/landcover/{z}/{x}/{y}.png` and the frontend fetches them on every coverage compute. The "Land cover: USGS NLCD" status chip in the Coverage panel shows whether tiles are healthy or the model is using the fallback class.
+
+## The aggression scaler
+
+Inside the Coverage and Scan panels, the **Clutter** control is a 3-stop slider:
+
+| Stop | Multiplier | When to use |
+|---|---|---|
+| Conservative | 0.7× | Predictions are pessimistic — measured links beat what the model says |
+| **Calibrated** | **1.0×** | **Default. ITU baseline. Use this unless you have measured-link data** |
+| Aggressive | 1.3× | Predictions are optimistic — measured links fall short. Heavier obstruction than published averages |
+
+The scaler multiplies the final `(A_h_TX + A_h_RX + L_v)` clutter-loss sum. ITM path loss and free-space loss are unaffected.
+
+The default (1.0×) reflects ITU-R P.452 / P.833 published values. Don't sit at 0.7× or 1.3× without a reason — the calibrated baseline is the most accurate prediction. The slider exists because:
+
+- Real-world obstruction varies: a Sierra-foothills canopy is denser than the published "evergreen forest" averages; a Mojave Desert "shrub/scrub" is thinner than the averages
+- Operators with measured links can tune to match observations
+- The same calibration won't be perfect everywhere on Earth
+
+## What the model does *not* do
+
+These are scope limits that affect prediction accuracy in specific scenarios:
+
+- **Indoor receivers (ITU-R P.2109)** — RX inside a building gets +10–20 dB additional loss not modeled. Outdoor-to-outdoor only.
+- **Per-tree / per-building height** — uses class-nominal canopy heights (15 m deciduous, 20 m evergreen, etc.), not measured heights from LIDAR. A single tall redwood next to your antenna isn't picked up.
+- **Seasonal foliage** — deciduous classes assume leaf-on (summer) at 0.5 dB/m. Out-of-leaf is ~0.15 dB/m; not modeled. Future work.
+- **Frequencies other than 915 MHz** — the P.833 specific-attenuation values are calibrated at 915 MHz. Adding 868 MHz (EU) or 433 MHz would need a per-band lookup.
+- **Polarization-dependent vegetation loss** — uses unpolarized averages (the slight per-polarization difference is in the noise floor here).
+- **Atmospheric refractivity** — fixed at N=301 (Continental Temperate, NA Meshtastic default). Maritime / arid regions are slightly different.
+
+## References
+
+- ITU-R Rec. **P.526** — diffraction-related propagation
+- ITU-R Rec. **P.452-17** — terrestrial interference; §4.5.4 is the clutter formula
+- ITU-R Rec. **P.833-9** — vegetation attenuation; §4.1 is the MED model
+- ITU-R Rec. **P.2108** — newer clutter-loss recommendation (future migration target)
+- ITU-R Rec. **P.2109** — building entry loss (indoor RX, deferred)
+- USGS NLCD: <https://www.mrlc.gov/data>
+- ITM v1.4: <https://github.com/NTIA/itm>
+
+## How to validate
+
+The right way to know if the model is accurate for *your* mesh: pick known links with measured RSSI/SNR and predicted distance, run them through the Best Neighbors / Coverage tools, compare predicted vs. measured. The aggression slider exists for exactly this tuning step.
+
+A formal validation harness (feed N known links → publish RMSE) is on the roadmap but depends on a corpus of validated link data appearing.

--- a/api/api.py
+++ b/api/api.py
@@ -21,11 +21,8 @@ app = FastAPI()
 
 
 class ImmutableTileFiles(StaticFiles):
-    """StaticFiles subclass that tags every response with a long-lived cache header.
-
-    Land-cover tiles are content-addressed by (z,x,y) within a single bake; class IDs
-    don't change between bakes, so a 1-year immutable cache is correct.
-    """
+    """StaticFiles with a 1-year immutable cache header. Tiles are content-addressed
+    by (z,x,y) within a bake; class IDs don't change between bakes."""
     async def get_response(self, path: str, scope):  # type: ignore[override]
         response = await super().get_response(path, scope)
         if isinstance(response, FileResponse):
@@ -431,9 +428,9 @@ class API:
         async def server_config(request: Request) -> JSONResponse:
             return jsonable_encoder({'config': Config.cleanse(self.config)})
 
-        # Land-cover tiles for the coverage/scan clutter model. Tiles are pre-baked
-        # once by scripts/landcover_tiles.py; missing tiles 404 and the frontend falls
-        # back to a default class. See docs/clutter-design.md.
+        # Land-cover tiles for the coverage/scan clutter model. Pre-baked by
+        # scripts/landcover_tiles.py; missing tiles 404 and the frontend falls
+        # back to a default class. See RF-MODEL.md.
         landcover_cfg = self.config.get("landcover", {}) or {}
         if landcover_cfg.get("enabled", False):
             tile_dir = Path(landcover_cfg.get("tile_dir", "output/landcover"))

--- a/api/api.py
+++ b/api/api.py
@@ -2,11 +2,14 @@ import asyncio
 import datetime
 import logging
 import os
+from pathlib import Path
 from fastapi.encoders import jsonable_encoder
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response
+from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.responses import FileResponse
 
 from config import Config
 from api.static_map import generate_static_map
@@ -15,6 +18,19 @@ import utils
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+
+
+class ImmutableTileFiles(StaticFiles):
+    """StaticFiles subclass that tags every response with a long-lived cache header.
+
+    Land-cover tiles are content-addressed by (z,x,y) within a single bake; class IDs
+    don't change between bakes, so a 1-year immutable cache is correct.
+    """
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        response = await super().get_response(path, scope)
+        if isinstance(response, FileResponse):
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response
 
 class API:
     def __init__(self, config, data):
@@ -415,6 +431,25 @@ class API:
         async def server_config(request: Request) -> JSONResponse:
             return jsonable_encoder({'config': Config.cleanse(self.config)})
 
+        # Land-cover tiles for the coverage/scan clutter model. Tiles are pre-baked
+        # once by scripts/landcover_tiles.py; missing tiles 404 and the frontend falls
+        # back to a default class. See docs/clutter-design.md.
+        landcover_cfg = self.config.get("landcover", {}) or {}
+        if landcover_cfg.get("enabled", False):
+            tile_dir = Path(landcover_cfg.get("tile_dir", "output/landcover"))
+            if tile_dir.is_dir():
+                app.mount(
+                    "/tiles/landcover",
+                    ImmutableTileFiles(directory=str(tile_dir)),
+                    name="landcover_tiles",
+                )
+                logger.info("Mounted land-cover tiles at /tiles/landcover from %s", tile_dir.resolve())
+            else:
+                logger.info(
+                    "Land-cover tiles enabled but %s does not exist — frontend will use default class. "
+                    "Run scripts/landcover_tiles.py to populate.",
+                    tile_dir,
+                )
 
         allow_origins = os.getenv("ALLOW_ORIGINS", "").split(",")
         logger.info("Allowed origins: %s (%d)", allow_origins, len(allow_origins))

--- a/api/api.py
+++ b/api/api.py
@@ -20,13 +20,14 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 
-class ImmutableTileFiles(StaticFiles):
-    """StaticFiles with a 1-year immutable cache header. Tiles are content-addressed
-    by (z,x,y) within a bake; class IDs don't change between bakes."""
+class TileFiles(StaticFiles):
+    """StaticFiles with a 1-day cache header. Re-bakes for a new NLCD vintage
+    propagate to clients within ~24 h; Starlette's built-in ETag handling makes
+    the post-cache revalidation a free 304 when the file hasn't changed."""
     async def get_response(self, path: str, scope):  # type: ignore[override]
         response = await super().get_response(path, scope)
         if isinstance(response, FileResponse):
-            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            response.headers["Cache-Control"] = "public, max-age=86400"
         return response
 
 class API:
@@ -437,7 +438,7 @@ class API:
             if tile_dir.is_dir():
                 app.mount(
                     "/tiles/landcover",
-                    ImmutableTileFiles(directory=str(tile_dir)),
+                    TileFiles(directory=str(tile_dir)),
                     name="landcover_tiles",
                 )
                 logger.info("Mounted land-cover tiles at /tiles/landcover from %s", tile_dir.resolve())

--- a/config.py
+++ b/config.py
@@ -130,14 +130,13 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "max_pool_size": 5,
         },
     },
-    # Per-pixel land-cover clutter for coverage / scan tools (see docs/clutter-design.md).
-    # When enabled and tile_dir exists, the API mounts {tile_dir} at /tiles/landcover.
-    # Tiles are pre-baked once via scripts/landcover_tiles.py; an absent tile_dir simply
-    # means the frontend falls back to a default "Mixed Forest" class everywhere.
+    # Per-pixel land-cover clutter for coverage / scan (see RF-MODEL.md).
+    # Tiles are pre-baked via scripts/landcover_tiles.py; absent tile_dir → frontend
+    # falls back to a default class everywhere.
     "landcover": {
         "enabled": True,
         "tile_dir": "output/landcover",
-        "source": "USGS NLCD 2021",  # surfaced to the UI attribution chip
+        "source": "USGS NLCD 2021",
     },
     "debug": False,
 }

--- a/config.py
+++ b/config.py
@@ -130,6 +130,15 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "max_pool_size": 5,
         },
     },
+    # Per-pixel land-cover clutter for coverage / scan tools (see docs/clutter-design.md).
+    # When enabled and tile_dir exists, the API mounts {tile_dir} at /tiles/landcover.
+    # Tiles are pre-baked once via scripts/landcover_tiles.py; an absent tile_dir simply
+    # means the frontend falls back to a default "Mixed Forest" class everywhere.
+    "landcover": {
+        "enabled": True,
+        "tile_dir": "output/landcover",
+        "source": "USGS NLCD 2021",  # surfaced to the UI attribution chip
+    },
     "debug": False,
 }
 

--- a/config.py
+++ b/config.py
@@ -136,7 +136,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "landcover": {
         "enabled": True,
         "tile_dir": "output/landcover",
-        "source": "USGS NLCD 2021",
+        "source": "USGS NLCD 2024",
     },
     "debug": False,
 }

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -307,14 +307,14 @@ style = "mapbox/dark-v11"
 # default class everywhere — coverage still works, just less accurate.
 #
 # To populate tiles, run scripts/landcover_tiles.py once. See
-# scripts/README-landcover.md for the operator guide and docs/clutter-design.md
-# for the RF model.
+# scripts/README-landcover.md for the operator guide and RF-MODEL.md for
+# the RF model.
 # ─────────────────────────────────────────────────────────────────────────────
 
 [landcover]
 enabled = true
 tile_dir = "output/landcover"   # bind-mounted into the meshinfo container
-source = "USGS NLCD 2021"       # surfaced in the map UI attribution chip
+source = "USGS NLCD 2024"       # surfaced in the map UI attribution chip
 
 # ─────────────────────────────────────────────────────────────────────────────
 # UI Customization — Optional

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -300,6 +300,23 @@ style = "mapbox/dark-v11"
 # style = "mapbox/light-v11"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Land cover — Optional
+# Per-pixel ITU-R clutter loss for the map's coverage and scan tools, sampled
+# from pre-baked NLCD tiles. When tile_dir exists and enabled = true, the API
+# mounts it at /tiles/landcover. Without a bake, the frontend falls back to a
+# default class everywhere — coverage still works, just less accurate.
+#
+# To populate tiles, run scripts/landcover_tiles.py once. See
+# scripts/README-landcover.md for the operator guide and docs/clutter-design.md
+# for the RF model.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[landcover]
+enabled = true
+tile_dir = "output/landcover"   # bind-mounted into the meshinfo container
+source = "USGS NLCD 2021"       # surfaced in the map UI attribution chip
+
+# ─────────────────────────────────────────────────────────────────────────────
 # UI Customization — Optional
 # External tools and node detail links shown in the web UI.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -78,5 +78,14 @@ services:
       mqtt:
         condition: service_started
 
+  # `docker compose -f docker-compose-dev.yml --profile bake run --rm landcover-bake` — see scripts/README-landcover.md.
+  landcover-bake:
+    profiles: ["bake"]
+    build:
+      context: .
+      dockerfile: Dockerfile.landcover
+    volumes:
+      - ./output:/app/output
+
 volumes:
   meshinfo_pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,5 +76,14 @@ services:
       - meshinfo
       - frontend
 
+  # `docker compose --profile bake run --rm landcover-bake` — see scripts/README-landcover.md.
+  landcover-bake:
+    profiles: ["bake"]
+    build:
+      context: .
+      dockerfile: Dockerfile.landcover
+    volumes:
+      - ./output:/app/output
+
 volumes:
   meshinfo_pgdata:

--- a/frontend/src/maps/mapStyle.ts
+++ b/frontend/src/maps/mapStyle.ts
@@ -17,9 +17,8 @@ const ATTRIB_CARTO =
   '© <a href="https://carto.com/attributions" target="_blank" rel="noopener">CARTO</a>';
 const ATTRIB_MAPBOX =
   '© <a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener">Mapbox</a>';
-// Tilezen elevation has no required attribution: 3DEP/SRTM/GMTED are public-domain
-// USGS / NASA data, and Mapzen (the Tilezen project) is defunct. Source is still
-// credited where users actually look — the panel's "Terrain data" footer.
+// Tilezen DEM has no required attribution (public-domain USGS/NASA sources).
+// The panel's "Terrain data" footer credits it where users actually look.
 
 const TERRAIN_SOURCE_ID = "terrain-dem";
 const BASE_SOURCE_ID = "base";

--- a/frontend/src/maps/mapStyle.ts
+++ b/frontend/src/maps/mapStyle.ts
@@ -17,8 +17,9 @@ const ATTRIB_CARTO =
   '© <a href="https://carto.com/attributions" target="_blank" rel="noopener">CARTO</a>';
 const ATTRIB_MAPBOX =
   '© <a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener">Mapbox</a>';
-const ATTRIB_TILEZEN =
-  'Elevation: <a href="https://registry.opendata.aws/terrain-tiles/" target="_blank" rel="noopener">AWS Terrain Tiles</a> (Tilezen/Mapzen, 3DEP/SRTM/GMTED)';
+// Tilezen elevation has no required attribution: 3DEP/SRTM/GMTED are public-domain
+// USGS / NASA data, and Mapzen (the Tilezen project) is defunct. Source is still
+// credited where users actually look — the panel's "Terrain data" footer.
 
 const TERRAIN_SOURCE_ID = "terrain-dem";
 const BASE_SOURCE_ID = "base";
@@ -139,7 +140,6 @@ export function demSourceSpec(): RasterDEMSourceSpecification {
     tileSize: 256,
     maxzoom: 15,
     encoding: "terrarium",
-    attribution: ATTRIB_TILEZEN,
   };
 }
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -14,7 +14,7 @@ import { useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../
 import { type ITraceroutesResponse,NodeRole, roleTitles } from "../types";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
 import { ClusterDonutLayer } from "./map/clusterDonutLayer";
-import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult,effectiveSensitivityDbm, ENVIRONMENTS, MESHTASTIC_PRESETS, reliabilityPreset } from "./map/coverageAnalysis";
+import { AGGRESSION_STOPS, COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX,effectiveSensitivityDbm, MESHTASTIC_PRESETS, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./map/coverageAnalysis";
 import { type ContourFeatureCollection,extractCoverageContours } from "./map/coverageContours";
 import type { RasterParams } from "./map/coverageRaster";
 import { extractCoverageRays, type VisibilityRayFeatureCollection } from "./map/coverageRays";
@@ -92,20 +92,6 @@ function relativeTime(iso: string | null | undefined): string {
   if (h < 24) return `${h}h ago`;
   const d = Math.floor(h / 24);
   return `${d}d ago`;
-}
-
-/**
- * Transitional mapping from the legacy 4-preset Environment dropdown to the new
- * per-pixel ITU clutter model's aggression scaler. PR 4 will replace the
- * dropdown with a slider that drives this directly; until then the existing
- * preset selection is reinterpreted:
- *   0 (Open / Rural)         → 0.0× (zero clutter)
- *   1 (Light terrain)        → 0.5×
- *   2 (Suburban)             → 1.0× (calibrated default)
- *   3 (Urban / Dense forest) → 1.5× (conservative)
- */
-function envIdxToAggression(idx: number): number {
-  return [0.0, 0.5, 1.0, 1.5][idx] ?? 1.0;
 }
 
 /** SVG signal bars (1-4) colored by best SNR. */
@@ -334,6 +320,9 @@ export function Map() {
   // total === 0 means idle / drag preview / terrain fetch
   const [coverageProgress, setCoverageProgress] = useState<{ completed: number; total: number }>({ completed: 0, total: 0 });
   const [coverageDemSource, setCoverageDemSource] = useState<DemSource | null>(null);
+  /** Tile-availability telemetry from the most recent compute. Drives the panel's land-cover status chip. */
+  const [coverageClutterStatus, setCoverageClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
+  const [scanClutterStatus, setScanClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
   const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(3);
   const coverageAntennaDbi = COMMON_ANTENNAS[coverageAntennaIdx]?.dbi ?? 3;
@@ -347,7 +336,13 @@ export function Map() {
   const coverageTxDbm = COMMON_HARDWARE[coverageHardwareIdx].isCustom
     ? coverageCustomTxDbm
     : COMMON_HARDWARE[coverageHardwareIdx].txDbm;
-  const [coverageEnvIdx, setCoverageEnvIdx] = useState(0);
+  const [coverageAggressionIdx, setCoverageAggressionIdxRaw] = useState(() =>
+    readJson<number>(LS_KEYS.coverageAggressionIdx, DEFAULT_AGGRESSION_IDX),
+  );
+  const setCoverageAggressionIdx = useCallback((idx: number) => {
+    setCoverageAggressionIdxRaw(idx);
+    writeJson(LS_KEYS.coverageAggressionIdx, idx);
+  }, []);
   const [coveragePresetIdx, setCoveragePresetIdx] = useState(0); // MediumFast
   const [coverageCustomSensDbm, setCoverageCustomSensDbm] = useState(-133);
   const coverageSensitivityDbm = MESHTASTIC_PRESETS[coveragePresetIdx].isCustom
@@ -380,7 +375,13 @@ export function Map() {
   const scanTxDbm = COMMON_HARDWARE[scanHardwareIdx].isCustom
     ? scanCustomTxDbm
     : COMMON_HARDWARE[scanHardwareIdx].txDbm;
-  const [scanEnvIdx, setScanEnvIdx] = useState(0);
+  const [scanAggressionIdx, setScanAggressionIdxRaw] = useState(() =>
+    readJson<number>(LS_KEYS.scanAggressionIdx, DEFAULT_AGGRESSION_IDX),
+  );
+  const setScanAggressionIdx = useCallback((idx: number) => {
+    setScanAggressionIdxRaw(idx);
+    writeJson(LS_KEYS.scanAggressionIdx, idx);
+  }, []);
   const [scanPresetIdx, setScanPresetIdx] = useState(0);
   const [scanCustomSensDbm, setScanCustomSensDbm] = useState(-133);
   const scanSensitivityDbm = MESHTASTIC_PRESETS[scanPresetIdx].isCustom
@@ -395,10 +396,13 @@ export function Map() {
 
   // DEM/raster bbox size from free-space budget. Capped at 200 km — beyond that
   // low tile-zoom averages terrain away (Mt. Oso reads ~200 m low at 500 km bbox).
+  // Per-pixel clutter only resolves once the bbox is set, so the sizer pre-charges
+  // a representative Mixed-Forest-handheld value scaled by the user's aggression.
   const coverageRadiusKm = useMemo(() => {
     const CABLE = 0.5;
     const FADE = 15;
-    const clutter = ENVIRONMENTS[coverageEnvIdx]?.clutterLossDb ?? 0;
+    const aggression = AGGRESSION_STOPS[coverageAggressionIdx]?.value ?? 1.0;
+    const clutter = REPRESENTATIVE_CLUTTER_DB * aggression;
     const budget =
       coverageTxDbm +
       coverageAntennaDbi +
@@ -410,7 +414,7 @@ export function Map() {
     const plConstant = 32.45 + 20 * Math.log10(915);
     const maxKm = Math.pow(10, (budget - plConstant) / 20);
     return Math.max(5, Math.min(200, Math.round(maxKm)));
-  }, [coverageAntennaDbi, coverageRxAntennaDbi, coverageTxDbm, coverageEffectiveSensitivityDbm, coverageEnvIdx]);
+  }, [coverageAntennaDbi, coverageRxAntennaDbi, coverageTxDbm, coverageEffectiveSensitivityDbm, coverageAggressionIdx]);
   /** 3D LoS tube layer; created once per map. */
   const losTubeLayerRef = useRef<LosTubeLayer | null>(null);
   /** DOM pin for the Coverage origin (draggable). */
@@ -1430,6 +1434,7 @@ export function Map() {
         ]);
         if (cancelled) return;
         setScanDemSource(demSourceUsedForScan);
+        setScanClutterStatus({ tilesPresent: scanClutter.tilesPresent, tilesTotal: scanClutter.tilesTotal });
 
         // Override GPS altitude with terrain + configured AGL (matches coverage).
         // Falls back to GPS altitude if DEM sampling fails.
@@ -1461,7 +1466,7 @@ export function Map() {
           rxAntennaDbi: scanRxAntennaDbi,
           rxSensitivityDbm: scanEffectiveSensitivityDbm,
           clutterRaster: scanClutter,
-          clutterAggression: envIdxToAggression(scanEnvIdx),
+          clutterAggression: AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0,
           queryTerrainM: (lng, lat) => {
             const elev = sampleDEMAt(dem, lng, lat);
             return Number.isNaN(elev) ? null : elev;
@@ -1494,7 +1499,7 @@ export function Map() {
     return () => { cancelled = true; };
   }, [activeTool, toolStep, toolFromId, toolVirtualPos, provider, terrain3D, nodes,
       scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
-      scanEnvIdx, scanAntennaHeightM]);
+      scanAggressionIdx, scanAntennaHeightM]);
 
   // Per-class map visibility filter (compute still runs for hidden classes).
   useEffect(() => {
@@ -1629,10 +1634,7 @@ export function Map() {
       rxSensitivityDbm: coverageEffectiveSensitivityDbm,
       fadeMarginDb: 15,
       cableLossDb: 0.5,
-      // Map the legacy 4-preset Environment dropdown to an aggression scaler over
-      // the new per-pixel ITU clutter model. PR 4 will replace the dropdown with a
-      // direct slider; until then this gives users continuity with the existing UI.
-      clutterAggression: envIdxToAggression(coverageEnvIdx),
+      clutterAggression: AGGRESSION_STOPS[coverageAggressionIdx]?.value ?? 1.0,
       // Continental Temperate + N=301 is the NA Meshtastic default
       climate: 5 /* Climate.ContinentalTemperate */,
       surfaceRefractivityN: 301,
@@ -1671,6 +1673,7 @@ export function Map() {
           }),
         ]);
         setCoverageDemSource(demSourceUsed);
+        setCoverageClutterStatus({ tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal });
         mark("demFetchMs", tFetch);
         if (cancelled || requestId !== coverageRequestIdRef.current) {
           setIsFetchingCoverageTerrain(false);
@@ -1859,7 +1862,7 @@ export function Map() {
     return () => {
       cancelled = true;
     };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageEnvIdx, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
 
   // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry
   useEffect(() => {
@@ -3972,8 +3975,9 @@ export function Map() {
           onHardwareIdxChange={setCoverageHardwareIdx}
           customTxDbm={coverageCustomTxDbm}
           onCustomTxDbmChange={setCoverageCustomTxDbm}
-          envIdx={coverageEnvIdx}
-          onEnvIdxChange={setCoverageEnvIdx}
+          aggressionIdx={coverageAggressionIdx}
+          onAggressionIdxChange={setCoverageAggressionIdx}
+          clutterStatus={coverageClutterStatus}
           presetIdx={coveragePresetIdx}
           onPresetIdxChange={setCoveragePresetIdx}
           customSensitivityDbm={coverageCustomSensDbm}
@@ -4078,8 +4082,9 @@ export function Map() {
           onRxAntennaIdxChange={setScanRxAntennaIdx}
           customTxDbm={scanCustomTxDbm}
           onCustomTxDbmChange={setScanCustomTxDbm}
-          envIdx={scanEnvIdx}
-          onEnvIdxChange={setScanEnvIdx}
+          aggressionIdx={scanAggressionIdx}
+          onAggressionIdxChange={setScanAggressionIdx}
+          clutterStatus={scanClutterStatus}
           presetIdx={scanPresetIdx}
           onPresetIdxChange={setScanPresetIdx}
           customSensitivityDbm={scanCustomSensDbm}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -22,6 +22,11 @@ import type { CoverageSliceRequest } from "./map/coverageSliceWorker";
 import { CoverageWorkerPool } from "./map/coverageWorkerPool";
 import { FiltersResetPill } from "./map/FiltersResetPill";
 import { Climate, computeP2PLoss, type ItmContext, loadItmContext, Polarization } from "./map/itm";
+import {
+  buildClutterRaster,
+  type ClutterRaster,
+  downsampleClutterRaster,
+} from "./map/landcoverTiles";
 import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId } from "./map/linkFeatures";
 import { analyzeLineOfSight, type LoSResult } from "./map/losAnalysis";
 import { losPointsToTubeData, LosTubeLayer, obstructionsToGeoJSON, pickObstructions } from "./map/losTubeLayer";
@@ -87,6 +92,20 @@ function relativeTime(iso: string | null | undefined): string {
   if (h < 24) return `${h}h ago`;
   const d = Math.floor(h / 24);
   return `${d}d ago`;
+}
+
+/**
+ * Transitional mapping from the legacy 4-preset Environment dropdown to the new
+ * per-pixel ITU clutter model's aggression scaler. PR 4 will replace the
+ * dropdown with a slider that drives this directly; until then the existing
+ * preset selection is reinterpreted:
+ *   0 (Open / Rural)         → 0.0× (zero clutter)
+ *   1 (Light terrain)        → 0.5×
+ *   2 (Suburban)             → 1.0× (calibrated default)
+ *   3 (Urban / Dense forest) → 1.5× (conservative)
+ */
+function envIdxToAggression(idx: number): number {
+  return [0.0, 0.5, 1.0, 1.5][idx] ?? 1.0;
 }
 
 /** SVG signal bars (1-4) colored by best SNR. */
@@ -431,6 +450,10 @@ export function Map() {
   const coverageDemRef = useRef<DEM | null>(null);
   /** 256² downsample of the above; lets drag preview run LR at ~8-12 fps. */
   const coverageDragDemRef = useRef<DEM | null>(null);
+  /** Cached authoritative class-ID raster. Null until the first compute completes (or fully out-of-bbox). */
+  const coverageClutterRef = useRef<ClutterRaster | null>(null);
+  /** 256² downsample of the above; drag preview ships this to workers alongside the drag DEM. */
+  const coverageDragClutterRef = useRef<ClutterRaster | null>(null);
   /** Latest raster params snapshot (drag preview reuses untouched). */
   const coverageLastRasterParamsRef = useRef<RasterParams | null>(null);
   /** Last origin context (bounds); drag re-samples DEM per move. */
@@ -618,6 +641,8 @@ export function Map() {
    *  Shared by main compute + drag preview. Null = superseded or WASM missing. */
   const renderCoverageToImageSource = useCallback(async (opts: {
     dem: DEM;
+    /** Optional class-ID raster aligned to DEM bounds. Null = workers fall back to default class. */
+    clutter?: ClutterRaster | null;
     origin: [number, number];
     originHeightM: number;
     /** TX antenna AGL (m); ITM wants AGL not MSL. */
@@ -642,7 +667,7 @@ export function Map() {
     outputHeight: number;
     itmUnavailable?: boolean;
   } | null> => {
-    const { dem, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
+    const { dem, clutter, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
     const outputWidth = opts.outputWidth ?? dem.width;
     const outputHeight = opts.outputHeight ?? dem.height;
     const mb = mbMapRef.current;
@@ -674,6 +699,8 @@ export function Map() {
       if (rowStart >= outputHeight) break;
       const rowEnd = Math.min(rowStart + rowsPerTask, outputHeight);
       const demCopy = new Float32Array(dem.data);
+      // Per-worker clutter copy mirrors the DEM-copy pattern (transferable buffers can't be shared).
+      const clutterCopy = clutter ? new Uint8Array(clutter.data) : null;
       const req: CoverageSliceRequest = {
         requestId,
         demBuffer: demCopy.buffer,
@@ -688,9 +715,14 @@ export function Map() {
         outputHeight,
         rowStart,
         rowEnd,
+        clutterBuffer: clutterCopy?.buffer,
+        clutterWidth: clutter?.width,
+        clutterHeight: clutter?.height,
       };
+      const transfer: Transferable[] = [demCopy.buffer];
+      if (clutterCopy) transfer.push(clutterCopy.buffer);
       tasks.push(
-        pool.dispatch(req, [demCopy.buffer]).then((resp) => {
+        pool.dispatch(req, transfer).then((resp) => {
           sliceResponses.push(resp);
           completedSlices += 1;
           if (requestId === coverageRequestIdRef.current) {
@@ -1383,12 +1415,19 @@ export function Map() {
           return;
         }
         const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
-        const { dem, source: demSourceUsedForScan } = await buildDem({
-          bounds: scanBounds,
-          targetWidth: 1024,
-          targetHeight: 1024,
-          token: mapboxToken,
-        });
+        const [{ dem, source: demSourceUsedForScan }, scanClutter] = await Promise.all([
+          buildDem({
+            bounds: scanBounds,
+            targetWidth: 1024,
+            targetHeight: 1024,
+            token: mapboxToken,
+          }),
+          buildClutterRaster({
+            bounds: scanBounds,
+            targetWidth: 1024,
+            targetHeight: 1024,
+          }),
+        ]);
         if (cancelled) return;
         setScanDemSource(demSourceUsedForScan);
 
@@ -1421,7 +1460,8 @@ export function Map() {
           txAntennaDbi: scanAntennaDbi,
           rxAntennaDbi: scanRxAntennaDbi,
           rxSensitivityDbm: scanEffectiveSensitivityDbm,
-          clutterLossDb: ENVIRONMENTS[scanEnvIdx]?.clutterLossDb ?? 0,
+          clutterRaster: scanClutter,
+          clutterAggression: envIdxToAggression(scanEnvIdx),
           queryTerrainM: (lng, lat) => {
             const elev = sampleDEMAt(dem, lng, lat);
             return Number.isNaN(elev) ? null : elev;
@@ -1579,7 +1619,6 @@ export function Map() {
     // DEM is fixed 2048²; "Detail" only changes OUTPUT_SIZE (paint pixelation, not RF accuracy).
     const DEM_SIZE = 2048;
     const OUTPUT_SIZE = COVERAGE_DETAIL_SIZE[coverageDetail];
-    const envEntry = ENVIRONMENTS[coverageEnvIdx];
     const rel = reliabilityPreset(coverageReliability);
     const rasterParams: RasterParams = {
       freqMhz: 915,
@@ -1590,7 +1629,10 @@ export function Map() {
       rxSensitivityDbm: coverageEffectiveSensitivityDbm,
       fadeMarginDb: 15,
       cableLossDb: 0.5,
-      clutterLossDb: envEntry.clutterLossDb,
+      // Map the legacy 4-preset Environment dropdown to an aggression scaler over
+      // the new per-pixel ITU clutter model. PR 4 will replace the dropdown with a
+      // direct slider; until then this gives users continuity with the existing UI.
+      clutterAggression: envIdxToAggression(coverageEnvIdx),
       // Continental Temperate + N=301 is the NA Meshtastic default
       climate: 5 /* Climate.ContinentalTemperate */,
       surfaceRefractivityN: 301,
@@ -1609,16 +1651,25 @@ export function Map() {
         timings[name] = performance.now() - fromMs;
       };
       try {
-        // 1. Fetch terrain tiles, build full DEM on main thread (Tilezen → Mapbox fallback)
+        // 1. Fetch terrain + land-cover tiles in parallel; both build at DEM_SIZE so
+        //    the worker can sample DEM and clutter at the same lng/lat indexing.
         const tFetch = performance.now();
         setIsFetchingCoverageTerrain(true);
-        const { dem, source: demSourceUsed } = await buildDem({
-          bounds: demBounds,
-          targetWidth: DEM_SIZE,
-          targetHeight: DEM_SIZE,
-          token: mapboxToken,
-          maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
-        });
+        const [{ dem, source: demSourceUsed }, clutter] = await Promise.all([
+          buildDem({
+            bounds: demBounds,
+            targetWidth: DEM_SIZE,
+            targetHeight: DEM_SIZE,
+            token: mapboxToken,
+            maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
+          }),
+          buildClutterRaster({
+            bounds: demBounds,
+            targetWidth: DEM_SIZE,
+            targetHeight: DEM_SIZE,
+            maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
+          }),
+        ]);
         setCoverageDemSource(demSourceUsed);
         mark("demFetchMs", tFetch);
         if (cancelled || requestId !== coverageRequestIdRef.current) {
@@ -1679,6 +1730,7 @@ export function Map() {
         const tDispatch = performance.now();
         const rendered = await renderCoverageToImageSource({
           dem,
+          clutter,
           origin: origin!,
           originHeightM,
           originAntennaHeightAboveGroundM: txAboveGroundM,
@@ -1707,9 +1759,11 @@ export function Map() {
           return;
         }
 
-        // 4. Cache full + downsampled DEM for the drag-preview pass.
+        // 4. Cache full + downsampled DEM and clutter raster for the drag-preview pass.
         coverageDemRef.current = dem;
         coverageDragDemRef.current = downsampleDEM(dem, 256, 256);
+        coverageClutterRef.current = clutter;
+        coverageDragClutterRef.current = downsampleClutterRaster(clutter, 256, 256);
         coverageLastRasterParamsRef.current = rasterParams;
         coverageLastOriginContextRef.current = { bounds: dem.bounds };
 
@@ -1916,6 +1970,7 @@ export function Map() {
           return;
         }
         const dem = coverageDragDemRef.current;
+        const clutter = coverageDragClutterRef.current;
         const params = coverageLastRasterParamsRef.current;
         if (!dem || !params) return;
         dragPreviewBusyRef.current = true;
@@ -1936,6 +1991,7 @@ export function Map() {
           coverageRequestIdRef.current = previewId;
           await renderCoverageToImageSource({
             dem,
+            clutter,
             origin: lngLat,
             originHeightM: originH,
             originAntennaHeightAboveGroundM: txAboveGroundM,

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -2386,6 +2386,23 @@ export function Map() {
     });
 
     map.addControl(new maplibregl.AttributionControl({ compact: true }), "top-right");
+    // MapLibre 5 lands the compact attribution EXPANDED. The first
+    // _updateAttributions-with-content adds `maplibregl-compact-show` + the
+    // <details open> attribute. We use a MutationObserver instead of `once('idle')`
+    // so the add → remove happens inside the same render frame (microtask runs
+    // before paint), no visible expand-then-collapse flicker. After our one-shot
+    // removal we disconnect so the user's click toggle works normally.
+    const attribEl = map.getContainer().querySelector<HTMLElement>(".maplibregl-ctrl-attrib");
+    if (attribEl) {
+      const observer = new MutationObserver(() => {
+        if (attribEl.classList.contains("maplibregl-compact-show")) {
+          attribEl.classList.remove("maplibregl-compact-show");
+          attribEl.removeAttribute("open");
+          observer.disconnect();
+        }
+      });
+      observer.observe(attribEl, { attributes: true, attributeFilter: ["class", "open"] });
+    }
 
     mbMapRef.current = map;
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -343,6 +343,13 @@ export function Map() {
     setCoverageAggressionIdxRaw(idx);
     writeJson(LS_KEYS.coverageAggressionIdx, idx);
   }, []);
+  const [coverageClutterEnabled, setCoverageClutterEnabledRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.coverageClutterEnabled, true),
+  );
+  const setCoverageClutterEnabled = useCallback((v: boolean) => {
+    setCoverageClutterEnabledRaw(v);
+    writeJson(LS_KEYS.coverageClutterEnabled, v);
+  }, []);
   const [coveragePresetIdx, setCoveragePresetIdx] = useState(0); // MediumFast
   const [coverageCustomSensDbm, setCoverageCustomSensDbm] = useState(-133);
   const coverageSensitivityDbm = MESHTASTIC_PRESETS[coveragePresetIdx].isCustom
@@ -382,6 +389,13 @@ export function Map() {
     setScanAggressionIdxRaw(idx);
     writeJson(LS_KEYS.scanAggressionIdx, idx);
   }, []);
+  const [scanClutterEnabled, setScanClutterEnabledRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.scanClutterEnabled, true),
+  );
+  const setScanClutterEnabled = useCallback((v: boolean) => {
+    setScanClutterEnabledRaw(v);
+    writeJson(LS_KEYS.scanClutterEnabled, v);
+  }, []);
   const [scanPresetIdx, setScanPresetIdx] = useState(0);
   const [scanCustomSensDbm, setScanCustomSensDbm] = useState(-133);
   const scanSensitivityDbm = MESHTASTIC_PRESETS[scanPresetIdx].isCustom
@@ -398,10 +412,13 @@ export function Map() {
   // low tile-zoom averages terrain away (Mt. Oso reads ~200 m low at 500 km bbox).
   // The sizer can't run the per-pixel clutter model before the bbox exists, so
   // it uses REPRESENTATIVE_CLUTTER_DB scaled by aggression as a sizing heuristic.
+  // When the user disables the model entirely, drop the clutter term to 0.
   const coverageRadiusKm = useMemo(() => {
     const CABLE = 0.5;
     const FADE = 15;
-    const aggression = AGGRESSION_STOPS[coverageAggressionIdx]?.value ?? 1.0;
+    const aggression = coverageClutterEnabled
+      ? (AGGRESSION_STOPS[coverageAggressionIdx]?.value ?? 1.0)
+      : 0;
     const clutter = REPRESENTATIVE_CLUTTER_DB * aggression;
     const budget =
       coverageTxDbm +
@@ -414,7 +431,7 @@ export function Map() {
     const plConstant = 32.45 + 20 * Math.log10(915);
     const maxKm = Math.pow(10, (budget - plConstant) / 20);
     return Math.max(5, Math.min(200, Math.round(maxKm)));
-  }, [coverageAntennaDbi, coverageRxAntennaDbi, coverageTxDbm, coverageEffectiveSensitivityDbm, coverageAggressionIdx]);
+  }, [coverageAntennaDbi, coverageRxAntennaDbi, coverageTxDbm, coverageEffectiveSensitivityDbm, coverageAggressionIdx, coverageClutterEnabled]);
   /** 3D LoS tube layer; created once per map. */
   const losTubeLayerRef = useRef<LosTubeLayer | null>(null);
   /** DOM pin for the Coverage origin (draggable). */
@@ -1465,7 +1482,10 @@ export function Map() {
           rxAntennaDbi: scanRxAntennaDbi,
           rxSensitivityDbm: scanEffectiveSensitivityDbm,
           clutterRaster: scanClutter,
-          clutterAggression: AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0,
+          // aggression = 0 when the user has toggled the model off → ITM-only path loss.
+          clutterAggression: scanClutterEnabled
+            ? (AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0)
+            : 0,
           queryTerrainM: (lng, lat) => {
             const elev = sampleDEMAt(dem, lng, lat);
             return Number.isNaN(elev) ? null : elev;
@@ -1498,7 +1518,7 @@ export function Map() {
     return () => { cancelled = true; };
   }, [activeTool, toolStep, toolFromId, toolVirtualPos, provider, terrain3D, nodes,
       scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
-      scanAggressionIdx, scanAntennaHeightM]);
+      scanAggressionIdx, scanClutterEnabled, scanAntennaHeightM]);
 
   // Per-class map visibility filter (compute still runs for hidden classes).
   useEffect(() => {
@@ -1633,7 +1653,9 @@ export function Map() {
       rxSensitivityDbm: coverageEffectiveSensitivityDbm,
       fadeMarginDb: 15,
       cableLossDb: 0.5,
-      clutterAggression: AGGRESSION_STOPS[coverageAggressionIdx]?.value ?? 1.0,
+      clutterAggression: coverageClutterEnabled
+        ? (AGGRESSION_STOPS[coverageAggressionIdx]?.value ?? 1.0)
+        : 0,
       // Continental Temperate + N=301 is the NA Meshtastic default
       climate: 5 /* Climate.ContinentalTemperate */,
       surfaceRefractivityN: 301,
@@ -1861,7 +1883,7 @@ export function Map() {
     return () => {
       cancelled = true;
     };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
 
   // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry
   useEffect(() => {
@@ -3991,6 +4013,8 @@ export function Map() {
           onCustomTxDbmChange={setCoverageCustomTxDbm}
           aggressionIdx={coverageAggressionIdx}
           onAggressionIdxChange={setCoverageAggressionIdx}
+          clutterEnabled={coverageClutterEnabled}
+          onClutterEnabledChange={setCoverageClutterEnabled}
           clutterStatus={coverageClutterStatus}
           presetIdx={coveragePresetIdx}
           onPresetIdxChange={setCoveragePresetIdx}
@@ -4098,6 +4122,8 @@ export function Map() {
           onCustomTxDbmChange={setScanCustomTxDbm}
           aggressionIdx={scanAggressionIdx}
           onAggressionIdxChange={setScanAggressionIdx}
+          clutterEnabled={scanClutterEnabled}
+          onClutterEnabledChange={setScanClutterEnabled}
           clutterStatus={scanClutterStatus}
           presetIdx={scanPresetIdx}
           onPresetIdxChange={setScanPresetIdx}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -94,6 +94,13 @@ function relativeTime(iso: string | null | undefined): string {
   return `${d}d ago`;
 }
 
+function clampAggressionIdx(idx: number): number {
+  if (!Number.isInteger(idx)) return DEFAULT_AGGRESSION_IDX;
+  if (idx < 0) return 0;
+  if (idx >= AGGRESSION_STOPS.length) return AGGRESSION_STOPS.length - 1;
+  return idx;
+}
+
 /** SVG signal bars (1-4) colored by best SNR. */
 function signalBarsHtml(snr: number | null): string {
   let bars: number;
@@ -336,12 +343,16 @@ export function Map() {
   const coverageTxDbm = COMMON_HARDWARE[coverageHardwareIdx].isCustom
     ? coverageCustomTxDbm
     : COMMON_HARDWARE[coverageHardwareIdx].txDbm;
+  // Clamp on read so corrupted / out-of-range LS values can't leave the slider
+  // with no active stop (which silently fell back to 1.0× via the AGGRESSION_STOPS
+  // index lookup). Same pattern for scan below.
   const [coverageAggressionIdx, setCoverageAggressionIdxRaw] = useState(() =>
-    readJson<number>(LS_KEYS.coverageAggressionIdx, DEFAULT_AGGRESSION_IDX),
+    clampAggressionIdx(readJson<number>(LS_KEYS.coverageAggressionIdx, DEFAULT_AGGRESSION_IDX)),
   );
   const setCoverageAggressionIdx = useCallback((idx: number) => {
-    setCoverageAggressionIdxRaw(idx);
-    writeJson(LS_KEYS.coverageAggressionIdx, idx);
+    const clamped = clampAggressionIdx(idx);
+    setCoverageAggressionIdxRaw(clamped);
+    writeJson(LS_KEYS.coverageAggressionIdx, clamped);
   }, []);
   const [coverageClutterEnabled, setCoverageClutterEnabledRaw] = useState(() =>
     readJson<boolean>(LS_KEYS.coverageClutterEnabled, true),
@@ -383,11 +394,12 @@ export function Map() {
     ? scanCustomTxDbm
     : COMMON_HARDWARE[scanHardwareIdx].txDbm;
   const [scanAggressionIdx, setScanAggressionIdxRaw] = useState(() =>
-    readJson<number>(LS_KEYS.scanAggressionIdx, DEFAULT_AGGRESSION_IDX),
+    clampAggressionIdx(readJson<number>(LS_KEYS.scanAggressionIdx, DEFAULT_AGGRESSION_IDX)),
   );
   const setScanAggressionIdx = useCallback((idx: number) => {
-    setScanAggressionIdxRaw(idx);
-    writeJson(LS_KEYS.scanAggressionIdx, idx);
+    const clamped = clampAggressionIdx(idx);
+    setScanAggressionIdxRaw(clamped);
+    writeJson(LS_KEYS.scanAggressionIdx, clamped);
   }, []);
   const [scanClutterEnabled, setScanClutterEnabledRaw] = useState(() =>
     readJson<boolean>(LS_KEYS.scanClutterEnabled, true),
@@ -1442,15 +1454,20 @@ export function Map() {
             targetHeight: 1024,
             token: mapboxToken,
           }),
-          buildClutterRaster({
-            bounds: scanBounds,
-            targetWidth: 1024,
-            targetHeight: 1024,
-          }),
+          // Skip the clutter fetch when the model is toggled off.
+          scanClutterEnabled
+            ? buildClutterRaster({
+                bounds: scanBounds,
+                targetWidth: 1024,
+                targetHeight: 1024,
+              })
+            : Promise.resolve(null),
         ]);
         if (cancelled) return;
         setScanDemSource(demSourceUsedForScan);
-        setScanClutterStatus({ tilesPresent: scanClutter.tilesPresent, tilesTotal: scanClutter.tilesTotal });
+        setScanClutterStatus(
+          scanClutter ? { tilesPresent: scanClutter.tilesPresent, tilesTotal: scanClutter.tilesTotal } : null,
+        );
 
         // Override GPS altitude with terrain + configured AGL (matches coverage).
         // Falls back to GPS altitude if DEM sampling fails.
@@ -1674,8 +1691,10 @@ export function Map() {
         timings[name] = performance.now() - fromMs;
       };
       try {
-        // 1. Fetch terrain + land-cover in parallel; both at DEM_SIZE so the worker
-        //    samples DEM and clutter at the same lng/lat indexing.
+        // 1. Fetch terrain + (when enabled) land-cover in parallel; both at DEM_SIZE
+        //    so the worker samples DEM and clutter at the same lng/lat indexing.
+        //    Skip the clutter fetch entirely when the model is toggled off — saves
+        //    the network + decode cost.
         const tFetch = performance.now();
         setIsFetchingCoverageTerrain(true);
         const [{ dem, source: demSourceUsed }, clutter] = await Promise.all([
@@ -1686,15 +1705,19 @@ export function Map() {
             token: mapboxToken,
             maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
           }),
-          buildClutterRaster({
-            bounds: demBounds,
-            targetWidth: DEM_SIZE,
-            targetHeight: DEM_SIZE,
-            maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
-          }),
+          coverageClutterEnabled
+            ? buildClutterRaster({
+                bounds: demBounds,
+                targetWidth: DEM_SIZE,
+                targetHeight: DEM_SIZE,
+                maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
+              })
+            : Promise.resolve(null),
         ]);
         setCoverageDemSource(demSourceUsed);
-        setCoverageClutterStatus({ tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal });
+        setCoverageClutterStatus(
+          clutter ? { tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal } : null,
+        );
         mark("demFetchMs", tFetch);
         if (cancelled || requestId !== coverageRequestIdRef.current) {
           setIsFetchingCoverageTerrain(false);
@@ -1787,7 +1810,7 @@ export function Map() {
         coverageDemRef.current = dem;
         coverageDragDemRef.current = downsampleDEM(dem, 256, 256);
         coverageClutterRef.current = clutter;
-        coverageDragClutterRef.current = downsampleClutterRaster(clutter, 256, 256);
+        coverageDragClutterRef.current = clutter ? downsampleClutterRaster(clutter, 256, 256) : null;
         coverageLastRasterParamsRef.current = rasterParams;
         coverageLastOriginContextRef.current = { bounds: dem.bounds };
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -320,7 +320,7 @@ export function Map() {
   // total === 0 means idle / drag preview / terrain fetch
   const [coverageProgress, setCoverageProgress] = useState<{ completed: number; total: number }>({ completed: 0, total: 0 });
   const [coverageDemSource, setCoverageDemSource] = useState<DemSource | null>(null);
-  /** Tile-availability telemetry from the most recent compute. Drives the panel's land-cover status chip. */
+  // Drives the land-cover status chip in each panel.
   const [coverageClutterStatus, setCoverageClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   const [scanClutterStatus, setScanClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
@@ -396,8 +396,8 @@ export function Map() {
 
   // DEM/raster bbox size from free-space budget. Capped at 200 km — beyond that
   // low tile-zoom averages terrain away (Mt. Oso reads ~200 m low at 500 km bbox).
-  // Per-pixel clutter only resolves once the bbox is set, so the sizer pre-charges
-  // a representative Mixed-Forest-handheld value scaled by the user's aggression.
+  // The sizer can't run the per-pixel clutter model before the bbox exists, so
+  // it uses REPRESENTATIVE_CLUTTER_DB scaled by aggression as a sizing heuristic.
   const coverageRadiusKm = useMemo(() => {
     const CABLE = 0.5;
     const FADE = 15;
@@ -454,9 +454,8 @@ export function Map() {
   const coverageDemRef = useRef<DEM | null>(null);
   /** 256² downsample of the above; lets drag preview run LR at ~8-12 fps. */
   const coverageDragDemRef = useRef<DEM | null>(null);
-  /** Cached authoritative class-ID raster. Null until the first compute completes (or fully out-of-bbox). */
+  /** Authoritative + 256² downsampled class-ID rasters; drag preview reuses these. */
   const coverageClutterRef = useRef<ClutterRaster | null>(null);
-  /** 256² downsample of the above; drag preview ships this to workers alongside the drag DEM. */
   const coverageDragClutterRef = useRef<ClutterRaster | null>(null);
   /** Latest raster params snapshot (drag preview reuses untouched). */
   const coverageLastRasterParamsRef = useRef<RasterParams | null>(null);
@@ -703,7 +702,7 @@ export function Map() {
       if (rowStart >= outputHeight) break;
       const rowEnd = Math.min(rowStart + rowsPerTask, outputHeight);
       const demCopy = new Float32Array(dem.data);
-      // Per-worker clutter copy mirrors the DEM-copy pattern (transferable buffers can't be shared).
+      // Transferable buffers can't be shared across workers; copy per slice.
       const clutterCopy = clutter ? new Uint8Array(clutter.data) : null;
       const req: CoverageSliceRequest = {
         requestId,
@@ -1653,8 +1652,8 @@ export function Map() {
         timings[name] = performance.now() - fromMs;
       };
       try {
-        // 1. Fetch terrain + land-cover tiles in parallel; both build at DEM_SIZE so
-        //    the worker can sample DEM and clutter at the same lng/lat indexing.
+        // 1. Fetch terrain + land-cover in parallel; both at DEM_SIZE so the worker
+        //    samples DEM and clutter at the same lng/lat indexing.
         const tFetch = performance.now();
         setIsFetchingCoverageTerrain(true);
         const [{ dem, source: demSourceUsed }, clutter] = await Promise.all([
@@ -1762,7 +1761,7 @@ export function Map() {
           return;
         }
 
-        // 4. Cache full + downsampled DEM and clutter raster for the drag-preview pass.
+        // 4. Cache full + downsampled rasters for the drag-preview pass.
         coverageDemRef.current = dem;
         coverageDragDemRef.current = downsampleDEM(dem, 256, 256);
         coverageClutterRef.current = clutter;
@@ -2386,12 +2385,10 @@ export function Map() {
     });
 
     map.addControl(new maplibregl.AttributionControl({ compact: true }), "top-right");
-    // MapLibre 5 lands the compact attribution EXPANDED. The first
-    // _updateAttributions-with-content adds `maplibregl-compact-show` + the
-    // <details open> attribute. We use a MutationObserver instead of `once('idle')`
-    // so the add → remove happens inside the same render frame (microtask runs
-    // before paint), no visible expand-then-collapse flicker. After our one-shot
-    // removal we disconnect so the user's click toggle works normally.
+    // MapLibre 5 lands compact attributions EXPANDED on first content (sets
+    // `maplibregl-compact-show` + <details open>). MutationObserver beats the
+    // paint — microtask drains before render, so no flicker. once('idle') was
+    // too late: it fires after the browser has already painted the open state.
     const attribEl = map.getContainer().querySelector<HTMLElement>(".maplibregl-ctrl-attrib");
     if (attribEl) {
       const observer = new MutationObserver(() => {

--- a/frontend/src/pages/NodeMap.tsx
+++ b/frontend/src/pages/NodeMap.tsx
@@ -200,6 +200,20 @@ export const NodeMap = ({ node }: { node: INode }) => {
         maxPitch: 85,
       });
 
+      // MapLibre 5 lands compact attributions expanded. MutationObserver beats
+      // the paint so there's no flicker; see Map.tsx for the longer rationale.
+      const attribEl = map.getContainer().querySelector<HTMLElement>(".maplibregl-ctrl-attrib");
+      if (attribEl) {
+        const observer = new MutationObserver(() => {
+          if (attribEl.classList.contains("maplibregl-compact-show")) {
+            attribEl.classList.remove("maplibregl-compact-show");
+            attribEl.removeAttribute("open");
+            observer.disconnect();
+          }
+        });
+        observer.observe(attribEl, { attributes: true, attributeFilter: ["class", "open"] });
+      }
+
       mbMapRef.current = map;
       map.addControl(new maplibregl.NavigationControl({ showCompass: true }), "top-left");
 

--- a/frontend/src/pages/map/ClutterUI.tsx
+++ b/frontend/src/pages/map/ClutterUI.tsx
@@ -10,18 +10,26 @@ const LEGEND_REF_AGL_M = 2;
 export function AggressionSlider({
   aggressionIdx,
   onChange,
+  enabled = true,
 }: {
   aggressionIdx: number;
   onChange: (idx: number) => void;
+  /** When false, buttons render dimmed and non-interactive. */
+  enabled?: boolean;
 }) {
   return (
-    <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
+    <div
+      className={`flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium ${
+        enabled ? "" : "opacity-40 pointer-events-none"
+      }`}
+    >
       {AGGRESSION_STOPS.map((stop, i) => {
         const active = aggressionIdx === i;
         return (
           <button
             key={stop.id}
             type="button"
+            disabled={!enabled}
             onClick={() => onChange(i)}
             title={stop.description}
             className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
@@ -42,9 +50,20 @@ export function AggressionSlider({
 export interface ClutterStatusChipProps {
   /** Null until first compute. */
   status: { tilesPresent: number; tilesTotal: number } | null;
+  /** When false, the chip overrides any tile state with "Clutter model: off". */
+  enabled?: boolean;
 }
 
-export function ClutterStatusChip({ status }: ClutterStatusChipProps) {
+export function ClutterStatusChip({ status, enabled = true }: ClutterStatusChipProps) {
+  if (!enabled) {
+    return (
+      <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
+        <span className="mt-0.5 inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-gray-500/60" aria-hidden />
+        <span>Clutter model: <span className="text-gray-400">off</span> — ITM-only path loss.</span>
+      </div>
+    );
+  }
+
   const fallback = status != null && status.tilesTotal > 0 && status.tilesPresent === 0;
   const partial =
     status != null &&

--- a/frontend/src/pages/map/ClutterUI.tsx
+++ b/frontend/src/pages/map/ClutterUI.tsx
@@ -69,7 +69,7 @@ export function ClutterStatusChip({ status }: ClutterStatusChipProps) {
   return (
     <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
       <span
-        className={`mt-0.5 inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+        className={`mt-0.5 inline-block w-1.5 h-1.5 rounded-full shrink-0 ${
           fallback ? "bg-amber-400/80" : "bg-emerald-400/70"
         }`}
         aria-hidden
@@ -82,7 +82,7 @@ export function ClutterStatusChip({ status }: ClutterStatusChipProps) {
           </>
         ) : (
           <>
-            Land cover: <span className="text-gray-300">USGS NLCD 2021</span>
+            Land cover: <span className="text-gray-300">USGS NLCD</span>
             {partial && (
               <span className="text-amber-400/80">
                 {" "}
@@ -125,7 +125,7 @@ export function ClassLegend() {
         </svg>
       </button>
       {open && (
-        <div className="mt-1 max-h-48 overflow-y-auto rounded border border-white/5 bg-white/[0.02]">
+        <div className="mt-1 max-h-48 overflow-y-auto rounded border border-white/5 bg-white/2">
           <table className="w-full text-[9px]">
             <thead className="text-gray-500 border-b border-white/5">
               <tr>

--- a/frontend/src/pages/map/ClutterUI.tsx
+++ b/frontend/src/pages/map/ClutterUI.tsx
@@ -1,0 +1,162 @@
+/**
+ * Shared UI bits for the per-pixel ITU clutter model — used by both
+ * MapCoveragePanel and MapScanPanel:
+ *
+ *   - <AggressionSlider/>   3-stop conservative / calibrated / aggressive picker
+ *   - <ClutterStatusChip/>  "Land cover: USGS NLCD 2021" or fallback indicator
+ *   - <ClassLegend/>        collapsible 16-row NLCD legend with per-class dB hints
+ *
+ * Kept compact and self-contained so it can drop into either panel's settings block.
+ */
+import { useState } from "react";
+
+import { endpointClutterDb, NLCD_CLASSES } from "./clutterClasses";
+import { AGGRESSION_STOPS } from "./coverageAnalysis";
+
+const F_915 = 915;
+/** Reference antenna height (m) used to populate the legend's "@ 2 m" column. */
+const LEGEND_REF_AGL_M = 2;
+
+export function AggressionSlider({
+  aggressionIdx,
+  onChange,
+}: {
+  aggressionIdx: number;
+  onChange: (idx: number) => void;
+}) {
+  return (
+    <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
+      {AGGRESSION_STOPS.map((stop, i) => {
+        const active = aggressionIdx === i;
+        return (
+          <button
+            key={stop.id}
+            type="button"
+            onClick={() => onChange(i)}
+            title={stop.description}
+            className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
+              active
+                ? "bg-cyan-500/20 text-cyan-200"
+                : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
+            }`}
+          >
+            <div>{stop.short}</div>
+            <div className="text-[9px] text-gray-500 font-normal">×{stop.value.toFixed(1)}</div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export interface ClutterStatusChipProps {
+  /** Most recent compute's tile-availability snapshot. Null until first compute. */
+  status: { tilesPresent: number; tilesTotal: number } | null;
+}
+
+export function ClutterStatusChip({ status }: ClutterStatusChipProps) {
+  // Three states:
+  //   - status === null: first compute hasn't completed; assume the bake is healthy
+  //   - tilesPresent === 0 && tilesTotal > 0: fully out of the baked region or the
+  //     API has no tile mount → fall back to default class everywhere
+  //   - otherwise: at least some tiles came back; show the source name
+  const fallback = status != null && status.tilesTotal > 0 && status.tilesPresent === 0;
+  const partial =
+    status != null &&
+    status.tilesPresent > 0 &&
+    status.tilesPresent < status.tilesTotal;
+
+  return (
+    <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
+      <span
+        className={`mt-0.5 inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+          fallback ? "bg-amber-400/80" : "bg-emerald-400/70"
+        }`}
+        aria-hidden
+      />
+      <span>
+        {fallback ? (
+          <>
+            <span className="text-amber-300/90">Mixed Forest fallback</span>
+            <span className="text-gray-500"> — no land-cover tiles for this region. Run the bake (see scripts/README-landcover.md).</span>
+          </>
+        ) : (
+          <>
+            Land cover: <span className="text-gray-300">USGS NLCD 2021</span>
+            {partial && (
+              <span className="text-amber-400/80">
+                {" "}
+                · partial coverage ({status?.tilesPresent}/{status?.tilesTotal} tiles)
+              </span>
+            )}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/** Collapsible table summarizing the 16 NLCD CONUS classes the model uses. */
+export function ClassLegend() {
+  const [open, setOpen] = useState(false);
+
+  // Order classes by ID for predictable legend ordering.
+  const rows = Object.values(NLCD_CLASSES)
+    .sort((a, b) => a.id - b.id)
+    // Skip AK-only and lichen/moss rows in the default view — keeps the legend
+    // focused on the classes a CONUS operator actually sees.
+    .filter((c) => ![51, 72, 73, 74].includes(c.id));
+
+  return (
+    <div className="text-[10px]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between gap-1 px-1 py-1 rounded text-gray-400 hover:text-gray-200 hover:bg-white/5 transition-colors"
+      >
+        <span>Show class legend</span>
+        <svg
+          className={`w-3 h-3 transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="mt-1 max-h-48 overflow-y-auto rounded border border-white/5 bg-white/[0.02]">
+          <table className="w-full text-[9px]">
+            <thead className="text-gray-500 border-b border-white/5">
+              <tr>
+                <th className="text-left px-1.5 py-1 font-medium">ID</th>
+                <th className="text-left px-1.5 py-1 font-medium">Class</th>
+                <th className="text-right px-1.5 py-1 font-medium" title="ITU-R P.452-17 endpoint clutter at 2 m AGL, 915 MHz">@ 2 m</th>
+                <th className="text-right px-1.5 py-1 font-medium" title="Path-traversed vegetation can attenuate signals through this class">Pen.</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-400">
+              {rows.map((cls) => {
+                const ahDb = endpointClutterDb(cls, LEGEND_REF_AGL_M, F_915);
+                return (
+                  <tr key={cls.id} className="border-b border-white/5 last:border-b-0">
+                    <td className="px-1.5 py-0.5 font-mono">{cls.id}</td>
+                    <td className="px-1.5 py-0.5">{cls.label}</td>
+                    <td className="px-1.5 py-0.5 text-right font-mono tabular-nums">
+                      {ahDb >= 1 ? `${ahDb.toFixed(0)} dB` : "—"}
+                    </td>
+                    <td className="px-1.5 py-0.5 text-right">{cls.penetrable ? "yes" : "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <div className="px-1.5 py-1 text-[9px] text-gray-500 border-t border-white/5 leading-snug">
+            <span className="text-gray-400">@ 2 m</span> = ITU-R P.452-17 endpoint clutter at 2 m AGL, 915 MHz.
+            Penetrable classes also accumulate ITU-R P.833-9 vegetation loss along the path.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/map/ClutterUI.tsx
+++ b/frontend/src/pages/map/ClutterUI.tsx
@@ -1,20 +1,10 @@
-/**
- * Shared UI bits for the per-pixel ITU clutter model — used by both
- * MapCoveragePanel and MapScanPanel:
- *
- *   - <AggressionSlider/>   3-stop conservative / calibrated / aggressive picker
- *   - <ClutterStatusChip/>  "Land cover: USGS NLCD 2021" or fallback indicator
- *   - <ClassLegend/>        collapsible 16-row NLCD legend with per-class dB hints
- *
- * Kept compact and self-contained so it can drop into either panel's settings block.
- */
+/** Shared clutter-UI bits used by MapCoveragePanel and MapScanPanel. */
 import { useState } from "react";
 
 import { endpointClutterDb, NLCD_CLASSES } from "./clutterClasses";
 import { AGGRESSION_STOPS } from "./coverageAnalysis";
 
 const F_915 = 915;
-/** Reference antenna height (m) used to populate the legend's "@ 2 m" column. */
 const LEGEND_REF_AGL_M = 2;
 
 export function AggressionSlider({
@@ -50,16 +40,11 @@ export function AggressionSlider({
 }
 
 export interface ClutterStatusChipProps {
-  /** Most recent compute's tile-availability snapshot. Null until first compute. */
+  /** Null until first compute. */
   status: { tilesPresent: number; tilesTotal: number } | null;
 }
 
 export function ClutterStatusChip({ status }: ClutterStatusChipProps) {
-  // Three states:
-  //   - status === null: first compute hasn't completed; assume the bake is healthy
-  //   - tilesPresent === 0 && tilesTotal > 0: fully out of the baked region or the
-  //     API has no tile mount → fall back to default class everywhere
-  //   - otherwise: at least some tiles came back; show the source name
   const fallback = status != null && status.tilesTotal > 0 && status.tilesPresent === 0;
   const partial =
     status != null &&
@@ -96,15 +81,12 @@ export function ClutterStatusChip({ status }: ClutterStatusChipProps) {
   );
 }
 
-/** Collapsible table summarizing the 16 NLCD CONUS classes the model uses. */
 export function ClassLegend() {
   const [open, setOpen] = useState(false);
 
-  // Order classes by ID for predictable legend ordering.
+  // CONUS-relevant rows only; AK-only classes and lichen/moss are skipped.
   const rows = Object.values(NLCD_CLASSES)
     .sort((a, b) => a.id - b.id)
-    // Skip AK-only and lichen/moss rows in the default view — keeps the legend
-    // focused on the classes a CONUS operator actually sees.
     .filter((c) => ![51, 72, 73, 74].includes(c.id));
 
   return (

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -81,6 +81,8 @@ export function MapCoveragePanel({
   onCustomTxDbmChange,
   aggressionIdx,
   onAggressionIdxChange,
+  clutterEnabled,
+  onClutterEnabledChange,
   clutterStatus,
   presetIdx,
   onPresetIdxChange,
@@ -133,6 +135,9 @@ export function MapCoveragePanel({
   /** Index into AGGRESSION_STOPS (0/1/2). Drives the per-pixel ITU clutter scaler. */
   aggressionIdx: number;
   onAggressionIdxChange: (idx: number) => void;
+  /** Master on/off for the clutter model. Off → ITM-only path loss. */
+  clutterEnabled: boolean;
+  onClutterEnabledChange: (enabled: boolean) => void;
   /** Tile-availability telemetry from the most recent compute; null if none yet. */
   clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
@@ -801,18 +806,28 @@ export function MapCoveragePanel({
 
               {/* Clutter (per-pixel ITU model + aggression scaler). */}
               <div className="space-y-1.5">
-                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
-                  <span>Clutter</span>
-                  <InfoTip align="left">
-                    Per-pixel building / vegetation loss from USGS NLCD land
-                    cover, applied via ITU-R P.452-17 (endpoint clutter) and
-                    P.833-9 (path-traversed vegetation). The slider scales the
-                    calibrated baseline — leave at <em>Calibrated</em> unless
-                    measured links say otherwise.
-                  </InfoTip>
-                </label>
-                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} />
-                <ClutterStatusChip status={clutterStatus} />
+                <div className="flex items-center justify-between gap-2">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                    <span>Clutter</span>
+                    <InfoTip align="left">
+                      Per-pixel building / vegetation loss from USGS NLCD land
+                      cover, applied via ITU-R P.452-17 (endpoint clutter) and
+                      P.833-9 (path-traversed vegetation). Toggle off for
+                      ITM-only bare-earth predictions.
+                    </InfoTip>
+                  </label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={clutterEnabled}
+                      onChange={(e) => onClutterEnabledChange(e.target.checked)}
+                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                    />
+                    <span>Enabled</span>
+                  </label>
+                </div>
+                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
+                <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
                 <ClassLegend />
               </div>
 

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
-import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult,ENVIRONMENTS, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
+import { AggressionSlider, ClassLegend, ClutterStatusChip } from "./ClutterUI";
+import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
 
@@ -78,8 +79,9 @@ export function MapCoveragePanel({
   onRxHeightChange,
   customTxDbm,
   onCustomTxDbmChange,
-  envIdx,
-  onEnvIdxChange,
+  aggressionIdx,
+  onAggressionIdxChange,
+  clutterStatus,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -128,8 +130,11 @@ export function MapCoveragePanel({
   onRxHeightChange: (m: number) => void;
   customTxDbm: number;
   onCustomTxDbmChange: (dbm: number) => void;
-  envIdx: number;
-  onEnvIdxChange: (idx: number) => void;
+  /** Index into AGGRESSION_STOPS (0/1/2). Drives the per-pixel ITU clutter scaler. */
+  aggressionIdx: number;
+  onAggressionIdxChange: (idx: number) => void;
+  /** Tile-availability telemetry from the most recent compute; null if none yet. */
+  clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -794,45 +799,21 @@ export function MapCoveragePanel({
                 </div>
               </div>
 
-              {/* Environment (clutter-loss preset). */}
-              <div>
-                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
-                  <span>Environment</span>
+              {/* Clutter (per-pixel ITU model + aggression scaler). */}
+              <div className="space-y-1.5">
+                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                  <span>Clutter</span>
                   <InfoTip align="left">
-                    Flat clutter-loss offset added on top of ITM to
-                    approximate buildings and vegetation. A foliage/building raster is on the roadmap — it will
-                    replace this with a per-path loss based on real canopy
-                    data.
+                    Per-pixel building / vegetation loss from USGS NLCD land
+                    cover, applied via ITU-R P.452-17 (endpoint clutter) and
+                    P.833-9 (path-traversed vegetation). The slider scales the
+                    calibrated baseline — leave at <em>Calibrated</em> unless
+                    measured links say otherwise.
                   </InfoTip>
                 </label>
-                <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
-                  {ENVIRONMENTS.map((env, i) => {
-                    const active = envIdx === i;
-                    const shortLabel =
-                      env.id === "open" ? "Open"
-                      : env.id === "mixed" ? "Light"
-                      : env.id === "suburban" ? "Suburb"
-                      : "Urban";
-                    return (
-                      <button
-                        key={i}
-                        type="button"
-                        onClick={() => onEnvIdxChange(i)}
-                        title={env.description}
-                        className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
-                          active
-                            ? "bg-cyan-500/20 text-cyan-200"
-                            : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
-                        }`}
-                      >
-                        <div>{shortLabel}</div>
-                        <div className="text-[9px] text-gray-500 font-normal">
-                          {env.clutterLossDb === 0 ? "0 dB" : `+${env.clutterLossDb} dB`}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
+                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} />
+                <ClutterStatusChip status={clutterStatus} />
+                <ClassLegend />
               </div>
 
               {/* Reliability (ITM TLS preset) */}

--- a/frontend/src/pages/map/MapDetailsPanel.tsx
+++ b/frontend/src/pages/map/MapDetailsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { HardwareModel, roleTitles, type NodeRole } from "../../types";
+import { HardwareModel, type NodeRole,roleTitles } from "../../types";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLinks";
 import { normNodeId } from "./linkFeatures";
 import { TelemetrySection } from "./TelemetrySection";

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
-import { ElevationProfile } from "./ElevationProfile";
+
 import {
   COMMON_ANTENNAS,
   COMMON_HARDWARE,
   effectiveSensitivityDbm,
   MESHTASTIC_PRESETS,
 } from "./coverageAnalysis";
+import { ElevationProfile } from "./ElevationProfile";
 import type { LoSResult } from "./losAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -41,6 +41,8 @@ export function MapScanPanel({
   onCustomTxDbmChange,
   aggressionIdx,
   onAggressionIdxChange,
+  clutterEnabled,
+  onClutterEnabledChange,
   clutterStatus,
   presetIdx,
   onPresetIdxChange,
@@ -78,6 +80,9 @@ export function MapScanPanel({
   /** Index into AGGRESSION_STOPS (0/1/2) for the per-pixel ITU clutter model. */
   aggressionIdx: number;
   onAggressionIdxChange: (idx: number) => void;
+  /** Master on/off for the clutter model. Off → ITM-only path loss. */
+  clutterEnabled: boolean;
+  onClutterEnabledChange: (enabled: boolean) => void;
   /** Tile-availability telemetry from the most recent scan; null until first run. */
   clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
@@ -409,11 +414,22 @@ export function MapScanPanel({
 
               {/* Clutter (per-pixel ITU model + aggression scaler). */}
               <div className="space-y-1.5">
-                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
-                  Clutter
-                </label>
-                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} />
-                <ClutterStatusChip status={clutterStatus} />
+                <div className="flex items-center justify-between gap-2">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                    Clutter
+                  </label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={clutterEnabled}
+                      onChange={(e) => onClutterEnabledChange(e.target.checked)}
+                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                    />
+                    <span>Enabled</span>
+                  </label>
+                </div>
+                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
+                <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
                 <ClassLegend />
               </div>
 

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -1,7 +1,8 @@
 /** Scan-results panel: ranked LoS from origin to every node in view. */
 import { useEffect, useMemo, useState } from "react";
 
-import { COMMON_ANTENNAS, COMMON_HARDWARE, ENVIRONMENTS, MESHTASTIC_PRESETS } from "./coverageAnalysis";
+import { AggressionSlider, ClassLegend, ClutterStatusChip } from "./ClutterUI";
+import { COMMON_ANTENNAS, COMMON_HARDWARE, MESHTASTIC_PRESETS } from "./coverageAnalysis";
 import type { ScanClass, ScanResult,ScanSummary } from "./scanAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
@@ -38,8 +39,9 @@ export function MapScanPanel({
   onRxAntennaIdxChange,
   customTxDbm,
   onCustomTxDbmChange,
-  envIdx,
-  onEnvIdxChange,
+  aggressionIdx,
+  onAggressionIdxChange,
+  clutterStatus,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -73,8 +75,11 @@ export function MapScanPanel({
   onRxAntennaIdxChange: (idx: number) => void;
   customTxDbm: number;
   onCustomTxDbmChange: (dbm: number) => void;
-  envIdx: number;
-  onEnvIdxChange: (idx: number) => void;
+  /** Index into AGGRESSION_STOPS (0/1/2) for the per-pixel ITU clutter model. */
+  aggressionIdx: number;
+  onAggressionIdxChange: (idx: number) => void;
+  /** Tile-availability telemetry from the most recent scan; null until first run. */
+  clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -402,39 +407,14 @@ export function MapScanPanel({
                 </div>
               </div>
 
-              {/* Environment */}
-              <div>
-                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                  Environment
+              {/* Clutter (per-pixel ITU model + aggression scaler). */}
+              <div className="space-y-1.5">
+                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                  Clutter
                 </label>
-                <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
-                  {ENVIRONMENTS.map((env, i) => {
-                    const active = envIdx === i;
-                    const shortLabel =
-                      env.id === "open" ? "Open"
-                      : env.id === "mixed" ? "Light"
-                      : env.id === "suburban" ? "Suburb"
-                      : "Urban";
-                    return (
-                      <button
-                        key={i}
-                        type="button"
-                        onClick={() => onEnvIdxChange(i)}
-                        title={env.description}
-                        className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
-                          active
-                            ? "bg-cyan-500/20 text-cyan-200"
-                            : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
-                        }`}
-                      >
-                        <div>{shortLabel}</div>
-                        <div className="text-[9px] text-gray-500 font-normal">
-                          {env.clutterLossDb === 0 ? "0 dB" : `+${env.clutterLossDb} dB`}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
+                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} />
+                <ClutterStatusChip status={clutterStatus} />
+                <ClassLegend />
               </div>
 
               <div className="pt-2 border-t border-white/5 text-[10px] text-gray-500 leading-relaxed">

--- a/frontend/src/pages/map/clutterClasses.test.ts
+++ b/frontend/src/pages/map/clutterClasses.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for ITU-R P.452-17 §4.5.4 endpoint clutter and P.833-9 §4.1 MED
- * vegetation loss. Worked examples in docs/clutter-design.md were derived from
- * the same formulas, so these tests double as a numerical regression suite.
+ * vegetation loss. Worked examples in RF-MODEL.md were derived from the same
+ * formulas, so these tests double as a numerical regression suite.
  *
  * @vitest-environment node
  */

--- a/frontend/src/pages/map/clutterClasses.test.ts
+++ b/frontend/src/pages/map/clutterClasses.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for ITU-R P.452-17 §4.5.4 endpoint clutter and P.833-9 §4.1 MED
+ * vegetation loss. Worked examples in docs/clutter-design.md were derived from
+ * the same formulas, so these tests double as a numerical regression suite.
+ *
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  classForId,
+  type ClutterClass,
+  endpointClutterDb,
+  freqFactor,
+  NLCD_CLASSES,
+  NLCD_DEFAULT_CLASS_ID,
+  vegetationPathLossDb,
+} from "./clutterClasses";
+
+const F_915 = 915;
+
+describe("freqFactor (P.452-17 §4.5.4 F_fc)", () => {
+  it("≈ 0.9986 at 915 MHz", () => {
+    expect(freqFactor(F_915)).toBeCloseTo(0.9986, 3);
+  });
+
+  it("≈ 0.9974 at 868 MHz (EU band)", () => {
+    expect(freqFactor(868)).toBeCloseTo(0.9974, 3);
+  });
+
+  it("saturates near 1.0 at 2400 MHz", () => {
+    expect(freqFactor(2400)).toBeGreaterThan(0.999);
+    expect(freqFactor(2400)).toBeLessThanOrEqual(1.0);
+  });
+
+  it("approaches 0.25 at very low frequency", () => {
+    // f → 0: tanh(7.5·(0 - 0.5)) = tanh(-3.75) ≈ -0.99887, so F_fc ≈ 0.25 + 0.375·0.00113
+    expect(freqFactor(1)).toBeCloseTo(0.25, 2);
+  });
+});
+
+describe("endpointClutterDb (P.452-17 §4.5.4)", () => {
+  // Convenience accessors so each test reads as a physical scenario.
+  const denseUrban = NLCD_CLASSES[24];
+  const suburban = NLCD_CLASSES[22];
+  const evergreen = NLCD_CLASSES[42];
+  const deciduous = NLCD_CLASSES[41];
+  const water = NLCD_CLASSES[11];
+
+  it("returns 0 for h_a = 0 (water) regardless of antenna height", () => {
+    expect(endpointClutterDb(water, 0, F_915)).toBe(0);
+    expect(endpointClutterDb(water, 100, F_915)).toBe(0);
+  });
+
+  it("dense urban handheld (h=2, h_a=25): ≈ 19.7 dB", () => {
+    expect(endpointClutterDb(denseUrban, 2, F_915)).toBeCloseTo(19.71, 1);
+  });
+
+  it("dense urban tower (h=30, h_a=25): clamped to 0", () => {
+    expect(endpointClutterDb(denseUrban, 30, F_915)).toBe(0);
+  });
+
+  it("suburban handheld (h=2, h_a=9): ≈ 19.5 dB", () => {
+    expect(endpointClutterDb(suburban, 2, F_915)).toBeCloseTo(19.48, 1);
+  });
+
+  it("suburban above clutter (h=10, h_a=9): clamped to 0", () => {
+    expect(endpointClutterDb(suburban, 10, F_915)).toBe(0);
+  });
+
+  it("evergreen handheld (h=2, h_a=20): ≈ 19.1 dB", () => {
+    expect(endpointClutterDb(evergreen, 2, F_915)).toBeCloseTo(19.11, 1);
+  });
+
+  it("evergreen above canopy (h=25, h_a=20): clamped to 0", () => {
+    expect(endpointClutterDb(evergreen, 25, F_915)).toBe(0);
+  });
+
+  it("monotonically non-increasing as antenna rises through the clutter layer", () => {
+    let prev = Infinity;
+    for (const h of [0, 1, 2, 5, 10, 15, 20, 30]) {
+      const a = endpointClutterDb(deciduous, h, F_915);
+      expect(a).toBeLessThanOrEqual(prev + 1e-9);
+      prev = a;
+    }
+  });
+
+  it("never returns a negative value (clamp at 0)", () => {
+    // Sweep 100 (class, height) pairs; clamp must hold everywhere.
+    for (const cls of Object.values(NLCD_CLASSES)) {
+      for (const h of [0, 0.5, 1, 2, 5, 10, 20, 50, 100, 1000]) {
+        expect(endpointClutterDb(cls, h, F_915)).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("clamps negative antenna height to 0 instead of producing garbage", () => {
+    const a0 = endpointClutterDb(deciduous, 0, F_915);
+    const aNeg = endpointClutterDb(deciduous, -5, F_915);
+    expect(aNeg).toBeCloseTo(a0, 6);
+  });
+});
+
+describe("vegetationPathLossDb (P.833-9 §4.1 MED)", () => {
+  const evergreen = NLCD_CLASSES[42]; // γ=0.7, A=27
+  const water = NLCD_CLASSES[11];
+  const denseUrban = NLCD_CLASSES[24];
+  const grassland = NLCD_CLASSES[71];
+
+  it("returns 0 for non-penetrable classes (water, built-up, grassland)", () => {
+    expect(vegetationPathLossDb(water, 1000)).toBe(0);
+    expect(vegetationPathLossDb(denseUrban, 1000)).toBe(0);
+    expect(vegetationPathLossDb(grassland, 1000)).toBe(0);
+  });
+
+  it("returns 0 for d ≤ 0", () => {
+    expect(vegetationPathLossDb(evergreen, 0)).toBe(0);
+    expect(vegetationPathLossDb(evergreen, -10)).toBe(0);
+  });
+
+  it("evergreen 10 m graze: ≈ 6.2 dB", () => {
+    expect(vegetationPathLossDb(evergreen, 10)).toBeCloseTo(6.17, 1);
+  });
+
+  it("evergreen 50 m: ≈ 19.6 dB (worked example in design doc)", () => {
+    expect(vegetationPathLossDb(evergreen, 50)).toBeCloseTo(19.62, 1);
+  });
+
+  it("evergreen 200 m: ≈ 26.9 dB (near saturation)", () => {
+    expect(vegetationPathLossDb(evergreen, 200)).toBeCloseTo(26.85, 1);
+  });
+
+  it("evergreen 1000 m: saturates at A = 27 dB", () => {
+    const L = vegetationPathLossDb(evergreen, 1000);
+    expect(L).toBeGreaterThan(26.99);
+    expect(L).toBeLessThanOrEqual(27.0);
+  });
+
+  it("L → A as d → ∞", () => {
+    const L = vegetationPathLossDb(evergreen, 1e6);
+    expect(L).toBeCloseTo(27, 6);
+  });
+
+  it("monotonically non-decreasing in d", () => {
+    let prev = -Infinity;
+    for (const d of [0, 1, 5, 10, 50, 100, 500, 5000]) {
+      const L = vegetationPathLossDb(evergreen, d);
+      expect(L).toBeGreaterThanOrEqual(prev - 1e-9);
+      prev = L;
+    }
+  });
+
+  it("never exceeds the class saturation A", () => {
+    for (const cls of Object.values(NLCD_CLASSES).filter((c) => c.penetrable)) {
+      const L = vegetationPathLossDb(cls, 1e6);
+      expect(L).toBeLessThanOrEqual(cls.vegSaturationDb + 1e-9);
+    }
+  });
+});
+
+describe("classForId + NLCD_CLASSES table integrity", () => {
+  it("default class is 43 (Mixed Forest)", () => {
+    expect(NLCD_DEFAULT_CLASS_ID).toBe(43);
+    expect(NLCD_CLASSES[43]).toBeDefined();
+    expect(NLCD_CLASSES[43].label).toMatch(/Mixed Forest/i);
+  });
+
+  it("returns the matching class for known IDs", () => {
+    expect(classForId(42).label).toMatch(/Evergreen/);
+    expect(classForId(11).label).toMatch(/Water/);
+  });
+
+  it("falls back to default class for unknown IDs", () => {
+    // 0 = nodata sentinel; 99 / 100 / 200 are unused in the NLCD legend.
+    for (const id of [0, 99, 100, 200, 255]) {
+      expect(classForId(id).id).toBe(NLCD_DEFAULT_CLASS_ID);
+    }
+  });
+
+  it("every entry's key matches its id field", () => {
+    for (const [key, cls] of Object.entries(NLCD_CLASSES)) {
+      expect(cls.id).toBe(Number(key));
+    }
+  });
+
+  it("penetrable classes have non-zero gamma and A; non-penetrable have both zero", () => {
+    for (const cls of Object.values(NLCD_CLASSES)) {
+      if (cls.penetrable) {
+        expect(cls.vegAttenuationDbPerM).toBeGreaterThan(0);
+        expect(cls.vegSaturationDb).toBeGreaterThan(0);
+      } else {
+        expect(cls.vegAttenuationDbPerM).toBe(0);
+        expect(cls.vegSaturationDb).toBe(0);
+      }
+    }
+  });
+
+  it("contains all CONUS NLCD classes documented in the design", () => {
+    const expectedIds = [11, 12, 21, 22, 23, 24, 31, 41, 42, 43, 52, 71, 81, 82, 90, 95];
+    for (const id of expectedIds) {
+      expect(NLCD_CLASSES[id]).toBeDefined();
+    }
+  });
+
+  it("readonly type — runtime guarantees not enforced, just spot-check structure", () => {
+    // Sanity that every row has the full ClutterClass shape.
+    const required: (keyof ClutterClass)[] = [
+      "id", "label", "nominalHeightM", "nominalDistanceKm",
+      "vegAttenuationDbPerM", "vegSaturationDb", "penetrable",
+    ];
+    for (const cls of Object.values(NLCD_CLASSES)) {
+      for (const k of required) {
+        expect(cls).toHaveProperty(k);
+      }
+    }
+  });
+});

--- a/frontend/src/pages/map/clutterClasses.ts
+++ b/frontend/src/pages/map/clutterClasses.ts
@@ -1,93 +1,70 @@
 /**
- * NLCD land-cover class table + ITU-R clutter math for the coverage / scan models.
- *
- * Two-component model (see docs/clutter-design.md):
- *   1. Endpoint clutter loss   — ITU-R P.452-17 §4.5.4 (height-gain at TX & RX)
- *   2. Path-traversed foliage — ITU-R P.833-9   §4.1   (modified exponential decay)
- *
- * All values calibrated for 915 MHz. The frequency factor F_fc for P.452 is
- * computed in `freqFactor` so non-US bands (868/433 MHz) work when wired up;
- * the P.833 γ/A values in the table assume 915 MHz and would need a per-band
- * lookup if the region selector lands.
+ * NLCD land-cover class table + ITU-R clutter math. See RF-MODEL.md for the
+ * full derivation; sources are P.452-17 §4.5.4 (endpoint clutter) and P.833-9
+ * §4.1 (path-traversed vegetation, MED). γ/A values are calibrated at 915 MHz.
  */
 
-/** One row of the NLCD → ITU parameter map. */
 export interface ClutterClass {
-  /** NLCD legend ID (e.g. 42 = Evergreen Forest). */
   id: number;
   label: string;
-  /** Nominal clutter height (m AGL). P.452-17 §4.5.4 symbol h_a. 0 for non-clutter. */
+  /** P.452-17 §4.5.4 h_a — nominal clutter height (m AGL). 0 for non-clutter. */
   nominalHeightM: number;
-  /** Nominal antenna-to-clutter distance (km). P.452-17 §4.5.4 symbol d_k. */
+  /** P.452-17 §4.5.4 d_k — nominal antenna-to-clutter distance (km). */
   nominalDistanceKm: number;
-  /** P.833-9 specific attenuation γ (dB/m at 915 MHz). 0 when not penetrable. */
+  /** P.833-9 γ — specific attenuation (dB/m at 915 MHz). 0 if not penetrable. */
   vegAttenuationDbPerM: number;
-  /** P.833-9 saturation A (dB). 0 when not penetrable. */
+  /** P.833-9 A — saturation (dB). */
   vegSaturationDb: number;
-  /** Whether the propagation path can pass *through* this class (foliage true; built-up/water false). */
+  /** Whether the propagation path can pass *through* this class. */
   penetrable: boolean;
 }
 
 /**
- * NLCD class table. Citations live next to each row so the source of truth is auditable.
- *
- * Sources keyed by abbreviation:
- *   P.452-T4  — ITU-R Rec. P.452-17, Table 4 (nominal clutter heights & distances)
- *   P.833-§4  — ITU-R Rec. P.833-9, §4.1 (vegetation specific attenuation, MED model)
- *
- * Where NLCD has no exact ITU analogue, the closest published category is chosen and noted.
+ * Per-row citations: P.452-T4 = ITU-R P.452-17 Table 4; P.833-§4 = P.833-9 §4.1.
+ * Where NLCD has no direct ITU analogue, the closest published category is chosen.
  */
 export const NLCD_CLASSES: Readonly<Record<number, ClutterClass>> = {
-  // --- No-clutter classes (water, barren, ice/snow) ---
-  // h_a=0 means the endpoint formula short-circuits to 0; not penetrable so MED is also 0.
   11: { id: 11, label: "Open Water",            nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0,   vegSaturationDb: 0,  penetrable: false },
   12: { id: 12, label: "Perennial Ice/Snow",    nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0,   vegSaturationDb: 0,  penetrable: false },
   31: { id: 31, label: "Barren Land",           nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0,   vegSaturationDb: 0,  penetrable: false },
 
-  // --- Developed (built-up); not penetrable, endpoint clutter only. P.452-T4 anchors. ---
   21: { id: 21, label: "Developed, Open Space",      nominalHeightM: 4,  nominalDistanceKm: 0.10,  vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Park land / sparse houses"
   22: { id: 22, label: "Developed, Low Intensity",   nominalHeightM: 9,  nominalDistanceKm: 0.025, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Suburban"
   23: { id: 23, label: "Developed, Medium Intensity", nominalHeightM: 15, nominalDistanceKm: 0.020, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Urban"
   24: { id: 24, label: "Developed, High Intensity",  nominalHeightM: 25, nominalDistanceKm: 0.020, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Dense urban"
 
-  // --- Forest (penetrable). P.452-T4 + P.833-§4. ---
-  41: { id: 41, label: "Deciduous Forest",  nominalHeightM: 15, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.5, vegSaturationDb: 24, penetrable: true }, // in-leaf at 900 MHz; out-of-leaf is γ≈0.15, A≈20 (deferred to v2 seasonal)
-  42: { id: 42, label: "Evergreen Forest",  nominalHeightM: 20, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.7, vegSaturationDb: 27, penetrable: true }, // P.833-§4 conifer values
-  43: { id: 43, label: "Mixed Forest",      nominalHeightM: 15, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.6, vegSaturationDb: 25, penetrable: true }, // averaged deciduous + evergreen; also serves as out-of-bbox default
+  41: { id: 41, label: "Deciduous Forest",  nominalHeightM: 15, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.5, vegSaturationDb: 24, penetrable: true }, // P.833 in-leaf at 900 MHz; out-of-leaf is γ≈0.15, A≈20
+  42: { id: 42, label: "Evergreen Forest",  nominalHeightM: 20, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.7, vegSaturationDb: 27, penetrable: true }, // P.833 conifer values
+  43: { id: 43, label: "Mixed Forest",      nominalHeightM: 15, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.6, vegSaturationDb: 25, penetrable: true }, // averaged deciduous + evergreen; default fallback class
 
-  // --- Shrub / scrub. No direct P.452-T4 anchor; closest is between "high crop" and "deciduous". ---
   51: { id: 51, label: "Dwarf Scrub (AK)",  nominalHeightM: 1, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.2, vegSaturationDb: 6,  penetrable: true },
   52: { id: 52, label: "Shrub/Scrub",       nominalHeightM: 2, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.3, vegSaturationDb: 12, penetrable: true },
 
-  // --- Herbaceous (too short to attenuate at 915 MHz for typical antennas). ---
   // h_a≈0.5 means h/h_a is large for any handheld → endpoint formula returns ~0 dB.
   71: { id: 71, label: "Grassland/Herbaceous",       nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
   72: { id: 72, label: "Sedge/Herbaceous (AK)",      nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
   73: { id: 73, label: "Lichens (AK)",               nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
   74: { id: 74, label: "Moss (AK)",                  nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
 
-  // --- Cultivated. ---
-  81: { id: 81, label: "Pasture/Hay",        nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0,   vegSaturationDb: 0, penetrable: false }, // mowed; effectively invisible
-  82: { id: 82, label: "Cultivated Crops",   nominalHeightM: 4,   nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.3, vegSaturationDb: 8, penetrable: true },  // P.452-T4 "High crop fields"; conservative — assumes tall crops
+  81: { id: 81, label: "Pasture/Hay",        nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0,   vegSaturationDb: 0, penetrable: false },
+  82: { id: 82, label: "Cultivated Crops",   nominalHeightM: 4,   nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.3, vegSaturationDb: 8, penetrable: true },  // P.452-T4 "High crop fields"; assumes tall crops
 
-  // --- Wetlands. ---
-  90: { id: 90, label: "Woody Wetlands",                nominalHeightM: 10, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.5, vegSaturationDb: 20, penetrable: true }, // tree-dominated wetland; like deciduous but lower density
-  95: { id: 95, label: "Emergent Herbaceous Wetlands",  nominalHeightM: 2,  nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.2, vegSaturationDb: 6,  penetrable: true }, // cattails / reeds
+  90: { id: 90, label: "Woody Wetlands",                nominalHeightM: 10, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.5, vegSaturationDb: 20, penetrable: true },
+  95: { id: 95, label: "Emergent Herbaceous Wetlands",  nominalHeightM: 2,  nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.2, vegSaturationDb: 6,  penetrable: true },
 };
 
-/** Mixed Forest — used when a tile is missing or the class ID is unknown. Conservative default. */
+/** Mixed Forest — fallback when a tile is missing or the class ID is unknown. */
 export const NLCD_DEFAULT_CLASS_ID = 43;
 
-/** Lookup with safe fallback. Unknown IDs (including the 0 nodata sentinel) return the default class. */
+/** Unknown IDs (including the 0 nodata sentinel) return the default class. */
 export function classForId(id: number): ClutterClass {
   return NLCD_CLASSES[id] ?? NLCD_CLASSES[NLCD_DEFAULT_CLASS_ID];
 }
 
 /**
- * Frequency factor F_fc for the P.452-17 §4.5.4 endpoint clutter formula.
- *   F_fc = 0.25 + 0.375 · {1 + tanh[7.5 · (f - 0.5)]}   (f in GHz)
- * At 915 MHz ≈ 0.9986; at 868 MHz ≈ 0.9974; at 433 MHz ≈ 0.6839 (formula is
- * defined down to 30 MHz, but accuracy below ~700 MHz is reduced).
+ * P.452-17 §4.5.4 frequency factor F_fc:
+ *   F_fc = 0.25 + 0.375 · {1 + tanh[7.5 · (f − 0.5)]}   (f in GHz)
+ * 915 MHz ≈ 0.9986; 868 MHz ≈ 0.9974. Below ~700 MHz the formula's accuracy drops.
  */
 export function freqFactor(freqMhz: number): number {
   const fGhz = freqMhz / 1000;
@@ -95,15 +72,10 @@ export function freqFactor(freqMhz: number): number {
 }
 
 /**
- * Endpoint clutter loss A_h (dB) per ITU-R P.452-17 §4.5.4.
- *
- *   A_h = 10.25 · F_fc · exp(-d_k) · {1 - tanh[6 · (h/h_a - 0.625)]} - 0.33
- *
- * - Returns 0 when the class has no defined clutter (h_a ≤ 0).
- * - Returns 0 when the antenna sits well above clutter (formula goes mildly
- *   negative due to the -0.33 term; physically this means "no clutter loss").
- *
- * Inputs are clamped only where physical: antennaAGLm < 0 is treated as 0.
+ * P.452-17 §4.5.4 endpoint clutter A_h (dB):
+ *   A_h = 10.25 · F_fc · exp(−d_k) · {1 − tanh[6 · (h/h_a − 0.625)]} − 0.33
+ * Clamped to ≥0; the −0.33 term lets the formula go mildly negative when the
+ * antenna is well above clutter (physically: no clutter loss).
  */
 export function endpointClutterDb(
   cls: ClutterClass,
@@ -122,16 +94,10 @@ export function endpointClutterDb(
 }
 
 /**
- * Path-traversed vegetation loss L (dB) per ITU-R P.833-9 §4.1 (modified exponential decay).
- *
- *   L = A · {1 - exp[-γ · d / A]}
- *
- * - Linear in d for short grazes; saturates at A for long penetration.
- * - Returns 0 for non-penetrable classes, d ≤ 0, γ ≤ 0, or A ≤ 0.
- *
- * Note: callers should accumulate `pathLengthThroughClassM` per class separately
- * before calling this — a path can traverse multiple class types and each gets
- * its own MED evaluation.
+ * P.833-9 §4.1 modified exponential decay for path-traversed vegetation:
+ *   L = A · {1 − exp[−γ · d / A]}
+ * Callers must accumulate `pathLengthThroughClassM` per class — a path crossing
+ * multiple class types is summed by class, each evaluated independently.
  */
 export function vegetationPathLossDb(
   cls: ClutterClass,

--- a/frontend/src/pages/map/clutterClasses.ts
+++ b/frontend/src/pages/map/clutterClasses.ts
@@ -1,0 +1,144 @@
+/**
+ * NLCD land-cover class table + ITU-R clutter math for the coverage / scan models.
+ *
+ * Two-component model (see docs/clutter-design.md):
+ *   1. Endpoint clutter loss   — ITU-R P.452-17 §4.5.4 (height-gain at TX & RX)
+ *   2. Path-traversed foliage — ITU-R P.833-9   §4.1   (modified exponential decay)
+ *
+ * All values calibrated for 915 MHz. The frequency factor F_fc for P.452 is
+ * computed in `freqFactor` so non-US bands (868/433 MHz) work when wired up;
+ * the P.833 γ/A values in the table assume 915 MHz and would need a per-band
+ * lookup if the region selector lands.
+ */
+
+/** One row of the NLCD → ITU parameter map. */
+export interface ClutterClass {
+  /** NLCD legend ID (e.g. 42 = Evergreen Forest). */
+  id: number;
+  label: string;
+  /** Nominal clutter height (m AGL). P.452-17 §4.5.4 symbol h_a. 0 for non-clutter. */
+  nominalHeightM: number;
+  /** Nominal antenna-to-clutter distance (km). P.452-17 §4.5.4 symbol d_k. */
+  nominalDistanceKm: number;
+  /** P.833-9 specific attenuation γ (dB/m at 915 MHz). 0 when not penetrable. */
+  vegAttenuationDbPerM: number;
+  /** P.833-9 saturation A (dB). 0 when not penetrable. */
+  vegSaturationDb: number;
+  /** Whether the propagation path can pass *through* this class (foliage true; built-up/water false). */
+  penetrable: boolean;
+}
+
+/**
+ * NLCD class table. Citations live next to each row so the source of truth is auditable.
+ *
+ * Sources keyed by abbreviation:
+ *   P.452-T4  — ITU-R Rec. P.452-17, Table 4 (nominal clutter heights & distances)
+ *   P.833-§4  — ITU-R Rec. P.833-9, §4.1 (vegetation specific attenuation, MED model)
+ *
+ * Where NLCD has no exact ITU analogue, the closest published category is chosen and noted.
+ */
+export const NLCD_CLASSES: Readonly<Record<number, ClutterClass>> = {
+  // --- No-clutter classes (water, barren, ice/snow) ---
+  // h_a=0 means the endpoint formula short-circuits to 0; not penetrable so MED is also 0.
+  11: { id: 11, label: "Open Water",            nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0,   vegSaturationDb: 0,  penetrable: false },
+  12: { id: 12, label: "Perennial Ice/Snow",    nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0,   vegSaturationDb: 0,  penetrable: false },
+  31: { id: 31, label: "Barren Land",           nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0,   vegSaturationDb: 0,  penetrable: false },
+
+  // --- Developed (built-up); not penetrable, endpoint clutter only. P.452-T4 anchors. ---
+  21: { id: 21, label: "Developed, Open Space",      nominalHeightM: 4,  nominalDistanceKm: 0.10,  vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Park land / sparse houses"
+  22: { id: 22, label: "Developed, Low Intensity",   nominalHeightM: 9,  nominalDistanceKm: 0.025, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Suburban"
+  23: { id: 23, label: "Developed, Medium Intensity", nominalHeightM: 15, nominalDistanceKm: 0.020, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Urban"
+  24: { id: 24, label: "Developed, High Intensity",  nominalHeightM: 25, nominalDistanceKm: 0.020, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false }, // P.452-T4 "Dense urban"
+
+  // --- Forest (penetrable). P.452-T4 + P.833-§4. ---
+  41: { id: 41, label: "Deciduous Forest",  nominalHeightM: 15, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.5, vegSaturationDb: 24, penetrable: true }, // in-leaf at 900 MHz; out-of-leaf is γ≈0.15, A≈20 (deferred to v2 seasonal)
+  42: { id: 42, label: "Evergreen Forest",  nominalHeightM: 20, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.7, vegSaturationDb: 27, penetrable: true }, // P.833-§4 conifer values
+  43: { id: 43, label: "Mixed Forest",      nominalHeightM: 15, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.6, vegSaturationDb: 25, penetrable: true }, // averaged deciduous + evergreen; also serves as out-of-bbox default
+
+  // --- Shrub / scrub. No direct P.452-T4 anchor; closest is between "high crop" and "deciduous". ---
+  51: { id: 51, label: "Dwarf Scrub (AK)",  nominalHeightM: 1, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.2, vegSaturationDb: 6,  penetrable: true },
+  52: { id: 52, label: "Shrub/Scrub",       nominalHeightM: 2, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.3, vegSaturationDb: 12, penetrable: true },
+
+  // --- Herbaceous (too short to attenuate at 915 MHz for typical antennas). ---
+  // h_a≈0.5 means h/h_a is large for any handheld → endpoint formula returns ~0 dB.
+  71: { id: 71, label: "Grassland/Herbaceous",       nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
+  72: { id: 72, label: "Sedge/Herbaceous (AK)",      nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
+  73: { id: 73, label: "Lichens (AK)",               nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
+  74: { id: 74, label: "Moss (AK)",                  nominalHeightM: 0,   nominalDistanceKm: 0,    vegAttenuationDbPerM: 0, vegSaturationDb: 0, penetrable: false },
+
+  // --- Cultivated. ---
+  81: { id: 81, label: "Pasture/Hay",        nominalHeightM: 0.5, nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0,   vegSaturationDb: 0, penetrable: false }, // mowed; effectively invisible
+  82: { id: 82, label: "Cultivated Crops",   nominalHeightM: 4,   nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.3, vegSaturationDb: 8, penetrable: true },  // P.452-T4 "High crop fields"; conservative — assumes tall crops
+
+  // --- Wetlands. ---
+  90: { id: 90, label: "Woody Wetlands",                nominalHeightM: 10, nominalDistanceKm: 0.05, vegAttenuationDbPerM: 0.5, vegSaturationDb: 20, penetrable: true }, // tree-dominated wetland; like deciduous but lower density
+  95: { id: 95, label: "Emergent Herbaceous Wetlands",  nominalHeightM: 2,  nominalDistanceKm: 0.10, vegAttenuationDbPerM: 0.2, vegSaturationDb: 6,  penetrable: true }, // cattails / reeds
+};
+
+/** Mixed Forest — used when a tile is missing or the class ID is unknown. Conservative default. */
+export const NLCD_DEFAULT_CLASS_ID = 43;
+
+/** Lookup with safe fallback. Unknown IDs (including the 0 nodata sentinel) return the default class. */
+export function classForId(id: number): ClutterClass {
+  return NLCD_CLASSES[id] ?? NLCD_CLASSES[NLCD_DEFAULT_CLASS_ID];
+}
+
+/**
+ * Frequency factor F_fc for the P.452-17 §4.5.4 endpoint clutter formula.
+ *   F_fc = 0.25 + 0.375 · {1 + tanh[7.5 · (f - 0.5)]}   (f in GHz)
+ * At 915 MHz ≈ 0.9986; at 868 MHz ≈ 0.9974; at 433 MHz ≈ 0.6839 (formula is
+ * defined down to 30 MHz, but accuracy below ~700 MHz is reduced).
+ */
+export function freqFactor(freqMhz: number): number {
+  const fGhz = freqMhz / 1000;
+  return 0.25 + 0.375 * (1 + Math.tanh(7.5 * (fGhz - 0.5)));
+}
+
+/**
+ * Endpoint clutter loss A_h (dB) per ITU-R P.452-17 §4.5.4.
+ *
+ *   A_h = 10.25 · F_fc · exp(-d_k) · {1 - tanh[6 · (h/h_a - 0.625)]} - 0.33
+ *
+ * - Returns 0 when the class has no defined clutter (h_a ≤ 0).
+ * - Returns 0 when the antenna sits well above clutter (formula goes mildly
+ *   negative due to the -0.33 term; physically this means "no clutter loss").
+ *
+ * Inputs are clamped only where physical: antennaAGLm < 0 is treated as 0.
+ */
+export function endpointClutterDb(
+  cls: ClutterClass,
+  antennaAGLm: number,
+  freqMhz: number,
+): number {
+  if (cls.nominalHeightM <= 0) return 0;
+  const h = Math.max(0, antennaAGLm);
+  const ratio = h / cls.nominalHeightM;
+  const fc = freqFactor(freqMhz);
+  const a =
+    10.25 * fc * Math.exp(-cls.nominalDistanceKm) *
+      (1 - Math.tanh(6 * (ratio - 0.625))) -
+    0.33;
+  return a > 0 ? a : 0;
+}
+
+/**
+ * Path-traversed vegetation loss L (dB) per ITU-R P.833-9 §4.1 (modified exponential decay).
+ *
+ *   L = A · {1 - exp[-γ · d / A]}
+ *
+ * - Linear in d for short grazes; saturates at A for long penetration.
+ * - Returns 0 for non-penetrable classes, d ≤ 0, γ ≤ 0, or A ≤ 0.
+ *
+ * Note: callers should accumulate `pathLengthThroughClassM` per class separately
+ * before calling this — a path can traverse multiple class types and each gets
+ * its own MED evaluation.
+ */
+export function vegetationPathLossDb(
+  cls: ClutterClass,
+  pathLengthThroughClassM: number,
+): number {
+  if (!cls.penetrable) return 0;
+  const { vegAttenuationDbPerM: gamma, vegSaturationDb: A } = cls;
+  if (gamma <= 0 || A <= 0 || pathLengthThroughClassM <= 0) return 0;
+  return A * (1 - Math.exp((-gamma * pathLengthThroughClassM) / A));
+}

--- a/frontend/src/pages/map/clutterPath.test.ts
+++ b/frontend/src/pages/map/clutterPath.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for computePathClutterLoss — the orchestration that combines P.452 endpoint
+ * clutter with P.833 path-integrated vegetation.
+ *
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  endpointClutterDb,
+  NLCD_CLASSES,
+  vegetationPathLossDb,
+} from "./clutterClasses";
+import {
+  CLUTTER_SCRATCH_LEN,
+  computePathClutterLoss,
+  makeClutterScratch,
+} from "./clutterPath";
+
+const F_915 = 915;
+
+/**
+ * Build a flat-terrain profile of N samples with one constant class everywhere.
+ * Returns (profileM, profileClasses).
+ */
+function flatProfile(
+  n: number,
+  classId: number,
+  groundM: number = 0,
+): { profileM: Float64Array; profileClasses: Uint8Array } {
+  const profileM = new Float64Array(n).fill(groundM);
+  const profileClasses = new Uint8Array(n).fill(classId);
+  return { profileM, profileClasses };
+}
+
+describe("makeClutterScratch", () => {
+  it("returns a Float32Array of CLUTTER_SCRATCH_LEN zeros", () => {
+    const s = makeClutterScratch();
+    expect(s.length).toBe(CLUTTER_SCRATCH_LEN);
+    expect(s.every((v) => v === 0)).toBe(true);
+  });
+});
+
+describe("computePathClutterLoss — degenerate cases", () => {
+  it("returns 0 for nSamples < 2", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(1, 42);
+    expect(
+      computePathClutterLoss(profileM, profileClasses, 1, 100, 2, 2, F_915, 1.0, scratch),
+    ).toBe(0);
+  });
+
+  it("returns 0 for pointSpacingM ≤ 0", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(50, 42);
+    expect(
+      computePathClutterLoss(profileM, profileClasses, 50, 0, 2, 2, F_915, 1.0, scratch),
+    ).toBe(0);
+  });
+});
+
+describe("computePathClutterLoss — water path (non-clutter everywhere)", () => {
+  it("≈ 0 dB for an open-water path with above-water antennas", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(50, 11); // class 11 = Open Water
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, 50, 200, 5, 5, F_915, 1.0, scratch,
+    );
+    expect(loss).toBe(0);
+  });
+});
+
+describe("computePathClutterLoss — endpoint clutter dominates", () => {
+  // Path above canopy → no MED; loss should equal endpoint A_h_tx + A_h_rx.
+  it("matches sum of endpoint terms when both antennas are above evergreen canopy", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 42); // evergreen everywhere
+    const txAGL = 25; // above 20 m canopy
+    const rxAGL = 25;
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, txAGL, rxAGL, F_915, 1.0, scratch,
+    );
+    const expected =
+      endpointClutterDb(NLCD_CLASSES[42], txAGL, F_915) +
+      endpointClutterDb(NLCD_CLASSES[42], rxAGL, F_915);
+    // Tower above canopy → both endpoint terms clamp to 0.
+    expect(loss).toBeCloseTo(expected, 3);
+    expect(loss).toBeCloseTo(0, 3);
+  });
+
+  it("evergreen handhelds at both ends ≈ 2 × 19.1 dB endpoint, no MED for short paths", () => {
+    const scratch = makeClutterScratch();
+    // Short path (50 m) with handheld antennas — endpoint exclusion (skip d_k=50 m at each end)
+    // covers nearly the whole profile, so MED contribution is ~0.
+    const { profileM, profileClasses } = flatProfile(15, 42);
+    const pointSpacingM = 50 / 14; // 50 m total / 14 spacings
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, 15, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+    );
+    const a = endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
+    expect(loss).toBeCloseTo(2 * a, 0); // endpoint × 2
+    expect(loss).toBeGreaterThan(35); // ~38 dB
+    expect(loss).toBeLessThan(42);
+  });
+});
+
+describe("computePathClutterLoss — path-integrated MED", () => {
+  it("long evergreen path adds ~saturation A on top of endpoint terms", () => {
+    const scratch = makeClutterScratch();
+    // 5 km path, 100 samples, handhelds (2 m). Endpoint clutter ~19.1 each end;
+    // path integration through 4900 m of penetrable canopy saturates at A=27 dB.
+    const { profileM, profileClasses } = flatProfile(100, 42);
+    const pointSpacingM = 5000 / 99;
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, 100, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+    );
+    const aH = endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
+    // 2 endpoints + saturated MED ≈ 2·19.1 + 27 ≈ 65 dB
+    expect(loss).toBeGreaterThan(60);
+    expect(loss).toBeLessThan(72);
+    // Concretely: endpoint × 2 + saturated A
+    expect(loss).toBeCloseTo(2 * aH + 27, 0);
+  });
+
+  it("monotonically non-decreasing in path length through forest", () => {
+    const scratch = makeClutterScratch();
+    let prev = -Infinity;
+    for (const n of [10, 20, 50, 100, 200, 500]) {
+      const { profileM, profileClasses } = flatProfile(n, 42);
+      const pointSpacingM = 50; // 50 m steps
+      const loss = computePathClutterLoss(
+        profileM, profileClasses, n, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+      );
+      expect(loss).toBeGreaterThanOrEqual(prev - 1e-6);
+      prev = loss;
+    }
+  });
+
+  it("mixed-class path: deciduous half + evergreen half, MED summed per class", () => {
+    const scratch = makeClutterScratch();
+    const N = 100;
+    const profileM = new Float64Array(N); // flat
+    const profileClasses = new Uint8Array(N);
+    for (let i = 0; i < N / 2; i++) profileClasses[i] = 41;        // deciduous
+    for (let i = N / 2; i < N; i++) profileClasses[i] = 42;        // evergreen
+    const pointSpacingM = 5000 / 99; // 5 km
+
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, N, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+    );
+
+    // Each half ≈ 2.5 km of penetrable canopy — both saturate near their A.
+    // Deciduous A=24, evergreen A=27 → MED ≈ 24 + 27 = 51.
+    // Endpoint at TX (deciduous, 2m) ~19.1; at RX (evergreen, 2m) ~19.1.
+    // Total ≈ 19.1 + 19.1 + 51 ≈ 89 dB.
+    expect(loss).toBeGreaterThan(85);
+    expect(loss).toBeLessThan(93);
+  });
+});
+
+describe("computePathClutterLoss — aggression scaler", () => {
+  it("0× zeros out the result", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 42);
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 0, scratch,
+    );
+    expect(loss).toBe(0);
+  });
+
+  it("scales the total linearly", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 42);
+    const at1 = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
+    );
+    const at07 = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 0.7, scratch,
+    );
+    const at13 = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.3, scratch,
+    );
+    expect(at07).toBeCloseTo(at1 * 0.7, 5);
+    expect(at13).toBeCloseTo(at1 * 1.3, 5);
+  });
+});
+
+describe("computePathClutterLoss — scratch buffer hygiene", () => {
+  it("leaves scratch back at zero after each call (O(touched) reset)", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 42);
+    computePathClutterLoss(profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
+    expect(scratch.every((v) => v === 0)).toBe(true);
+  });
+
+  it("two back-to-back calls with different classes don't leak distance", () => {
+    const scratch = makeClutterScratch();
+    // Call 1: evergreen
+    const a = flatProfile(80, 42);
+    const lossA = computePathClutterLoss(a.profileM, a.profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
+    // Call 2: deciduous (different class). If scratch leaked, the result would
+    // include accumulated evergreen distance.
+    const b = flatProfile(80, 41);
+    const lossB = computePathClutterLoss(b.profileM, b.profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
+
+    // Independent: rerun call 2 with a fresh scratch and compare.
+    const fresh = makeClutterScratch();
+    const lossBFresh = computePathClutterLoss(b.profileM, b.profileClasses, 80, 100, 2, 2, F_915, 1.0, fresh);
+    expect(lossB).toBeCloseTo(lossBFresh, 6);
+    expect(lossA).not.toBe(lossB);
+  });
+});
+
+describe("computePathClutterLoss — z_path above canopy on tall terrain", () => {
+  it("excludes samples where the lerp'd path is above the local canopy", () => {
+    const scratch = makeClutterScratch();
+    // Path between two 100 m hilltops, with a 0 m valley in the middle.
+    // Even though the valley is forested, the antennas are at 2 m AGL on hills,
+    // so z_path well above the valley canopy for all but the endpoints.
+    const N = 50;
+    const profileM = new Float64Array(N);
+    profileM[0] = 100;
+    profileM[N - 1] = 100;
+    for (let i = 1; i < N - 1; i++) profileM[i] = 0; // deep valley
+    const profileClasses = new Uint8Array(N).fill(42);
+    const pointSpacingM = 200;
+    const lossWithCanopyMask = computePathClutterLoss(
+      profileM, profileClasses, N, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+    );
+
+    // Endpoints (at 2m AGL on 100m hills) → 100m+2m=102m antenna MSL each end.
+    // Valley canopy top = 0 + 20 = 20 m. Path z(s=middle) ≈ 102 m → above canopy → no MED.
+    // So MED contribution should be ~0; total ≈ 2 × endpoint clutter (each end is forest h=2).
+    const expected = 2 * vegetationPathLossDb(NLCD_CLASSES[42], 0)
+      + 2 * /* hilltop forest endpoint */
+        endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
+    expect(lossWithCanopyMask).toBeCloseTo(expected, 0);
+  });
+});

--- a/frontend/src/pages/map/clutterPath.test.ts
+++ b/frontend/src/pages/map/clutterPath.test.ts
@@ -1,9 +1,4 @@
-/**
- * Tests for computePathClutterLoss — the orchestration that combines P.452 endpoint
- * clutter with P.833 path-integrated vegetation.
- *
- * @vitest-environment node
- */
+/** @vitest-environment node */
 import { describe, expect, it } from "vitest";
 
 import {
@@ -19,10 +14,6 @@ import {
 
 const F_915 = 915;
 
-/**
- * Build a flat-terrain profile of N samples with one constant class everywhere.
- * Returns (profileM, profileClasses).
- */
 function flatProfile(
   n: number,
   classId: number,
@@ -62,7 +53,7 @@ describe("computePathClutterLoss — degenerate cases", () => {
 describe("computePathClutterLoss — water path (non-clutter everywhere)", () => {
   it("≈ 0 dB for an open-water path with above-water antennas", () => {
     const scratch = makeClutterScratch();
-    const { profileM, profileClasses } = flatProfile(50, 11); // class 11 = Open Water
+    const { profileM, profileClasses } = flatProfile(50, 11);
     const loss = computePathClutterLoss(
       profileM, profileClasses, 50, 200, 5, 5, F_915, 1.0, scratch,
     );
@@ -71,11 +62,10 @@ describe("computePathClutterLoss — water path (non-clutter everywhere)", () =>
 });
 
 describe("computePathClutterLoss — endpoint clutter dominates", () => {
-  // Path above canopy → no MED; loss should equal endpoint A_h_tx + A_h_rx.
   it("matches sum of endpoint terms when both antennas are above evergreen canopy", () => {
     const scratch = makeClutterScratch();
-    const { profileM, profileClasses } = flatProfile(80, 42); // evergreen everywhere
-    const txAGL = 25; // above 20 m canopy
+    const { profileM, profileClasses } = flatProfile(80, 42);
+    const txAGL = 25;
     const rxAGL = 25;
     const loss = computePathClutterLoss(
       profileM, profileClasses, 80, 100, txAGL, rxAGL, F_915, 1.0, scratch,
@@ -83,23 +73,22 @@ describe("computePathClutterLoss — endpoint clutter dominates", () => {
     const expected =
       endpointClutterDb(NLCD_CLASSES[42], txAGL, F_915) +
       endpointClutterDb(NLCD_CLASSES[42], rxAGL, F_915);
-    // Tower above canopy → both endpoint terms clamp to 0.
     expect(loss).toBeCloseTo(expected, 3);
     expect(loss).toBeCloseTo(0, 3);
   });
 
   it("evergreen handhelds at both ends ≈ 2 × 19.1 dB endpoint, no MED for short paths", () => {
     const scratch = makeClutterScratch();
-    // Short path (50 m) with handheld antennas — endpoint exclusion (skip d_k=50 m at each end)
-    // covers nearly the whole profile, so MED contribution is ~0.
+    // 50 m path with handhelds: endpoint exclusion (d_k=50 m each end) covers
+    // nearly the whole profile, so MED contribution is ~0.
     const { profileM, profileClasses } = flatProfile(15, 42);
-    const pointSpacingM = 50 / 14; // 50 m total / 14 spacings
+    const pointSpacingM = 50 / 14;
     const loss = computePathClutterLoss(
       profileM, profileClasses, 15, pointSpacingM, 2, 2, F_915, 1.0, scratch,
     );
     const a = endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
-    expect(loss).toBeCloseTo(2 * a, 0); // endpoint × 2
-    expect(loss).toBeGreaterThan(35); // ~38 dB
+    expect(loss).toBeCloseTo(2 * a, 0);
+    expect(loss).toBeGreaterThan(35);
     expect(loss).toBeLessThan(42);
   });
 });
@@ -107,18 +96,14 @@ describe("computePathClutterLoss — endpoint clutter dominates", () => {
 describe("computePathClutterLoss — path-integrated MED", () => {
   it("long evergreen path adds ~saturation A on top of endpoint terms", () => {
     const scratch = makeClutterScratch();
-    // 5 km path, 100 samples, handhelds (2 m). Endpoint clutter ~19.1 each end;
-    // path integration through 4900 m of penetrable canopy saturates at A=27 dB.
     const { profileM, profileClasses } = flatProfile(100, 42);
     const pointSpacingM = 5000 / 99;
     const loss = computePathClutterLoss(
       profileM, profileClasses, 100, pointSpacingM, 2, 2, F_915, 1.0, scratch,
     );
     const aH = endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
-    // 2 endpoints + saturated MED ≈ 2·19.1 + 27 ≈ 65 dB
     expect(loss).toBeGreaterThan(60);
     expect(loss).toBeLessThan(72);
-    // Concretely: endpoint × 2 + saturated A
     expect(loss).toBeCloseTo(2 * aH + 27, 0);
   });
 
@@ -127,9 +112,8 @@ describe("computePathClutterLoss — path-integrated MED", () => {
     let prev = -Infinity;
     for (const n of [10, 20, 50, 100, 200, 500]) {
       const { profileM, profileClasses } = flatProfile(n, 42);
-      const pointSpacingM = 50; // 50 m steps
       const loss = computePathClutterLoss(
-        profileM, profileClasses, n, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+        profileM, profileClasses, n, 50, 2, 2, F_915, 1.0, scratch,
       );
       expect(loss).toBeGreaterThanOrEqual(prev - 1e-6);
       prev = loss;
@@ -139,20 +123,18 @@ describe("computePathClutterLoss — path-integrated MED", () => {
   it("mixed-class path: deciduous half + evergreen half, MED summed per class", () => {
     const scratch = makeClutterScratch();
     const N = 100;
-    const profileM = new Float64Array(N); // flat
+    const profileM = new Float64Array(N);
     const profileClasses = new Uint8Array(N);
-    for (let i = 0; i < N / 2; i++) profileClasses[i] = 41;        // deciduous
-    for (let i = N / 2; i < N; i++) profileClasses[i] = 42;        // evergreen
-    const pointSpacingM = 5000 / 99; // 5 km
+    for (let i = 0; i < N / 2; i++) profileClasses[i] = 41;
+    for (let i = N / 2; i < N; i++) profileClasses[i] = 42;
+    const pointSpacingM = 5000 / 99;
 
     const loss = computePathClutterLoss(
       profileM, profileClasses, N, pointSpacingM, 2, 2, F_915, 1.0, scratch,
     );
 
-    // Each half ≈ 2.5 km of penetrable canopy — both saturate near their A.
-    // Deciduous A=24, evergreen A=27 → MED ≈ 24 + 27 = 51.
-    // Endpoint at TX (deciduous, 2m) ~19.1; at RX (evergreen, 2m) ~19.1.
-    // Total ≈ 19.1 + 19.1 + 51 ≈ 89 dB.
+    // Each half saturates near A: deciduous A=24 + evergreen A=27 = 51.
+    // Endpoints: 2 × ~19.1 ≈ 38. Total ≈ 89 dB.
     expect(loss).toBeGreaterThan(85);
     expect(loss).toBeLessThan(93);
   });
@@ -186,7 +168,7 @@ describe("computePathClutterLoss — aggression scaler", () => {
 });
 
 describe("computePathClutterLoss — scratch buffer hygiene", () => {
-  it("leaves scratch back at zero after each call (O(touched) reset)", () => {
+  it("leaves scratch back at zero after each call", () => {
     const scratch = makeClutterScratch();
     const { profileM, profileClasses } = flatProfile(80, 42);
     computePathClutterLoss(profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
@@ -195,15 +177,11 @@ describe("computePathClutterLoss — scratch buffer hygiene", () => {
 
   it("two back-to-back calls with different classes don't leak distance", () => {
     const scratch = makeClutterScratch();
-    // Call 1: evergreen
     const a = flatProfile(80, 42);
     const lossA = computePathClutterLoss(a.profileM, a.profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
-    // Call 2: deciduous (different class). If scratch leaked, the result would
-    // include accumulated evergreen distance.
     const b = flatProfile(80, 41);
     const lossB = computePathClutterLoss(b.profileM, b.profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
 
-    // Independent: rerun call 2 with a fresh scratch and compare.
     const fresh = makeClutterScratch();
     const lossBFresh = computePathClutterLoss(b.profileM, b.profileClasses, 80, 100, 2, 2, F_915, 1.0, fresh);
     expect(lossB).toBeCloseTo(lossBFresh, 6);
@@ -211,29 +189,62 @@ describe("computePathClutterLoss — scratch buffer hygiene", () => {
   });
 });
 
+describe("computePathClutterLoss — asymmetric endpoint exclusion", () => {
+  it("uses each endpoint's own d_k, not max(tx, rx)", () => {
+    // TX evergreen (d_k=50 m), RX dense urban (d_k=20 m), forest interior, 10 m spacing.
+    // Symmetric max() would skip 5 samples each end; asymmetric correctly skips 5/2,
+    // yielding 4 forest samples (40 m → 17.4 dB MED) instead of 1 (10 m → 6.2 dB).
+    const scratch = makeClutterScratch();
+    const N = 11;
+    const profileM = new Float64Array(N);
+    const profileClasses = new Uint8Array(N).fill(42);
+    profileClasses[N - 1] = 24;
+
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, N, 10, 2, 2, F_915, 1.0, scratch,
+    );
+    expect(loss).toBeGreaterThan(53);
+    expect(loss).toBeLessThan(60);
+  });
+});
+
+describe("computePathClutterLoss — raw nodata id=0 canonicalizes to default class", () => {
+  it("interleaved nodata + literal 43 yields the same result as uniform 43", () => {
+    const scratch = makeClutterScratch();
+    const N = 50;
+    const profileM = new Float64Array(N);
+    const profileClasses = new Uint8Array(N);
+    for (let i = 0; i < N; i++) profileClasses[i] = i % 2 === 0 ? 0 : 43;
+
+    const lossInterleaved = computePathClutterLoss(
+      profileM, profileClasses, N, 100, 2, 2, F_915, 1.0, scratch,
+    );
+    const allMixed = new Uint8Array(N).fill(43);
+    const lossUniform = computePathClutterLoss(
+      profileM, allMixed, N, 100, 2, 2, F_915, 1.0, scratch,
+    );
+    expect(lossInterleaved).toBeCloseTo(lossUniform, 5);
+  });
+});
+
 describe("computePathClutterLoss — z_path above canopy on tall terrain", () => {
   it("excludes samples where the lerp'd path is above the local canopy", () => {
     const scratch = makeClutterScratch();
-    // Path between two 100 m hilltops, with a 0 m valley in the middle.
-    // Even though the valley is forested, the antennas are at 2 m AGL on hills,
-    // so z_path well above the valley canopy for all but the endpoints.
+    // Two 100 m hilltops with a 0 m forested valley between. Antennas at 2 m AGL
+    // on the hills → z_path ~102 m, well above the 20 m valley canopy → no MED.
     const N = 50;
     const profileM = new Float64Array(N);
     profileM[0] = 100;
     profileM[N - 1] = 100;
-    for (let i = 1; i < N - 1; i++) profileM[i] = 0; // deep valley
+    for (let i = 1; i < N - 1; i++) profileM[i] = 0;
     const profileClasses = new Uint8Array(N).fill(42);
-    const pointSpacingM = 200;
-    const lossWithCanopyMask = computePathClutterLoss(
-      profileM, profileClasses, N, pointSpacingM, 2, 2, F_915, 1.0, scratch,
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, N, 200, 2, 2, F_915, 1.0, scratch,
     );
 
-    // Endpoints (at 2m AGL on 100m hills) → 100m+2m=102m antenna MSL each end.
-    // Valley canopy top = 0 + 20 = 20 m. Path z(s=middle) ≈ 102 m → above canopy → no MED.
-    // So MED contribution should be ~0; total ≈ 2 × endpoint clutter (each end is forest h=2).
-    const expected = 2 * vegetationPathLossDb(NLCD_CLASSES[42], 0)
-      + 2 * /* hilltop forest endpoint */
-        endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
-    expect(lossWithCanopyMask).toBeCloseTo(expected, 0);
+    const expected =
+      2 * vegetationPathLossDb(NLCD_CLASSES[42], 0) +
+      2 * endpointClutterDb(NLCD_CLASSES[42], 2, F_915);
+    expect(loss).toBeCloseTo(expected, 0);
   });
 });

--- a/frontend/src/pages/map/clutterPath.test.ts
+++ b/frontend/src/pages/map/clutterPath.test.ts
@@ -25,10 +25,11 @@ function flatProfile(
 }
 
 describe("makeClutterScratch", () => {
-  it("returns a Float32Array of CLUTTER_SCRATCH_LEN zeros", () => {
+  it("returns a ClutterScratch with zeroed distance + touched buffers of CLUTTER_SCRATCH_LEN", () => {
     const s = makeClutterScratch();
-    expect(s.length).toBe(CLUTTER_SCRATCH_LEN);
-    expect(s.every((v) => v === 0)).toBe(true);
+    expect(s.distances.length).toBe(CLUTTER_SCRATCH_LEN);
+    expect(s.touched.length).toBe(CLUTTER_SCRATCH_LEN);
+    expect(s.distances.every((v) => v === 0)).toBe(true);
   });
 });
 
@@ -168,11 +169,11 @@ describe("computePathClutterLoss — aggression scaler", () => {
 });
 
 describe("computePathClutterLoss — scratch buffer hygiene", () => {
-  it("leaves scratch back at zero after each call", () => {
+  it("leaves the distances buffer back at zero after each call", () => {
     const scratch = makeClutterScratch();
     const { profileM, profileClasses } = flatProfile(80, 42);
     computePathClutterLoss(profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch);
-    expect(scratch.every((v) => v === 0)).toBe(true);
+    expect(scratch.distances.every((v) => v === 0)).toBe(true);
   });
 
   it("two back-to-back calls with different classes don't leak distance", () => {

--- a/frontend/src/pages/map/clutterPath.ts
+++ b/frontend/src/pages/map/clutterPath.ts
@@ -1,11 +1,8 @@
 /**
  * Path-aware clutter loss = P.452-17 endpoint clutter (TX & RX) + P.833-9 §4.1
- * MED for path-traversed vegetation. The two recommendations are designed to be
- * additive; we skip the first/last d_k km of the profile from MED accumulation
- * to avoid double-counting the near-antenna zone P.452 already covers.
- *
- * z_path(s) is a linear lerp of TX/RX MSL antenna heights — ITM handles terrain
- * diffraction internally, so canopy along ITM-blocked paths is moot anyway.
+ * MED for path-traversed vegetation. Skip first txSkipN / last rxSkipN samples
+ * from MED accumulation to avoid double-counting the near-antenna zone P.452
+ * already covers. z_path is a linear lerp of TX/RX MSL antenna heights.
  */
 import {
   classForId,
@@ -14,7 +11,7 @@ import {
   vegetationPathLossDb,
 } from "./clutterClasses";
 
-/** NLCD legend max ID is 95; +1 for inclusive index. */
+/** NLCD legend max ID is 95. */
 export const CLUTTER_SCRATCH_LEN = 96;
 
 export function makeClutterScratch(): Float32Array {
@@ -22,11 +19,8 @@ export function makeClutterScratch(): Float32Array {
 }
 
 /**
- * Total clutter loss in dB for one TX→RX profile.
- *
- * `profileClasses[0]` and `profileClasses[nSamples-1]` are the TX/RX endpoints.
- * `scratch` (length ≥ 96, reused across pixels) accumulates per-class distance
- * to avoid per-call allocation; touched slots are reset before return.
+ * `scratch` (length ≥ 96, reused across pixels) accumulates per-class distance;
+ * touched slots are reset before return.
  */
 export function computePathClutterLoss(
   profileM: Float64Array,
@@ -50,17 +44,14 @@ export function computePathClutterLoss(
   const txMsl = profileM[0] + txAntennaAGLm;
   const rxMsl = profileM[nSamples - 1] + rxAntennaAGLm;
 
-  const skipDistanceM =
-    Math.max(txClass.nominalDistanceKm, rxClass.nominalDistanceKm) * 1000;
-  const skipN = Math.ceil(skipDistanceM / pointSpacingM);
+  const txSkipN = Math.ceil((txClass.nominalDistanceKm * 1000) / pointSpacingM);
+  const rxSkipN = Math.ceil((rxClass.nominalDistanceKm * 1000) / pointSpacingM);
 
-  // Track touched slots so cleanup is O(touched), not O(96).
   const touched: number[] = [];
 
   const lastIdx = nSamples - 1;
-  for (let s = skipN; s <= lastIdx - skipN; s++) {
-    const id = profileClasses[s];
-    const cls = classForId(id);
+  for (let s = txSkipN; s <= lastIdx - rxSkipN; s++) {
+    const cls = classForId(profileClasses[s]);
     if (!cls.penetrable) continue;
 
     const t = s / lastIdx;
@@ -71,13 +62,16 @@ export function computePathClutterLoss(
     if (zPath >= canopyTop) continue;
     if (zPath < zTerrain) continue;
 
-    if (scratch[id] === 0) touched.push(id);
-    scratch[id] += pointSpacingM;
+    // Key by canonical cls.id; raw 0 (NLCD nodata) would otherwise split into
+    // scratch[0] and scratch[43] and double-count via concave MED.
+    const idx = cls.id;
+    if (scratch[idx] === 0) touched.push(idx);
+    scratch[idx] += pointSpacingM;
   }
 
   let lV = 0;
   for (const id of touched) {
-    lV += vegetationPathLossDb(NLCD_CLASSES[id] ?? classForId(id), scratch[id]);
+    lV += vegetationPathLossDb(NLCD_CLASSES[id], scratch[id]);
     scratch[id] = 0;
   }
 

--- a/frontend/src/pages/map/clutterPath.ts
+++ b/frontend/src/pages/map/clutterPath.ts
@@ -1,26 +1,11 @@
 /**
- * Path-aware clutter loss orchestration.
+ * Path-aware clutter loss = P.452-17 endpoint clutter (TX & RX) + P.833-9 §4.1
+ * MED for path-traversed vegetation. The two recommendations are designed to be
+ * additive; we skip the first/last d_k km of the profile from MED accumulation
+ * to avoid double-counting the near-antenna zone P.452 already covers.
  *
- * Composes:
- *   - ITU-R P.452-17 §4.5.4 endpoint clutter at TX & RX (height-gain function)
- *   - ITU-R P.833-9 §4.1   path-traversed vegetation (modified exponential decay)
- *
- * The two ITU recommendations are explicitly designed to be additive: the P.452
- * formula models near-antenna scattering / multipath, while P.833 models direct
- * absorption through a volume of foliage along the path. To avoid double-counting
- * the immediate near-antenna zone, MED accumulation skips the first/last d_k km
- * of the profile.
- *
- * "Inside canopy" geometry uses a linear lerp of TX/RX MSL antenna heights as
- * z_path(s); ITM internally accounts for terrain diffraction so canopy along
- * obstructed paths is mostly irrelevant anyway. This is the standard
- * simplification (SPLAT!, Radio Mobile, CloudRF use the same).
- *
- * Hot-loop notes:
- *   - Caller passes a `scratch` Float32Array (length ≥ 96) reused across pixels
- *     to avoid per-pixel allocation. Length 96 covers all NLCD class IDs (0..95).
- *   - We accumulate touched class IDs in a small stack so cleanup is O(touched)
- *     rather than O(96) per call.
+ * z_path(s) is a linear lerp of TX/RX MSL antenna heights — ITM handles terrain
+ * diffraction internally, so canopy along ITM-blocked paths is moot anyway.
  */
 import {
   classForId,
@@ -29,27 +14,19 @@ import {
   vegetationPathLossDb,
 } from "./clutterClasses";
 
-/** Class ID range; NLCD legend tops out at 95. */
+/** NLCD legend max ID is 95; +1 for inclusive index. */
 export const CLUTTER_SCRATCH_LEN = 96;
 
-/** Allocate a reusable per-class distance accumulator. Length matches CLUTTER_SCRATCH_LEN. */
 export function makeClutterScratch(): Float32Array {
   return new Float32Array(CLUTTER_SCRATCH_LEN);
 }
 
 /**
- * Total clutter loss in dB for a single TX→RX profile.
+ * Total clutter loss in dB for one TX→RX profile.
  *
- * @param profileM         Terrain MSL per sample (length ≥ nSamples).
- * @param profileClasses   NLCD class ID per sample (length ≥ nSamples). 0 falls back to default class.
- * @param nSamples         Number of valid samples to consume from the buffers (≥ 2).
- * @param pointSpacingM    Distance between consecutive samples (m).
- * @param txAntennaAGLm    TX antenna height above local terrain (m).
- * @param rxAntennaAGLm    RX antenna height above local terrain (m).
- * @param freqMhz          Operating frequency (MHz).
- * @param aggression       User-facing scalar (0.7 / 1.0 / 1.3) applied to the final result.
- * @param scratch          Length-96 Float32Array; cleared internally for the IDs touched by this call.
- * @returns Clutter loss in dB; always ≥ 0.
+ * `profileClasses[0]` and `profileClasses[nSamples-1]` are the TX/RX endpoints.
+ * `scratch` (length ≥ 96, reused across pixels) accumulates per-class distance
+ * to avoid per-call allocation; touched slots are reset before return.
  */
 export function computePathClutterLoss(
   profileM: Float64Array,
@@ -64,26 +41,20 @@ export function computePathClutterLoss(
 ): number {
   if (nSamples < 2 || pointSpacingM <= 0) return 0;
 
-  // Endpoint classes are sampled at the literal first/last profile points.
-  // In coverageRaster these are the TX origin and the RX pixel respectively.
   const txClass = classForId(profileClasses[0]);
   const rxClass = classForId(profileClasses[nSamples - 1]);
 
   const aHTx = endpointClutterDb(txClass, txAntennaAGLm, freqMhz);
   const aHRx = endpointClutterDb(rxClass, rxAntennaAGLm, freqMhz);
 
-  // z_path is linear MSL between (TX terrain + TX AGL) and (RX terrain + RX AGL).
-  // 4/3-Earth bulge ignored; ITM already handles diffraction over terrain.
   const txMsl = profileM[0] + txAntennaAGLm;
   const rxMsl = profileM[nSamples - 1] + rxAntennaAGLm;
 
-  // Endpoint exclusion: skip first/last d_k km of profile (P.452 captures it as endpoint clutter).
   const skipDistanceM =
     Math.max(txClass.nominalDistanceKm, rxClass.nominalDistanceKm) * 1000;
   const skipN = Math.ceil(skipDistanceM / pointSpacingM);
 
-  // Track which scratch slots got written so cleanup is O(touched), not O(96).
-  // Worst-case ~16 distinct classes per path; 32 is generous.
+  // Track touched slots so cleanup is O(touched), not O(96).
   const touched: number[] = [];
 
   const lastIdx = nSamples - 1;
@@ -97,14 +68,13 @@ export function computePathClutterLoss(
     const zTerrain = profileM[s];
     const canopyTop = zTerrain + cls.nominalHeightM;
 
-    if (zPath >= canopyTop) continue; // path above canopy
-    if (zPath < zTerrain) continue;   // sanity (shouldn't happen)
+    if (zPath >= canopyTop) continue;
+    if (zPath < zTerrain) continue;
 
     if (scratch[id] === 0) touched.push(id);
     scratch[id] += pointSpacingM;
   }
 
-  // Sum MED contribution per class encountered, then reset scratch slots.
   let lV = 0;
   for (const id of touched) {
     lV += vegetationPathLossDb(NLCD_CLASSES[id] ?? classForId(id), scratch[id]);

--- a/frontend/src/pages/map/clutterPath.ts
+++ b/frontend/src/pages/map/clutterPath.ts
@@ -1,0 +1,115 @@
+/**
+ * Path-aware clutter loss orchestration.
+ *
+ * Composes:
+ *   - ITU-R P.452-17 §4.5.4 endpoint clutter at TX & RX (height-gain function)
+ *   - ITU-R P.833-9 §4.1   path-traversed vegetation (modified exponential decay)
+ *
+ * The two ITU recommendations are explicitly designed to be additive: the P.452
+ * formula models near-antenna scattering / multipath, while P.833 models direct
+ * absorption through a volume of foliage along the path. To avoid double-counting
+ * the immediate near-antenna zone, MED accumulation skips the first/last d_k km
+ * of the profile.
+ *
+ * "Inside canopy" geometry uses a linear lerp of TX/RX MSL antenna heights as
+ * z_path(s); ITM internally accounts for terrain diffraction so canopy along
+ * obstructed paths is mostly irrelevant anyway. This is the standard
+ * simplification (SPLAT!, Radio Mobile, CloudRF use the same).
+ *
+ * Hot-loop notes:
+ *   - Caller passes a `scratch` Float32Array (length ≥ 96) reused across pixels
+ *     to avoid per-pixel allocation. Length 96 covers all NLCD class IDs (0..95).
+ *   - We accumulate touched class IDs in a small stack so cleanup is O(touched)
+ *     rather than O(96) per call.
+ */
+import {
+  classForId,
+  endpointClutterDb,
+  NLCD_CLASSES,
+  vegetationPathLossDb,
+} from "./clutterClasses";
+
+/** Class ID range; NLCD legend tops out at 95. */
+export const CLUTTER_SCRATCH_LEN = 96;
+
+/** Allocate a reusable per-class distance accumulator. Length matches CLUTTER_SCRATCH_LEN. */
+export function makeClutterScratch(): Float32Array {
+  return new Float32Array(CLUTTER_SCRATCH_LEN);
+}
+
+/**
+ * Total clutter loss in dB for a single TX→RX profile.
+ *
+ * @param profileM         Terrain MSL per sample (length ≥ nSamples).
+ * @param profileClasses   NLCD class ID per sample (length ≥ nSamples). 0 falls back to default class.
+ * @param nSamples         Number of valid samples to consume from the buffers (≥ 2).
+ * @param pointSpacingM    Distance between consecutive samples (m).
+ * @param txAntennaAGLm    TX antenna height above local terrain (m).
+ * @param rxAntennaAGLm    RX antenna height above local terrain (m).
+ * @param freqMhz          Operating frequency (MHz).
+ * @param aggression       User-facing scalar (0.7 / 1.0 / 1.3) applied to the final result.
+ * @param scratch          Length-96 Float32Array; cleared internally for the IDs touched by this call.
+ * @returns Clutter loss in dB; always ≥ 0.
+ */
+export function computePathClutterLoss(
+  profileM: Float64Array,
+  profileClasses: Uint8Array,
+  nSamples: number,
+  pointSpacingM: number,
+  txAntennaAGLm: number,
+  rxAntennaAGLm: number,
+  freqMhz: number,
+  aggression: number,
+  scratch: Float32Array,
+): number {
+  if (nSamples < 2 || pointSpacingM <= 0) return 0;
+
+  // Endpoint classes are sampled at the literal first/last profile points.
+  // In coverageRaster these are the TX origin and the RX pixel respectively.
+  const txClass = classForId(profileClasses[0]);
+  const rxClass = classForId(profileClasses[nSamples - 1]);
+
+  const aHTx = endpointClutterDb(txClass, txAntennaAGLm, freqMhz);
+  const aHRx = endpointClutterDb(rxClass, rxAntennaAGLm, freqMhz);
+
+  // z_path is linear MSL between (TX terrain + TX AGL) and (RX terrain + RX AGL).
+  // 4/3-Earth bulge ignored; ITM already handles diffraction over terrain.
+  const txMsl = profileM[0] + txAntennaAGLm;
+  const rxMsl = profileM[nSamples - 1] + rxAntennaAGLm;
+
+  // Endpoint exclusion: skip first/last d_k km of profile (P.452 captures it as endpoint clutter).
+  const skipDistanceM =
+    Math.max(txClass.nominalDistanceKm, rxClass.nominalDistanceKm) * 1000;
+  const skipN = Math.ceil(skipDistanceM / pointSpacingM);
+
+  // Track which scratch slots got written so cleanup is O(touched), not O(96).
+  // Worst-case ~16 distinct classes per path; 32 is generous.
+  const touched: number[] = [];
+
+  const lastIdx = nSamples - 1;
+  for (let s = skipN; s <= lastIdx - skipN; s++) {
+    const id = profileClasses[s];
+    const cls = classForId(id);
+    if (!cls.penetrable) continue;
+
+    const t = s / lastIdx;
+    const zPath = txMsl + (rxMsl - txMsl) * t;
+    const zTerrain = profileM[s];
+    const canopyTop = zTerrain + cls.nominalHeightM;
+
+    if (zPath >= canopyTop) continue; // path above canopy
+    if (zPath < zTerrain) continue;   // sanity (shouldn't happen)
+
+    if (scratch[id] === 0) touched.push(id);
+    scratch[id] += pointSpacingM;
+  }
+
+  // Sum MED contribution per class encountered, then reset scratch slots.
+  let lV = 0;
+  for (const id of touched) {
+    lV += vegetationPathLossDb(NLCD_CLASSES[id] ?? classForId(id), scratch[id]);
+    scratch[id] = 0;
+  }
+
+  return aggression * (aHTx + aHRx + lV);
+}

--- a/frontend/src/pages/map/clutterPath.ts
+++ b/frontend/src/pages/map/clutterPath.ts
@@ -3,6 +3,9 @@
  * MED for path-traversed vegetation. Skip first txSkipN / last rxSkipN samples
  * from MED accumulation to avoid double-counting the near-antenna zone P.452
  * already covers. z_path is a linear lerp of TX/RX MSL antenna heights.
+ *
+ * Hot loop is alloc-free — caller allocates ClutterScratch once and reuses
+ * across all per-pixel calls.
  */
 import {
   classForId,
@@ -14,13 +17,27 @@ import {
 /** NLCD legend max ID is 95. */
 export const CLUTTER_SCRATCH_LEN = 96;
 
-export function makeClutterScratch(): Float32Array {
-  return new Float32Array(CLUTTER_SCRATCH_LEN);
+/**
+ * Reusable per-call scratch state. `distances` accumulates per-class metres;
+ * `touched` records which class IDs were written this call so cleanup is
+ * O(touched) instead of O(96). Length tracked locally per call.
+ */
+export interface ClutterScratch {
+  distances: Float32Array;
+  touched: Uint8Array;
+}
+
+export function makeClutterScratch(): ClutterScratch {
+  return {
+    distances: new Float32Array(CLUTTER_SCRATCH_LEN),
+    touched: new Uint8Array(CLUTTER_SCRATCH_LEN),
+  };
 }
 
 /**
- * `scratch` (length ≥ 96, reused across pixels) accumulates per-class distance;
- * touched slots are reset before return.
+ * Total clutter loss in dB for one TX→RX profile.
+ *
+ * `profileClasses[0]` and `profileClasses[nSamples-1]` are TX/RX endpoints.
  */
 export function computePathClutterLoss(
   profileM: Float64Array,
@@ -31,7 +48,7 @@ export function computePathClutterLoss(
   rxAntennaAGLm: number,
   freqMhz: number,
   aggression: number,
-  scratch: Float32Array,
+  scratch: ClutterScratch,
 ): number {
   if (nSamples < 2 || pointSpacingM <= 0) return 0;
 
@@ -47,7 +64,8 @@ export function computePathClutterLoss(
   const txSkipN = Math.ceil((txClass.nominalDistanceKm * 1000) / pointSpacingM);
   const rxSkipN = Math.ceil((rxClass.nominalDistanceKm * 1000) / pointSpacingM);
 
-  const touched: number[] = [];
+  const { distances, touched } = scratch;
+  let touchedLen = 0;
 
   const lastIdx = nSamples - 1;
   for (let s = txSkipN; s <= lastIdx - rxSkipN; s++) {
@@ -63,16 +81,19 @@ export function computePathClutterLoss(
     if (zPath < zTerrain) continue;
 
     // Key by canonical cls.id; raw 0 (NLCD nodata) would otherwise split into
-    // scratch[0] and scratch[43] and double-count via concave MED.
+    // distances[0] and distances[43] and double-count via concave MED.
     const idx = cls.id;
-    if (scratch[idx] === 0) touched.push(idx);
-    scratch[idx] += pointSpacingM;
+    if (distances[idx] === 0) {
+      touched[touchedLen++] = idx;
+    }
+    distances[idx] += pointSpacingM;
   }
 
   let lV = 0;
-  for (const id of touched) {
-    lV += vegetationPathLossDb(NLCD_CLASSES[id], scratch[id]);
-    scratch[id] = 0;
+  for (let i = 0; i < touchedLen; i++) {
+    const id = touched[i];
+    lV += vegetationPathLossDb(NLCD_CLASSES[id], distances[id]);
+    distances[id] = 0;
   }
 
   return aggression * (aHTx + aHRx + lV);

--- a/frontend/src/pages/map/coverageAnalysis.ts
+++ b/frontend/src/pages/map/coverageAnalysis.ts
@@ -1,19 +1,38 @@
 /** Coverage prediction constants/presets shared between the panel UI and the worker. */
 
-/** Propagation environment; excess path loss beyond free-space. */
-export interface Environment {
+/**
+ * Aggression scaler stops for the per-pixel ITU clutter model.
+ * 1.0 is the calibrated default (matches ITU-R P.452-17 + P.833-9 published values);
+ * <1 dials conservatism down (your measured links beat predictions);
+ * >1 dials it up (your area has heavier clutter than the published averages).
+ *
+ * This value is multiplied into the final A_h_tx + A_h_rx + L_v sum in computePathClutterLoss.
+ */
+export interface AggressionStop {
   id: string;
   label: string;
-  /** Excess loss (dB) added on top of ITM to represent building/foliage clutter (ITM doesn't model either). */
-  clutterLossDb: number;
+  /** Short label for the compact 3-button row. */
+  short: string;
+  value: number;
   description: string;
 }
-export const ENVIRONMENTS: Environment[] = [
-  { id: "open",     label: "Open / Rural",         clutterLossDb: 0,  description: "Line-of-sight with no obstacles — open country, water, desert" },
-  { id: "mixed",    label: "Light terrain",        clutterLossDb: 3,  description: "Scattered trees and rolling hills — mixed countryside" },
-  { id: "suburban", label: "Suburban",             clutterLossDb: 6,  description: "Residential neighborhoods with buildings and moderate clutter" },
-  { id: "urban",    label: "Urban / Dense forest", clutterLossDb: 12, description: "Heavy obstruction — city core, thick canopy, industrial" },
+export const AGGRESSION_STOPS: AggressionStop[] = [
+  { id: "conservative", label: "Conservative", short: "Cons.", value: 0.7, description: "Predictions are pessimistic — measured links are reaching farther than the model says." },
+  { id: "calibrated",   label: "Calibrated",   short: "Cal.",  value: 1.0, description: "ITU-R P.452 / P.833 calibrated baseline. Use this unless you have measured-link data telling you otherwise." },
+  { id: "aggressive",   label: "Aggressive",   short: "Aggr.", value: 1.3, description: "Predictions are optimistic — measured links fall short. Heavier clutter than published averages (dense canopy, urban valleys)." },
 ];
+
+/** Index of the calibrated-default stop. Keep in sync with AGGRESSION_STOPS. */
+export const DEFAULT_AGGRESSION_IDX = 1;
+export const DEFAULT_AGGRESSION = AGGRESSION_STOPS[DEFAULT_AGGRESSION_IDX].value;
+
+/**
+ * Representative clutter dB used by the bbox sizer when picking a coverage radius.
+ * The sizer can't run the per-pixel model before knowing the bbox, so it scales
+ * a Mixed-Forest-handheld endpoint estimate (~16 dB) by the active aggression.
+ * Approximate; the bbox is a sizing heuristic, not the RF answer.
+ */
+export const REPRESENTATIVE_CLUTTER_DB = 16;
 
 /** Meshtastic modem presets. `sensitivityDbm` is real-world typical (~3 dB worse than
  *  SX1262 datasheet). SX1276 adds another ~2 dB (see COMMON_HARDWARE.chipset + effectiveSensitivityDbm).

--- a/frontend/src/pages/map/coverageAnalysis.ts
+++ b/frontend/src/pages/map/coverageAnalysis.ts
@@ -1,17 +1,12 @@
 /** Coverage prediction constants/presets shared between the panel UI and the worker. */
 
 /**
- * Aggression scaler stops for the per-pixel ITU clutter model.
- * 1.0 is the calibrated default (matches ITU-R P.452-17 + P.833-9 published values);
- * <1 dials conservatism down (your measured links beat predictions);
- * >1 dials it up (your area has heavier clutter than the published averages).
- *
- * This value is multiplied into the final A_h_tx + A_h_rx + L_v sum in computePathClutterLoss.
+ * Aggression scaler stops for the per-pixel ITU clutter model. Multiplied into
+ * the final A_h_tx + A_h_rx + L_v sum in computePathClutterLoss.
  */
 export interface AggressionStop {
   id: string;
   label: string;
-  /** Short label for the compact 3-button row. */
   short: string;
   value: number;
   description: string;
@@ -22,15 +17,13 @@ export const AGGRESSION_STOPS: AggressionStop[] = [
   { id: "aggressive",   label: "Aggressive",   short: "Aggr.", value: 1.3, description: "Predictions are optimistic — measured links fall short. Heavier clutter than published averages (dense canopy, urban valleys)." },
 ];
 
-/** Index of the calibrated-default stop. Keep in sync with AGGRESSION_STOPS. */
+/** Keep in sync with AGGRESSION_STOPS. */
 export const DEFAULT_AGGRESSION_IDX = 1;
 export const DEFAULT_AGGRESSION = AGGRESSION_STOPS[DEFAULT_AGGRESSION_IDX].value;
 
 /**
- * Representative clutter dB used by the bbox sizer when picking a coverage radius.
- * The sizer can't run the per-pixel model before knowing the bbox, so it scales
- * a Mixed-Forest-handheld endpoint estimate (~16 dB) by the active aggression.
- * Approximate; the bbox is a sizing heuristic, not the RF answer.
+ * Used by the bbox sizer (which runs before the per-pixel model). ~Mixed-Forest
+ * handheld endpoint estimate; scaled by aggression. Sizing heuristic only.
  */
 export const REPRESENTATIVE_CLUTTER_DB = 16;
 

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -4,12 +4,18 @@
  * Profile length adapts to path length (15-96 samples, ~1.5/km).
  */
 import {
+  computePathClutterLoss,
+  makeClutterScratch,
+} from "./clutterPath";
+import {
   Climate,
   computeP2PLossFast,
   type ItmContext,
   ModeOfVariability,
   Polarization,
 } from "./itm";
+import type { ClutterRaster } from "./landcoverTiles";
+import { sampleClutterClassAt } from "./landcoverTiles";
 import { type DEM, sampleDEMAt } from "./terrainDEM";
 
 const R_EARTH_KM = 6371;
@@ -25,8 +31,12 @@ export interface RasterParams {
   rxSensitivityDbm: number;
   fadeMarginDb: number;
   cableLossDb: number;
-  /** Clutter loss (dB) added on top of ITM (which doesn't model buildings/foliage). */
-  clutterLossDb: number;
+  /**
+   * Aggression scaler applied to the per-pixel ITU-R clutter model
+   * (P.452-17 endpoint + P.833-9 path-traversed vegetation). 1.0 is the calibrated
+   * default; <1 dials conservatism down, >1 up. See docs/clutter-design.md.
+   */
+  clutterAggression: number;
   climate: Climate;
   /** Surface refractivity in N-units (e.g. 301 continental). */
   surfaceRefractivityN: number;
@@ -132,6 +142,8 @@ export function renderCoverageRaster(
   origin: RasterOrigin,
   rowRange?: RowRange,
   output?: OutputGrid,
+  /** Optional class-ID raster aligned to the DEM bounds. Null = treat every sample as default class. */
+  clutter?: ClutterRaster | null,
 ): RasterResult {
   const { bounds } = dem;
   const outputWidth = output?.width ?? dem.width;
@@ -145,7 +157,7 @@ export function renderCoverageRaster(
   marginDbBuf.fill(Number.NaN);
   const {
     freqMhz, txDbm, txAntennaDbi, rxAntennaDbi, rxAntennaHeightAboveGroundM,
-    rxSensitivityDbm, fadeMarginDb, cableLossDb, clutterLossDb,
+    rxSensitivityDbm, fadeMarginDb, cableLossDb, clutterAggression,
     climate, surfaceRefractivityN, polarization,
     groundDielectric, groundConductivity,
     timePct = 50, locationPct = 50, situationPct = 50,
@@ -162,6 +174,10 @@ export function renderCoverageRaster(
   );
   const maxSamples = profileSampleCount(diagonalKm);
   const profileBuf = new Float64Array(maxSamples);
+  // Per-sample NLCD class ID. Reused across pixels (only `nSamples` entries valid per pixel).
+  const profileClassBuf = new Uint8Array(maxSamples);
+  // Class-distance accumulator scratch reused by computePathClutterLoss across pixels.
+  const clutterScratch = makeClutterScratch();
 
   const [origLng, origLat] = origin.position;
   // Step over OUTPUT grid; terrain via bilinear sampleDEMAt is (lng,lat)-continuous
@@ -229,6 +245,8 @@ export function renderCoverageRaster(
           break;
         }
         profileBuf[s] = elev;
+        // Same lerp serves clutter classification — out-of-raster falls back to default class.
+        profileClassBuf[s] = clutter ? sampleClutterClassAt(clutter, sLng, sLat) : 0;
       }
       if (!validProfile) {
         rgba[outPxIdx * 4 + 3] = 0;
@@ -237,7 +255,8 @@ export function renderCoverageRaster(
 
       // subarray = no-copy view; slice() would allocate
       itmInput.profileM = profileBuf.subarray(0, nSamples);
-      itmInput.pointSpacingM = (distKm * 1000) / (nSamples - 1);
+      const pointSpacingM = (distKm * 1000) / (nSamples - 1);
+      itmInput.pointSpacingM = pointSpacingM;
       itmInput.rxHeightM = receiverAntennaAboveGroundM;
 
       const lossDb = computeP2PLossFast(itm, itmInput);
@@ -247,6 +266,19 @@ export function renderCoverageRaster(
         blockedCount++;
         continue;
       }
+
+      // Per-pixel clutter via P.452 endpoint + P.833 MED path integration.
+      const clutterLossDb = computePathClutterLoss(
+        profileBuf,
+        profileClassBuf,
+        nSamples,
+        pointSpacingM,
+        txHeightAgM,
+        receiverAntennaAboveGroundM,
+        freqMhz,
+        clutterAggression,
+        clutterScratch,
+      );
 
       const totalLossDb = lossDb + clutterLossDb + cableLossDb;
       const rssiDbm = txDbm + txGain + rxGain - totalLossDb;

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -31,11 +31,7 @@ export interface RasterParams {
   rxSensitivityDbm: number;
   fadeMarginDb: number;
   cableLossDb: number;
-  /**
-   * Aggression scaler applied to the per-pixel ITU-R clutter model
-   * (P.452-17 endpoint + P.833-9 path-traversed vegetation). 1.0 is the calibrated
-   * default; <1 dials conservatism down, >1 up. See docs/clutter-design.md.
-   */
+  /** Scalar on the ITU-R clutter model output. 1.0 = calibrated baseline. */
   clutterAggression: number;
   climate: Climate;
   /** Surface refractivity in N-units (e.g. 301 continental). */
@@ -174,9 +170,7 @@ export function renderCoverageRaster(
   );
   const maxSamples = profileSampleCount(diagonalKm);
   const profileBuf = new Float64Array(maxSamples);
-  // Per-sample NLCD class ID. Reused across pixels (only `nSamples` entries valid per pixel).
   const profileClassBuf = new Uint8Array(maxSamples);
-  // Class-distance accumulator scratch reused by computePathClutterLoss across pixels.
   const clutterScratch = makeClutterScratch();
 
   const [origLng, origLat] = origin.position;
@@ -245,7 +239,6 @@ export function renderCoverageRaster(
           break;
         }
         profileBuf[s] = elev;
-        // Same lerp serves clutter classification — out-of-raster falls back to default class.
         profileClassBuf[s] = clutter ? sampleClutterClassAt(clutter, sLng, sLat) : 0;
       }
       if (!validProfile) {
@@ -267,7 +260,6 @@ export function renderCoverageRaster(
         continue;
       }
 
-      // Per-pixel clutter via P.452 endpoint + P.833 MED path integration.
       const clutterLossDb = computePathClutterLoss(
         profileBuf,
         profileClassBuf,

--- a/frontend/src/pages/map/coverageSliceWorker.ts
+++ b/frontend/src/pages/map/coverageSliceWorker.ts
@@ -13,6 +13,7 @@ import {
   loadItmContext,
   Polarization,
 } from "./itm";
+import type { ClutterRaster } from "./landcoverTiles";
 import type { DEM, DEMBounds } from "./terrainDEM";
 
 export interface CoverageSliceRequest {
@@ -32,6 +33,10 @@ export interface CoverageSliceRequest {
   outputHeight: number;
   rowStart: number;
   rowEnd: number;
+  /** Optional class-ID raster aligned to DEM bounds. Absent → workers treat all samples as default class. */
+  clutterBuffer?: ArrayBuffer;
+  clutterWidth?: number;
+  clutterHeight?: number;
 }
 
 export interface CoverageSliceResponse {
@@ -100,6 +105,18 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
       height: msg.demHeight,
       bounds: msg.bounds,
     };
+    const clutter: ClutterRaster | null =
+      msg.clutterBuffer && msg.clutterWidth && msg.clutterHeight
+        ? {
+            data: new Uint8Array(msg.clutterBuffer),
+            width: msg.clutterWidth,
+            height: msg.clutterHeight,
+            bounds: msg.bounds,
+            // Telemetry fields not used in the worker; default to 0 so the type matches.
+            tilesPresent: 0,
+            tilesTotal: 0,
+          }
+        : null;
     const rendered = renderCoverageRaster(
       dem,
       msg.params,
@@ -111,6 +128,7 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
       },
       { rowStart: msg.rowStart, rowEnd: msg.rowEnd },
       { width: msg.outputWidth, height: msg.outputHeight },
+      clutter,
     );
     post({
       requestId: msg.requestId,

--- a/frontend/src/pages/map/coverageSliceWorker.ts
+++ b/frontend/src/pages/map/coverageSliceWorker.ts
@@ -33,7 +33,7 @@ export interface CoverageSliceRequest {
   outputHeight: number;
   rowStart: number;
   rowEnd: number;
-  /** Optional class-ID raster aligned to DEM bounds. Absent → workers treat all samples as default class. */
+  /** Optional class-ID raster aligned to DEM bounds. Absent → default class everywhere. */
   clutterBuffer?: ArrayBuffer;
   clutterWidth?: number;
   clutterHeight?: number;
@@ -112,7 +112,6 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
             width: msg.clutterWidth,
             height: msg.clutterHeight,
             bounds: msg.bounds,
-            // Telemetry fields not used in the worker; default to 0 so the type matches.
             tilesPresent: 0,
             tilesTotal: 0,
           }

--- a/frontend/src/pages/map/landcoverTiles.test.ts
+++ b/frontend/src/pages/map/landcoverTiles.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for landcoverTiles.ts. Network calls are stubbed via global `fetch`;
+ * decode-path tests use jsdom's OffscreenCanvas polyfill (skipped when absent).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
+import {
+  _resetLandcoverCacheForTests,
+  buildClutterRaster,
+  sampleClutterClassAt,
+  selectLandcoverZoom,
+} from "./landcoverTiles";
+import type { DEMBounds } from "./terrainDEM";
+
+const CA_BBOX: DEMBounds = { west: -120, east: -119, south: 36, north: 37 };
+
+describe("selectLandcoverZoom", () => {
+  it("picks a higher zoom for a smaller bbox at the same target px size", () => {
+    const small: DEMBounds = { west: -120, east: -119.9, south: 36, north: 36.1 };
+    const big: DEMBounds = { west: -120, east: -110, south: 36, north: 46 };
+    const zSmall = selectLandcoverZoom(small, 30);
+    const zBig = selectLandcoverZoom(big, 30);
+    expect(zSmall).toBeGreaterThanOrEqual(zBig);
+  });
+
+  it("clamps at MAX_ZOOM (12) regardless of how fine the request is", () => {
+    expect(selectLandcoverZoom(CA_BBOX, 0.1)).toBeLessThanOrEqual(12);
+  });
+
+  it("respects the maxTiles budget (degrades to coarser zoom)", () => {
+    // CONUS-scale bbox forces a coarse zoom under a tight tile cap.
+    const conus: DEMBounds = { west: -125, east: -67, south: 24, north: 49 };
+    const z = selectLandcoverZoom(conus, 1, 16);
+    expect(z).toBeLessThan(12);
+  });
+});
+
+describe("sampleClutterClassAt", () => {
+  // Hand-build a 4×4 raster covering CA_BBOX with deliberate class IDs:
+  //   row 0 (north): 11 11 11 11   (water)
+  //   row 1:         42 42 42 42   (evergreen)
+  //   row 2:         24 24 24 24   (high-density urban)
+  //   row 3 (south): 71 71 71 71   (grassland)
+  const raster = (() => {
+    const data = new Uint8Array(16);
+    for (let i = 0; i < 4; i++) data[0 * 4 + i] = 11;
+    for (let i = 0; i < 4; i++) data[1 * 4 + i] = 42;
+    for (let i = 0; i < 4; i++) data[2 * 4 + i] = 24;
+    for (let i = 0; i < 4; i++) data[3 * 4 + i] = 71;
+    return { data, width: 4, height: 4, bounds: CA_BBOX };
+  })();
+
+  it("returns the class at the north edge", () => {
+    expect(sampleClutterClassAt(raster, -119.5, 37)).toBe(11);
+  });
+
+  it("returns the class at the south edge", () => {
+    expect(sampleClutterClassAt(raster, -119.5, 36)).toBe(71);
+  });
+
+  it("returns the class somewhere in the middle (band-2 row)", () => {
+    // Lat 36.34 is in row 2 (high-density urban).
+    expect(sampleClutterClassAt(raster, -119.5, 36.34)).toBe(24);
+  });
+
+  it("returns NLCD_DEFAULT_CLASS_ID for out-of-bounds queries", () => {
+    expect(sampleClutterClassAt(raster, -130, 36.5)).toBe(NLCD_DEFAULT_CLASS_ID);
+    expect(sampleClutterClassAt(raster, -119.5, 50)).toBe(NLCD_DEFAULT_CLASS_ID);
+  });
+
+  it("uses nearest-neighbor (categorical), not bilinear", () => {
+    // Query at the exact midpoint between two rows of distinct classes;
+    // bilinear would invent (11+42)/2 = 26.5 (a non-existent ID).
+    // Nearest-neighbor must pick one or the other (whichever the rounding lands on).
+    const v = sampleClutterClassAt(raster, -119.5, (37 + 36) / 2 + 0.001);
+    expect([11, 42, 24, 71]).toContain(v);
+  });
+});
+
+describe("buildClutterRaster — out-of-bbox (all tiles 404)", () => {
+  beforeEach(() => {
+    _resetLandcoverCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fills every pixel with the default class when every tile 404s", async () => {
+    // jsdom doesn't ship URL utility for window.location.origin in some setups;
+    // make sure it's at least a string the fetch URL builder can use.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 404 }));
+
+    const raster = await buildClutterRaster({
+      bounds: CA_BBOX,
+      targetWidth: 32,
+      targetHeight: 32,
+    });
+
+    expect(raster.width).toBe(32);
+    expect(raster.height).toBe(32);
+    expect(raster.tilesPresent).toBe(0);
+    expect(raster.tilesTotal).toBeGreaterThan(0);
+    // All pixels should be the default class.
+    expect(raster.data.every((v) => v === NLCD_DEFAULT_CLASS_ID)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("does not throw on transient network errors (treats them as missing tiles)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const raster = await buildClutterRaster({
+      bounds: CA_BBOX,
+      targetWidth: 16,
+      targetHeight: 16,
+    });
+    expect(raster.tilesPresent).toBe(0);
+    expect(raster.data.every((v) => v === NLCD_DEFAULT_CLASS_ID)).toBe(true);
+  });
+});

--- a/frontend/src/pages/map/landcoverTiles.ts
+++ b/frontend/src/pages/map/landcoverTiles.ts
@@ -290,6 +290,39 @@ export function sampleClutterClassAt(
   return data[y * width + x];
 }
 
+/**
+ * Nearest-neighbor downsample of a ClutterRaster to (newWidth × newHeight) over
+ * the same geographic bounds. Used to keep a small raster alongside the cached
+ * DEM for the drag-preview compute path.
+ */
+export function downsampleClutterRaster(
+  src: ClutterRaster,
+  newWidth: number,
+  newHeight: number,
+): ClutterRaster {
+  const data = new Uint8Array(newWidth * newHeight);
+  data.fill(NLCD_DEFAULT_CLASS_ID);
+  for (let j = 0; j < newHeight; j++) {
+    const lat =
+      src.bounds.north -
+      ((src.bounds.north - src.bounds.south) * j) / Math.max(1, newHeight - 1);
+    for (let i = 0; i < newWidth; i++) {
+      const lng =
+        src.bounds.west +
+        ((src.bounds.east - src.bounds.west) * i) / Math.max(1, newWidth - 1);
+      data[j * newWidth + i] = sampleClutterClassAt(src, lng, lat);
+    }
+  }
+  return {
+    data,
+    width: newWidth,
+    height: newHeight,
+    bounds: src.bounds,
+    tilesPresent: src.tilesPresent,
+    tilesTotal: src.tilesTotal,
+  };
+}
+
 /** Reset the tile cache. Test-only. */
 export function _resetLandcoverCacheForTests(): void {
   (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();

--- a/frontend/src/pages/map/landcoverTiles.ts
+++ b/frontend/src/pages/map/landcoverTiles.ts
@@ -1,16 +1,8 @@
 /**
- * Land-cover (NLCD) tile fetcher. Mirrors terrainRgb.ts at the surface level —
- * slippy XYZ tiles, LRU cache, OffscreenCanvas decode — but encodes class IDs
- * in the red channel rather than terrain elevation.
- *
- * Tiles are produced by scripts/landcover_tiles.py and served at
- * /tiles/landcover/{z}/{x}/{y}.png. A 404 means the tile is outside the bake
- * bbox; callers fall back to NLCD_DEFAULT_CLASS_ID at the corresponding pixels.
- *
- * Tile encoding (per docs/clutter-design.md §8):
- *   R = NLCD class ID (0 = nodata)
- *   A = 0 for nodata, 255 for valid pixels
- *   G, B unused (reserved)
+ * Land-cover (NLCD) tile fetcher. Tiles are produced by scripts/landcover_tiles.py
+ * and served at /tiles/landcover/{z}/{x}/{y}.png. Encoding: R = NLCD class ID,
+ * A = 0/255 for nodata/valid, G/B reserved. A 404 means the tile is outside the
+ * bake bbox; the per-pixel fallback uses NLCD_DEFAULT_CLASS_ID.
  */
 import { env } from "../../env";
 import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
@@ -18,19 +10,14 @@ import type { DEMBounds } from "./terrainDEM";
 
 const TILE_SIZE = 256;
 const MIN_ZOOM = 0;
-/** Bake script's default ceiling — z=12 ≈ 10 m/px at lat 37, matching NLCD's 30 m source. */
+/** Matches the bake's default ceiling; z=12 ≈ 10 m/px at lat 37, NLCD is 30 m native. */
 const MAX_ZOOM = 12;
 const DEFAULT_MAX_TILES_PER_REQUEST = 256;
 
 function tileBaseUrl(): string {
-  // Same base resolution as apiSlice.ts: runtime > build-time > origin.
   const apiBase = env.API_BASE_URL ?? window.location.origin;
   return `${apiBase}/tiles/landcover`;
 }
-
-// --- Slippy Map / Web Mercator helpers ---
-// Same forms as terrainRgb.ts; could be deduplicated later. Keeping them inlined keeps
-// landcoverTiles.ts self-contained for the worker imports.
 
 function lng2tileX(lng: number, zoom: number): number {
   return ((lng + 180) / 360) * Math.pow(2, zoom);
@@ -76,21 +63,18 @@ export function selectLandcoverZoom(
   return MIN_ZOOM;
 }
 
-/** Decoded tile content. */
 export interface CachedLandcoverTile {
-  /** Row-major class IDs, length TILE_SIZE². 0 = nodata (transparent pixel). */
+  /** Row-major class IDs, length TILE_SIZE². 0 = nodata. */
   data: Uint8Array;
-  /** Always TILE_SIZE; kept as a field for symmetry with terrainRgb.ts. */
   size: number;
 }
 
-/** Sentinel returned for tiles that 404'd. Distinct from "tile not yet attempted." */
+/** Sentinel for 404'd tiles, distinct from "not yet attempted." */
 export const TILE_MISSING: CachedLandcoverTile = Object.freeze({
   data: new Uint8Array(0),
   size: TILE_SIZE,
 }) as CachedLandcoverTile;
 
-/** LRU; same shape as terrainRgb.ts TileLRU. Insertion order = recency. */
 class LandcoverTileLRU {
   private cache = new Map<string, CachedLandcoverTile>();
   constructor(private readonly maxEntries: number) {}
@@ -114,10 +98,10 @@ class LandcoverTileLRU {
   }
 }
 
-// 256 tiles × 256² × 1B ≈ 16 MB worst case. Per-tile is 1/4 the size of terrain-rgb cache.
+// 256 tiles × 256² × 1B ≈ 16 MB worst case.
 const tileCache = new LandcoverTileLRU(256);
 
-/** Fetch + decode one slippy tile. Returns TILE_MISSING for 404 (not an error). */
+/** Returns TILE_MISSING for 404 (not an error). */
 export async function fetchLandcoverTile(
   z: number,
   x: number,
@@ -155,7 +139,6 @@ export async function fetchLandcoverTile(
     const img = ctx.getImageData(0, 0, w, h);
     const px = img.data;
     const data = new Uint8Array(w * h);
-    // Class ID lives in R; A=0 means nodata → keep 0 (caller substitutes default class).
     for (let i = 0, n = data.length; i < n; i++) {
       const o = i * 4;
       data[i] = px[o + 3] === 0 ? 0 : px[o];
@@ -170,30 +153,26 @@ export async function fetchLandcoverTile(
 
 export interface BuildClutterRasterOptions {
   bounds: DEMBounds;
-  /** Output grid resolution; matches DEM dims so the worker can sample with one index per pixel. */
   targetWidth: number;
   targetHeight: number;
-  /** Overrides DEFAULT_MAX_TILES_PER_REQUEST. Coverage Detail tiers should pass the same cap as buildDem. */
   maxTiles?: number;
 }
 
 export interface ClutterRaster {
-  /** Row-major class IDs, length width*height. NLCD_DEFAULT_CLASS_ID where the source had no data or the tile 404'd. */
+  /** Row-major class IDs. NLCD_DEFAULT_CLASS_ID where the source had no data or the tile 404'd. */
   data: Uint8Array;
   width: number;
   height: number;
   bounds: DEMBounds;
-  /** Number of tiles successfully fetched / total tiles intersecting the bbox. Useful for telemetry + UI fallback indicator. */
+  /** For telemetry + UI fallback indicator. */
   tilesPresent: number;
   tilesTotal: number;
 }
 
 /**
- * Build a class-ID raster covering `bounds` at `targetWidth × targetHeight`.
- *
- * Sampling: nearest-neighbor (class IDs are categorical; bilinear would invent
- * non-existent IDs). Missing tiles → pixels filled with NLCD_DEFAULT_CLASS_ID.
- * The function never throws on 404 — that's the documented out-of-bbox path.
+ * Class-ID raster covering `bounds`. Nearest-neighbor (categorical IDs;
+ * bilinear would invent non-existent IDs). Missing tiles → NLCD_DEFAULT_CLASS_ID.
+ * Never throws on 404 — that's the out-of-bbox path.
  */
 export async function buildClutterRaster(
   opts: BuildClutterRasterOptions,
@@ -201,7 +180,6 @@ export async function buildClutterRaster(
   const { bounds, targetWidth, targetHeight } = opts;
   const maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES_PER_REQUEST;
 
-  // Match resolution to the DEM grid so each output pixel maps to ≤ 1 source tile pixel.
   const midLat = (bounds.north + bounds.south) / 2;
   const bboxWidthM =
     (bounds.east - bounds.west) * 111_320 * Math.cos((midLat * Math.PI) / 180);
@@ -214,7 +192,6 @@ export async function buildClutterRaster(
   const yMax = Math.floor(lat2tileY(bounds.south, zoom));
   const tilesTotal = (xMax - xMin + 1) * (yMax - yMin + 1);
 
-  // Parallel fetch; 404s become TILE_MISSING.
   const tileMap = new Map<string, CachedLandcoverTile>();
   const jobs: Promise<void>[] = [];
   for (let x = xMin; x <= xMax; x++) {
@@ -237,12 +214,11 @@ export async function buildClutterRaster(
     if (t !== TILE_MISSING && t.data.length > 0) tilesPresent++;
   }
 
-  // Nearest-neighbor resample into the output grid.
   const data = new Uint8Array(targetWidth * targetHeight);
   data.fill(NLCD_DEFAULT_CLASS_ID);
   const scale = Math.pow(2, zoom);
 
-  /** Class ID at absolute tile-pixel (absX, absY). Returns 0 for missing/nodata. */
+  /** Class ID at absolute tile-pixel; 0 for missing/nodata. */
   const lookup = (absX: number, absY: number): number => {
     const tileX = Math.floor(absX / TILE_SIZE);
     const tileY = Math.floor(absY / TILE_SIZE);
@@ -267,7 +243,6 @@ export async function buildClutterRaster(
       const xIdx = Math.floor(absX);
 
       const cls = lookup(xIdx, yIdx);
-      // 0 = nodata sentinel; keep the pre-filled default class instead.
       if (cls !== 0) data[j * targetWidth + i] = cls;
     }
   }
@@ -290,11 +265,7 @@ export function sampleClutterClassAt(
   return data[y * width + x];
 }
 
-/**
- * Nearest-neighbor downsample of a ClutterRaster to (newWidth × newHeight) over
- * the same geographic bounds. Used to keep a small raster alongside the cached
- * DEM for the drag-preview compute path.
- */
+/** Nearest-neighbor downsample over the same bounds. */
 export function downsampleClutterRaster(
   src: ClutterRaster,
   newWidth: number,
@@ -323,7 +294,7 @@ export function downsampleClutterRaster(
   };
 }
 
-/** Reset the tile cache. Test-only. */
+/** Test-only. */
 export function _resetLandcoverCacheForTests(): void {
   (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();
 }

--- a/frontend/src/pages/map/landcoverTiles.ts
+++ b/frontend/src/pages/map/landcoverTiles.ts
@@ -1,0 +1,296 @@
+/**
+ * Land-cover (NLCD) tile fetcher. Mirrors terrainRgb.ts at the surface level —
+ * slippy XYZ tiles, LRU cache, OffscreenCanvas decode — but encodes class IDs
+ * in the red channel rather than terrain elevation.
+ *
+ * Tiles are produced by scripts/landcover_tiles.py and served at
+ * /tiles/landcover/{z}/{x}/{y}.png. A 404 means the tile is outside the bake
+ * bbox; callers fall back to NLCD_DEFAULT_CLASS_ID at the corresponding pixels.
+ *
+ * Tile encoding (per docs/clutter-design.md §8):
+ *   R = NLCD class ID (0 = nodata)
+ *   A = 0 for nodata, 255 for valid pixels
+ *   G, B unused (reserved)
+ */
+import { env } from "../../env";
+import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
+import type { DEMBounds } from "./terrainDEM";
+
+const TILE_SIZE = 256;
+const MIN_ZOOM = 0;
+/** Bake script's default ceiling — z=12 ≈ 10 m/px at lat 37, matching NLCD's 30 m source. */
+const MAX_ZOOM = 12;
+const DEFAULT_MAX_TILES_PER_REQUEST = 256;
+
+function tileBaseUrl(): string {
+  // Same base resolution as apiSlice.ts: runtime > build-time > origin.
+  const apiBase = env.API_BASE_URL ?? window.location.origin;
+  return `${apiBase}/tiles/landcover`;
+}
+
+// --- Slippy Map / Web Mercator helpers ---
+// Same forms as terrainRgb.ts; could be deduplicated later. Keeping them inlined keeps
+// landcoverTiles.ts self-contained for the worker imports.
+
+function lng2tileX(lng: number, zoom: number): number {
+  return ((lng + 180) / 360) * Math.pow(2, zoom);
+}
+
+function lat2tileY(lat: number, zoom: number): number {
+  const latRad = (lat * Math.PI) / 180;
+  return (
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) *
+    Math.pow(2, zoom)
+  );
+}
+
+function tileMetersPerPixel(lat: number, zoom: number, tileSize: number): number {
+  const equatorCircumferenceM = 40_075_017;
+  return (equatorCircumferenceM * Math.cos((lat * Math.PI) / 180)) / (tileSize * Math.pow(2, zoom));
+}
+
+function tileCountForBounds(bounds: DEMBounds, zoom: number): number {
+  const xMin = Math.floor(lng2tileX(bounds.west, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.east, zoom));
+  const yMin = Math.floor(lat2tileY(bounds.north, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.south, zoom));
+  return (xMax - xMin + 1) * (yMax - yMin + 1);
+}
+
+/** Highest zoom (≤ MAX_ZOOM) where m/px ≤ targetPixelSizeM and tile count ≤ maxTiles. */
+export function selectLandcoverZoom(
+  bounds: DEMBounds,
+  targetPixelSizeM: number,
+  maxTiles: number = DEFAULT_MAX_TILES_PER_REQUEST,
+): number {
+  const midLat = (bounds.north + bounds.south) / 2;
+  for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+    const res = tileMetersPerPixel(midLat, z, TILE_SIZE);
+    if (res > targetPixelSizeM) continue;
+    if (tileCountForBounds(bounds, z) <= maxTiles) return z;
+  }
+  // Fallback: coarsest zoom with tolerable tile count
+  for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+    if (tileCountForBounds(bounds, z) <= maxTiles) return z;
+  }
+  return MIN_ZOOM;
+}
+
+/** Decoded tile content. */
+export interface CachedLandcoverTile {
+  /** Row-major class IDs, length TILE_SIZE². 0 = nodata (transparent pixel). */
+  data: Uint8Array;
+  /** Always TILE_SIZE; kept as a field for symmetry with terrainRgb.ts. */
+  size: number;
+}
+
+/** Sentinel returned for tiles that 404'd. Distinct from "tile not yet attempted." */
+export const TILE_MISSING: CachedLandcoverTile = Object.freeze({
+  data: new Uint8Array(0),
+  size: TILE_SIZE,
+}) as CachedLandcoverTile;
+
+/** LRU; same shape as terrainRgb.ts TileLRU. Insertion order = recency. */
+class LandcoverTileLRU {
+  private cache = new Map<string, CachedLandcoverTile>();
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: string): CachedLandcoverTile | undefined {
+    const v = this.cache.get(key);
+    if (!v) return undefined;
+    this.cache.delete(key);
+    this.cache.set(key, v);
+    return v;
+  }
+
+  set(key: string, tile: CachedLandcoverTile): void {
+    if (this.cache.has(key)) this.cache.delete(key);
+    this.cache.set(key, tile);
+    while (this.cache.size > this.maxEntries) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest === undefined) break;
+      this.cache.delete(oldest);
+    }
+  }
+}
+
+// 256 tiles × 256² × 1B ≈ 16 MB worst case. Per-tile is 1/4 the size of terrain-rgb cache.
+const tileCache = new LandcoverTileLRU(256);
+
+/** Fetch + decode one slippy tile. Returns TILE_MISSING for 404 (not an error). */
+export async function fetchLandcoverTile(
+  z: number,
+  x: number,
+  y: number,
+): Promise<CachedLandcoverTile> {
+  const key = `${z}/${x}/${y}`;
+  const hit = tileCache.get(key);
+  if (hit) return hit;
+
+  const url = `${tileBaseUrl()}/${z}/${x}/${y}.png`;
+  const res = await fetch(url);
+  if (res.status === 404) {
+    tileCache.set(key, TILE_MISSING);
+    return TILE_MISSING;
+  }
+  if (!res.ok) {
+    throw new Error(`landcover tile fetch failed ${z}/${x}/${y}: HTTP ${res.status}`);
+  }
+
+  const blob = await res.blob();
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const w = bitmap.width;
+    const h = bitmap.height;
+    if (w !== h) {
+      throw new Error(`landcover tile ${key} has non-square dimensions ${w}x${h}`);
+    }
+    if (w !== TILE_SIZE) {
+      throw new Error(`landcover tile ${key} unexpected size ${w} (want ${TILE_SIZE})`);
+    }
+    const canvas = new OffscreenCanvas(w, h);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("OffscreenCanvas 2d context unavailable");
+    ctx.drawImage(bitmap, 0, 0);
+    const img = ctx.getImageData(0, 0, w, h);
+    const px = img.data;
+    const data = new Uint8Array(w * h);
+    // Class ID lives in R; A=0 means nodata → keep 0 (caller substitutes default class).
+    for (let i = 0, n = data.length; i < n; i++) {
+      const o = i * 4;
+      data[i] = px[o + 3] === 0 ? 0 : px[o];
+    }
+    const tile: CachedLandcoverTile = { data, size: w };
+    tileCache.set(key, tile);
+    return tile;
+  } finally {
+    bitmap.close();
+  }
+}
+
+export interface BuildClutterRasterOptions {
+  bounds: DEMBounds;
+  /** Output grid resolution; matches DEM dims so the worker can sample with one index per pixel. */
+  targetWidth: number;
+  targetHeight: number;
+  /** Overrides DEFAULT_MAX_TILES_PER_REQUEST. Coverage Detail tiers should pass the same cap as buildDem. */
+  maxTiles?: number;
+}
+
+export interface ClutterRaster {
+  /** Row-major class IDs, length width*height. NLCD_DEFAULT_CLASS_ID where the source had no data or the tile 404'd. */
+  data: Uint8Array;
+  width: number;
+  height: number;
+  bounds: DEMBounds;
+  /** Number of tiles successfully fetched / total tiles intersecting the bbox. Useful for telemetry + UI fallback indicator. */
+  tilesPresent: number;
+  tilesTotal: number;
+}
+
+/**
+ * Build a class-ID raster covering `bounds` at `targetWidth × targetHeight`.
+ *
+ * Sampling: nearest-neighbor (class IDs are categorical; bilinear would invent
+ * non-existent IDs). Missing tiles → pixels filled with NLCD_DEFAULT_CLASS_ID.
+ * The function never throws on 404 — that's the documented out-of-bbox path.
+ */
+export async function buildClutterRaster(
+  opts: BuildClutterRasterOptions,
+): Promise<ClutterRaster> {
+  const { bounds, targetWidth, targetHeight } = opts;
+  const maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES_PER_REQUEST;
+
+  // Match resolution to the DEM grid so each output pixel maps to ≤ 1 source tile pixel.
+  const midLat = (bounds.north + bounds.south) / 2;
+  const bboxWidthM =
+    (bounds.east - bounds.west) * 111_320 * Math.cos((midLat * Math.PI) / 180);
+  const targetPixelSizeM = Math.max(1, bboxWidthM / targetWidth);
+  const zoom = selectLandcoverZoom(bounds, targetPixelSizeM, maxTiles);
+
+  const xMin = Math.floor(lng2tileX(bounds.west, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.east, zoom));
+  const yMin = Math.floor(lat2tileY(bounds.north, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.south, zoom));
+  const tilesTotal = (xMax - xMin + 1) * (yMax - yMin + 1);
+
+  // Parallel fetch; 404s become TILE_MISSING.
+  const tileMap = new Map<string, CachedLandcoverTile>();
+  const jobs: Promise<void>[] = [];
+  for (let x = xMin; x <= xMax; x++) {
+    for (let y = yMin; y <= yMax; y++) {
+      const key = `${zoom}/${x}/${y}`;
+      jobs.push(
+        fetchLandcoverTile(zoom, x, y)
+          .then((t) => void tileMap.set(key, t))
+          .catch((err) => {
+            console.warn("[landcoverTiles]", err);
+            tileMap.set(key, TILE_MISSING);
+          }),
+      );
+    }
+  }
+  await Promise.all(jobs);
+
+  let tilesPresent = 0;
+  for (const t of tileMap.values()) {
+    if (t !== TILE_MISSING && t.data.length > 0) tilesPresent++;
+  }
+
+  // Nearest-neighbor resample into the output grid.
+  const data = new Uint8Array(targetWidth * targetHeight);
+  data.fill(NLCD_DEFAULT_CLASS_ID);
+  const scale = Math.pow(2, zoom);
+
+  /** Class ID at absolute tile-pixel (absX, absY). Returns 0 for missing/nodata. */
+  const lookup = (absX: number, absY: number): number => {
+    const tileX = Math.floor(absX / TILE_SIZE);
+    const tileY = Math.floor(absY / TILE_SIZE);
+    const px = absX - tileX * TILE_SIZE;
+    const py = absY - tileY * TILE_SIZE;
+    const xWrapped = ((tileX % scale) + scale) % scale;
+    const t = tileMap.get(`${zoom}/${xWrapped}/${tileY}`);
+    if (!t || t === TILE_MISSING || t.data.length === 0) return 0;
+    return t.data[py * TILE_SIZE + px];
+  };
+
+  for (let j = 0; j < targetHeight; j++) {
+    const lat =
+      bounds.north - ((bounds.north - bounds.south) * j) / (targetHeight - 1);
+    const absY = lat2tileY(lat, zoom) * TILE_SIZE;
+    const yIdx = Math.floor(absY);
+
+    for (let i = 0; i < targetWidth; i++) {
+      const lng =
+        bounds.west + ((bounds.east - bounds.west) * i) / (targetWidth - 1);
+      const absX = lng2tileX(lng, zoom) * TILE_SIZE;
+      const xIdx = Math.floor(absX);
+
+      const cls = lookup(xIdx, yIdx);
+      // 0 = nodata sentinel; keep the pre-filled default class instead.
+      if (cls !== 0) data[j * targetWidth + i] = cls;
+    }
+  }
+
+  return { data, width: targetWidth, height: targetHeight, bounds, tilesPresent, tilesTotal };
+}
+
+/** Nearest-neighbor sample at lng/lat. Returns NLCD_DEFAULT_CLASS_ID for out-of-bounds. */
+export function sampleClutterClassAt(
+  raster: { data: Uint8Array; width: number; height: number; bounds: DEMBounds },
+  lng: number,
+  lat: number,
+): number {
+  const { width, height, bounds, data } = raster;
+  const fx = ((lng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
+  const fy = ((bounds.north - lat) / (bounds.north - bounds.south)) * (height - 1);
+  if (fx < 0 || fx > width - 1 || fy < 0 || fy > height - 1) return NLCD_DEFAULT_CLASS_ID;
+  const x = Math.round(fx);
+  const y = Math.round(fy);
+  return data[y * width + x];
+}
+
+/** Reset the tile cache. Test-only. */
+export function _resetLandcoverCacheForTests(): void {
+  (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();
+}

--- a/frontend/src/pages/map/scanAnalysis.ts
+++ b/frontend/src/pages/map/scanAnalysis.ts
@@ -64,16 +64,9 @@ export interface ScanInput {
   rxSensitivityDbm?: number;
   fadeMarginDb?: number;
   cableLossDb?: number;
-  /**
-   * Optional class-ID raster for the per-pixel ITU clutter model (P.452 endpoint
-   * + P.833 path-traversed vegetation). Null/absent → workers fall back to the
-   * default class everywhere, which is conservative.
-   */
+  /** Optional class-ID raster aligned to bbox; absent → default class everywhere. */
   clutterRaster?: ClutterRaster | null;
-  /**
-   * Aggression scaler applied to the clutter model output. 1.0 = calibrated default.
-   * Pairs with coverage's slider (PR 4) so scan and coverage stay synchronized.
-   */
+  /** Scalar on the ITU clutter model output. 1.0 = calibrated baseline. */
   clutterAggression?: number;
   /** Skip targets farther than this km. Default Infinity. */
   maxDistanceKm?: number;
@@ -125,7 +118,6 @@ export function runScan(input: ScanInput): ScanSummary {
   let diffractedCount = 0;
   let blockedCount = 0;
 
-  // Reusable scratch for the clutter model — one per scan run, shared across targets.
   const clutterScratch = makeClutterScratch();
 
   for (const t of targets) {
@@ -144,9 +136,7 @@ export function runScan(input: ScanInput): ScanSummary {
       queryTerrainM,
     });
 
-    // Per-target clutter loss via the shared P.452 + P.833 model (matches coverage).
-    // We re-sample classes along the great-circle from origin → target using the
-    // same lerp coverage uses; LoS points carry distanceKm but not lng/lat.
+    // LoS points only carry distanceKm; lerp lng/lat ourselves to sample classes.
     const profileM = new Float64Array(los.points.map((p) => p.ground));
     const profileClasses = new Uint8Array(profileM.length);
     if (clutterRaster) {

--- a/frontend/src/pages/map/scanAnalysis.ts
+++ b/frontend/src/pages/map/scanAnalysis.ts
@@ -2,8 +2,11 @@
  * Best-neighbors scan: LoS + link budget from origin to each target, classified and ranked.
  * Stays on the main thread with 60 samples/ray.
  */
+import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
+import { computePathClutterLoss, makeClutterScratch } from "./clutterPath";
 import { pathLossDb } from "./coverageAnalysis";
 import { computeP2PLossFast, type ItmContext,ModeOfVariability } from "./itm";
+import { type ClutterRaster, sampleClutterClassAt } from "./landcoverTiles";
 import { analyzeLineOfSight, haversineKm, type TerrainSampler } from "./losAnalysis";
 
 /** Optional ITM config; when provided, ITM replaces FSPL+knife-edge for path loss. */
@@ -61,8 +64,17 @@ export interface ScanInput {
   rxSensitivityDbm?: number;
   fadeMarginDb?: number;
   cableLossDb?: number;
-  /** Flat clutter-loss offset (dB) added on top of path loss — pairs with coverage's Environment preset. */
-  clutterLossDb?: number;
+  /**
+   * Optional class-ID raster for the per-pixel ITU clutter model (P.452 endpoint
+   * + P.833 path-traversed vegetation). Null/absent → workers fall back to the
+   * default class everywhere, which is conservative.
+   */
+  clutterRaster?: ClutterRaster | null;
+  /**
+   * Aggression scaler applied to the clutter model output. 1.0 = calibrated default.
+   * Pairs with coverage's slider (PR 4) so scan and coverage stay synchronized.
+   */
+  clutterAggression?: number;
   /** Skip targets farther than this km. Default Infinity. */
   maxDistanceKm?: number;
   /** Use ITM for path loss; LoS/Fresnel classification still comes from analyzeLineOfSight. */
@@ -101,7 +113,8 @@ export function runScan(input: ScanInput): ScanSummary {
     rxSensitivityDbm = -130,
     fadeMarginDb = 15,
     cableLossDb = 0.5,
-    clutterLossDb = 0,
+    clutterRaster = null,
+    clutterAggression = 1.0,
     maxDistanceKm = Infinity,
   } = input;
 
@@ -111,6 +124,9 @@ export function runScan(input: ScanInput): ScanSummary {
   let fresnelCount = 0;
   let diffractedCount = 0;
   let blockedCount = 0;
+
+  // Reusable scratch for the clutter model — one per scan run, shared across targets.
+  const clutterScratch = makeClutterScratch();
 
   for (const t of targets) {
     const d = haversineKm(origin, t.position);
@@ -128,14 +144,47 @@ export function runScan(input: ScanInput): ScanSummary {
       queryTerrainM,
     });
 
+    // Per-target clutter loss via the shared P.452 + P.833 model (matches coverage).
+    // We re-sample classes along the great-circle from origin → target using the
+    // same lerp coverage uses; LoS points carry distanceKm but not lng/lat.
+    const profileM = new Float64Array(los.points.map((p) => p.ground));
+    const profileClasses = new Uint8Array(profileM.length);
+    if (clutterRaster) {
+      for (let s = 0; s < profileM.length; s++) {
+        const tFrac = profileM.length > 1 ? s / (profileM.length - 1) : 0;
+        const sLng = origin[0] + (t.position[0] - origin[0]) * tFrac;
+        const sLat = origin[1] + (t.position[1] - origin[1]) * tFrac;
+        profileClasses[s] = sampleClutterClassAt(clutterRaster, sLng, sLat);
+      }
+    } else {
+      profileClasses.fill(NLCD_DEFAULT_CLASS_ID);
+    }
+
+    const spacingM = profileM.length > 1 ? (d * 1000) / (profileM.length - 1) : 0;
+    const txAGLm = los.points.length > 0
+      ? Math.max(0.5, los.fromHeightM - los.points[0].ground)
+      : 2;
+    const rxAGLm = los.points.length > 0
+      ? Math.max(0.5, los.toHeightM - los.points[los.points.length - 1].ground)
+      : 2;
+    const clutterLossDb = computePathClutterLoss(
+      profileM,
+      profileClasses,
+      profileM.length,
+      spacingM,
+      txAGLm,
+      rxAGLm,
+      freqMhz,
+      clutterAggression,
+      clutterScratch,
+    );
+
     // Path loss: ITM (terrain-aware) when available, else FSPL + knife-edge
     let totalLossDb: number;
     if (input.itm && los.points.length >= 2) {
-      const profileM = new Float64Array(los.points.map((p) => p.ground));
-      const spacingM = (d * 1000) / (profileM.length - 1);
       const itmLoss = computeP2PLossFast(input.itm.context, {
-        txHeightM: Math.max(0.5, los.fromHeightM - los.points[0].ground),
-        rxHeightM: Math.max(0.5, los.toHeightM - los.points[los.points.length - 1].ground),
+        txHeightM: txAGLm,
+        rxHeightM: rxAGLm,
         profileM,
         pointSpacingM: spacingM,
         climate: input.itm.climate,

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -11,6 +11,9 @@ export const LS_KEYS = {
   /** AGGRESSION_STOPS index (0/1/2). Default 1 = calibrated baseline. */
   coverageAggressionIdx: "meshinfo.map.coverageAggressionIdx",
   scanAggressionIdx: "meshinfo.map.scanAggressionIdx",
+  /** Clutter model on/off. Off → aggression = 0, ITM-only path loss. */
+  coverageClutterEnabled: "meshinfo.map.coverageClutterEnabled",
+  scanClutterEnabled: "meshinfo.map.scanClutterEnabled",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -8,6 +8,9 @@ export const LS_KEYS = {
   linkMode: "meshinfo.map.linkMode",
   myNodeId: "meshinfo.map.myNodeId",
   terrain3D: "meshinfo.map.terrain3D",
+  /** AGGRESSION_STOPS index (0/1/2). Default 1 = calibrated baseline. */
+  coverageAggressionIdx: "meshinfo.map.coverageAggressionIdx",
+  scanAggressionIdx: "meshinfo.map.scanAggressionIdx",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/scripts/README-landcover.md
+++ b/scripts/README-landcover.md
@@ -1,0 +1,139 @@
+# Land-cover tile bake (operator guide)
+
+Meshinfo's coverage and scan tools sample per-pixel land-cover classes for
+ITU-R clutter loss. Tiles are pre-baked from USGS NLCD and served as static
+PNGs under `/tiles/landcover/{z}/{x}/{y}.png`. See
+[../docs/clutter-design.md](../docs/clutter-design.md) for the full RF model.
+
+This guide walks through running the bake once per region. Re-bake every 2–3
+years when a new NLCD release ships.
+
+## What you get
+
+- `output/landcover/{z}/{x}/{y}.png` — slippy-tile pyramid, z=8..12 by default.
+- ~700 MB – 1.1 GB on disk for the full CONUS bake.
+- Bake time: ~30–90 min depending on CPU and disk speed.
+
+Tiles outside the bake bbox 404 at request time, and the frontend falls back
+to a "Mixed Forest" default class. So an operator who only deploys in one
+state can pass `--bbox` to bake just that state.
+
+## Prerequisites
+
+```bash
+# In a venv:
+pip install -r scripts/requirements-landcover.txt
+```
+
+`rasterio` ships GDAL wheels on PyPI for Linux/macOS/Windows — no system GDAL
+is required for typical bakes.
+
+## Source data
+
+NLCD is published by the USGS Multi-Resolution Land Characteristics consortium
+at <https://www.mrlc.gov/data>. Pick the **Land Cover** product for the year
+you want and your region:
+
+| Region | File (example, 2021 release) |
+|---|---|
+| CONUS (lower 48) | `nlcd_2021_land_cover_l48_<rev>.img` |
+| Alaska | `NLCD_2016_Land_Cover_AK_<rev>.img` |
+| Hawaii | (separate; see MRLC portal) |
+| Puerto Rico | (separate; see MRLC portal) |
+
+The MRLC site requires a free account but downloads are public-domain.
+Download the IMG/TIF; the bake script accepts either via `rasterio`.
+
+## Running the bake (CONUS default)
+
+```bash
+python scripts/landcover_tiles.py \
+    --source ~/Downloads/nlcd_2021_land_cover_l48_20230630.img \
+    --out output/landcover
+```
+
+The default bbox covers the CONUS lower 48 (`-125 24 -67 49`) and the default
+zoom range is `8 12`. With 8 worker processes on a modern CPU, expect
+roughly 30–60 minutes for the full CONUS pyramid.
+
+The script is **idempotent** — already-baked tiles are skipped, so you can
+ctrl-C and resume by re-running the same command.
+
+## Baking a smaller region
+
+To bake just California, for example:
+
+```bash
+python scripts/landcover_tiles.py \
+    --source nlcd_2021_land_cover_l48_20230630.img \
+    --out output/landcover \
+    --bbox -125 32 -113 43
+```
+
+Smaller bbox → fewer tiles → faster bake and less storage. Operators outside
+the bbox transparently fall back to the default class.
+
+## Adding AK / HI / PR
+
+Run the bake again with the matching source file and the appropriate bbox.
+The output directory can be the same — tile coordinates don't collide.
+
+```bash
+# Alaska (using the regional NLCD file)
+python scripts/landcover_tiles.py \
+    --source nlcd_alaska_2016_land_cover.img \
+    --out output/landcover \
+    --bbox -180 50 -129 72
+```
+
+## Refreshing for a new NLCD release
+
+NLCD releases a new full product every 2–3 years. To refresh:
+
+```bash
+python scripts/landcover_tiles.py \
+    --source nlcd_2024_land_cover_l48_<rev>.img \
+    --out output/landcover \
+    --force
+```
+
+`--force` overwrites existing tiles; without it, the script skips them.
+
+## Serving the tiles
+
+The Meshinfo API mounts `output/landcover` (configurable via
+`landcover.tile_dir`) at `/tiles/landcover` automatically when
+`landcover.enabled = true` in `config.toml` (default).
+
+Both `docker-compose.yml` and `docker-compose-dev.yml` already bind-mount
+`./output:/app/output`, so tiles baked on the host appear at
+`/app/output/landcover` inside the container with no extra volume config.
+
+The frontend fetches tiles through the existing Caddy `/api/*` proxy:
+
+```
+/api/tiles/landcover/{z}/{x}/{y}.png   →   meshinfo:9000/tiles/landcover/{z}/{x}/{y}.png
+```
+
+Tiles respond with `Cache-Control: public, max-age=31536000, immutable`
+because class IDs don't change between bakes.
+
+## Troubleshooting
+
+- **`Missing dependency: rasterio`** — install requirements-landcover.txt.
+- **`Source raster not found`** — pass an absolute path, or run from the
+  Meshinfo root.
+- **All tiles report `empty`** — your bbox doesn't overlap the source raster.
+  Check that you're using the right NLCD region file for your bbox.
+- **Slow bake** — increase `--workers`, or check that the source file is on
+  a fast local disk (network filesystems hurt random-access reprojection).
+
+## File format reference
+
+Each output tile is a 256×256 RGBA PNG:
+
+- **R** = NLCD class ID (11–95). 0 = nodata.
+- **G**, **B** = 0 (reserved for future encoding — e.g. canopy height).
+- **A** = 255 valid, 0 nodata.
+
+The frontend's `landcoverTiles.ts` reads the R channel directly.

--- a/scripts/README-landcover.md
+++ b/scripts/README-landcover.md
@@ -2,8 +2,10 @@
 
 Meshinfo's coverage and scan tools sample per-pixel land-cover classes for
 ITU-R clutter loss. Tiles are pre-baked from USGS NLCD and served as static
-PNGs under `/tiles/landcover/{z}/{x}/{y}.png`. See
-[../docs/clutter-design.md](../docs/clutter-design.md) for the full RF model.
+PNGs under `/tiles/landcover/{z}/{x}/{y}.png`.
+
+For the propagation model that consumes these tiles (ITM + ITU-R P.452-17 +
+ITU-R P.833-9), see [../RF-MODEL.md](../RF-MODEL.md).
 
 This guide walks through running the bake once per region. Re-bake every 2–3
 years when a new NLCD release ships.

--- a/scripts/README-landcover.md
+++ b/scripts/README-landcover.md
@@ -7,130 +7,113 @@ PNGs under `/tiles/landcover/{z}/{x}/{y}.png`.
 For the propagation model that consumes these tiles (ITM + ITU-R P.452-17 +
 ITU-R P.833-9), see [../RF-MODEL.md](../RF-MODEL.md).
 
-This guide walks through running the bake once per region. Re-bake every 2–3
-years when a new NLCD release ships.
+## Quick start
 
-## What you get
+The bake auto-downloads NLCD 2024 (CONUS, Annual Collection 1.1) from MRLC if
+no source file is provided. Two ways to run:
 
-- `output/landcover/{z}/{x}/{y}.png` — slippy-tile pyramid, z=8..12 by default.
-- ~700 MB – 1.1 GB on disk for the full CONUS bake.
-- Bake time: ~30–90 min depending on CPU and disk speed.
-
-Tiles outside the bake bbox 404 at request time, and the frontend falls back
-to a "Mixed Forest" default class. So an operator who only deploys in one
-state can pass `--bbox` to bake just that state.
-
-## Prerequisites
+### Docker (recommended — no host Python deps)
 
 ```bash
-# In a venv:
+docker compose --profile bake run --rm landcover-bake
+```
+
+### Python directly
+
+```bash
 pip install -r scripts/requirements-landcover.txt
+python scripts/landcover_tiles.py
 ```
 
-`rasterio` ships GDAL wheels on PyPI for Linux/macOS/Windows — no system GDAL
-is required for typical bakes.
+Either way, the script:
 
-## Source data
+1. Downloads `Annual_NLCD_LndCov_2024_CU_C1V1.zip` (~1.4 GB) into
+   `output/landcover-source/` if not already present.
+2. Extracts the GeoTIFF.
+3. Bakes the full CONUS pyramid (z=8..12) into `output/landcover/`.
 
-NLCD is published by the USGS Multi-Resolution Land Characteristics consortium
-at <https://www.mrlc.gov/data>. Pick the **Land Cover** product for the year
-you want and your region:
+The Meshinfo API picks the tiles up automatically on next start (or restart if
+already running) — no extra config.
 
-| Region | File (example, 2021 release) |
-|---|---|
-| CONUS (lower 48) | `nlcd_2021_land_cover_l48_<rev>.img` |
-| Alaska | `NLCD_2016_Land_Cover_AK_<rev>.img` |
-| Hawaii | (separate; see MRLC portal) |
-| Puerto Rico | (separate; see MRLC portal) |
+**First-run footprint:** ~1.4 GB zip + ~1.7 GB extracted raster + ~1 GB tiles.
+Delete `output/landcover-source/` after the bake if you don't plan to re-bake.
 
-The MRLC site requires a free account but downloads are public-domain.
-Download the IMG/TIF; the bake script accepts either via `rasterio`.
+**Time:** ~15–90 min depending on CPU. The bake is idempotent — ctrl-C and re-run
+to resume; already-baked tiles are skipped.
 
-## Running the bake (CONUS default)
+## Sub-region or offline bake
+
+Pass `--source` to skip the download and use a local raster (mirror, regional
+NLCD release, alternate vintage):
 
 ```bash
-python scripts/landcover_tiles.py \
-    --source ~/Downloads/nlcd_2021_land_cover_l48_20230630.img \
-    --out output/landcover
+python scripts/landcover_tiles.py --source /path/to/nlcd.tif
 ```
 
-The default bbox covers the CONUS lower 48 (`-125 24 -67 49`) and the default
-zoom range is `8 12`. With 8 worker processes on a modern CPU, expect
-roughly 30–60 minutes for the full CONUS pyramid.
-
-The script is **idempotent** — already-baked tiles are skipped, so you can
-ctrl-C and resume by re-running the same command.
-
-## Baking a smaller region
-
-To bake just California, for example:
+Or restrict the bbox to a single state for a faster bake:
 
 ```bash
-python scripts/landcover_tiles.py \
-    --source nlcd_2021_land_cover_l48_20230630.img \
-    --out output/landcover \
-    --bbox -125 32 -113 43
+# California only
+python scripts/landcover_tiles.py --bbox -125 32 -113 43
 ```
 
-Smaller bbox → fewer tiles → faster bake and less storage. Operators outside
-the bbox transparently fall back to the default class.
+Operators who only deploy in one region can save storage and bake time this
+way; the frontend falls back to the default "Mixed Forest" class everywhere
+outside the baked bbox.
 
-## Adding AK / HI / PR
+## All flags
 
-Run the bake again with the matching source file and the appropriate bbox.
-The output directory can be the same — tile coordinates don't collide.
-
-```bash
-# Alaska (using the regional NLCD file)
-python scripts/landcover_tiles.py \
-    --source nlcd_alaska_2016_land_cover.img \
-    --out output/landcover \
-    --bbox -180 50 -129 72
+```
+--source PATH       Use a local NLCD raster instead of auto-downloading.
+--out PATH          Tile output directory (default: output/landcover).
+--bbox W S E N      Geographic bbox (default: CONUS -125 24 -67 49).
+--zooms MIN MAX     Zoom range (default: 8 12; NLCD is 30 m native).
+--workers N         Parallel worker count (default: cpu_count).
+--force             Overwrite existing tiles instead of skipping.
 ```
 
 ## Refreshing for a new NLCD release
 
-NLCD releases a new full product every 2–3 years. To refresh:
+NLCD publishes a new vintage every 1–3 years (Annual NLCD has yearly snapshots
+since 2019). Class IDs follow the standard NLCD legend, which has been stable
+since 2001 — bake-time tuning is rarely needed.
 
-```bash
-python scripts/landcover_tiles.py \
-    --source nlcd_2024_land_cover_l48_<rev>.img \
-    --out output/landcover \
-    --force
-```
+To refresh: update `DEFAULT_SOURCE_URL` in [landcover_tiles.py](landcover_tiles.py)
+to the newer vintage, delete `output/landcover-source/` and `output/landcover/`,
+and re-run the bake.
 
-`--force` overwrites existing tiles; without it, the script skips them.
+## How the tiles are served
 
-## Serving the tiles
+The Meshinfo API mounts `output/landcover` (configurable via `landcover.tile_dir`
+in `config.toml`) at `/tiles/landcover` automatically when `landcover.enabled =
+true` (default).
 
-The Meshinfo API mounts `output/landcover` (configurable via
-`landcover.tile_dir`) at `/tiles/landcover` automatically when
-`landcover.enabled = true` in `config.toml` (default).
-
-Both `docker-compose.yml` and `docker-compose-dev.yml` already bind-mount
+Both `docker-compose.yml` and `docker-compose-dev.yml` bind-mount
 `./output:/app/output`, so tiles baked on the host appear at
-`/app/output/landcover` inside the container with no extra volume config.
+`/app/output/landcover` inside the container with no extra config.
 
-The frontend fetches tiles through the existing Caddy `/api/*` proxy:
+The frontend fetches via the Caddy `/api/*` proxy:
 
 ```
 /api/tiles/landcover/{z}/{x}/{y}.png   →   meshinfo:9000/tiles/landcover/{z}/{x}/{y}.png
 ```
 
-Tiles respond with `Cache-Control: public, max-age=31536000, immutable`
-because class IDs don't change between bakes.
+Tiles respond with `Cache-Control: public, max-age=31536000, immutable` since
+class IDs don't change within a bake.
 
 ## Troubleshooting
 
-- **`Missing dependency: rasterio`** — install requirements-landcover.txt.
-- **`Source raster not found`** — pass an absolute path, or run from the
-  Meshinfo root.
-- **All tiles report `empty`** — your bbox doesn't overlap the source raster.
-  Check that you're using the right NLCD region file for your bbox.
-- **Slow bake** — increase `--workers`, or check that the source file is on
-  a fast local disk (network filesystems hurt random-access reprojection).
+- **`Missing dependency: rasterio`** — install `scripts/requirements-landcover.txt`.
+- **Download interrupted** — re-run the same command. Resumes via HTTP Range if
+  the server supports it; otherwise restarts cleanly.
+- **`Extracted X but no .tif or .img found`** — corrupt zip. Delete
+  `output/landcover-source/*.zip` and re-run.
+- **All tiles report `empty`** — bbox doesn't overlap the source raster. Check
+  you're not passing a non-CONUS `--bbox` against the CONUS source file.
+- **Slow bake** — bump `--workers`, ensure the source file is on a local disk
+  (network filesystems hurt random-access reprojection).
 
-## File format reference
+## File format
 
 Each output tile is a 256×256 RGBA PNG:
 

--- a/scripts/landcover_tiles.py
+++ b/scripts/landcover_tiles.py
@@ -19,7 +19,7 @@ import sys
 import urllib.error
 import urllib.request
 import zipfile
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
 from dataclasses import dataclass
 from os import cpu_count
 from pathlib import Path
@@ -179,9 +179,30 @@ def _download_with_progress(url: str, dest: Path) -> None:
 
 
 def _extract_zip(zip_path: Path, dest_dir: Path) -> None:
+    """Extracts members one at a time, validating each resolved path stays within
+    dest_dir so a malicious archive can't write outside it (zip-slip)."""
     log.info("Extracting %s ...", zip_path.name)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    resolved_dest = dest_dir.resolve()
     with zipfile.ZipFile(zip_path) as zf:
-        zf.extractall(dest_dir)
+        for member in zf.infolist():
+            target = (dest_dir / member.filename).resolve()
+            try:
+                target.relative_to(resolved_dest)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"Refusing to extract suspicious archive entry: {member.filename}"
+                ) from exc
+            if member.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member) as src, target.open("wb") as dst:
+                while True:
+                    chunk = src.read(1 << 20)
+                    if not chunk:
+                        break
+                    dst.write(chunk)
     log.info("Extraction complete")
 
 
@@ -310,26 +331,43 @@ def main() -> int:
     )
 
     counts = {"written": 0, "skipped": 0, "empty": 0, "error": 0}
-
     progress_step = max(1, total // 100)
 
+    # Bounded streaming submission: keep ~2× workers in flight rather than
+    # materializing all `total` futures up front. CONUS at z=8..12 is 318k tiles
+    # (~64 MB of Future objects); a global bake would be 10×+ that.
+    in_flight_target = max(args.workers * 2, args.workers + 1)
+
     with ProcessPoolExecutor(max_workers=args.workers) as pool:
-        futures = {pool.submit(bake_tile, job): None for job in jobs}
-        for i, fut in enumerate(as_completed(futures), 1):
+        pending = set()
+        for _ in range(in_flight_target):
             try:
-                result = fut.result()
-                counts[result] += 1
-            except Exception as exc:
-                counts["error"] += 1
-                log.warning("Tile failed: %s", exc)
-            if i % progress_step == 0 or i == total:
-                pct = 100.0 * i / total if total else 100.0
-                log.info(
-                    "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
-                    pct, i, total,
-                    counts["written"], counts["skipped"],
-                    counts["empty"], counts["error"],
-                )
+                pending.add(pool.submit(bake_tile, next(jobs)))
+            except StopIteration:
+                break
+
+        completed = 0
+        while pending:
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for fut in done:
+                completed += 1
+                try:
+                    counts[fut.result()] += 1
+                except Exception as exc:
+                    counts["error"] += 1
+                    log.warning("Tile failed: %s", exc)
+                try:
+                    pending.add(pool.submit(bake_tile, next(jobs)))
+                except StopIteration:
+                    pass
+                if completed % progress_step == 0 or completed == total:
+                    pct = 100.0 * completed / total if total else 100.0
+                    log.info(
+                        "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
+                        pct, completed, total,
+                        counts["written"], counts["skipped"],
+                        counts["empty"], counts["error"],
+                    )
 
     log.info(
         "Done. written=%d skipped=%d empty=%d error=%d",

--- a/scripts/landcover_tiles.py
+++ b/scripts/landcover_tiles.py
@@ -1,8 +1,12 @@
 """
-Bake an NLCD land-cover GeoTIFF into a {z}/{x}/{y}.png slippy tile pyramid.
+Bake an NLCD land-cover raster into a {z}/{x}/{y}.png slippy tile pyramid.
 Output tiles encode the NLCD class ID in the red channel (A=255 valid / 0 nodata).
 See RF-MODEL.md for what the tiles are for, scripts/README-landcover.md for the
 operator runbook.
+
+When --source is omitted, the script auto-downloads NLCD 2024 (CONUS, Annual NLCD
+Collection 1.1) from MRLC into output/landcover-source/, extracts, and bakes.
+Pass --source to point at a pre-downloaded raster (offline / mirror / regional).
 
 Idempotent: existing tiles are skipped unless --force, so interrupted bakes
 resume by re-running.
@@ -12,6 +16,9 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+import urllib.error
+import urllib.request
+import zipfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from os import cpu_count
@@ -42,6 +49,15 @@ TILE_PX = 256
 
 # CONUS bbox (lower 48). AK/HI/PR are separate NLCD source files.
 CONUS_BBOX = (-125.0, 24.0, -67.0, 49.0)
+
+# MRLC direct download (anonymous-public). Update for a new vintage; class IDs
+# follow the standard NLCD legend, stable since NLCD 2001, so existing class
+# table doesn't need re-tuning.
+DEFAULT_SOURCE_URL = (
+    "https://www.mrlc.gov/downloads/sciweb1/shared/mrlc/data-bundles/"
+    "Annual_NLCD_LndCov_2024_CU_C1V1.zip"
+)
+DEFAULT_SOURCE_DIR = Path("output/landcover-source")
 
 
 @dataclass(frozen=True)
@@ -110,16 +126,107 @@ def count_tiles(bbox: tuple[float, float, float, float], zooms: range) -> int:
     return sum(1 for _ in iter_tiles(bbox, zooms))
 
 
+def _find_raster(src_dir: Path) -> Path | None:
+    for pattern in ("*.tif", "*.img"):
+        for cand in sorted(src_dir.glob(pattern)):
+            return cand
+    return None
+
+
+def _download_with_progress(url: str, dest: Path) -> None:
+    """Resumes via Range when a partial file exists and the server returns 206;
+    falls back to a fresh download if the server returns 200 instead."""
+    existing = dest.stat().st_size if dest.exists() else 0
+    headers = {"Range": f"bytes={existing}-"} if existing > 0 else {}
+    req = urllib.request.Request(url, headers=headers)
+
+    log.info("Downloading %s", url)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            status = resp.status
+            if existing > 0 and status == 206:
+                mode = "ab"
+                total = existing + int(resp.headers.get("Content-Length", 0))
+                downloaded = existing
+                log.info("Resuming from byte %d", existing)
+            else:
+                if existing > 0:
+                    log.info("Server returned %d (no Range); restarting download", status)
+                mode = "wb"
+                total = int(resp.headers.get("Content-Length", 0))
+                downloaded = 0
+
+            chunk = 1 << 16
+            last_pct = -5
+            with dest.open(mode) as f:
+                while True:
+                    buf = resp.read(chunk)
+                    if not buf:
+                        break
+                    f.write(buf)
+                    downloaded += len(buf)
+                    if total:
+                        pct = (downloaded * 100) // total
+                        if pct >= last_pct + 5:
+                            log.info("  [%3d%%]  %.1f / %.1f MB",
+                                     pct, downloaded / 1e6, total / 1e6)
+                            last_pct = pct
+    except urllib.error.URLError as e:
+        # Leave the partial file in place so a re-run can resume.
+        raise RuntimeError(f"Download failed: {e}. Re-run to resume.") from e
+
+    log.info("Download complete: %s (%.1f MB)", dest, dest.stat().st_size / 1e6)
+
+
+def _extract_zip(zip_path: Path, dest_dir: Path) -> None:
+    log.info("Extracting %s ...", zip_path.name)
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(dest_dir)
+    log.info("Extraction complete")
+
+
+def ensure_source(source_arg: str | None) -> Path:
+    """If --source is given, use it. Otherwise look for a raster in
+    output/landcover-source/, then a zip to extract, then download the default."""
+    if source_arg:
+        p = Path(source_arg)
+        if not p.exists():
+            raise RuntimeError(f"Source raster not found: {p}")
+        return p
+
+    DEFAULT_SOURCE_DIR.mkdir(parents=True, exist_ok=True)
+
+    raster = _find_raster(DEFAULT_SOURCE_DIR)
+    if raster:
+        log.info("Using existing raster: %s", raster)
+        return raster
+
+    zips = sorted(DEFAULT_SOURCE_DIR.glob("*.zip"))
+    if not zips:
+        zip_dest = DEFAULT_SOURCE_DIR / Path(DEFAULT_SOURCE_URL).name
+        _download_with_progress(DEFAULT_SOURCE_URL, zip_dest)
+        zips = [zip_dest]
+
+    _extract_zip(zips[0], DEFAULT_SOURCE_DIR)
+    raster = _find_raster(DEFAULT_SOURCE_DIR)
+    if not raster:
+        raise RuntimeError(
+            f"Extracted {zips[0].name} but no .tif or .img found in {DEFAULT_SOURCE_DIR}"
+        )
+    return raster
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Bake NLCD GeoTIFF into a slippy tile pyramid for Meshinfo clutter model.",
+        description="Bake NLCD into a slippy tile pyramid for the Meshinfo clutter model.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
     p.add_argument(
         "--source",
-        required=True,
-        help="Path to NLCD source raster (GeoTIFF, IMG, or COG). Single band, uint8 class IDs.",
+        default=None,
+        help="Path to NLCD source raster (GeoTIFF, IMG, or COG). "
+             "Omit to auto-download NLCD 2024 CONUS into output/landcover-source/.",
     )
     p.add_argument(
         "--out",
@@ -141,7 +248,7 @@ def parse_args() -> argparse.Namespace:
         metavar=("MIN", "MAX"),
         default=[8, 12],
         help="Inclusive zoom range to bake (default: 8 12). NLCD is 30 m native; "
-             "z=12 ≈ 10 m/px is the matching frontier.",
+             "z=12 ~= 10 m/px is the matching frontier.",
     )
     p.add_argument(
         "--workers",
@@ -160,9 +267,10 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
 
-    source = Path(args.source)
-    if not source.exists():
-        log.error("Source raster not found: %s", source)
+    try:
+        source = ensure_source(args.source)
+    except RuntimeError as e:
+        log.error("%s", e)
         return 1
 
     out_dir = Path(args.out)

--- a/scripts/landcover_tiles.py
+++ b/scripts/landcover_tiles.py
@@ -1,24 +1,11 @@
 """
 Bake an NLCD land-cover GeoTIFF into a {z}/{x}/{y}.png slippy tile pyramid.
+Output tiles encode the NLCD class ID in the red channel (A=255 valid / 0 nodata).
+See RF-MODEL.md for what the tiles are for, scripts/README-landcover.md for the
+operator runbook.
 
-One-shot operator script. Output tiles encode the NLCD class ID in the red
-channel (G=B=0, A=255 valid / 0 nodata). The Meshinfo coverage and scan tools
-sample these tiles per-pixel for ITU-R clutter loss; see docs/clutter-design.md.
-
-Usage:
-    python scripts/landcover_tiles.py \\
-        --source /path/to/nlcd_2021_land_cover_l48_20230630.img \\
-        --out output/landcover \\
-        --zooms 8 12 \\
-        --bbox -125 24 -67 49
-
-Source data: USGS NLCD 2021 (CONUS) from https://www.mrlc.gov/data
-Default bbox is the lower 48; pass --bbox to bake AK / HI / PR or a sub-region.
-Pyramid range z=8..12 matches NLCD's 30 m native resolution; deeper zooms
-inflate storage without adding information.
-
-The script is idempotent — existing tiles are skipped unless --force is set,
-so an interrupted bake can be resumed by re-running.
+Idempotent: existing tiles are skipped unless --force, so interrupted bakes
+resume by re-running.
 """
 from __future__ import annotations
 
@@ -72,10 +59,7 @@ def _tile_path(out_dir: Path, z: int, x: int, y: int) -> Path:
 
 
 def bake_tile(job: TileJob) -> str:
-    """Reproject one source-CRS window into a 256² Web Mercator PNG.
-
-    Returns "written", "skipped" (already exists), or "empty" (all nodata).
-    """
+    """Returns "written", "skipped" (already exists), or "empty" (all nodata)."""
     out_path = _tile_path(Path(job.out_dir), job.z, job.x, job.y)
     if out_path.exists() and not job.force:
         return "skipped"
@@ -88,7 +72,7 @@ def bake_tile(job: TileJob) -> str:
     dst = np.zeros((TILE_PX, TILE_PX), dtype=np.uint8)
 
     with rasterio.open(job.source) as src:
-        # nearest-neighbor: classes are categorical, bilinear would invent IDs
+        # Nearest-neighbor: bilinear over categorical IDs would invent IDs.
         reproject(
             source=rasterio.band(src, 1),
             destination=dst,
@@ -98,12 +82,10 @@ def bake_tile(job: TileJob) -> str:
             dst_nodata=0,
         )
 
-    # Ocean / out-of-source tiles are entirely nodata; skip rather than write a 4 KB no-op.
-    # Frontend treats 404 as "out-of-bbox, fall back to default class."
+    # Skip empty tiles; frontend treats 404 as out-of-bbox and falls back.
     if not dst.any():
         return "empty"
 
-    # R = class ID; A = 0 for nodata pixels so the frontend can mask them.
     rgba = np.zeros((TILE_PX, TILE_PX, 4), dtype=np.uint8)
     rgba[..., 0] = dst
     rgba[..., 3] = np.where(dst == 0, 0, 255)

--- a/scripts/landcover_tiles.py
+++ b/scripts/landcover_tiles.py
@@ -1,0 +1,252 @@
+"""
+Bake an NLCD land-cover GeoTIFF into a {z}/{x}/{y}.png slippy tile pyramid.
+
+One-shot operator script. Output tiles encode the NLCD class ID in the red
+channel (G=B=0, A=255 valid / 0 nodata). The Meshinfo coverage and scan tools
+sample these tiles per-pixel for ITU-R clutter loss; see docs/clutter-design.md.
+
+Usage:
+    python scripts/landcover_tiles.py \\
+        --source /path/to/nlcd_2021_land_cover_l48_20230630.img \\
+        --out output/landcover \\
+        --zooms 8 12 \\
+        --bbox -125 24 -67 49
+
+Source data: USGS NLCD 2021 (CONUS) from https://www.mrlc.gov/data
+Default bbox is the lower 48; pass --bbox to bake AK / HI / PR or a sub-region.
+Pyramid range z=8..12 matches NLCD's 30 m native resolution; deeper zooms
+inflate storage without adding information.
+
+The script is idempotent — existing tiles are skipped unless --force is set,
+so an interrupted bake can be resumed by re-running.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+from os import cpu_count
+from pathlib import Path
+from typing import Iterator
+
+try:
+    import mercantile
+    import numpy as np
+    import rasterio
+    from PIL import Image
+    from rasterio.warp import Resampling, reproject
+except ImportError as exc:
+    sys.stderr.write(
+        f"Missing dependency: {exc.name}.\n"
+        "Install with: pip install -r scripts/requirements-landcover.txt\n"
+    )
+    sys.exit(2)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("landcover_tiles")
+
+TILE_PX = 256
+
+# CONUS bbox (lower 48). AK/HI/PR are separate NLCD source files.
+CONUS_BBOX = (-125.0, 24.0, -67.0, 49.0)
+
+
+@dataclass(frozen=True)
+class TileJob:
+    z: int
+    x: int
+    y: int
+    source: str
+    out_dir: str
+    force: bool
+
+
+def _tile_path(out_dir: Path, z: int, x: int, y: int) -> Path:
+    return out_dir / str(z) / str(x) / f"{y}.png"
+
+
+def bake_tile(job: TileJob) -> str:
+    """Reproject one source-CRS window into a 256² Web Mercator PNG.
+
+    Returns "written", "skipped" (already exists), or "empty" (all nodata).
+    """
+    out_path = _tile_path(Path(job.out_dir), job.z, job.x, job.y)
+    if out_path.exists() and not job.force:
+        return "skipped"
+
+    bounds = mercantile.xy_bounds(job.x, job.y, job.z)
+    dst_transform = rasterio.transform.from_bounds(
+        bounds.left, bounds.bottom, bounds.right, bounds.top,
+        TILE_PX, TILE_PX,
+    )
+    dst = np.zeros((TILE_PX, TILE_PX), dtype=np.uint8)
+
+    with rasterio.open(job.source) as src:
+        # nearest-neighbor: classes are categorical, bilinear would invent IDs
+        reproject(
+            source=rasterio.band(src, 1),
+            destination=dst,
+            dst_transform=dst_transform,
+            dst_crs="EPSG:3857",
+            resampling=Resampling.nearest,
+            dst_nodata=0,
+        )
+
+    # Ocean / out-of-source tiles are entirely nodata; skip rather than write a 4 KB no-op.
+    # Frontend treats 404 as "out-of-bbox, fall back to default class."
+    if not dst.any():
+        return "empty"
+
+    # R = class ID; A = 0 for nodata pixels so the frontend can mask them.
+    rgba = np.zeros((TILE_PX, TILE_PX, 4), dtype=np.uint8)
+    rgba[..., 0] = dst
+    rgba[..., 3] = np.where(dst == 0, 0, 255)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(rgba, mode="RGBA").save(out_path, format="PNG", optimize=True)
+    return "written"
+
+
+def iter_tiles(
+    bbox: tuple[float, float, float, float],
+    zooms: range,
+) -> Iterator[mercantile.Tile]:
+    """Yield every (z, x, y) tile intersecting *bbox* across *zooms*."""
+    west, south, east, north = bbox
+    for z in zooms:
+        for tile in mercantile.tiles(west, south, east, north, zooms=[z]):
+            yield tile
+
+
+def count_tiles(bbox: tuple[float, float, float, float], zooms: range) -> int:
+    return sum(1 for _ in iter_tiles(bbox, zooms))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Bake NLCD GeoTIFF into a slippy tile pyramid for Meshinfo clutter model.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--source",
+        required=True,
+        help="Path to NLCD source raster (GeoTIFF, IMG, or COG). Single band, uint8 class IDs.",
+    )
+    p.add_argument(
+        "--out",
+        default="output/landcover",
+        help="Output tile directory (default: output/landcover).",
+    )
+    p.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        metavar=("WEST", "SOUTH", "EAST", "NORTH"),
+        default=CONUS_BBOX,
+        help="Geographic bbox in EPSG:4326 (default: CONUS lower 48).",
+    )
+    p.add_argument(
+        "--zooms",
+        nargs=2,
+        type=int,
+        metavar=("MIN", "MAX"),
+        default=[8, 12],
+        help="Inclusive zoom range to bake (default: 8 12). NLCD is 30 m native; "
+             "z=12 ≈ 10 m/px is the matching frontier.",
+    )
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=cpu_count() or 4,
+        help="Parallel worker processes (default: cpu_count).",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing tiles. Default is skip-if-exists (resumable).",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    source = Path(args.source)
+    if not source.exists():
+        log.error("Source raster not found: %s", source)
+        return 1
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    bbox = tuple(args.bbox)
+    zmin, zmax = args.zooms
+    if zmin > zmax:
+        log.error("Invalid zoom range: min %d > max %d", zmin, zmax)
+        return 1
+    zooms = range(zmin, zmax + 1)
+
+    log.info("Source:  %s", source.resolve())
+    log.info("Output:  %s", out_dir.resolve())
+    log.info("BBox:    W=%.3f S=%.3f E=%.3f N=%.3f", *bbox)
+    log.info("Zooms:   %d..%d (inclusive)", zmin, zmax)
+    log.info("Workers: %d", args.workers)
+    log.info("Force:   %s", args.force)
+
+    # Sanity check the source CRS once on the main process before forking.
+    with rasterio.open(source) as src:
+        log.info("Source CRS: %s, size %dx%d, dtype %s",
+                 src.crs, src.width, src.height, src.dtypes[0])
+        if src.dtypes[0] != "uint8":
+            log.warning(
+                "Source dtype is %s, expected uint8. Class IDs may be truncated.",
+                src.dtypes[0],
+            )
+
+    log.info("Counting tiles for progress estimate...")
+    total = count_tiles(bbox, zooms)
+    log.info("Total tiles to consider: %d", total)
+
+    jobs = (
+        TileJob(t.z, t.x, t.y, str(source), str(out_dir), args.force)
+        for t in iter_tiles(bbox, zooms)
+    )
+
+    counts = {"written": 0, "skipped": 0, "empty": 0, "error": 0}
+
+    progress_step = max(1, total // 100)
+
+    with ProcessPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(bake_tile, job): None for job in jobs}
+        for i, fut in enumerate(as_completed(futures), 1):
+            try:
+                result = fut.result()
+                counts[result] += 1
+            except Exception as exc:
+                counts["error"] += 1
+                log.warning("Tile failed: %s", exc)
+            if i % progress_step == 0 or i == total:
+                pct = 100.0 * i / total if total else 100.0
+                log.info(
+                    "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
+                    pct, i, total,
+                    counts["written"], counts["skipped"],
+                    counts["empty"], counts["error"],
+                )
+
+    log.info(
+        "Done. written=%d skipped=%d empty=%d error=%d",
+        counts["written"], counts["skipped"], counts["empty"], counts["error"],
+    )
+    return 0 if counts["error"] == 0 else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/requirements-landcover.txt
+++ b/scripts/requirements-landcover.txt
@@ -1,0 +1,11 @@
+# Dependencies for scripts/landcover_tiles.py.
+# Not installed in the production image — operators install ad-hoc:
+#   pip install -r scripts/requirements-landcover.txt
+#
+# rasterio bundles its own GDAL wheels on PyPI (Linux/macOS/Windows), so no
+# system GDAL install is required for typical runs.
+
+rasterio>=1.3,<2
+mercantile>=1.2,<2
+numpy>=1.24
+Pillow>=10


### PR DESCRIPTION
## Summary

- Replaces the legacy 4-preset Environment dropdown (0/3/6/12 dB flat clutter) with a calibrated per-pixel model: **ITU-R P.452-17** endpoint clutter at TX/RX + **ITU-R P.833-9** path-traversed vegetation, driven by **USGS NLCD** land cover (16 CONUS classes).
- Operator setup is one command: `docker compose --profile bake run --rm landcover-bake` auto-downloads NLCD 2024 from MRLC and bakes the tile pyramid. Skip the bake and coverage falls back to a "Mixed Forest" default everywhere, with a clear amber status chip telling the operator how to enable.
- New UI in Coverage + Scan settings: on/off toggle, 3-stop aggression slider (Conservative 0.7× / Calibrated 1.0× / Aggressive 1.3×), status chip, collapsible 16-class legend with per-class dB hints. State persists per-tool to localStorage.

## Architecture

**Frontend math** — new `clutterClasses.ts` (NLCD class table + ITU formulas, citations on every row) and `clutterPath.ts` (per-pixel orchestration: P.452 endpoints + P.833 path integration with asymmetric `d_k` endpoint exclusion and canonical-id scratch buffer reused across pixels).

**Frontend wiring** — `landcoverTiles.ts` (LRU-cached slippy fetcher, `buildClutterRaster` with nearest-neighbor categorical resampling, downsampler for drag preview). Worker plumbing extended with a clutter buffer alongside the existing DEM. `Map.tsx` builds DEM + clutter in parallel, threads through to the worker pool, captures `tilesPresent / tilesTotal` telemetry for the status chip.

**Backend** — new `/tiles/landcover` static mount in `api/api.py` with year-long immutable cache. New `scripts/landcover_tiles.py` one-shot bake: auto-download with HTTP Range resume, zip extraction, multi-process tile generation (~16 min CONUS on 32 threads). New `Dockerfile.landcover` + `landcover-bake` compose service under `profiles: ["bake"]` so the bake doesn't run as part of normal `docker compose up`.

**Docs** — new top-level `RF-MODEL.md` (public-facing model explainer), `scripts/README-landcover.md` rewritten with the one-command flow as the headline, top-level `README.md` updated.

## Side improvements

- Map attribution control collapsed by default.
