### PR TITLE
feat: Coverage: per-pixel canopy + building DSM, multi-origin merge

### DIFF
--- a/Dockerfile.buildings
+++ b/Dockerfile.buildings
@@ -1,7 +1,7 @@
 # One-shot bake image. Run via `docker compose --profile bake run --rm building-bake`.
-# rasterio's manylinux wheels link against libexpat which python:3.12-slim
-# doesn't bundle — install it explicitly.
-FROM python:3.12-slim
+# rasterio's manylinux wheels link against libexpat which python:slim variants
+# don't bundle — install it explicitly.
+FROM python:3.14-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libexpat1 \

--- a/Dockerfile.buildings
+++ b/Dockerfile.buildings
@@ -1,0 +1,21 @@
+# One-shot bake image. Run via `docker compose --profile bake run --rm building-bake`.
+# rasterio's manylinux wheels link against libexpat which python:3.12-slim
+# doesn't bundle — install it explicitly.
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libexpat1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cap GDAL's per-process cache. Default 5% of RAM × N workers blows past
+# Docker Desktop's 16 GB ceiling and OOMs mid-bake.
+ENV GDAL_CACHEMAX=64
+
+WORKDIR /app
+
+COPY scripts/requirements-buildings.txt scripts/
+RUN pip install --no-cache-dir -r scripts/requirements-buildings.txt
+
+COPY scripts/building_tiles.py scripts/
+
+CMD ["python", "scripts/building_tiles.py"]

--- a/Dockerfile.canopy
+++ b/Dockerfile.canopy
@@ -1,7 +1,7 @@
 # One-shot bake image. Run via `docker compose --profile bake run --rm canopy-bake`.
-# rasterio's manylinux wheels link against libexpat which python:3.12-slim
-# doesn't bundle — install it explicitly.
-FROM python:3.12-slim
+# rasterio's manylinux wheels link against libexpat which python:slim variants
+# don't bundle — install it explicitly.
+FROM python:3.14-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libexpat1 \

--- a/Dockerfile.canopy
+++ b/Dockerfile.canopy
@@ -1,0 +1,21 @@
+# One-shot bake image. Run via `docker compose --profile bake run --rm canopy-bake`.
+# rasterio's manylinux wheels link against libexpat which python:3.12-slim
+# doesn't bundle — install it explicitly.
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libexpat1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cap GDAL's per-process cache. Default 5% of RAM × N workers blows past
+# Docker Desktop's 16 GB ceiling and OOMs mid-bake.
+ENV GDAL_CACHEMAX=64
+
+WORKDIR /app
+
+COPY scripts/requirements-canopy.txt scripts/
+RUN pip install --no-cache-dir -r scripts/requirements-canopy.txt
+
+COPY scripts/canopy_tiles.py scripts/
+
+CMD ["python", "scripts/canopy_tiles.py"]

--- a/Dockerfile.landcover
+++ b/Dockerfile.landcover
@@ -1,7 +1,11 @@
 # One-shot bake image. Run via `docker compose --profile bake run --rm landcover-bake`.
-# Kept separate from the prod image to keep that image lean. rasterio ships GDAL
-# wheels on PyPI, so no system GDAL install is needed.
+# rasterio's manylinux wheels link against libexpat which python:3.12-slim
+# doesn't bundle — install it explicitly.
 FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libexpat1 \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/Dockerfile.landcover
+++ b/Dockerfile.landcover
@@ -1,7 +1,7 @@
 # One-shot bake image. Run via `docker compose --profile bake run --rm landcover-bake`.
-# rasterio's manylinux wheels link against libexpat which python:3.12-slim
-# doesn't bundle — install it explicitly.
-FROM python:3.12-slim
+# rasterio's manylinux wheels link against libexpat which python:slim variants
+# don't bundle — install it explicitly.
+FROM python:3.14-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libexpat1 \

--- a/RF-MODEL.md
+++ b/RF-MODEL.md
@@ -103,6 +103,23 @@ The full per-class P.452 (hₐ, dₖ) and P.833 (γ, A) parameters are visible i
 
 Outside the United States (or anywhere the NLCD bake doesn't cover), the model falls back to **Mixed Forest** as a conservative default for every pixel. Future work tracks adding ESA WorldCover as a global fallback.
 
+## Per-pixel canopy heights — ETH 10 m (optional)
+
+NLCD tells the model *what kind* of canopy is at a pixel; class-nominal heights from P.452 Table 4 (15 m deciduous, 20 m evergreen, 15 m mixed, 10 m woody-wetland, 2 m emergent-wetland) tell it *how tall* that canopy is. Real canopy varies — a 50 m redwood next to a 5 m madrone in the same NLCD "Evergreen Forest" pixel both got coded as 20 m without measurement.
+
+When canopy tiles are baked from **ETH Global Canopy Height 2020** (Lang et al. 2023, 10 m global, CC BY 4.0), the P.833 MED loop uses the measured height per sample instead of the class-nominal:
+
+- The path-integral gate `zPath < terrain + canopyHeight` evaluates against measured canopy at every profile sample.
+- Where the measured value is 0 (clearings, fire scars, recent logging), MED contributes nothing for that sample — the path is above any canopy.
+- Where the bake doesn't cover a pixel (out-of-bbox / ocean adjacency), the loop falls back to the class-nominal value silently.
+- Endpoint clutter (P.452) still uses class-nominal heights — Tier 3 only refines the path-integrated MED. Endpoint heights are a Tier-2 (per-pixel building heights) refinement.
+
+If the bake includes the optional standard-deviation file (`scripts/canopy_tiles.py --include-stddev`), pixels with σ ≥ height are blended 50/50 with the class-nominal so a single noisy ETH pixel can't dominate the integral.
+
+The "Canopy heights" toggle in the Coverage and Scan settings panels lets operators turn the refinement off (e.g. to compare measured-vs-nominal predictions, or to validate the older behavior). Default is on.
+
+**Operator runbook for the canopy bake:** [scripts/README-canopy.md](scripts/README-canopy.md).
+
 ## Setup — running the bake
 
 NLCD data is not bundled with MeshInfo (it's ~2 GB). Operators run a one-shot bake script after deploying:
@@ -118,6 +135,14 @@ CONUS at full resolution takes 15–90 min depending on CPU. Tiles are bind-moun
 **Full operator runbook:** [scripts/README-landcover.md](scripts/README-landcover.md)
 
 Once tiles exist, the API mounts them at `/tiles/landcover/{z}/{x}/{y}.png` and the frontend fetches them on every coverage compute. The "Land cover: USGS NLCD" status chip in the Coverage panel shows whether tiles are healthy or the model is using the fallback class.
+
+For the optional canopy-height refinement, run the canopy bake separately:
+
+```bash
+docker compose --profile bake run --rm canopy-bake     # CONUS default; --scope global also supported
+```
+
+CONUS canopy bake is ~30 GB of source COGs + ~1–2 GB of output tiles. Time: 1–4 hours depending on the ETH file server and CPU. Without this bake, the model uses class-nominal canopy heights — the coverage tool still works.
 
 ## The aggression scaler
 
@@ -142,7 +167,7 @@ The default (1.0×) reflects ITU-R P.452 / P.833 published values. Don't sit at 
 These are scope limits that affect prediction accuracy in specific scenarios:
 
 - **Indoor receivers (ITU-R P.2109)** — RX inside a building gets +10–20 dB additional loss not modeled. Outdoor-to-outdoor only.
-- **Per-tree / per-building height** — uses class-nominal canopy heights (15 m deciduous, 20 m evergreen, etc.), not measured heights from LIDAR. A single tall redwood next to your antenna isn't picked up.
+- **Per-building height** — uses class-nominal heights (4 / 9 / 15 / 25 m for the four NLCD developed-intensity classes); a single tall office tower next to your antenna isn't picked up. Per-pixel canopy heights from ETH 10 m **are** modeled when the canopy bake is in place — that lifts the per-tree limitation for forest classes; per-building heights are tracked as Tier 2 follow-up.
 - **Seasonal foliage** — deciduous classes assume leaf-on (summer) at 0.5 dB/m. Out-of-leaf is ~0.15 dB/m; not modeled. Future work.
 - **Frequencies other than 915 MHz** — the P.833 specific-attenuation values are calibrated at 915 MHz. Adding 868 MHz (EU) or 433 MHz would need a per-band lookup.
 - **Polarization-dependent vegetation loss** — uses unpolarized averages (the slight per-polarization difference is in the noise floor here).
@@ -156,6 +181,7 @@ These are scope limits that affect prediction accuracy in specific scenarios:
 - ITU-R Rec. **P.2108** — newer clutter-loss recommendation (future migration target)
 - ITU-R Rec. **P.2109** — building entry loss (indoor RX, deferred)
 - USGS NLCD: <https://www.mrlc.gov/data>
+- ETH Global Canopy Height 2020 (Lang et al. 2023): <https://langnico.github.io/globalcanopyheight/>
 - ITM v1.4: <https://github.com/NTIA/itm>
 
 ## How to validate

--- a/RF-MODEL.md
+++ b/RF-MODEL.md
@@ -103,6 +103,21 @@ The full per-class P.452 (hₐ, dₖ) and P.833 (γ, A) parameters are visible i
 
 Outside the United States (or anywhere the NLCD bake doesn't cover), the model falls back to **Mixed Forest** as a conservative default for every pixel. Future work tracks adding ESA WorldCover as a global fallback.
 
+## Per-pixel building heights — JRC GHS-BUILT-H 100 m (optional)
+
+NLCD's developed-intensity classes (21/22/23/24) ship with class-nominal heights of 4 / 9 / 15 / 25 m from P.452 Table 4. These are continental averages — wrong by ±15 m for any specific neighbourhood. They also can't put real diffractors (apartment blocks, industrial silos, isolated office towers) into the ITM propagation profile.
+
+When building tiles are baked from **JRC GHS-BUILT-H R2023A ANBH** (Average Net Building Height, 100 m global, CC BY 4.0), two integration sites in the model use the measurements:
+
+1. **DSM into the ITM profile.** Mid-path samples become `terrain + measured_building_height` so ITM's diffraction algorithm sees rooftops as actual obstacles. Endpoints (TX and RX) stay bare-earth — your `txHeightM` / `rxHeightM` are AGL above local ground, not on top of a presumed building. Operators with rooftop-mounted antennas should add the building's height to their antenna AGL field manually.
+2. **Measured `h_a` in P.452 endpoint clutter.** For developed-class pixels (21/22/23/24) at TX and RX, the measured ANBH replaces `cls.nominalHeightM` in the height-gain formula. A 2 m handheld in a 100 m cell that ANBH says is 4 m gets the same ~19 dB endpoint loss; in a cell that's actually 14 m, the cell-specific value drives the calculation. Non-developed classes (vegetation, water, etc.) keep their class-nominal heights so trees don't get erased when a forest pixel happens to read ANBH = 0.
+
+**100 m averaging caveats.** ANBH averages over the *built portion* of each 100 m cell, so a neighbourhood of 30% 9 m houses + 5% 25 m apartment block reads as ~11 m — the apartment block is captured as elevated DSM but its sharp edges get smeared. ITM's above-rooftop diffraction (the dominant path at typical link distances) is well-served by this; ground-level street-canyon waveguide effects need ray-tracing, not raster, regardless of resolution.
+
+The "Building heights" toggle in the Coverage and Scan settings panels lets operators turn the refinement off (compare measured-vs-nominal, or use bare-earth ITM for a baseline). Default is on.
+
+**Operator runbook for the building bake:** [scripts/README-buildings.md](scripts/README-buildings.md).
+
 ## Per-pixel canopy heights — ETH 10 m (optional)
 
 NLCD tells the model *what kind* of canopy is at a pixel; class-nominal heights from P.452 Table 4 (15 m deciduous, 20 m evergreen, 15 m mixed, 10 m woody-wetland, 2 m emergent-wetland) tell it *how tall* that canopy is. Real canopy varies — a 50 m redwood next to a 5 m madrone in the same NLCD "Evergreen Forest" pixel both got coded as 20 m without measurement.
@@ -144,6 +159,14 @@ docker compose --profile bake run --rm canopy-bake     # CONUS default; --scope 
 
 CONUS canopy bake is ~30 GB of source COGs + ~1–2 GB of output tiles. Time: 1–4 hours depending on the ETH file server and CPU. Without this bake, the model uses class-nominal canopy heights — the coverage tool still works.
 
+For the optional building-height refinement, run the building bake:
+
+```bash
+docker compose --profile bake run --rm building-bake   # global default; --scope conus also supported
+```
+
+Global building bake is ~1.8 GB of source GeoTIFF + ~1–2 GB of output tiles. Time: 1–3 hours. Without this bake, the model uses class-nominal heights for developed classes and bare-earth ITM — the coverage tool still works.
+
 ## The aggression scaler
 
 Inside the Coverage and Scan panels, the **Clutter** control is a 3-stop slider:
@@ -167,7 +190,7 @@ The default (1.0×) reflects ITU-R P.452 / P.833 published values. Don't sit at 
 These are scope limits that affect prediction accuracy in specific scenarios:
 
 - **Indoor receivers (ITU-R P.2109)** — RX inside a building gets +10–20 dB additional loss not modeled. Outdoor-to-outdoor only.
-- **Per-building height** — uses class-nominal heights (4 / 9 / 15 / 25 m for the four NLCD developed-intensity classes); a single tall office tower next to your antenna isn't picked up. Per-pixel canopy heights from ETH 10 m **are** modeled when the canopy bake is in place — that lifts the per-tree limitation for forest classes; per-building heights are tracked as Tier 2 follow-up.
+- **Per-building height** — when the building bake is in place, JRC GHS-BUILT-H 100 m measurements replace class-nominal heights for developed classes and feed buildings into the ITM DSM. The 100 m averaging captures first-order diffraction physics but smooths individual rooftops; per-building precision (a single tall office tower across the street from your antenna) needs vector pipelines beyond this raster model.
 - **Seasonal foliage** — deciduous classes assume leaf-on (summer) at 0.5 dB/m. Out-of-leaf is ~0.15 dB/m; not modeled. Future work.
 - **Frequencies other than 915 MHz** — the P.833 specific-attenuation values are calibrated at 915 MHz. Adding 868 MHz (EU) or 433 MHz would need a per-band lookup.
 - **Polarization-dependent vegetation loss** — uses unpolarized averages (the slight per-polarization difference is in the noise floor here).
@@ -182,6 +205,7 @@ These are scope limits that affect prediction accuracy in specific scenarios:
 - ITU-R Rec. **P.2109** — building entry loss (indoor RX, deferred)
 - USGS NLCD: <https://www.mrlc.gov/data>
 - ETH Global Canopy Height 2020 (Lang et al. 2023): <https://langnico.github.io/globalcanopyheight/>
+- JRC GHS-BUILT-H R2023A: <https://human-settlement.emergency.copernicus.eu/ghs_buH2023.php>
 - ITM v1.4: <https://github.com/NTIA/itm>
 
 ## How to validate

--- a/api/api.py
+++ b/api/api.py
@@ -469,6 +469,26 @@ class API:
                     tile_dir,
                 )
 
+        # Building-height tiles for the P.452 endpoint formula and ITM DSM.
+        # Pre-baked by scripts/building_tiles.py; missing tiles 404 and the
+        # frontend falls back to class-nominal. See RF-MODEL.md.
+        buildings_cfg = self.config.get("buildings", {}) or {}
+        if buildings_cfg.get("enabled", False):
+            tile_dir = Path(buildings_cfg.get("tile_dir", "output/buildings"))
+            if tile_dir.is_dir():
+                app.mount(
+                    "/tiles/buildings",
+                    TileFiles(directory=str(tile_dir)),
+                    name="building_tiles",
+                )
+                logger.info("Mounted building-height tiles at /tiles/buildings from %s", tile_dir.resolve())
+            else:
+                logger.info(
+                    "Building-height tiles enabled but %s does not exist — frontend will use class-nominal heights. "
+                    "Run scripts/building_tiles.py to populate.",
+                    tile_dir,
+                )
+
         allow_origins = os.getenv("ALLOW_ORIGINS", "").split(",")
         logger.info("Allowed origins: %s (%d)", allow_origins, len(allow_origins))
 

--- a/api/api.py
+++ b/api/api.py
@@ -449,6 +449,26 @@ class API:
                     tile_dir,
                 )
 
+        # Canopy-height tiles for the P.833-9 vegetation loss loop. Pre-baked by
+        # scripts/canopy_tiles.py; missing tiles 404 and the frontend falls back
+        # to class-nominal heights. See RF-MODEL.md.
+        canopy_cfg = self.config.get("canopy", {}) or {}
+        if canopy_cfg.get("enabled", False):
+            tile_dir = Path(canopy_cfg.get("tile_dir", "output/canopy"))
+            if tile_dir.is_dir():
+                app.mount(
+                    "/tiles/canopy",
+                    TileFiles(directory=str(tile_dir)),
+                    name="canopy_tiles",
+                )
+                logger.info("Mounted canopy-height tiles at /tiles/canopy from %s", tile_dir.resolve())
+            else:
+                logger.info(
+                    "Canopy-height tiles enabled but %s does not exist — frontend will use class-nominal heights. "
+                    "Run scripts/canopy_tiles.py to populate.",
+                    tile_dir,
+                )
+
         allow_origins = os.getenv("ALLOW_ORIGINS", "").split(",")
         logger.info("Allowed origins: %s (%d)", allow_origins, len(allow_origins))
 

--- a/config.py
+++ b/config.py
@@ -146,6 +146,14 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "tile_dir": "output/canopy",
         "source": "ETH Global Canopy Height 2020",
     },
+    # Per-pixel measured building heights for P.452 endpoint clutter and the
+    # ITM DSM. Tiles are pre-baked via scripts/building_tiles.py; absent
+    # tile_dir → frontend falls back to class-nominal heights.
+    "buildings": {
+        "enabled": True,
+        "tile_dir": "output/buildings",
+        "source": "JRC GHS-BUILT-H R2023A",
+    },
     "debug": False,
 }
 

--- a/config.py
+++ b/config.py
@@ -138,6 +138,14 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "tile_dir": "output/landcover",
         "source": "USGS NLCD 2024",
     },
+    # Per-pixel measured canopy heights for the P.833 vegetation loss loop.
+    # Tiles are pre-baked via scripts/canopy_tiles.py; absent tile_dir → frontend
+    # falls back to class-nominal heights.
+    "canopy": {
+        "enabled": True,
+        "tile_dir": "output/canopy",
+        "source": "ETH Global Canopy Height 2020",
+    },
     "debug": False,
 }
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -334,6 +334,24 @@ tile_dir = "output/canopy"      # bind-mounted into the meshinfo container
 source = "ETH Global Canopy Height 2020"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Building heights — Optional
+# Per-pixel measured building heights for ITU-R P.452-17 endpoint clutter and
+# the ITM DSM along the propagation path. Replaces class-nominal heights
+# (4/9/15/25 m for the four NLCD developed-intensity classes) with
+# measurements from JRC GHS-BUILT-H ANBH (100 m global, CC-BY-4.0).
+# When tile_dir exists and enabled = true, the API mounts it at /tiles/buildings.
+# Without a bake, the frontend falls back to class-nominal heights.
+#
+# To populate tiles, run scripts/building_tiles.py once. See
+# scripts/README-buildings.md for the operator guide.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[buildings]
+enabled = true
+tile_dir = "output/buildings"   # bind-mounted into the meshinfo container
+source = "JRC GHS-BUILT-H R2023A"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # UI Customization — Optional
 # External tools and node detail links shown in the web UI.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -306,9 +306,10 @@ style = "mapbox/dark-v11"
 # mounts it at /tiles/landcover. Without a bake, the frontend falls back to a
 # default class everywhere — coverage still works, just less accurate.
 #
-# To populate tiles, run scripts/landcover_tiles.py once. See
-# scripts/README-landcover.md for the operator guide and RF-MODEL.md for
-# the RF model.
+# To populate tiles, run the one-time bake (idempotent, safe to re-run):
+#   docker compose --profile bake run --rm landcover-bake
+# See scripts/README-landcover.md for sub-region bakes, disk/time estimates,
+# and the host-Python alternative. RF model details in RF-MODEL.md.
 # ─────────────────────────────────────────────────────────────────────────────
 
 [landcover]
@@ -324,8 +325,10 @@ source = "USGS NLCD 2024"       # surfaced in the map UI attribution chip
 # When tile_dir exists and enabled = true, the API mounts it at /tiles/canopy.
 # Without a bake, the frontend falls back to class-nominal heights.
 #
-# To populate tiles, run scripts/canopy_tiles.py once. See
-# scripts/README-canopy.md for the operator guide.
+# To populate tiles, run the one-time bake (idempotent, safe to re-run):
+#   docker compose --profile bake run --rm canopy-bake
+# See scripts/README-canopy.md for sub-region bakes, disk/time estimates,
+# and the host-Python alternative.
 # ─────────────────────────────────────────────────────────────────────────────
 
 [canopy]
@@ -342,8 +345,10 @@ source = "ETH Global Canopy Height 2020"
 # When tile_dir exists and enabled = true, the API mounts it at /tiles/buildings.
 # Without a bake, the frontend falls back to class-nominal heights.
 #
-# To populate tiles, run scripts/building_tiles.py once. See
-# scripts/README-buildings.md for the operator guide.
+# To populate tiles, run the one-time bake (idempotent, safe to re-run):
+#   docker compose --profile bake run --rm building-bake
+# See scripts/README-buildings.md for sub-region bakes, disk/time estimates,
+# and the host-Python alternative.
 # ─────────────────────────────────────────────────────────────────────────────
 
 [buildings]

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -317,6 +317,23 @@ tile_dir = "output/landcover"   # bind-mounted into the meshinfo container
 source = "USGS NLCD 2024"       # surfaced in the map UI attribution chip
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Canopy heights — Optional
+# Per-pixel measured canopy heights for ITU-R P.833-9 path-integrated
+# vegetation loss. Replaces class-nominal heights (15-20 m by class) with
+# measurements from ETH Global Canopy Height 2020 (Lang et al. 2023, 10 m).
+# When tile_dir exists and enabled = true, the API mounts it at /tiles/canopy.
+# Without a bake, the frontend falls back to class-nominal heights.
+#
+# To populate tiles, run scripts/canopy_tiles.py once. See
+# scripts/README-canopy.md for the operator guide.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[canopy]
+enabled = true
+tile_dir = "output/canopy"      # bind-mounted into the meshinfo container
+source = "ETH Global Canopy Height 2020"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # UI Customization — Optional
 # External tools and node detail links shown in the web UI.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -96,5 +96,14 @@ services:
     volumes:
       - ./output:/app/output
 
+  # `docker compose -f docker-compose-dev.yml --profile bake run --rm building-bake` — see scripts/README-buildings.md.
+  building-bake:
+    profiles: ["bake"]
+    build:
+      context: .
+      dockerfile: Dockerfile.buildings
+    volumes:
+      - ./output:/app/output
+
 volumes:
   meshinfo_pgdata:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -87,5 +87,14 @@ services:
     volumes:
       - ./output:/app/output
 
+  # `docker compose -f docker-compose-dev.yml --profile bake run --rm canopy-bake` — see scripts/README-canopy.md.
+  canopy-bake:
+    profiles: ["bake"]
+    build:
+      context: .
+      dockerfile: Dockerfile.canopy
+    volumes:
+      - ./output:/app/output
+
 volumes:
   meshinfo_pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,5 +85,14 @@ services:
     volumes:
       - ./output:/app/output
 
+  # `docker compose --profile bake run --rm canopy-bake` — see scripts/README-canopy.md.
+  canopy-bake:
+    profiles: ["bake"]
+    build:
+      context: .
+      dockerfile: Dockerfile.canopy
+    volumes:
+      - ./output:/app/output
+
 volumes:
   meshinfo_pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,5 +94,14 @@ services:
     volumes:
       - ./output:/app/output
 
+  # `docker compose --profile bake run --rm building-bake` — see scripts/README-buildings.md.
+  building-bake:
+    profiles: ["bake"]
+    build:
+      context: .
+      dockerfile: Dockerfile.buildings
+    volumes:
+      - ./output:/app/output
+
 volumes:
   meshinfo_pgdata:

--- a/frontend/src/maps/mapStyle.ts
+++ b/frontend/src/maps/mapStyle.ts
@@ -23,6 +23,11 @@ const ATTRIB_MAPBOX =
 const TERRAIN_SOURCE_ID = "terrain-dem";
 const BASE_SOURCE_ID = "base";
 const BASE_LAYER_ID = "base";
+const BUILDINGS_3D_SOURCE_ID = "buildings-3d";
+const BUILDINGS_3D_LAYER_ID = "buildings-3d";
+
+const ATTRIB_OPENFREEMAP =
+  '© <a href="https://www.openmaptiles.org/" target="_blank" rel="noopener">OpenMapTiles</a> · <a href="https://openfreemap.org/" target="_blank" rel="noopener">OpenFreeMap</a>';
 
 const SKY_SPEC: SkySpecification = {
   "sky-color": "#7fb3d5",
@@ -163,8 +168,52 @@ export function removeTerrain(map: MlMap): void {
   try { map.triggerRepaint(); } catch {}
 }
 
+/** Cosmetic 3D buildings via OpenFreeMap vector tiles — paint-only, independent
+ *  of the RF building-height raster. minzoom=14 because OpenFreeMap doesn't
+ *  ship buildings below z13 and z13 is too distant to be visually useful.
+ *  Idempotent — safe to re-call after style reloads. */
+export function ensureBuildings3D(map: MlMap): void {
+  if (!map.getSource(BUILDINGS_3D_SOURCE_ID)) {
+    map.addSource(BUILDINGS_3D_SOURCE_ID, {
+      type: "vector",
+      url: "https://tiles.openfreemap.org/planet",
+      attribution: ATTRIB_OPENFREEMAP,
+    });
+  }
+  if (!map.getLayer(BUILDINGS_3D_LAYER_ID)) {
+    map.addLayer({
+      id: BUILDINGS_3D_LAYER_ID,
+      type: "fill-extrusion",
+      source: BUILDINGS_3D_SOURCE_ID,
+      "source-layer": "building",
+      minzoom: 14,
+      // OpenMapTiles schema opt-out flag.
+      filter: ["!=", ["get", "hide_3d"], true],
+      paint: {
+        // Low opacity so basemap labels under tall buildings stay readable.
+        "fill-extrusion-color": [
+          "interpolate", ["linear"], ["get", "render_height"],
+          0, "#a8b5c4",
+          50, "#8a98aa",
+          200, "#6e7d92",
+        ],
+        "fill-extrusion-height": ["coalesce", ["get", "render_height"], 0],
+        "fill-extrusion-base": ["coalesce", ["get", "render_min_height"], 0],
+        "fill-extrusion-opacity": 0.65,
+      },
+    });
+  }
+}
+
+export function removeBuildings3D(map: MlMap): void {
+  try { if (map.getLayer(BUILDINGS_3D_LAYER_ID)) map.removeLayer(BUILDINGS_3D_LAYER_ID); } catch {}
+  try { if (map.getSource(BUILDINGS_3D_SOURCE_ID)) map.removeSource(BUILDINGS_3D_SOURCE_ID); } catch {}
+}
+
 export const MAP_STYLE_IDS = {
   baseSource: BASE_SOURCE_ID,
   baseLayer: BASE_LAYER_ID,
   terrainSource: TERRAIN_SOURCE_ID,
+  buildings3DSource: BUILDINGS_3D_SOURCE_ID,
+  buildings3DLayer: BUILDINGS_3D_LAYER_ID,
 } as const;

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -13,6 +13,7 @@ import { buildMapStyle, ensureTerrain, type OsmBasemap,removeTerrain } from "../
 import { useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
 import { type ITraceroutesResponse,NodeRole, roleTitles } from "../types";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
+import { buildBuildingRaster, type BuildingRaster, downsampleBuildingRaster } from "./map/buildingTiles";
 import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./map/canopyTiles";
 import { ClusterDonutLayer } from "./map/clusterDonutLayer";
 import { AGGRESSION_STOPS, COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX,effectiveSensitivityDbm, MESHTASTIC_PRESETS, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./map/coverageAnalysis";
@@ -334,6 +335,9 @@ export function Map() {
   // Drives the canopy-height status chip; null until first compute.
   const [coverageCanopyStatus, setCoverageCanopyStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   const [scanCanopyStatus, setScanCanopyStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
+  // Drives the building-height status chip; null until first compute.
+  const [coverageBuildingsStatus, setCoverageBuildingsStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
+  const [scanBuildingsStatus, setScanBuildingsStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
   const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(3);
   const coverageAntennaDbi = COMMON_ANTENNAS[coverageAntennaIdx]?.dbi ?? 3;
@@ -371,6 +375,13 @@ export function Map() {
   const setCoverageCanopyEnabled = useCallback((v: boolean) => {
     setCoverageCanopyEnabledRaw(v);
     writeJson(LS_KEYS.coverageCanopyEnabled, v);
+  }, []);
+  const [coverageBuildingsEnabled, setCoverageBuildingsEnabledRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.coverageBuildingsEnabled, true),
+  );
+  const setCoverageBuildingsEnabled = useCallback((v: boolean) => {
+    setCoverageBuildingsEnabledRaw(v);
+    writeJson(LS_KEYS.coverageBuildingsEnabled, v);
   }, []);
   const [coveragePresetIdx, setCoveragePresetIdx] = useState(0); // MediumFast
   const [coverageCustomSensDbm, setCoverageCustomSensDbm] = useState(-133);
@@ -425,6 +436,13 @@ export function Map() {
   const setScanCanopyEnabled = useCallback((v: boolean) => {
     setScanCanopyEnabledRaw(v);
     writeJson(LS_KEYS.scanCanopyEnabled, v);
+  }, []);
+  const [scanBuildingsEnabled, setScanBuildingsEnabledRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.scanBuildingsEnabled, true),
+  );
+  const setScanBuildingsEnabled = useCallback((v: boolean) => {
+    setScanBuildingsEnabledRaw(v);
+    writeJson(LS_KEYS.scanBuildingsEnabled, v);
   }, []);
   const [scanPresetIdx, setScanPresetIdx] = useState(0);
   const [scanCustomSensDbm, setScanCustomSensDbm] = useState(-133);
@@ -507,6 +525,9 @@ export function Map() {
   /** Authoritative + 256² downsampled canopy-height rasters; drag preview reuses these. */
   const coverageCanopyRef = useRef<CanopyRaster | null>(null);
   const coverageDragCanopyRef = useRef<CanopyRaster | null>(null);
+  /** Authoritative + 256² downsampled building-height rasters; drag preview reuses these. */
+  const coverageBuildingsRef = useRef<BuildingRaster | null>(null);
+  const coverageDragBuildingsRef = useRef<BuildingRaster | null>(null);
   /** Latest raster params snapshot (drag preview reuses untouched). */
   const coverageLastRasterParamsRef = useRef<RasterParams | null>(null);
   /** Last origin context (bounds); drag re-samples DEM per move. */
@@ -698,6 +719,8 @@ export function Map() {
     clutter?: ClutterRaster | null;
     /** Optional canopy-height raster aligned to DEM bounds. Null = workers fall back to class-nominal. */
     canopy?: CanopyRaster | null;
+    /** Optional building-height raster aligned to DEM bounds. Null = bare-earth + class-nominal endpoint h_a. */
+    buildings?: BuildingRaster | null;
     origin: [number, number];
     originHeightM: number;
     /** TX antenna AGL (m); ITM wants AGL not MSL. */
@@ -722,7 +745,7 @@ export function Map() {
     outputHeight: number;
     itmUnavailable?: boolean;
   } | null> => {
-    const { dem, clutter, canopy, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
+    const { dem, clutter, canopy, buildings, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
     const outputWidth = opts.outputWidth ?? dem.width;
     const outputHeight = opts.outputHeight ?? dem.height;
     const mb = mbMapRef.current;
@@ -759,6 +782,8 @@ export function Map() {
       const canopyHeightCopy = canopy ? new Float32Array(canopy.heightM) : null;
       const canopyStdCopy = canopy ? new Float32Array(canopy.stdM) : null;
       const canopyMaskCopy = canopy ? new Float32Array(canopy.mask) : null;
+      const buildingHeightCopy = buildings ? new Float32Array(buildings.heightM) : null;
+      const buildingMaskCopy = buildings ? new Float32Array(buildings.mask) : null;
       const req: CoverageSliceRequest = {
         requestId,
         demBuffer: demCopy.buffer,
@@ -781,12 +806,18 @@ export function Map() {
         canopyMaskBuffer: canopyMaskCopy?.buffer,
         canopyWidth: canopy?.width,
         canopyHeight: canopy?.height,
+        buildingHeightBuffer: buildingHeightCopy?.buffer,
+        buildingMaskBuffer: buildingMaskCopy?.buffer,
+        buildingWidth: buildings?.width,
+        buildingHeight: buildings?.height,
       };
       const transfer: Transferable[] = [demCopy.buffer];
       if (clutterCopy) transfer.push(clutterCopy.buffer);
       if (canopyHeightCopy) transfer.push(canopyHeightCopy.buffer);
       if (canopyStdCopy) transfer.push(canopyStdCopy.buffer);
       if (canopyMaskCopy) transfer.push(canopyMaskCopy.buffer);
+      if (buildingHeightCopy) transfer.push(buildingHeightCopy.buffer);
+      if (buildingMaskCopy) transfer.push(buildingMaskCopy.buffer);
       tasks.push(
         pool.dispatch(req, transfer).then((resp) => {
           sliceResponses.push(resp);
@@ -1481,14 +1512,14 @@ export function Map() {
           return;
         }
         const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
-        const [{ dem, source: demSourceUsedForScan }, scanClutter, scanCanopy] = await Promise.all([
+        const [{ dem, source: demSourceUsedForScan }, scanClutter, scanCanopy, scanBuildings] = await Promise.all([
           buildDem({
             bounds: scanBounds,
             targetWidth: 1024,
             targetHeight: 1024,
             token: mapboxToken,
           }),
-          // Skip the clutter / canopy fetches when their respective models are toggled off.
+          // Skip individual fetches when their respective models are toggled off.
           scanClutterEnabled
             ? buildClutterRaster({
                 bounds: scanBounds,
@@ -1503,6 +1534,13 @@ export function Map() {
                 targetHeight: 1024,
               })
             : Promise.resolve(null),
+          scanBuildingsEnabled
+            ? buildBuildingRaster({
+                bounds: scanBounds,
+                targetWidth: 1024,
+                targetHeight: 1024,
+              })
+            : Promise.resolve(null),
         ]);
         if (cancelled) return;
         setScanDemSource(demSourceUsedForScan);
@@ -1511,6 +1549,9 @@ export function Map() {
         );
         setScanCanopyStatus(
           scanCanopy ? { tilesPresent: scanCanopy.tilesPresent, tilesTotal: scanCanopy.tilesTotal } : null,
+        );
+        setScanBuildingsStatus(
+          scanBuildings ? { tilesPresent: scanBuildings.tilesPresent, tilesTotal: scanBuildings.tilesTotal } : null,
         );
 
         // Override GPS altitude with terrain + configured AGL (matches coverage).
@@ -1543,7 +1584,8 @@ export function Map() {
           rxAntennaDbi: scanRxAntennaDbi,
           rxSensitivityDbm: scanEffectiveSensitivityDbm,
           clutterRaster: scanClutter,
-          canopyRaster: scanCanopyEnabled ? scanCanopy : null,
+          canopyRaster: scanCanopy,
+          buildingRaster: scanBuildings,
           // aggression = 0 when the user has toggled the model off → ITM-only path loss.
           clutterAggression: scanClutterEnabled
             ? (AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0)
@@ -1580,7 +1622,7 @@ export function Map() {
     return () => { cancelled = true; };
   }, [activeTool, toolStep, toolFromId, toolVirtualPos, provider, terrain3D, nodes,
       scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
-      scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanAntennaHeightM]);
+      scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled, scanAntennaHeightM]);
 
   // Per-class map visibility filter (compute still runs for hidden classes).
   useEffect(() => {
@@ -1736,13 +1778,13 @@ export function Map() {
         timings[name] = performance.now() - fromMs;
       };
       try {
-        // 1. Fetch terrain + (when enabled) land-cover + canopy in parallel; all at
-        //    DEM_SIZE so the worker samples them at the same lng/lat indexing.
-        //    Skip the clutter / canopy fetches when their respective models are
-        //    toggled off — saves the network + decode cost.
+        // 1. Fetch terrain + (when enabled) land-cover + canopy + buildings in
+        //    parallel; all at DEM_SIZE so the worker samples them at the same
+        //    lng/lat indexing. Skip individual fetches when their respective
+        //    models are toggled off — saves the network + decode cost.
         const tFetch = performance.now();
         setIsFetchingCoverageTerrain(true);
-        const [{ dem, source: demSourceUsed }, clutter, canopy] = await Promise.all([
+        const [{ dem, source: demSourceUsed }, clutter, canopy, buildings] = await Promise.all([
           buildDem({
             bounds: demBounds,
             targetWidth: DEM_SIZE,
@@ -1766,6 +1808,14 @@ export function Map() {
                 maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
               })
             : Promise.resolve(null),
+          coverageBuildingsEnabled
+            ? buildBuildingRaster({
+                bounds: demBounds,
+                targetWidth: DEM_SIZE,
+                targetHeight: DEM_SIZE,
+                maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
+              })
+            : Promise.resolve(null),
         ]);
         setCoverageDemSource(demSourceUsed);
         setCoverageClutterStatus(
@@ -1773,6 +1823,9 @@ export function Map() {
         );
         setCoverageCanopyStatus(
           canopy ? { tilesPresent: canopy.tilesPresent, tilesTotal: canopy.tilesTotal } : null,
+        );
+        setCoverageBuildingsStatus(
+          buildings ? { tilesPresent: buildings.tilesPresent, tilesTotal: buildings.tilesTotal } : null,
         );
         mark("demFetchMs", tFetch);
         if (cancelled || requestId !== coverageRequestIdRef.current) {
@@ -1834,8 +1887,8 @@ export function Map() {
         const rendered = await renderCoverageToImageSource({
           dem,
           clutter,
-          // Toggle off → workers fall back to class-nominal canopy heights.
-          canopy: coverageCanopyEnabled ? canopy : null,
+          canopy,
+          buildings,
           origin: origin!,
           originHeightM,
           originAntennaHeightAboveGroundM: txAboveGroundM,
@@ -1871,6 +1924,8 @@ export function Map() {
         coverageDragClutterRef.current = clutter ? downsampleClutterRaster(clutter, 256, 256) : null;
         coverageCanopyRef.current = canopy;
         coverageDragCanopyRef.current = canopy ? downsampleCanopyRaster(canopy, 256, 256) : null;
+        coverageBuildingsRef.current = buildings;
+        coverageDragBuildingsRef.current = buildings ? downsampleBuildingRaster(buildings, 256, 256) : null;
         coverageLastRasterParamsRef.current = rasterParams;
         coverageLastOriginContextRef.current = { bounds: dem.bounds };
 
@@ -1966,7 +2021,7 @@ export function Map() {
     return () => {
       cancelled = true;
     };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
 
   // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry
   useEffect(() => {
@@ -2079,6 +2134,7 @@ export function Map() {
         const dem = coverageDragDemRef.current;
         const clutter = coverageDragClutterRef.current;
         const canopy = coverageDragCanopyRef.current;
+        const buildings = coverageDragBuildingsRef.current;
         const params = coverageLastRasterParamsRef.current;
         if (!dem || !params) return;
         dragPreviewBusyRef.current = true;
@@ -2101,6 +2157,7 @@ export function Map() {
             dem,
             clutter,
             canopy,
+            buildings,
             origin: lngLat,
             originHeightM: originH,
             originAntennaHeightAboveGroundM: txAboveGroundM,
@@ -4104,6 +4161,9 @@ export function Map() {
           canopyEnabled={coverageCanopyEnabled}
           onCanopyEnabledChange={setCoverageCanopyEnabled}
           canopyStatus={coverageCanopyStatus}
+          buildingsEnabled={coverageBuildingsEnabled}
+          onBuildingsEnabledChange={setCoverageBuildingsEnabled}
+          buildingsStatus={coverageBuildingsStatus}
           presetIdx={coveragePresetIdx}
           onPresetIdxChange={setCoveragePresetIdx}
           customSensitivityDbm={coverageCustomSensDbm}
@@ -4216,6 +4276,9 @@ export function Map() {
           canopyEnabled={scanCanopyEnabled}
           onCanopyEnabledChange={setScanCanopyEnabled}
           canopyStatus={scanCanopyStatus}
+          buildingsEnabled={scanBuildingsEnabled}
+          onBuildingsEnabledChange={setScanBuildingsEnabled}
+          buildingsStatus={scanBuildingsStatus}
           presetIdx={scanPresetIdx}
           onPresetIdxChange={setScanPresetIdx}
           customSensitivityDbm={scanCustomSensDbm}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -16,11 +16,11 @@ import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
 import { buildBuildingRaster, type BuildingRaster, downsampleBuildingRaster } from "./map/buildingTiles";
 import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./map/canopyTiles";
 import { ClusterDonutLayer } from "./map/clusterDonutLayer";
-import { AGGRESSION_STOPS, COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX,effectiveSensitivityDbm, MESHTASTIC_PRESETS, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./map/coverageAnalysis";
+import { AGGRESSION_STOPS, COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX,effectiveSensitivityDbm, MESHTASTIC_PRESETS, type MergeOrigin, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./map/coverageAnalysis";
 import { type ContourFeatureCollection,extractCoverageContours } from "./map/coverageContours";
 import type { RasterParams } from "./map/coverageRaster";
 import { extractCoverageRays, type VisibilityRayFeatureCollection } from "./map/coverageRays";
-import type { CoverageSliceRequest } from "./map/coverageSliceWorker";
+import type { CoverageSliceRequest, SliceOrigin } from "./map/coverageSliceWorker";
 import { CoverageWorkerPool } from "./map/coverageWorkerPool";
 import { FiltersResetPill } from "./map/FiltersResetPill";
 import { Climate, computeP2PLoss, type ItmContext, loadItmContext, Polarization } from "./map/itm";
@@ -340,6 +340,12 @@ export function Map() {
   // Drives the building-height status chip; null until first compute.
   const [coverageBuildingsStatus, setCoverageBuildingsStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   const [scanBuildingsStatus, setScanBuildingsStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
+  // Coverage-merge set is session-only by design — contextual to one analysis.
+  const [coverageMergeOrigins, setCoverageMergeOrigins] = useState<MergeOrigin[]>([]);
+  const removeCoverageMergeOrigin = useCallback((id: string) => {
+    setCoverageMergeOrigins((prev) => prev.filter((o) => o.id !== id));
+  }, []);
+  const clearCoverageMergeOrigins = useCallback(() => setCoverageMergeOrigins([]), []);
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
   const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(3);
   const coverageAntennaDbi = COMMON_ANTENNAS[coverageAntennaIdx]?.dbi ?? 3;
@@ -486,6 +492,9 @@ export function Map() {
   const losTubeLayerRef = useRef<LosTubeLayer | null>(null);
   /** DOM pin for the Coverage origin (draggable). */
   const coverageOriginMarkerRef = useRef<maplibregl.Marker | null>(null);
+  /** Per-id pins for additional merge origins; amber to distinguish from primary cyan.
+   *  globalThis.Map qualifies the constructor — the component itself is named `Map`. */
+  const coverageMergeMarkersRef = useRef<Map<string, maplibregl.Marker>>(new globalThis.Map());
   /** Draggable pin at the scan origin. */
   const scanOriginMarkerRef = useRef<maplibregl.Marker | null>(null);
   /** Map view captured when scan starts; restored by the origin row / pin. */
@@ -723,10 +732,9 @@ export function Map() {
     canopy?: CanopyRaster | null;
     /** Optional building-height raster aligned to DEM bounds. Null = bare-earth + class-nominal endpoint h_a. */
     buildings?: BuildingRaster | null;
-    origin: [number, number];
-    originHeightM: number;
-    /** TX antenna AGL (m); ITM wants AGL not MSL. */
-    originAntennaHeightAboveGroundM: number;
+    /** Primary + (optional) merge origins. Single-element array preserves the
+     *  pre-merge single-origin compute byte-identically. */
+    origins: SliceOrigin[];
     params: RasterParams;
     requestId: number;
     /** Defaults to DEM dims (drag-preview path where DEM == output == 256²). */
@@ -747,7 +755,7 @@ export function Map() {
     outputHeight: number;
     itmUnavailable?: boolean;
   } | null> => {
-    const { dem, clutter, canopy, buildings, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
+    const { dem, clutter, canopy, buildings, origins, params, requestId, onSliceProgress } = opts;
     const outputWidth = opts.outputWidth ?? dem.width;
     const outputHeight = opts.outputHeight ?? dem.height;
     const mb = mbMapRef.current;
@@ -792,9 +800,7 @@ export function Map() {
         demWidth: dem.width,
         demHeight: dem.height,
         bounds: dem.bounds,
-        origin,
-        originHeightM,
-        originAntennaHeightAboveGroundM,
+        origins,
         params,
         outputWidth,
         outputHeight,
@@ -1029,7 +1035,36 @@ export function Map() {
 
   const [detailsData, setDetailsData] = useState<NodeDetailsData | null>(null);
 
-  // Refs to avoid stale closures in long-lived map event handlers.
+  // Defined here (rather than next to the other coverage-merge state) so the
+  // closure can read the live `nodes` map.
+  const addCoverageMergeOriginById = useCallback((nodeId: string) => {
+    const n = nodes[nodeId] ?? nodes[`!${nodeId}`];
+    const pos = n?.map_position;
+    if (!pos) return;
+    const cleanId = nodeId.startsWith("!") ? nodeId.slice(1) : nodeId;
+    setCoverageMergeOrigins((prev) =>
+      prev.some((o) => o.id === cleanId)
+        ? prev
+        : [...prev, {
+            id: cleanId,
+            label: n?.shortname || n?.longname || cleanId,
+            position: [pos[0], pos[1]],
+            altitudeM: n?.position?.altitude ?? null,
+          }],
+    );
+  }, [nodes]);
+  const mergeNodeOptions = useMemo(() => {
+    const out: Array<{ id: string; shortname?: string; longname?: string }> = [];
+    const primaryId = toolFromId ? (toolFromId.startsWith("!") ? toolFromId.slice(1) : toolFromId) : null;
+    for (const [rawId, n] of Object.entries(nodes)) {
+      if (!n?.map_position) continue;
+      const cleanId = rawId.startsWith("!") ? rawId.slice(1) : rawId;
+      if (primaryId && cleanId === primaryId) continue;
+      out.push({ id: cleanId, shortname: n.shortname, longname: n.longname });
+    }
+    return out;
+  }, [nodes, toolFromId]);
+
   const nodesRef = useRef(nodes);
   const traceroutesRef = useRef(rawTraceroutes);
   const configRef = useRef(config);
@@ -1736,7 +1771,22 @@ export function Map() {
     setCoverageProgress({ completed: 0, total: 0 });
 
     const radKm = coverageRadiusKm;
-    const demBounds = demBoundsAround(origin, radKm, 1.05);
+    // Union bbox over primary + merge origins (all share radiusKm since TX
+    // params are global). Empty merge set collapses to the primary's bbox.
+    const primaryBounds = demBoundsAround(origin, radKm, 1.05);
+    let demBounds = primaryBounds;
+    if (coverageMergeOrigins.length > 0) {
+      let west = primaryBounds.west, south = primaryBounds.south;
+      let east = primaryBounds.east, north = primaryBounds.north;
+      for (const m of coverageMergeOrigins) {
+        const b = demBoundsAround(m.position, radKm, 1.05);
+        if (b.west < west) west = b.west;
+        if (b.south < south) south = b.south;
+        if (b.east > east) east = b.east;
+        if (b.north > north) north = b.north;
+      }
+      demBounds = { west, south, east, north };
+    }
     // Recenter on the pin; tile fetch is viewport-independent so we don't need to fly.
     mb.easeTo({ center: origin, duration: 300 });
 
@@ -1889,6 +1939,27 @@ export function Map() {
           ? originHeightM - originGroundFromDem
           : coverageAntennaHeightM;
 
+        // Sample terrain off the same DEM the workers see so txHeightM (AGL
+        // relative to profile[0]) collapses cleanly to coverageAntennaHeightM
+        // on flat terrain.
+        const mergeOriginsResolved: SliceOrigin[] = [];
+        for (const m of coverageMergeOrigins) {
+          const terrain = sampleDEMAt(dem, m.position[0], m.position[1]);
+          const terrainOk = !Number.isNaN(terrain);
+          const altOk =
+            m.altitudeM != null &&
+            Number.isFinite(m.altitudeM) &&
+            (!terrainOk ||
+              (m.altitudeM >= terrain && m.altitudeM <= terrain + 1000));
+          const baseM = altOk ? (m.altitudeM as number) : (terrainOk ? terrain : 0);
+          const heightM = baseM + coverageAntennaHeightM;
+          mergeOriginsResolved.push({
+            position: m.position,
+            heightM,
+            antennaHeightAboveGroundM: terrainOk ? heightM - terrain : coverageAntennaHeightM,
+          });
+        }
+
         // 3. Dispatch pool; OUTPUT_SIZE decoupled from DEM_SIZE so Detail only changes paint sharpness
         const tDispatch = performance.now();
         const rendered = await renderCoverageToImageSource({
@@ -1896,9 +1967,14 @@ export function Map() {
           clutter,
           canopy,
           buildings,
-          origin: origin!,
-          originHeightM,
-          originAntennaHeightAboveGroundM: txAboveGroundM,
+          origins: [
+            {
+              position: origin!,
+              heightM: originHeightM,
+              antennaHeightAboveGroundM: txAboveGroundM,
+            },
+            ...mergeOriginsResolved,
+          ],
           params: rasterParams,
           requestId,
           outputWidth: OUTPUT_SIZE,
@@ -1988,6 +2064,7 @@ export function Map() {
           originHeightM,
           originIsFallback,
           radiusKm: radKm,
+          mergeOriginCount: coverageMergeOrigins.length,
           clearCount: rendered.clearCount,
           fresnelCount: rendered.fresnelCount,
           blockedCount: rendered.blockedCount,
@@ -2028,7 +2105,7 @@ export function Map() {
     return () => {
       cancelled = true;
     };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageMergeOrigins, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
 
   // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry
   useEffect(() => {
@@ -2165,9 +2242,11 @@ export function Map() {
             clutter,
             canopy,
             buildings,
-            origin: lngLat,
-            originHeightM: originH,
-            originAntennaHeightAboveGroundM: txAboveGroundM,
+            origins: [{
+              position: lngLat,
+              heightM: originH,
+              antennaHeightAboveGroundM: txAboveGroundM,
+            }],
             params,
             requestId: previewId,
           });
@@ -2207,6 +2286,46 @@ export function Map() {
         coverageOriginMarkerRef.current.remove();
         coverageOriginMarkerRef.current = null;
       }
+    };
+  }, []);
+
+  // Cleared when the coverage tool isn't in result mode so amber pins don't linger.
+  useEffect(() => {
+    const mb = mbMapRef.current;
+    if (!mb) return;
+    const markers = coverageMergeMarkersRef.current;
+    const inCoverageResult = activeTool === "coverage" && toolStep === "result";
+    if (!inCoverageResult) {
+      for (const marker of markers.values()) marker.remove();
+      markers.clear();
+      return;
+    }
+    const wantedIds = new Set(coverageMergeOrigins.map((o) => o.id));
+    for (const [id, marker] of markers) {
+      if (!wantedIds.has(id)) {
+        marker.remove();
+        markers.delete(id);
+      }
+    }
+    for (const o of coverageMergeOrigins) {
+      const existing = markers.get(o.id);
+      if (existing) {
+        existing.setLngLat(o.position);
+      } else {
+        const marker = new maplibregl.Marker({ color: "#f59e0b" })
+          .setLngLat(o.position)
+          .setPopup(new maplibregl.Popup({ closeButton: false, offset: 24 }).setText(o.label))
+          .addTo(mb);
+        markers.set(o.id, marker);
+      }
+    }
+  }, [coverageMergeOrigins, activeTool, toolStep]);
+
+  useEffect(() => {
+    const markers = coverageMergeMarkersRef.current;
+    return () => {
+      for (const marker of markers.values()) marker.remove();
+      markers.clear();
     };
   }, []);
 
@@ -4191,6 +4310,11 @@ export function Map() {
           buildingsEnabled={coverageBuildingsEnabled}
           onBuildingsEnabledChange={setCoverageBuildingsEnabled}
           buildingsStatus={coverageBuildingsStatus}
+          mergeOrigins={coverageMergeOrigins}
+          onAddMergeOriginById={addCoverageMergeOriginById}
+          onRemoveMergeOrigin={removeCoverageMergeOrigin}
+          onClearMergeOrigins={clearCoverageMergeOrigins}
+          mergeNodeOptions={mergeNodeOptions}
           presetIdx={coveragePresetIdx}
           onPresetIdxChange={setCoveragePresetIdx}
           customSensitivityDbm={coverageCustomSensDbm}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -342,10 +342,21 @@ export function Map() {
   const [scanBuildingsStatus, setScanBuildingsStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   // Coverage-merge set is session-only by design — contextual to one analysis.
   const [coverageMergeOrigins, setCoverageMergeOrigins] = useState<MergeOrigin[]>([]);
+  // True while the panel's "Pick on map" button is armed; the next map click
+  // adds a virtual merge origin.
+  const [pickingMergeOrigin, setPickingMergeOrigin] = useState(false);
   const removeCoverageMergeOrigin = useCallback((id: string) => {
     setCoverageMergeOrigins((prev) => prev.filter((o) => o.id !== id));
   }, []);
-  const clearCoverageMergeOrigins = useCallback(() => setCoverageMergeOrigins([]), []);
+  const clearCoverageMergeOrigins = useCallback(() => {
+    setCoverageMergeOrigins([]);
+    setPickingMergeOrigin(false);
+  }, []);
+  const moveCoverageMergeOrigin = useCallback((id: string, position: [number, number]) => {
+    setCoverageMergeOrigins((prev) =>
+      prev.map((o) => (o.id === id ? { ...o, position } : o)),
+    );
+  }, []);
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
   const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(3);
   const coverageAntennaDbi = COMMON_ANTENNAS[coverageAntennaIdx]?.dbi ?? 3;
@@ -495,6 +506,8 @@ export function Map() {
   /** Per-id pins for additional merge origins; amber to distinguish from primary cyan.
    *  globalThis.Map qualifies the constructor — the component itself is named `Map`. */
   const coverageMergeMarkersRef = useRef<Map<string, maplibregl.Marker>>(new globalThis.Map());
+  /** Last origin we recentered on; used to suppress easeTo across pure parameter changes. */
+  const lastRecenteredOriginRef = useRef<[number, number] | null>(null);
   /** Draggable pin at the scan origin. */
   const scanOriginMarkerRef = useRef<maplibregl.Marker | null>(null);
   /** Map view captured when scan starts; restored by the origin row / pin. */
@@ -1732,6 +1745,7 @@ export function Map() {
       setIsFetchingCoverageTerrain(false);
       setCoverageError(null);
       setCoverageProgress({ completed: 0, total: 0 });
+      lastRecenteredOriginRef.current = null;
       return;
     }
     if (!terrain3D) {
@@ -1787,8 +1801,17 @@ export function Map() {
       }
       demBounds = { west, south, east, north };
     }
-    // Recenter on the pin; tile fetch is viewport-independent so we don't need to fly.
-    mb.easeTo({ center: origin, duration: 300 });
+    // Recenter only when the origin actually moved; pure parameter recomputes
+    // (TX power, antenna, clutter on/off, etc.) shouldn't yank the user's view.
+    const prev = lastRecenteredOriginRef.current;
+    const movedSignificantly =
+      !prev ||
+      Math.abs(prev[0] - origin[0]) > 1e-6 ||
+      Math.abs(prev[1] - origin[1]) > 1e-6;
+    if (movedSignificantly) {
+      mb.easeTo({ center: origin, duration: 300 });
+      lastRecenteredOriginRef.current = [origin[0], origin[1]];
+    }
 
     const mapboxToken = env.MAPBOX_TOKEN;
     if (!mapboxToken) {
@@ -2289,6 +2312,47 @@ export function Map() {
     };
   }, []);
 
+  // While picking, the next map click adds a virtual merge origin and exits.
+  // Auto-cancels if the user navigates away from the coverage tool.
+  useEffect(() => {
+    if (pickingMergeOrigin && activeTool !== "coverage") setPickingMergeOrigin(false);
+  }, [activeTool, pickingMergeOrigin]);
+  useEffect(() => {
+    if (!pickingMergeOrigin) return;
+    const mb = mbMapRef.current;
+    if (!mb) return;
+    const canvas = mb.getCanvas();
+    const prevCursor = canvas.style.cursor;
+    canvas.style.cursor = "crosshair";
+    const onClick = (e: maplibregl.MapMouseEvent) => {
+      const lng = e.lngLat.lng;
+      const lat = e.lngLat.lat;
+      // 6-dp coords give ~0.1 m precision and a stable id key.
+      const id = `virtual:${lng.toFixed(6)},${lat.toFixed(6)}`;
+      setCoverageMergeOrigins((prev) =>
+        prev.some((o) => o.id === id)
+          ? prev
+          : [...prev, {
+              id,
+              label: `Pin ${lat.toFixed(4)}, ${lng.toFixed(4)}`,
+              position: [lng, lat],
+              altitudeM: null,
+            }],
+      );
+      setPickingMergeOrigin(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPickingMergeOrigin(false);
+    };
+    mb.on("click", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      mb.off("click", onClick);
+      document.removeEventListener("keydown", onKey);
+      canvas.style.cursor = prevCursor;
+    };
+  }, [pickingMergeOrigin]);
+
   // Cleared when the coverage tool isn't in result mode so amber pins don't linger.
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -2312,14 +2376,21 @@ export function Map() {
       if (existing) {
         existing.setLngLat(o.position);
       } else {
-        const marker = new maplibregl.Marker({ color: "#f59e0b" })
+        const isVirtual = o.id.startsWith("virtual:");
+        const marker = new maplibregl.Marker({ color: "#f59e0b", draggable: isVirtual })
           .setLngLat(o.position)
           .setPopup(new maplibregl.Popup({ closeButton: false, offset: 24 }).setText(o.label))
           .addTo(mb);
+        if (isVirtual) {
+          marker.on("dragend", () => {
+            const ll = marker.getLngLat();
+            moveCoverageMergeOrigin(o.id, [ll.lng, ll.lat]);
+          });
+        }
         markers.set(o.id, marker);
       }
     }
-  }, [coverageMergeOrigins, activeTool, toolStep]);
+  }, [coverageMergeOrigins, activeTool, toolStep, moveCoverageMergeOrigin]);
 
   useEffect(() => {
     const markers = coverageMergeMarkersRef.current;
@@ -4315,6 +4386,9 @@ export function Map() {
           onRemoveMergeOrigin={removeCoverageMergeOrigin}
           onClearMergeOrigins={clearCoverageMergeOrigins}
           mergeNodeOptions={mergeNodeOptions}
+          pickingMergeOrigin={pickingMergeOrigin}
+          onStartPickMergeOrigin={() => setPickingMergeOrigin(true)}
+          onCancelPickMergeOrigin={() => setPickingMergeOrigin(false)}
           presetIdx={coveragePresetIdx}
           onPresetIdxChange={setCoveragePresetIdx}
           customSensitivityDbm={coverageCustomSensDbm}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -13,6 +13,7 @@ import { buildMapStyle, ensureTerrain, type OsmBasemap,removeTerrain } from "../
 import { useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
 import { type ITraceroutesResponse,NodeRole, roleTitles } from "../types";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
+import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./map/canopyTiles";
 import { ClusterDonutLayer } from "./map/clusterDonutLayer";
 import { AGGRESSION_STOPS, COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX,effectiveSensitivityDbm, MESHTASTIC_PRESETS, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./map/coverageAnalysis";
 import { type ContourFeatureCollection,extractCoverageContours } from "./map/coverageContours";
@@ -330,6 +331,9 @@ export function Map() {
   // Drives the land-cover status chip in each panel.
   const [coverageClutterStatus, setCoverageClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   const [scanClutterStatus, setScanClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
+  // Drives the canopy-height status chip; null until first compute.
+  const [coverageCanopyStatus, setCoverageCanopyStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
+  const [scanCanopyStatus, setScanCanopyStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
   const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(3);
   const coverageAntennaDbi = COMMON_ANTENNAS[coverageAntennaIdx]?.dbi ?? 3;
@@ -360,6 +364,13 @@ export function Map() {
   const setCoverageClutterEnabled = useCallback((v: boolean) => {
     setCoverageClutterEnabledRaw(v);
     writeJson(LS_KEYS.coverageClutterEnabled, v);
+  }, []);
+  const [coverageCanopyEnabled, setCoverageCanopyEnabledRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.coverageCanopyEnabled, true),
+  );
+  const setCoverageCanopyEnabled = useCallback((v: boolean) => {
+    setCoverageCanopyEnabledRaw(v);
+    writeJson(LS_KEYS.coverageCanopyEnabled, v);
   }, []);
   const [coveragePresetIdx, setCoveragePresetIdx] = useState(0); // MediumFast
   const [coverageCustomSensDbm, setCoverageCustomSensDbm] = useState(-133);
@@ -407,6 +418,13 @@ export function Map() {
   const setScanClutterEnabled = useCallback((v: boolean) => {
     setScanClutterEnabledRaw(v);
     writeJson(LS_KEYS.scanClutterEnabled, v);
+  }, []);
+  const [scanCanopyEnabled, setScanCanopyEnabledRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.scanCanopyEnabled, true),
+  );
+  const setScanCanopyEnabled = useCallback((v: boolean) => {
+    setScanCanopyEnabledRaw(v);
+    writeJson(LS_KEYS.scanCanopyEnabled, v);
   }, []);
   const [scanPresetIdx, setScanPresetIdx] = useState(0);
   const [scanCustomSensDbm, setScanCustomSensDbm] = useState(-133);
@@ -486,6 +504,9 @@ export function Map() {
   /** Authoritative + 256² downsampled class-ID rasters; drag preview reuses these. */
   const coverageClutterRef = useRef<ClutterRaster | null>(null);
   const coverageDragClutterRef = useRef<ClutterRaster | null>(null);
+  /** Authoritative + 256² downsampled canopy-height rasters; drag preview reuses these. */
+  const coverageCanopyRef = useRef<CanopyRaster | null>(null);
+  const coverageDragCanopyRef = useRef<CanopyRaster | null>(null);
   /** Latest raster params snapshot (drag preview reuses untouched). */
   const coverageLastRasterParamsRef = useRef<RasterParams | null>(null);
   /** Last origin context (bounds); drag re-samples DEM per move. */
@@ -675,6 +696,8 @@ export function Map() {
     dem: DEM;
     /** Optional class-ID raster aligned to DEM bounds. Null = workers fall back to default class. */
     clutter?: ClutterRaster | null;
+    /** Optional canopy-height raster aligned to DEM bounds. Null = workers fall back to class-nominal. */
+    canopy?: CanopyRaster | null;
     origin: [number, number];
     originHeightM: number;
     /** TX antenna AGL (m); ITM wants AGL not MSL. */
@@ -699,7 +722,7 @@ export function Map() {
     outputHeight: number;
     itmUnavailable?: boolean;
   } | null> => {
-    const { dem, clutter, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
+    const { dem, clutter, canopy, origin, originHeightM, originAntennaHeightAboveGroundM, params, requestId, onSliceProgress } = opts;
     const outputWidth = opts.outputWidth ?? dem.width;
     const outputHeight = opts.outputHeight ?? dem.height;
     const mb = mbMapRef.current;
@@ -733,6 +756,9 @@ export function Map() {
       const demCopy = new Float32Array(dem.data);
       // Transferable buffers can't be shared across workers; copy per slice.
       const clutterCopy = clutter ? new Uint8Array(clutter.data) : null;
+      const canopyHeightCopy = canopy ? new Float32Array(canopy.heightM) : null;
+      const canopyStdCopy = canopy ? new Float32Array(canopy.stdM) : null;
+      const canopyMaskCopy = canopy ? new Float32Array(canopy.mask) : null;
       const req: CoverageSliceRequest = {
         requestId,
         demBuffer: demCopy.buffer,
@@ -750,9 +776,17 @@ export function Map() {
         clutterBuffer: clutterCopy?.buffer,
         clutterWidth: clutter?.width,
         clutterHeight: clutter?.height,
+        canopyHeightBuffer: canopyHeightCopy?.buffer,
+        canopyStdBuffer: canopyStdCopy?.buffer,
+        canopyMaskBuffer: canopyMaskCopy?.buffer,
+        canopyWidth: canopy?.width,
+        canopyHeight: canopy?.height,
       };
       const transfer: Transferable[] = [demCopy.buffer];
       if (clutterCopy) transfer.push(clutterCopy.buffer);
+      if (canopyHeightCopy) transfer.push(canopyHeightCopy.buffer);
+      if (canopyStdCopy) transfer.push(canopyStdCopy.buffer);
+      if (canopyMaskCopy) transfer.push(canopyMaskCopy.buffer);
       tasks.push(
         pool.dispatch(req, transfer).then((resp) => {
           sliceResponses.push(resp);
@@ -1447,16 +1481,23 @@ export function Map() {
           return;
         }
         const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
-        const [{ dem, source: demSourceUsedForScan }, scanClutter] = await Promise.all([
+        const [{ dem, source: demSourceUsedForScan }, scanClutter, scanCanopy] = await Promise.all([
           buildDem({
             bounds: scanBounds,
             targetWidth: 1024,
             targetHeight: 1024,
             token: mapboxToken,
           }),
-          // Skip the clutter fetch when the model is toggled off.
+          // Skip the clutter / canopy fetches when their respective models are toggled off.
           scanClutterEnabled
             ? buildClutterRaster({
+                bounds: scanBounds,
+                targetWidth: 1024,
+                targetHeight: 1024,
+              })
+            : Promise.resolve(null),
+          scanCanopyEnabled
+            ? buildCanopyRaster({
                 bounds: scanBounds,
                 targetWidth: 1024,
                 targetHeight: 1024,
@@ -1467,6 +1508,9 @@ export function Map() {
         setScanDemSource(demSourceUsedForScan);
         setScanClutterStatus(
           scanClutter ? { tilesPresent: scanClutter.tilesPresent, tilesTotal: scanClutter.tilesTotal } : null,
+        );
+        setScanCanopyStatus(
+          scanCanopy ? { tilesPresent: scanCanopy.tilesPresent, tilesTotal: scanCanopy.tilesTotal } : null,
         );
 
         // Override GPS altitude with terrain + configured AGL (matches coverage).
@@ -1499,6 +1543,7 @@ export function Map() {
           rxAntennaDbi: scanRxAntennaDbi,
           rxSensitivityDbm: scanEffectiveSensitivityDbm,
           clutterRaster: scanClutter,
+          canopyRaster: scanCanopyEnabled ? scanCanopy : null,
           // aggression = 0 when the user has toggled the model off → ITM-only path loss.
           clutterAggression: scanClutterEnabled
             ? (AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0)
@@ -1535,7 +1580,7 @@ export function Map() {
     return () => { cancelled = true; };
   }, [activeTool, toolStep, toolFromId, toolVirtualPos, provider, terrain3D, nodes,
       scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
-      scanAggressionIdx, scanClutterEnabled, scanAntennaHeightM]);
+      scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanAntennaHeightM]);
 
   // Per-class map visibility filter (compute still runs for hidden classes).
   useEffect(() => {
@@ -1691,13 +1736,13 @@ export function Map() {
         timings[name] = performance.now() - fromMs;
       };
       try {
-        // 1. Fetch terrain + (when enabled) land-cover in parallel; both at DEM_SIZE
-        //    so the worker samples DEM and clutter at the same lng/lat indexing.
-        //    Skip the clutter fetch entirely when the model is toggled off — saves
-        //    the network + decode cost.
+        // 1. Fetch terrain + (when enabled) land-cover + canopy in parallel; all at
+        //    DEM_SIZE so the worker samples them at the same lng/lat indexing.
+        //    Skip the clutter / canopy fetches when their respective models are
+        //    toggled off — saves the network + decode cost.
         const tFetch = performance.now();
         setIsFetchingCoverageTerrain(true);
-        const [{ dem, source: demSourceUsed }, clutter] = await Promise.all([
+        const [{ dem, source: demSourceUsed }, clutter, canopy] = await Promise.all([
           buildDem({
             bounds: demBounds,
             targetWidth: DEM_SIZE,
@@ -1713,10 +1758,21 @@ export function Map() {
                 maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
               })
             : Promise.resolve(null),
+          coverageCanopyEnabled
+            ? buildCanopyRaster({
+                bounds: demBounds,
+                targetWidth: DEM_SIZE,
+                targetHeight: DEM_SIZE,
+                maxTiles: COVERAGE_DETAIL_MAX_TILES[coverageDetail],
+              })
+            : Promise.resolve(null),
         ]);
         setCoverageDemSource(demSourceUsed);
         setCoverageClutterStatus(
           clutter ? { tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal } : null,
+        );
+        setCoverageCanopyStatus(
+          canopy ? { tilesPresent: canopy.tilesPresent, tilesTotal: canopy.tilesTotal } : null,
         );
         mark("demFetchMs", tFetch);
         if (cancelled || requestId !== coverageRequestIdRef.current) {
@@ -1778,6 +1834,8 @@ export function Map() {
         const rendered = await renderCoverageToImageSource({
           dem,
           clutter,
+          // Toggle off → workers fall back to class-nominal canopy heights.
+          canopy: coverageCanopyEnabled ? canopy : null,
           origin: origin!,
           originHeightM,
           originAntennaHeightAboveGroundM: txAboveGroundM,
@@ -1811,6 +1869,8 @@ export function Map() {
         coverageDragDemRef.current = downsampleDEM(dem, 256, 256);
         coverageClutterRef.current = clutter;
         coverageDragClutterRef.current = clutter ? downsampleClutterRaster(clutter, 256, 256) : null;
+        coverageCanopyRef.current = canopy;
+        coverageDragCanopyRef.current = canopy ? downsampleCanopyRaster(canopy, 256, 256) : null;
         coverageLastRasterParamsRef.current = rasterParams;
         coverageLastOriginContextRef.current = { bounds: dem.bounds };
 
@@ -1906,7 +1966,7 @@ export function Map() {
     return () => {
       cancelled = true;
     };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
 
   // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry
   useEffect(() => {
@@ -2018,6 +2078,7 @@ export function Map() {
         }
         const dem = coverageDragDemRef.current;
         const clutter = coverageDragClutterRef.current;
+        const canopy = coverageDragCanopyRef.current;
         const params = coverageLastRasterParamsRef.current;
         if (!dem || !params) return;
         dragPreviewBusyRef.current = true;
@@ -2039,6 +2100,7 @@ export function Map() {
           await renderCoverageToImageSource({
             dem,
             clutter,
+            canopy,
             origin: lngLat,
             originHeightM: originH,
             originAntennaHeightAboveGroundM: txAboveGroundM,
@@ -4039,6 +4101,9 @@ export function Map() {
           clutterEnabled={coverageClutterEnabled}
           onClutterEnabledChange={setCoverageClutterEnabled}
           clutterStatus={coverageClutterStatus}
+          canopyEnabled={coverageCanopyEnabled}
+          onCanopyEnabledChange={setCoverageCanopyEnabled}
+          canopyStatus={coverageCanopyStatus}
           presetIdx={coveragePresetIdx}
           onPresetIdxChange={setCoveragePresetIdx}
           customSensitivityDbm={coverageCustomSensDbm}
@@ -4148,6 +4213,9 @@ export function Map() {
           clutterEnabled={scanClutterEnabled}
           onClutterEnabledChange={setScanClutterEnabled}
           clutterStatus={scanClutterStatus}
+          canopyEnabled={scanCanopyEnabled}
+          onCanopyEnabledChange={setScanCanopyEnabled}
+          canopyStatus={scanCanopyStatus}
           presetIdx={scanPresetIdx}
           onPresetIdxChange={setScanPresetIdx}
           customSensitivityDbm={scanCustomSensDbm}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -9,7 +9,7 @@ import { useSearchParams } from "react-router";
 
 import { env } from "../env";
 import { reverseGeocode } from "../maps/geocoder";
-import { buildMapStyle, ensureTerrain, type OsmBasemap,removeTerrain } from "../maps/mapStyle";
+import { buildMapStyle, ensureBuildings3D, ensureTerrain, type OsmBasemap, removeBuildings3D, removeTerrain } from "../maps/mapStyle";
 import { useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
 import { type ITraceroutesResponse,NodeRole, roleTitles } from "../types";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
@@ -307,6 +307,8 @@ export function Map() {
   // 3D terrain
   const [terrain3D, setTerrain3D] = useState<boolean>(() => readJson<boolean>(LS_KEYS.terrain3D, true));
   const terrainExaggeration = 1.5;
+  // Cosmetic 3D buildings (OpenFreeMap). Off by default to keep slow devices light.
+  const [buildings3D, setBuildings3D] = useState<boolean>(() => readJson<boolean>(LS_KEYS.buildings3D, false));
   const [losResult, setLosResult] = useState<LoSResult | null>(null);
   /** DEM tile source used for the last LoS compute. */
   const [losDemSource, setLosDemSource] = useState<DemSource | null>(null);
@@ -932,6 +934,7 @@ export function Map() {
   useEffect(() => writeJson(LS_KEYS.myNodeId, myNodeId), [myNodeId]);
   useEffect(() => writeJson(LS_KEYS.settingsPanelOpen, settingsPanelOpen), [settingsPanelOpen]);
   useEffect(() => writeJson(LS_KEYS.terrain3D, terrain3D), [terrain3D]);
+  useEffect(() => writeJson(LS_KEYS.buildings3D, buildings3D), [buildings3D]);
 
   // Obsolete key from the prior exaggeration slider; removeItem is idempotent.
   useEffect(() => {
@@ -1042,6 +1045,7 @@ export function Map() {
 
   const isPickingNode = activeTool != null && toolStep !== "result";
   const terrain3DRef = useRef(terrain3D);
+  const buildings3DRef = useRef(buildings3D);
   const setDetailsDataRef = useRef(setDetailsData);
 
   useEffect(() => {
@@ -1079,6 +1083,9 @@ export function Map() {
   useEffect(() => {
     terrain3DRef.current = terrain3D;
   }, [terrain3D]);
+  useEffect(() => {
+    buildings3DRef.current = buildings3D;
+  }, [buildings3D]);
 
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -3162,6 +3169,13 @@ export function Map() {
           console.warn("[Map] Terrain re-apply failed after style load:", err);
         }
       }
+      if (buildings3DRef.current) {
+        try {
+          ensureBuildings3D(map);
+        } catch (err) {
+          console.warn("[Map] 3D buildings re-apply failed after style load:", err);
+        }
+      }
 
       // Ensure sources have current data (important after style changes)
       refreshMapboxNodeData();
@@ -3845,6 +3859,17 @@ export function Map() {
     }
   }, [terrain3D, provider, mapboxToken, mapboxStyle, osmBasemap]);
 
+  useEffect(() => {
+    const map = mbMapRef.current;
+    if (!map || !styleEverLoadedRef.current) return;
+    try {
+      if (buildings3D) ensureBuildings3D(map);
+      else removeBuildings3D(map);
+    } catch (err) {
+      console.warn("[Map] 3D buildings apply failed:", err);
+    }
+  }, [buildings3D, provider, mapboxToken, mapboxStyle, osmBasemap]);
+
   // Live updates (nodes appear/disappear) via setData()
   useEffect(() => {
     const map = mbMapRef.current;
@@ -3948,6 +3973,8 @@ export function Map() {
         usingMapbox={usingMapbox}
         terrain3D={terrain3D}
         setTerrain3D={setTerrain3D}
+        buildings3D={buildings3D}
+        setBuildings3D={setBuildings3D}
         onExport={handleExport}
         hidden={!!detailsData}
         recentDays={recentDays}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -2087,7 +2087,6 @@ export function Map() {
           originHeightM,
           originIsFallback,
           radiusKm: radKm,
-          mergeOriginCount: coverageMergeOrigins.length,
           clearCount: rendered.clearCount,
           fresnelCount: rendered.fresnelCount,
           blockedCount: rendered.blockedCount,

--- a/frontend/src/pages/map/ClutterUI.tsx
+++ b/frontend/src/pages/map/ClutterUI.tsx
@@ -54,6 +54,55 @@ export interface ClutterStatusChipProps {
   enabled?: boolean;
 }
 
+export interface BuildingStatusChipProps {
+  /** Null until first compute. */
+  status: { tilesPresent: number; tilesTotal: number } | null;
+  /** When false, the chip overrides any tile state with "Building heights: off". */
+  enabled?: boolean;
+}
+
+export function BuildingStatusChip({ status, enabled = true }: BuildingStatusChipProps) {
+  if (!enabled) {
+    return (
+      <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
+        <span className="mt-0.5 inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-gray-500/60" aria-hidden />
+        <span>Building heights: <span className="text-gray-400">off</span> — bare-earth DEM + class-nominal h_a.</span>
+      </div>
+    );
+  }
+  const fallback = status != null && status.tilesTotal > 0 && status.tilesPresent === 0;
+  const partial =
+    status != null && status.tilesPresent > 0 && status.tilesPresent < status.tilesTotal;
+  return (
+    <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
+      <span
+        className={`mt-0.5 inline-block w-1.5 h-1.5 rounded-full shrink-0 ${
+          fallback ? "bg-amber-400/80" : "bg-emerald-400/70"
+        }`}
+        aria-hidden
+      />
+      <span>
+        {fallback ? (
+          <>
+            <span className="text-amber-300/90">Class-nominal buildings</span>
+            <span className="text-gray-500"> — no building tiles for this region. Run the bake (see scripts/README-buildings.md).</span>
+          </>
+        ) : (
+          <>
+            Buildings: <span className="text-gray-300">JRC GHS-BUILT-H 100 m</span>
+            {partial && (
+              <span className="text-amber-400/80">
+                {" "}
+                · partial coverage ({status?.tilesPresent}/{status?.tilesTotal} tiles)
+              </span>
+            )}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
 export interface CanopyStatusChipProps {
   /** Null until first compute. */
   status: { tilesPresent: number; tilesTotal: number } | null;
@@ -204,7 +253,8 @@ export function ClassLegend() {
           <div className="px-1.5 py-1 text-[9px] text-gray-500 border-t border-white/5 leading-snug">
             <span className="text-gray-400">@ 2 m</span> = ITU-R P.452-17 endpoint clutter at 2 m AGL, 915 MHz.
             Penetrable classes also accumulate ITU-R P.833-9 vegetation loss along the path.
-            Forest classes use ETH measured canopy heights when the canopy bake is available
+            Forest classes use ETH measured canopy heights, and developed classes use JRC
+            measured building heights, when the respective bakes are available
             (heights shown above are class-nominal fallbacks).
           </div>
         </div>

--- a/frontend/src/pages/map/ClutterUI.tsx
+++ b/frontend/src/pages/map/ClutterUI.tsx
@@ -54,6 +54,55 @@ export interface ClutterStatusChipProps {
   enabled?: boolean;
 }
 
+export interface CanopyStatusChipProps {
+  /** Null until first compute. */
+  status: { tilesPresent: number; tilesTotal: number } | null;
+  /** When false, the chip overrides any tile state with "Canopy heights: off". */
+  enabled?: boolean;
+}
+
+export function CanopyStatusChip({ status, enabled = true }: CanopyStatusChipProps) {
+  if (!enabled) {
+    return (
+      <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
+        <span className="mt-0.5 inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-gray-500/60" aria-hidden />
+        <span>Canopy heights: <span className="text-gray-400">off</span> — class-nominal heights only.</span>
+      </div>
+    );
+  }
+  const fallback = status != null && status.tilesTotal > 0 && status.tilesPresent === 0;
+  const partial =
+    status != null && status.tilesPresent > 0 && status.tilesPresent < status.tilesTotal;
+  return (
+    <div className="flex items-start gap-1.5 text-[10px] leading-snug text-gray-500">
+      <span
+        className={`mt-0.5 inline-block w-1.5 h-1.5 rounded-full shrink-0 ${
+          fallback ? "bg-amber-400/80" : "bg-emerald-400/70"
+        }`}
+        aria-hidden
+      />
+      <span>
+        {fallback ? (
+          <>
+            <span className="text-amber-300/90">Class-nominal canopy</span>
+            <span className="text-gray-500"> — no canopy tiles for this region. Run the bake (see scripts/README-canopy.md).</span>
+          </>
+        ) : (
+          <>
+            Canopy: <span className="text-gray-300">ETH 10 m</span>
+            {partial && (
+              <span className="text-amber-400/80">
+                {" "}
+                · partial coverage ({status?.tilesPresent}/{status?.tilesTotal} tiles)
+              </span>
+            )}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
 export function ClutterStatusChip({ status, enabled = true }: ClutterStatusChipProps) {
   if (!enabled) {
     return (
@@ -155,6 +204,8 @@ export function ClassLegend() {
           <div className="px-1.5 py-1 text-[9px] text-gray-500 border-t border-white/5 leading-snug">
             <span className="text-gray-400">@ 2 m</span> = ITU-R P.452-17 endpoint clutter at 2 m AGL, 915 MHz.
             Penetrable classes also accumulate ITU-R P.833-9 vegetation loss along the path.
+            Forest classes use ETH measured canopy heights when the canopy bake is available
+            (heights shown above are class-nominal fallbacks).
           </div>
         </div>
       )}

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
-import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
+import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, type MergeOrigin, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
+
+interface MergeNodeOption {
+  id: string;
+  shortname?: string;
+  longname?: string;
+}
 
 /** Parse "lat, lng" (Google Maps format) → [lng, lat]. Returns null if invalid. */
 function parseLatLng(input: string): [number, number] | null {
@@ -90,6 +96,11 @@ export function MapCoveragePanel({
   buildingsEnabled,
   onBuildingsEnabledChange,
   buildingsStatus,
+  mergeOrigins,
+  onAddMergeOriginById,
+  onRemoveMergeOrigin,
+  onClearMergeOrigins,
+  mergeNodeOptions,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -156,6 +167,13 @@ export function MapCoveragePanel({
   onBuildingsEnabledChange: (enabled: boolean) => void;
   /** Building tile-availability telemetry; null if no compute yet. */
   buildingsStatus: { tilesPresent: number; tilesTotal: number } | null;
+  /** Additional origins layered on top of the primary; per-pixel max margin. */
+  mergeOrigins: MergeOrigin[];
+  onAddMergeOriginById: (nodeId: string) => void;
+  onRemoveMergeOrigin: (id: string) => void;
+  onClearMergeOrigins: () => void;
+  /** Searchable list of nodes available to add as merge origins. */
+  mergeNodeOptions: MergeNodeOption[];
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -224,6 +242,23 @@ export function MapCoveragePanel({
     onRxHeightChange(clamped);
     setRxHeightInput(String(clamped));
   };
+
+  // The parent already excludes the primary from `mergeNodeOptions`; we just
+  // filter out IDs already in the merge set on top of that.
+  const [mergeOriginSearch, setMergeOriginSearch] = useState("");
+  const mergeOriginCandidates = useMemo(() => {
+    const q = mergeOriginSearch.trim().toLowerCase();
+    if (!q) return [];
+    const taken = new Set(mergeOrigins.map((o) => o.id));
+    return mergeNodeOptions
+      .filter((n) => !taken.has(n.id))
+      .filter((n) =>
+        (n.shortname?.toLowerCase().includes(q) ?? false) ||
+        (n.longname?.toLowerCase().includes(q) ?? false) ||
+        n.id.toLowerCase().includes(q),
+      )
+      .slice(0, 12);
+  }, [mergeOriginSearch, mergeOrigins, mergeNodeOptions]);
 
   // Lets the header "custom RX" pill open the advanced-settings <details>
   const gearRef = useRef<HTMLDetailsElement>(null);
@@ -818,6 +853,83 @@ export function MapCoveragePanel({
                     <span className="text-[10px] text-gray-500 shrink-0">m</span>
                   </div>
                 </div>
+              </div>
+
+              {/* Multi-origin merge. */}
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between gap-2">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                    <span>Merged origins{mergeOrigins.length > 0 && ` (${mergeOrigins.length})`}</span>
+                    <InfoTip align="left">
+                      Add other nodes to layer on top of the primary origin —
+                      the painted coverage takes the per-pixel best signal
+                      across all origins. Useful for asking "where can my mesh
+                      reach if any of these nodes works?" without picking
+                      one as primary. Session-only — not persisted.
+                    </InfoTip>
+                  </label>
+                  {mergeOrigins.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={onClearMergeOrigins}
+                      className="text-[10px] text-gray-500 hover:text-red-300"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                {mergeOrigins.length > 0 && (
+                  <div className="flex flex-col gap-1">
+                    {mergeOrigins.map((o) => (
+                      <div
+                        key={o.id}
+                        className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-white/5 text-[10px] text-gray-300"
+                      >
+                        <span className="truncate min-w-0 flex-1">{o.label}</span>
+                        <button
+                          type="button"
+                          onClick={() => onRemoveMergeOrigin(o.id)}
+                          className="text-gray-500 hover:text-red-300 shrink-0"
+                          aria-label={`Remove ${o.label} from merged origins`}
+                        >
+                          ×
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <input
+                  type="text"
+                  value={mergeOriginSearch}
+                  onChange={(e) => setMergeOriginSearch(e.target.value)}
+                  placeholder="Search nodes to merge…"
+                  className="w-full px-2 py-1 rounded-md bg-white/5 border border-white/10 text-[10px] text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-cyan-500/50"
+                />
+                {mergeOriginSearch.trim() !== "" && (
+                  <div className="max-h-32 overflow-y-auto rounded-md bg-black/20 border border-white/5 divide-y divide-white/5">
+                    {mergeOriginCandidates.length === 0 ? (
+                      <div className="text-[10px] text-gray-500 px-2 py-1.5">No matches.</div>
+                    ) : (
+                      mergeOriginCandidates.map((n) => (
+                        <button
+                          key={n.id}
+                          type="button"
+                          onClick={() => {
+                            onAddMergeOriginById(n.id);
+                            setMergeOriginSearch("");
+                          }}
+                          className="w-full text-left px-2 py-1 text-[10px] text-gray-300 hover:bg-white/5 truncate"
+                        >
+                          <span className="text-cyan-300/80 mr-1">+</span>
+                          {n.shortname ?? n.longname ?? n.id}
+                          {n.shortname && n.longname && (
+                            <span className="text-gray-500 ml-1.5">{n.longname}</span>
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
               </div>
 
               {/* Clutter (per-pixel ITU model + aggression scaler). */}

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -101,6 +101,9 @@ export function MapCoveragePanel({
   onRemoveMergeOrigin,
   onClearMergeOrigins,
   mergeNodeOptions,
+  pickingMergeOrigin,
+  onStartPickMergeOrigin,
+  onCancelPickMergeOrigin,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -174,6 +177,10 @@ export function MapCoveragePanel({
   onClearMergeOrigins: () => void;
   /** Searchable list of nodes available to add as merge origins. */
   mergeNodeOptions: MergeNodeOption[];
+  /** True while the next map click will drop a virtual merge pin. */
+  pickingMergeOrigin: boolean;
+  onStartPickMergeOrigin: () => void;
+  onCancelPickMergeOrigin: () => void;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -898,13 +905,27 @@ export function MapCoveragePanel({
                     ))}
                   </div>
                 )}
-                <input
-                  type="text"
-                  value={mergeOriginSearch}
-                  onChange={(e) => setMergeOriginSearch(e.target.value)}
-                  placeholder="Search nodes to merge…"
-                  className="w-full px-2 py-1 rounded-md bg-white/5 border border-white/10 text-[10px] text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-cyan-500/50"
-                />
+                <div className="flex items-center gap-1.5">
+                  <input
+                    type="text"
+                    value={mergeOriginSearch}
+                    onChange={(e) => setMergeOriginSearch(e.target.value)}
+                    placeholder="Search nodes to merge…"
+                    className="flex-1 min-w-0 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-[10px] text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-cyan-500/50"
+                  />
+                  <button
+                    type="button"
+                    onClick={pickingMergeOrigin ? onCancelPickMergeOrigin : onStartPickMergeOrigin}
+                    title={pickingMergeOrigin ? "Cancel pick (or press Esc)" : "Click on the map to drop a pin"}
+                    className={`px-2 py-1 rounded-md border text-[10px] whitespace-nowrap shrink-0 transition-colors ${
+                      pickingMergeOrigin
+                        ? "bg-amber-500/20 border-amber-500/40 text-amber-200"
+                        : "bg-white/5 border-white/10 text-gray-300 hover:bg-white/10"
+                    }`}
+                  >
+                    {pickingMergeOrigin ? "Click map…" : "+ Pin"}
+                  </button>
+                </div>
                 {mergeOriginSearch.trim() !== "" && (
                   <div className="max-h-32 overflow-y-auto rounded-md bg-black/20 border border-white/5 divide-y divide-white/5">
                     {mergeOriginCandidates.length === 0 ? (

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { AggressionSlider, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
+import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
@@ -87,6 +87,9 @@ export function MapCoveragePanel({
   canopyEnabled,
   onCanopyEnabledChange,
   canopyStatus,
+  buildingsEnabled,
+  onBuildingsEnabledChange,
+  buildingsStatus,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -148,6 +151,11 @@ export function MapCoveragePanel({
   onCanopyEnabledChange: (enabled: boolean) => void;
   /** Canopy tile-availability telemetry; null if no compute yet. */
   canopyStatus: { tilesPresent: number; tilesTotal: number } | null;
+  /** Building-height tier on/off. Off → bare-earth DEM + class-nominal endpoint h_a. */
+  buildingsEnabled: boolean;
+  onBuildingsEnabledChange: (enabled: boolean) => void;
+  /** Building tile-availability telemetry; null if no compute yet. */
+  buildingsStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -858,6 +866,29 @@ export function MapCoveragePanel({
                   </label>
                 </div>
                 <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
+                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                    <span>Building heights</span>
+                    <InfoTip align="left">
+                      Per-pixel measured building heights from JRC GHS-BUILT-H
+                      ANBH (100 m global). Adds rooftops as DSM obstacles for
+                      ITM diffraction along the propagation path, and replaces
+                      class-nominal h_a in the ITU-R P.452 endpoint formula for
+                      developed-class pixels. Toggle off for bare-earth DEM and
+                      class-nominal heights.
+                    </InfoTip>
+                  </label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={buildingsEnabled}
+                      onChange={(e) => onBuildingsEnabledChange(e.target.checked)}
+                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                    />
+                    <span>Enabled</span>
+                  </label>
+                </div>
+                <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
               </div>
 
               {/* Reliability (ITM TLS preset) */}

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { AggressionSlider, ClassLegend, ClutterStatusChip } from "./ClutterUI";
+import { AggressionSlider, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
@@ -84,6 +84,9 @@ export function MapCoveragePanel({
   clutterEnabled,
   onClutterEnabledChange,
   clutterStatus,
+  canopyEnabled,
+  onCanopyEnabledChange,
+  canopyStatus,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -140,6 +143,11 @@ export function MapCoveragePanel({
   onClutterEnabledChange: (enabled: boolean) => void;
   /** Tile-availability telemetry from the most recent compute; null if none yet. */
   clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
+  /** Canopy-height tier on/off. Off → class-nominal heights (still under clutter aggression). */
+  canopyEnabled: boolean;
+  onCanopyEnabledChange: (enabled: boolean) => void;
+  /** Canopy tile-availability telemetry; null if no compute yet. */
+  canopyStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -829,6 +837,27 @@ export function MapCoveragePanel({
                 <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
                 <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
                 <ClassLegend />
+                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                    <span>Canopy heights</span>
+                    <InfoTip align="left">
+                      Per-pixel measured canopy heights from ETH Global Canopy
+                      Height 2020 (Lang et al. 2023, 10 m). Replaces class-nominal
+                      heights in ITU-R P.833-9 vegetation loss for forest classes.
+                      Toggle off to fall back to class-nominal heights everywhere.
+                    </InfoTip>
+                  </label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={canopyEnabled}
+                      onChange={(e) => onCanopyEnabledChange(e.target.checked)}
+                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                    />
+                    <span>Enabled</span>
+                  </label>
+                </div>
+                <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
               </div>
 
               {/* Reliability (ITM TLS preset) */}

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -1,7 +1,7 @@
 /** Scan-results panel: ranked LoS from origin to every node in view. */
 import { useEffect, useMemo, useState } from "react";
 
-import { AggressionSlider, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
+import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, MESHTASTIC_PRESETS } from "./coverageAnalysis";
 import type { ScanClass, ScanResult,ScanSummary } from "./scanAnalysis";
 import type { DemSource } from "./terrainRgb";
@@ -47,6 +47,9 @@ export function MapScanPanel({
   canopyEnabled,
   onCanopyEnabledChange,
   canopyStatus,
+  buildingsEnabled,
+  onBuildingsEnabledChange,
+  buildingsStatus,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -93,6 +96,11 @@ export function MapScanPanel({
   onCanopyEnabledChange: (enabled: boolean) => void;
   /** Canopy tile-availability telemetry; null until first scan. */
   canopyStatus: { tilesPresent: number; tilesTotal: number } | null;
+  /** Building-height tier on/off. Off → bare-earth + class-nominal endpoint h_a. */
+  buildingsEnabled: boolean;
+  onBuildingsEnabledChange: (enabled: boolean) => void;
+  /** Building tile-availability telemetry; null until first scan. */
+  buildingsStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -454,6 +462,21 @@ export function MapScanPanel({
                   </label>
                 </div>
                 <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
+                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                    Building heights
+                  </label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={buildingsEnabled}
+                      onChange={(e) => onBuildingsEnabledChange(e.target.checked)}
+                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                    />
+                    <span>Enabled</span>
+                  </label>
+                </div>
+                <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
               </div>
 
               <div className="pt-2 border-t border-white/5 text-[10px] text-gray-500 leading-relaxed">

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -1,7 +1,7 @@
 /** Scan-results panel: ranked LoS from origin to every node in view. */
 import { useEffect, useMemo, useState } from "react";
 
-import { AggressionSlider, ClassLegend, ClutterStatusChip } from "./ClutterUI";
+import { AggressionSlider, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, MESHTASTIC_PRESETS } from "./coverageAnalysis";
 import type { ScanClass, ScanResult,ScanSummary } from "./scanAnalysis";
 import type { DemSource } from "./terrainRgb";
@@ -44,6 +44,9 @@ export function MapScanPanel({
   clutterEnabled,
   onClutterEnabledChange,
   clutterStatus,
+  canopyEnabled,
+  onCanopyEnabledChange,
+  canopyStatus,
   presetIdx,
   onPresetIdxChange,
   customSensitivityDbm,
@@ -85,6 +88,11 @@ export function MapScanPanel({
   onClutterEnabledChange: (enabled: boolean) => void;
   /** Tile-availability telemetry from the most recent scan; null until first run. */
   clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
+  /** Canopy-height tier on/off. Off → class-nominal heights. */
+  canopyEnabled: boolean;
+  onCanopyEnabledChange: (enabled: boolean) => void;
+  /** Canopy tile-availability telemetry; null until first scan. */
+  canopyStatus: { tilesPresent: number; tilesTotal: number } | null;
   presetIdx: number;
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
@@ -431,6 +439,21 @@ export function MapScanPanel({
                 <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
                 <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
                 <ClassLegend />
+                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                    Canopy heights
+                  </label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={canopyEnabled}
+                      onChange={(e) => onCanopyEnabledChange(e.target.checked)}
+                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                    />
+                    <span>Enabled</span>
+                  </label>
+                </div>
+                <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
               </div>
 
               <div className="pt-2 border-t border-white/5 text-[10px] text-gray-500 leading-relaxed">

--- a/frontend/src/pages/map/MapSettingsPanel.tsx
+++ b/frontend/src/pages/map/MapSettingsPanel.tsx
@@ -174,6 +174,8 @@ export function MapSettingsPanel({
   usingMapbox,
   terrain3D,
   setTerrain3D,
+  buildings3D,
+  setBuildings3D,
   onExport,
   hidden = false,
 
@@ -215,6 +217,8 @@ export function MapSettingsPanel({
   usingMapbox: boolean;
   terrain3D: boolean;
   setTerrain3D: Dispatch<SetStateAction<boolean>>;
+  buildings3D: boolean;
+  setBuildings3D: Dispatch<SetStateAction<boolean>>;
   onExport?: () => void;
   hidden?: boolean;
 
@@ -434,7 +438,11 @@ export function MapSettingsPanel({
               )}
             </Section>
 
-            <Section id="terrain" title="3D Terrain" subtitle={terrain3D ? "On" : "Off"}>
+            <Section
+              id="terrain"
+              title="3D Layers"
+              subtitle={[terrain3D && "Terrain", buildings3D && "Buildings"].filter(Boolean).join(" + ") || "Off"}
+            >
                 <div className="flex items-center justify-between p-2.5 rounded-lg bg-white/5">
                   <div className="flex flex-col">
                     <label htmlFor="terrain-3d-checkbox" className="text-sm font-medium text-gray-300">
@@ -451,6 +459,25 @@ export function MapSettingsPanel({
                     onChange={(e) => setTerrain3D(e.target.checked)}
                     className="h-4 w-4 rounded-sm border-gray-600 bg-gray-700 text-cyan-500 focus:ring-cyan-500"
                     aria-label="Toggle 3D terrain"
+                  />
+                </div>
+
+                <div className="flex items-center justify-between p-2.5 rounded-lg bg-white/5">
+                  <div className="flex flex-col">
+                    <label htmlFor="buildings-3d-checkbox" className="text-sm font-medium text-gray-300">
+                      Enable 3D Buildings
+                    </label>
+                    <p className="text-[11px] text-gray-500 mt-0.5">
+                      Cosmetic OpenFreeMap extrusions (visible at zoom ≥ 14)
+                    </p>
+                  </div>
+                  <input
+                    id="buildings-3d-checkbox"
+                    type="checkbox"
+                    checked={buildings3D}
+                    onChange={(e) => setBuildings3D(e.target.checked)}
+                    className="h-4 w-4 rounded-sm border-gray-600 bg-gray-700 text-cyan-500 focus:ring-cyan-500"
+                    aria-label="Toggle 3D buildings"
                   />
                 </div>
 

--- a/frontend/src/pages/map/buildingTiles.test.ts
+++ b/frontend/src/pages/map/buildingTiles.test.ts
@@ -5,9 +5,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  _buildingCacheSizeForTests,
+  _decodeBuildingPixelsForTests,
+  _putBuildingTileForTests,
   _resetBuildingCacheForTests,
   buildBuildingRaster,
   type BuildingRaster,
+  type CachedBuildingTile,
   downsampleBuildingRaster,
   sampleBuildingAt,
   selectBuildingZoom,
@@ -118,6 +122,68 @@ describe("downsampleBuildingRaster", () => {
     expect(ds.height).toBe(2);
     for (let i = 0; i < 4; i++) expect(ds.heightM[i]).toBeCloseTo(15, 5);
     for (let i = 0; i < 4; i++) expect(ds.mask[i]).toBe(1);
+  });
+});
+
+describe("decodeBuildingPixels — RGBA byte unpack", () => {
+  it("decodes R/G as uint16 height with R as high byte", () => {
+    // R=0x00, G=0x18 → height = 24 m (typical urban). B reserved (0). A=255.
+    const px = new Uint8ClampedArray([0x00, 0x18, 0, 255]);
+    const { height, mask } = _decodeBuildingPixelsForTests(px, 1);
+    expect(height[0]).toBe(24);
+    expect(mask[0]).toBe(255);
+  });
+
+  it("A=0 zeroes height and marks mask", () => {
+    const px = new Uint8ClampedArray([99, 99, 99, 0]);
+    const { height, mask } = _decodeBuildingPixelsForTests(px, 1);
+    expect(height[0]).toBe(0);
+    expect(mask[0]).toBe(0);
+  });
+
+  it("decodes max height 65535 m without truncation", () => {
+    const px = new Uint8ClampedArray([0xFF, 0xFF, 0, 255]);
+    const { height } = _decodeBuildingPixelsForTests(px, 1);
+    expect(height[0]).toBe(65535);
+  });
+
+  it("decodes a 2-pixel buffer end-to-end", () => {
+    const px = new Uint8ClampedArray([
+      0, 5, 0, 255,
+      77, 88, 99, 0,
+    ]);
+    const r = _decodeBuildingPixelsForTests(px, 2);
+    expect(Array.from(r.height)).toEqual([5, 0]);
+    expect(Array.from(r.mask)).toEqual([255, 0]);
+  });
+});
+
+describe("BuildingTileLRU — eviction", () => {
+  beforeEach(() => {
+    _resetBuildingCacheForTests();
+  });
+
+  function makeTile(h: number): CachedBuildingTile {
+    return {
+      height: Uint16Array.from([h]),
+      mask: Uint8Array.from([255]),
+      size: 1,
+    };
+  }
+
+  it("evicts the oldest entry once maxEntries (256) is exceeded", () => {
+    for (let i = 0; i < 256; i++) {
+      _putBuildingTileForTests(0, i, 0, makeTile(i));
+    }
+    expect(_buildingCacheSizeForTests()).toBe(256);
+    _putBuildingTileForTests(0, 256, 0, makeTile(256));
+    expect(_buildingCacheSizeForTests()).toBe(256);
+  });
+
+  it("re-inserting the same key does not grow the cache", () => {
+    _putBuildingTileForTests(0, 1, 0, makeTile(1));
+    _putBuildingTileForTests(0, 1, 0, makeTile(2));
+    expect(_buildingCacheSizeForTests()).toBe(1);
   });
 });
 

--- a/frontend/src/pages/map/buildingTiles.test.ts
+++ b/frontend/src/pages/map/buildingTiles.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for buildingTiles.ts. Network calls are stubbed via global `fetch`;
+ * the raster build path runs without OffscreenCanvas (404 path only).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetBuildingCacheForTests,
+  buildBuildingRaster,
+  type BuildingRaster,
+  downsampleBuildingRaster,
+  sampleBuildingAt,
+  selectBuildingZoom,
+} from "./buildingTiles";
+import type { DEMBounds } from "./terrainDEM";
+
+const CA_BBOX: DEMBounds = { west: -120, east: -119, south: 36, north: 37 };
+
+describe("selectBuildingZoom", () => {
+  it("clamps at MAX_ZOOM (10) — GHS-BUILT-H is 100 m native", () => {
+    expect(selectBuildingZoom(CA_BBOX, 0.1)).toBeLessThanOrEqual(10);
+  });
+
+  it("picks a higher zoom for a smaller bbox at the same target px size", () => {
+    const small: DEMBounds = { west: -120, east: -119.9, south: 36, north: 36.1 };
+    const big: DEMBounds = { west: -125, east: -115, south: 36, north: 46 };
+    expect(selectBuildingZoom(small, 30)).toBeGreaterThanOrEqual(selectBuildingZoom(big, 30));
+  });
+});
+
+function buildSyntheticRaster(opts: {
+  width: number;
+  height: number;
+  heights: number[];
+  mask?: number[];
+}): BuildingRaster {
+  const { width, height, heights } = opts;
+  if (heights.length !== width * height) throw new Error("len mismatch");
+  return {
+    heightM: Float32Array.from(heights),
+    mask: Float32Array.from(opts.mask ?? new Array(width * height).fill(1)),
+    width,
+    height,
+    bounds: CA_BBOX,
+    tilesPresent: 1,
+    tilesTotal: 1,
+  };
+}
+
+describe("sampleBuildingAt — bilinear over valid pixels", () => {
+  // 2×2 raster covering CA_BBOX with corner heights [10, 20 | 30, 40]
+  const raster = buildSyntheticRaster({
+    width: 2,
+    height: 2,
+    heights: [10, 20, 30, 40],
+  });
+
+  it("returns north-west corner exactly", () => {
+    const s = sampleBuildingAt(raster, CA_BBOX.west, CA_BBOX.north);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeCloseTo(10, 5);
+  });
+
+  it("returns south-east corner exactly", () => {
+    const s = sampleBuildingAt(raster, CA_BBOX.east, CA_BBOX.south);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeCloseTo(40, 5);
+  });
+
+  it("interpolates the centre as the mean of all four corners", () => {
+    const midLng = (CA_BBOX.west + CA_BBOX.east) / 2;
+    const midLat = (CA_BBOX.north + CA_BBOX.south) / 2;
+    const s = sampleBuildingAt(raster, midLng, midLat);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeCloseTo(25, 5);
+  });
+
+  it("returns null for out-of-bounds queries", () => {
+    expect(sampleBuildingAt(raster, -130, 36.5)).toBeNull();
+    expect(sampleBuildingAt(raster, -119.5, 50)).toBeNull();
+  });
+});
+
+describe("sampleBuildingAt — nodata-aware blending", () => {
+  it("returns null when every neighbour is masked off", () => {
+    const raster = buildSyntheticRaster({
+      width: 2,
+      height: 2,
+      heights: [10, 20, 30, 40],
+      mask: [0, 0, 0, 0],
+    });
+    expect(sampleBuildingAt(raster, -119.5, 36.5)).toBeNull();
+  });
+
+  it("excludes the masked neighbour from the bilinear weighted average", () => {
+    // NW corner masked off; sample close to it should ignore the 99 m sentinel.
+    const raster = buildSyntheticRaster({
+      width: 2,
+      height: 2,
+      heights: [99, 10, 10, 10],
+      mask: [0, 1, 1, 1],
+    });
+    const s = sampleBuildingAt(raster, CA_BBOX.west + 0.1, CA_BBOX.north - 0.1);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeLessThan(20);
+  });
+});
+
+describe("downsampleBuildingRaster", () => {
+  it("preserves uniform-height values under downsample", () => {
+    const src = buildSyntheticRaster({
+      width: 4,
+      height: 4,
+      heights: new Array(16).fill(15),
+    });
+    const ds = downsampleBuildingRaster(src, 2, 2);
+    expect(ds.width).toBe(2);
+    expect(ds.height).toBe(2);
+    for (let i = 0; i < 4; i++) expect(ds.heightM[i]).toBeCloseTo(15, 5);
+    for (let i = 0; i < 4; i++) expect(ds.mask[i]).toBe(1);
+  });
+});
+
+describe("buildBuildingRaster — out-of-bbox (all tiles 404)", () => {
+  beforeEach(() => {
+    _resetBuildingCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a zero raster with mask=0 when every tile 404s", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 404 }));
+    const raster = await buildBuildingRaster({
+      bounds: CA_BBOX,
+      targetWidth: 16,
+      targetHeight: 16,
+    });
+    expect(raster.width).toBe(16);
+    expect(raster.height).toBe(16);
+    expect(raster.tilesPresent).toBe(0);
+    expect(raster.tilesTotal).toBeGreaterThan(0);
+    expect(raster.heightM.every((v) => v === 0)).toBe(true);
+    expect(raster.mask.every((v) => v === 0)).toBe(true);
+  });
+
+  it("does not throw on transient network errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const raster = await buildBuildingRaster({
+      bounds: CA_BBOX,
+      targetWidth: 16,
+      targetHeight: 16,
+    });
+    expect(raster.tilesPresent).toBe(0);
+    expect(raster.heightM.every((v) => v === 0)).toBe(true);
+    expect(raster.mask.every((v) => v === 0)).toBe(true);
+  });
+});

--- a/frontend/src/pages/map/buildingTiles.ts
+++ b/frontend/src/pages/map/buildingTiles.ts
@@ -1,0 +1,376 @@
+/**
+ * Building-height tile fetcher; tiles produced by scripts/building_tiles.py
+ * from JRC GHS-BUILT-H ANBH (100 m global, average over built-area sub-pixels).
+ *
+ * Encoding:
+ *   R/G = average building height (uint16 metres, R=high byte)
+ *   B   = 0 (reserved; std-dev not published for GHS-BUILT-H)
+ *   A   = 255 valid, 0 nodata
+ *
+ * A=255 with height=0 is a real "no buildings in this 100 m cell" reading
+ * (open space, water, forest); A=0 means the bake didn't cover this region
+ * and the consumer should fall back to class-nominal heights.
+ */
+import { env } from "../../env";
+import type { DEMBounds } from "./terrainDEM";
+
+const TILE_SIZE = 256;
+const MIN_ZOOM = 0;
+/** Matches the bake's default ceiling; z=10 ~= 38 m/px at lat 37, GHS-BUILT-H is 100 m native. */
+const MAX_ZOOM = 10;
+const DEFAULT_MAX_TILES_PER_REQUEST = 256;
+
+function tileBaseUrl(): string {
+  const apiBase = env.API_BASE_URL ?? window.location.origin;
+  return `${apiBase}/tiles/buildings`;
+}
+
+function lng2tileX(lng: number, zoom: number): number {
+  return ((lng + 180) / 360) * Math.pow(2, zoom);
+}
+
+function lat2tileY(lat: number, zoom: number): number {
+  const latRad = (lat * Math.PI) / 180;
+  return (
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) *
+    Math.pow(2, zoom)
+  );
+}
+
+function tileMetersPerPixel(lat: number, zoom: number, tileSize: number): number {
+  const equatorCircumferenceM = 40_075_017;
+  return (equatorCircumferenceM * Math.cos((lat * Math.PI) / 180)) / (tileSize * Math.pow(2, zoom));
+}
+
+function tileCountForBounds(bounds: DEMBounds, zoom: number): number {
+  const xMin = Math.floor(lng2tileX(bounds.west, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.east, zoom));
+  const yMin = Math.floor(lat2tileY(bounds.north, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.south, zoom));
+  return (xMax - xMin + 1) * (yMax - yMin + 1);
+}
+
+export function selectBuildingZoom(
+  bounds: DEMBounds,
+  targetPixelSizeM: number,
+  maxTiles: number = DEFAULT_MAX_TILES_PER_REQUEST,
+): number {
+  const midLat = (bounds.north + bounds.south) / 2;
+  for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+    const res = tileMetersPerPixel(midLat, z, TILE_SIZE);
+    if (res > targetPixelSizeM) continue;
+    if (tileCountForBounds(bounds, z) <= maxTiles) return z;
+  }
+  for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+    if (tileCountForBounds(bounds, z) <= maxTiles) return z;
+  }
+  return MIN_ZOOM;
+}
+
+export interface CachedBuildingTile {
+  /** Row-major building heights in metres, length TILE_SIZE². 0 where mask is 0 too. */
+  height: Uint16Array;
+  /** Row-major valid mask: 255 = measured, 0 = nodata (fall back to class-nominal). */
+  mask: Uint8Array;
+  size: number;
+}
+
+/** Sentinel for 404'd tiles, distinct from "not yet attempted." */
+export const TILE_MISSING: CachedBuildingTile = Object.freeze({
+  height: new Uint16Array(0),
+  mask: new Uint8Array(0),
+  size: TILE_SIZE,
+}) as CachedBuildingTile;
+
+class BuildingTileLRU {
+  private cache = new Map<string, CachedBuildingTile>();
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: string): CachedBuildingTile | undefined {
+    const v = this.cache.get(key);
+    if (!v) return undefined;
+    this.cache.delete(key);
+    this.cache.set(key, v);
+    return v;
+  }
+
+  set(key: string, tile: CachedBuildingTile): void {
+    if (this.cache.has(key)) this.cache.delete(key);
+    this.cache.set(key, tile);
+    while (this.cache.size > this.maxEntries) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest === undefined) break;
+      this.cache.delete(oldest);
+    }
+  }
+}
+
+// 256 tiles × 256² × (2 + 1) ≈ 48 MB worst case (height u16 + mask u8).
+const tileCache = new BuildingTileLRU(256);
+
+export async function fetchBuildingTile(
+  z: number,
+  x: number,
+  y: number,
+): Promise<CachedBuildingTile> {
+  const key = `${z}/${x}/${y}`;
+  const hit = tileCache.get(key);
+  if (hit) return hit;
+
+  const url = `${tileBaseUrl()}/${z}/${x}/${y}.png`;
+  const res = await fetch(url);
+  if (res.status === 404) {
+    tileCache.set(key, TILE_MISSING);
+    return TILE_MISSING;
+  }
+  if (!res.ok) {
+    throw new Error(`building tile fetch failed ${z}/${x}/${y}: HTTP ${res.status}`);
+  }
+
+  const blob = await res.blob();
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const w = bitmap.width;
+    const h = bitmap.height;
+    if (w !== h || w !== TILE_SIZE) {
+      throw new Error(`building tile ${key} unexpected size ${w}x${h} (want ${TILE_SIZE})`);
+    }
+    const canvas = new OffscreenCanvas(w, h);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("OffscreenCanvas 2d context unavailable");
+    ctx.drawImage(bitmap, 0, 0);
+    const img = ctx.getImageData(0, 0, w, h);
+    const px = img.data;
+    const n = w * h;
+    const height = new Uint16Array(n);
+    const mask = new Uint8Array(n);
+    for (let i = 0; i < n; i++) {
+      const o = i * 4;
+      const valid = px[o + 3] !== 0;
+      mask[i] = valid ? 255 : 0;
+      if (valid) height[i] = (px[o] << 8) | px[o + 1];
+    }
+    const tile: CachedBuildingTile = { height, mask, size: w };
+    tileCache.set(key, tile);
+    return tile;
+  } finally {
+    bitmap.close();
+  }
+}
+
+export interface BuildBuildingRasterOptions {
+  bounds: DEMBounds;
+  targetWidth: number;
+  targetHeight: number;
+  maxTiles?: number;
+}
+
+export interface BuildingRaster {
+  /** Row-major building height in metres. 0 where mask is 0 (consumer falls back to class-nominal). */
+  heightM: Float32Array;
+  /** Row-major 1 = measured, 0 = nodata. Float32 to keep bilinear math simple. */
+  mask: Float32Array;
+  width: number;
+  height: number;
+  bounds: DEMBounds;
+  tilesPresent: number;
+  tilesTotal: number;
+}
+
+/**
+ * Build a height raster covering `bounds` at `targetWidth × targetHeight`.
+ * Weighted bilinear over valid neighbours; missing tiles → mask = 0 and the
+ * consumer falls back to class-nominal at those pixels.
+ */
+export async function buildBuildingRaster(
+  opts: BuildBuildingRasterOptions,
+): Promise<BuildingRaster> {
+  const { bounds, targetWidth, targetHeight } = opts;
+  const maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES_PER_REQUEST;
+
+  const midLat = (bounds.north + bounds.south) / 2;
+  const bboxWidthM =
+    (bounds.east - bounds.west) * 111_320 * Math.cos((midLat * Math.PI) / 180);
+  const targetPixelSizeM = Math.max(1, bboxWidthM / targetWidth);
+  const zoom = selectBuildingZoom(bounds, targetPixelSizeM, maxTiles);
+
+  const xMin = Math.floor(lng2tileX(bounds.west, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.east, zoom));
+  const yMin = Math.floor(lat2tileY(bounds.north, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.south, zoom));
+  const tilesTotal = (xMax - xMin + 1) * (yMax - yMin + 1);
+
+  const tileMap = new Map<string, CachedBuildingTile>();
+  const jobs: Promise<void>[] = [];
+  for (let x = xMin; x <= xMax; x++) {
+    for (let y = yMin; y <= yMax; y++) {
+      const key = `${zoom}/${x}/${y}`;
+      jobs.push(
+        fetchBuildingTile(zoom, x, y)
+          .then((t) => void tileMap.set(key, t))
+          .catch((err) => {
+            console.warn("[buildingTiles]", err);
+            tileMap.set(key, TILE_MISSING);
+          }),
+      );
+    }
+  }
+  await Promise.all(jobs);
+
+  let tilesPresent = 0;
+  for (const t of tileMap.values()) {
+    if (t !== TILE_MISSING && t.height.length > 0) tilesPresent++;
+  }
+
+  const n = targetWidth * targetHeight;
+  const heightOut = new Float32Array(n);
+  const maskOut = new Float32Array(n);
+  const scale = Math.pow(2, zoom);
+
+  /** Sample (h, m) at a fractional tile-pixel coord. m=0 if no valid neighbour. */
+  const sampleAt = (absX: number, absY: number): [number, number] => {
+    const x0 = Math.floor(absX);
+    const y0 = Math.floor(absY);
+    const x1 = x0 + 1;
+    const y1 = y0 + 1;
+    const fx = absX - x0;
+    const fy = absY - y0;
+
+    const get = (ax: number, ay: number): [number, number] => {
+      const tileX = Math.floor(ax / TILE_SIZE);
+      const tileY = Math.floor(ay / TILE_SIZE);
+      const px = ax - tileX * TILE_SIZE;
+      const py = ay - tileY * TILE_SIZE;
+      if (px < 0 || py < 0 || px >= TILE_SIZE || py >= TILE_SIZE) return [0, 0];
+      const xWrapped = ((tileX % scale) + scale) % scale;
+      const t = tileMap.get(`${zoom}/${xWrapped}/${tileY}`);
+      if (!t || t === TILE_MISSING || t.height.length === 0) return [0, 0];
+      const idx = py * TILE_SIZE + px;
+      const m = t.mask[idx];
+      if (m === 0) return [0, 0];
+      return [t.height[idx], 1];
+    };
+
+    const [h00, m00] = get(x0, y0);
+    const [h10, m10] = get(x1, y0);
+    const [h01, m01] = get(x0, y1);
+    const [h11, m11] = get(x1, y1);
+
+    const w00 = (1 - fx) * (1 - fy) * m00;
+    const w10 = fx * (1 - fy) * m10;
+    const w01 = (1 - fx) * fy * m01;
+    const w11 = fx * fy * m11;
+    const wSum = w00 + w10 + w01 + w11;
+    if (wSum <= 0) return [0, 0];
+    const h = (h00 * w00 + h10 * w10 + h01 * w01 + h11 * w11) / wSum;
+    return [h, 1];
+  };
+
+  for (let j = 0; j < targetHeight; j++) {
+    const lat =
+      bounds.north - ((bounds.north - bounds.south) * j) / Math.max(1, targetHeight - 1);
+    const absY = lat2tileY(lat, zoom) * TILE_SIZE - 0.5;
+    for (let i = 0; i < targetWidth; i++) {
+      const lng =
+        bounds.west + ((bounds.east - bounds.west) * i) / Math.max(1, targetWidth - 1);
+      const absX = lng2tileX(lng, zoom) * TILE_SIZE - 0.5;
+      const [h, m] = sampleAt(absX, absY);
+      const k = j * targetWidth + i;
+      heightOut[k] = h;
+      maskOut[k] = m;
+    }
+  }
+
+  return {
+    heightM: heightOut,
+    mask: maskOut,
+    width: targetWidth,
+    height: targetHeight,
+    bounds,
+    tilesPresent,
+    tilesTotal,
+  };
+}
+
+/**
+ * Bilinear sample of building height at lng/lat. Returns null only when every
+ * neighbour pixel is masked off (or the query is outside the raster). One
+ * valid neighbour is enough — same edge-aware policy as the canopy sampler.
+ */
+export interface BuildingSample {
+  heightM: number;
+}
+
+export function sampleBuildingAt(
+  raster: { heightM: Float32Array; mask: Float32Array; width: number; height: number; bounds: DEMBounds },
+  lng: number,
+  lat: number,
+): BuildingSample | null {
+  const { width, height, bounds, heightM, mask } = raster;
+  const fx = ((lng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
+  const fy = ((bounds.north - lat) / (bounds.north - bounds.south)) * (height - 1);
+  if (fx < 0 || fx > width - 1 || fy < 0 || fy > height - 1) return null;
+
+  const x0 = Math.floor(fx);
+  const y0 = Math.floor(fy);
+  const x1 = Math.min(width - 1, x0 + 1);
+  const y1 = Math.min(height - 1, y0 + 1);
+  const tx = fx - x0;
+  const ty = fy - y0;
+
+  const k00 = y0 * width + x0;
+  const k10 = y0 * width + x1;
+  const k01 = y1 * width + x0;
+  const k11 = y1 * width + x1;
+
+  const m00 = mask[k00], m10 = mask[k10], m01 = mask[k01], m11 = mask[k11];
+  const w00 = (1 - tx) * (1 - ty) * m00;
+  const w10 = tx * (1 - ty) * m10;
+  const w01 = (1 - tx) * ty * m01;
+  const w11 = tx * ty * m11;
+  const wSum = w00 + w10 + w01 + w11;
+  if (wSum <= 0) return null;
+
+  const h = (heightM[k00] * w00 + heightM[k10] * w10 + heightM[k01] * w01 + heightM[k11] * w11) / wSum;
+  return { heightM: h };
+}
+
+/** Bilinear downsample over the same bounds. */
+export function downsampleBuildingRaster(
+  src: BuildingRaster,
+  newWidth: number,
+  newHeight: number,
+): BuildingRaster {
+  const heightOut = new Float32Array(newWidth * newHeight);
+  const maskOut = new Float32Array(newWidth * newHeight);
+  for (let j = 0; j < newHeight; j++) {
+    const lat =
+      src.bounds.north -
+      ((src.bounds.north - src.bounds.south) * j) / Math.max(1, newHeight - 1);
+    for (let i = 0; i < newWidth; i++) {
+      const lng =
+        src.bounds.west +
+        ((src.bounds.east - src.bounds.west) * i) / Math.max(1, newWidth - 1);
+      const k = j * newWidth + i;
+      const sample = sampleBuildingAt(src, lng, lat);
+      if (sample) {
+        heightOut[k] = sample.heightM;
+        maskOut[k] = 1;
+      }
+    }
+  }
+  return {
+    heightM: heightOut,
+    mask: maskOut,
+    width: newWidth,
+    height: newHeight,
+    bounds: src.bounds,
+    tilesPresent: src.tilesPresent,
+    tilesTotal: src.tilesTotal,
+  };
+}
+
+/** Test-only. */
+export function _resetBuildingCacheForTests(): void {
+  (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();
+}

--- a/frontend/src/pages/map/buildingTiles.ts
+++ b/frontend/src/pages/map/buildingTiles.ts
@@ -16,7 +16,8 @@ import type { DEMBounds } from "./terrainDEM";
 
 const TILE_SIZE = 256;
 const MIN_ZOOM = 0;
-/** Matches the bake's default ceiling; z=10 ~= 38 m/px at lat 37, GHS-BUILT-H is 100 m native. */
+/** Matches the bake's default ceiling. GHS-BUILT-H source is 100 m native; z=10 is
+ *  ~122 m/px at lat 37, so tiles are near source resolution (no oversampling). */
 const MAX_ZOOM = 10;
 const DEFAULT_MAX_TILES_PER_REQUEST = 256;
 
@@ -108,6 +109,22 @@ class BuildingTileLRU {
 // 256 tiles × 256² × (2 + 1) ≈ 48 MB worst case (height u16 + mask u8).
 const tileCache = new BuildingTileLRU(256);
 
+/** R/G = uint16 ANBH metres (R=high byte), B reserved (no std-dev), A = mask. */
+function decodeBuildingPixels(
+  px: Uint8ClampedArray,
+  n: number,
+): { height: Uint16Array; mask: Uint8Array } {
+  const height = new Uint16Array(n);
+  const mask = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const o = i * 4;
+    const valid = px[o + 3] !== 0;
+    mask[i] = valid ? 255 : 0;
+    if (valid) height[i] = (px[o] << 8) | px[o + 1];
+  }
+  return { height, mask };
+}
+
 export async function fetchBuildingTile(
   z: number,
   x: number,
@@ -140,16 +157,7 @@ export async function fetchBuildingTile(
     if (!ctx) throw new Error("OffscreenCanvas 2d context unavailable");
     ctx.drawImage(bitmap, 0, 0);
     const img = ctx.getImageData(0, 0, w, h);
-    const px = img.data;
-    const n = w * h;
-    const height = new Uint16Array(n);
-    const mask = new Uint8Array(n);
-    for (let i = 0; i < n; i++) {
-      const o = i * 4;
-      const valid = px[o + 3] !== 0;
-      mask[i] = valid ? 255 : 0;
-      if (valid) height[i] = (px[o] << 8) | px[o + 1];
-    }
+    const { height, mask } = decodeBuildingPixels(img.data, w * h);
     const tile: CachedBuildingTile = { height, mask, size: w };
     tileCache.set(key, tile);
     return tile;
@@ -373,4 +381,22 @@ export function downsampleBuildingRaster(
 /** Test-only. */
 export function _resetBuildingCacheForTests(): void {
   (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();
+}
+
+/** Test-only. */
+export function _buildingCacheSizeForTests(): number {
+  return (tileCache as unknown as { cache: Map<string, unknown> }).cache.size;
+}
+
+/** Test-only. Inject a cached tile without going through fetch/Canvas. */
+export function _putBuildingTileForTests(z: number, x: number, y: number, tile: CachedBuildingTile): void {
+  tileCache.set(`${z}/${x}/${y}`, tile);
+}
+
+/** Test-only. Direct byte-decode access for round-trip pixel tests. */
+export function _decodeBuildingPixelsForTests(
+  px: Uint8ClampedArray,
+  n: number,
+): { height: Uint16Array; mask: Uint8Array } {
+  return decodeBuildingPixels(px, n);
 }

--- a/frontend/src/pages/map/canopyTiles.test.ts
+++ b/frontend/src/pages/map/canopyTiles.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for canopyTiles.ts. Network calls are stubbed via global `fetch`;
+ * the raster build path runs without OffscreenCanvas (404 path only).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetCanopyCacheForTests,
+  buildCanopyRaster,
+  type CanopyRaster,
+  downsampleCanopyRaster,
+  sampleCanopyAt,
+  selectCanopyZoom,
+} from "./canopyTiles";
+import type { DEMBounds } from "./terrainDEM";
+
+const CA_BBOX: DEMBounds = { west: -120, east: -119, south: 36, north: 37 };
+
+describe("selectCanopyZoom", () => {
+  it("picks a higher zoom for a smaller bbox at the same target px size", () => {
+    const small: DEMBounds = { west: -120, east: -119.9, south: 36, north: 36.1 };
+    const big: DEMBounds = { west: -125, east: -115, south: 36, north: 46 };
+    expect(selectCanopyZoom(small, 30)).toBeGreaterThanOrEqual(selectCanopyZoom(big, 30));
+  });
+
+  it("clamps at MAX_ZOOM (12)", () => {
+    expect(selectCanopyZoom(CA_BBOX, 0.1)).toBeLessThanOrEqual(12);
+  });
+});
+
+function buildSyntheticRaster(opts: {
+  width: number;
+  height: number;
+  heights: number[]; // row-major; length width*height
+  std?: number[];    // row-major; same length
+  mask?: number[];   // 1 = valid, 0 = nodata
+}): CanopyRaster {
+  const { width, height, heights } = opts;
+  if (heights.length !== width * height) throw new Error("len mismatch");
+  return {
+    heightM: Float32Array.from(heights),
+    stdM: Float32Array.from(opts.std ?? new Array(width * height).fill(0)),
+    mask: Float32Array.from(opts.mask ?? new Array(width * height).fill(1)),
+    width,
+    height,
+    bounds: CA_BBOX,
+    tilesPresent: 1,
+    tilesTotal: 1,
+  };
+}
+
+describe("sampleCanopyAt — bilinear over valid pixels", () => {
+  // 2×2 raster covering CA_BBOX with corner heights [10, 20 | 30, 40]
+  //   row 0 (north): 10 (W), 20 (E)
+  //   row 1 (south): 30 (W), 40 (E)
+  const raster = buildSyntheticRaster({
+    width: 2,
+    height: 2,
+    heights: [10, 20, 30, 40],
+  });
+
+  it("returns north-west corner exactly", () => {
+    const s = sampleCanopyAt(raster, CA_BBOX.west, CA_BBOX.north);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeCloseTo(10, 5);
+  });
+
+  it("returns south-east corner exactly", () => {
+    const s = sampleCanopyAt(raster, CA_BBOX.east, CA_BBOX.south);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeCloseTo(40, 5);
+  });
+
+  it("interpolates the centre as the mean of all four corners", () => {
+    const midLng = (CA_BBOX.west + CA_BBOX.east) / 2;
+    const midLat = (CA_BBOX.north + CA_BBOX.south) / 2;
+    const s = sampleCanopyAt(raster, midLng, midLat);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeCloseTo(25, 5);
+  });
+
+  it("returns null for out-of-bounds queries", () => {
+    expect(sampleCanopyAt(raster, -130, 36.5)).toBeNull();
+    expect(sampleCanopyAt(raster, -119.5, 50)).toBeNull();
+  });
+});
+
+describe("sampleCanopyAt — nodata-aware blending", () => {
+  it("returns null when every neighbour is masked off", () => {
+    const raster = buildSyntheticRaster({
+      width: 2,
+      height: 2,
+      heights: [10, 20, 30, 40],
+      mask: [0, 0, 0, 0],
+    });
+    expect(sampleCanopyAt(raster, -119.5, 36.5)).toBeNull();
+  });
+
+  it("uses only the valid neighbour when one corner is masked off", () => {
+    // Three corners 10 m valid, NW corner nodata. Sample at NW corner: must NOT
+    // return the NW value; bilinear weights collapse to neighbours.
+    const raster = buildSyntheticRaster({
+      width: 2,
+      height: 2,
+      heights: [99, 10, 10, 10],
+      mask: [0, 1, 1, 1],
+    });
+    // Sample slightly inside the bbox so all four corners contribute.
+    const s = sampleCanopyAt(raster, CA_BBOX.west + 0.1, CA_BBOX.north - 0.1);
+    expect(s).not.toBeNull();
+    expect(s!.heightM).toBeLessThan(20); // would-be 99 corner is excluded
+  });
+});
+
+describe("downsampleCanopyRaster", () => {
+  it("preserves bilinear means under downsample", () => {
+    const src = buildSyntheticRaster({
+      width: 4,
+      height: 4,
+      heights: [
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+      ],
+    });
+    const ds = downsampleCanopyRaster(src, 2, 2);
+    expect(ds.width).toBe(2);
+    expect(ds.height).toBe(2);
+    for (let i = 0; i < 4; i++) expect(ds.heightM[i]).toBeCloseTo(10, 5);
+    for (let i = 0; i < 4; i++) expect(ds.mask[i]).toBe(1);
+  });
+});
+
+describe("buildCanopyRaster — out-of-bbox (all tiles 404)", () => {
+  beforeEach(() => {
+    _resetCanopyCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a zero raster with mask=0 when every tile 404s", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 404 }));
+    const raster = await buildCanopyRaster({
+      bounds: CA_BBOX,
+      targetWidth: 16,
+      targetHeight: 16,
+    });
+    expect(raster.width).toBe(16);
+    expect(raster.height).toBe(16);
+    expect(raster.tilesPresent).toBe(0);
+    expect(raster.tilesTotal).toBeGreaterThan(0);
+    // No measured heights; consumer must fall back to class-nominal.
+    expect(raster.heightM.every((v) => v === 0)).toBe(true);
+    expect(raster.mask.every((v) => v === 0)).toBe(true);
+  });
+
+  it("does not throw on transient network errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const raster = await buildCanopyRaster({
+      bounds: CA_BBOX,
+      targetWidth: 16,
+      targetHeight: 16,
+    });
+    expect(raster.tilesPresent).toBe(0);
+    expect(raster.heightM.every((v) => v === 0)).toBe(true);
+    expect(raster.mask.every((v) => v === 0)).toBe(true);
+  });
+});

--- a/frontend/src/pages/map/canopyTiles.test.ts
+++ b/frontend/src/pages/map/canopyTiles.test.ts
@@ -5,8 +5,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  _canopyCacheSizeForTests,
+  _decodeCanopyPixelsForTests,
+  _putCanopyTileForTests,
   _resetCanopyCacheForTests,
   buildCanopyRaster,
+  type CachedCanopyTile,
   type CanopyRaster,
   downsampleCanopyRaster,
   sampleCanopyAt,
@@ -129,6 +133,80 @@ describe("downsampleCanopyRaster", () => {
     expect(ds.height).toBe(2);
     for (let i = 0; i < 4; i++) expect(ds.heightM[i]).toBeCloseTo(10, 5);
     for (let i = 0; i < 4; i++) expect(ds.mask[i]).toBe(1);
+  });
+});
+
+describe("decodeCanopyPixels — RGBA byte unpack", () => {
+  it("decodes R/G as uint16 height with R as high byte", () => {
+    // 1 pixel: R=0x01, G=0x2C → height = 0x012C = 300 m. B=5, A=255.
+    const px = new Uint8ClampedArray([0x01, 0x2C, 5, 255]);
+    const { height, std, mask } = _decodeCanopyPixelsForTests(px, 1);
+    expect(height[0]).toBe(300);
+    expect(std[0]).toBe(5);
+    expect(mask[0]).toBe(255);
+  });
+
+  it("uses B channel for std-dev metres", () => {
+    const px = new Uint8ClampedArray([0, 50, 12, 255]); // height 50, std 12
+    const { std } = _decodeCanopyPixelsForTests(px, 1);
+    expect(std[0]).toBe(12);
+  });
+
+  it("A=0 zeroes height/std and marks mask", () => {
+    // Real PNG bytes can carry junk in RGB when A=0; ensure we don't read them.
+    const px = new Uint8ClampedArray([99, 99, 99, 0]);
+    const { height, std, mask } = _decodeCanopyPixelsForTests(px, 1);
+    expect(height[0]).toBe(0);
+    expect(std[0]).toBe(0);
+    expect(mask[0]).toBe(0);
+  });
+
+  it("decodes max height 65535 m (R=0xFF, G=0xFF) without truncation", () => {
+    const px = new Uint8ClampedArray([0xFF, 0xFF, 0, 255]);
+    const { height } = _decodeCanopyPixelsForTests(px, 1);
+    expect(height[0]).toBe(65535);
+  });
+
+  it("decodes a 2-pixel buffer end-to-end", () => {
+    // px0: height=10, std=2, valid. px1: nodata.
+    const px = new Uint8ClampedArray([
+      0, 10, 2, 255,
+      77, 88, 99, 0,
+    ]);
+    const r = _decodeCanopyPixelsForTests(px, 2);
+    expect(Array.from(r.height)).toEqual([10, 0]);
+    expect(Array.from(r.mask)).toEqual([255, 0]);
+  });
+});
+
+describe("CanopyTileLRU — eviction", () => {
+  beforeEach(() => {
+    _resetCanopyCacheForTests();
+  });
+
+  function makeTile(h: number): CachedCanopyTile {
+    return {
+      height: Uint16Array.from([h]),
+      std: Uint8Array.from([0]),
+      mask: Uint8Array.from([255]),
+      size: 1,
+    };
+  }
+
+  it("evicts the oldest entry once maxEntries (256) is exceeded", () => {
+    for (let i = 0; i < 256; i++) {
+      _putCanopyTileForTests(0, i, 0, makeTile(i));
+    }
+    expect(_canopyCacheSizeForTests()).toBe(256);
+    _putCanopyTileForTests(0, 256, 0, makeTile(256));
+    // Size stays capped.
+    expect(_canopyCacheSizeForTests()).toBe(256);
+  });
+
+  it("re-inserting the same key does not grow the cache", () => {
+    _putCanopyTileForTests(0, 1, 0, makeTile(1));
+    _putCanopyTileForTests(0, 1, 0, makeTile(2));
+    expect(_canopyCacheSizeForTests()).toBe(1);
   });
 });
 

--- a/frontend/src/pages/map/canopyTiles.ts
+++ b/frontend/src/pages/map/canopyTiles.ts
@@ -15,7 +15,9 @@ import type { DEMBounds } from "./terrainDEM";
 
 const TILE_SIZE = 256;
 const MIN_ZOOM = 0;
-/** Matches the bake's default ceiling; z=12 ~= 10 m/px at lat 37, ETH is 10 m native. */
+/** Matches the bake's default ceiling. ETH source is 10 m native; z=12 is ~30 m/px
+ *  at lat 37, so tiles are ~3× downsampled. Higher max-zoom = exponentially more
+ *  disk; bump together with the bake's --zooms ceiling if you need native detail. */
 const MAX_ZOOM = 12;
 const DEFAULT_MAX_TILES_PER_REQUEST = 256;
 
@@ -110,6 +112,26 @@ class CanopyTileLRU {
 // 256 tiles × 256² × (2 + 1 + 1) ≈ 64 MB worst case (height u16 + std u8 + mask u8).
 const tileCache = new CanopyTileLRU(256);
 
+/** R/G = uint16 height (R=high byte), B = uint8 std-dev, A = mask. */
+function decodeCanopyPixels(
+  px: Uint8ClampedArray,
+  n: number,
+): { height: Uint16Array; std: Uint8Array; mask: Uint8Array } {
+  const height = new Uint16Array(n);
+  const std = new Uint8Array(n);
+  const mask = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const o = i * 4;
+    const valid = px[o + 3] !== 0;
+    mask[i] = valid ? 255 : 0;
+    if (valid) {
+      height[i] = (px[o] << 8) | px[o + 1];
+      std[i] = px[o + 2];
+    }
+  }
+  return { height, std, mask };
+}
+
 export async function fetchCanopyTile(
   z: number,
   x: number,
@@ -142,20 +164,7 @@ export async function fetchCanopyTile(
     if (!ctx) throw new Error("OffscreenCanvas 2d context unavailable");
     ctx.drawImage(bitmap, 0, 0);
     const img = ctx.getImageData(0, 0, w, h);
-    const px = img.data;
-    const n = w * h;
-    const height = new Uint16Array(n);
-    const std = new Uint8Array(n);
-    const mask = new Uint8Array(n);
-    for (let i = 0; i < n; i++) {
-      const o = i * 4;
-      const valid = px[o + 3] !== 0;
-      mask[i] = valid ? 255 : 0;
-      if (valid) {
-        height[i] = (px[o] << 8) | px[o + 1];
-        std[i] = px[o + 2];
-      }
-    }
+    const { height, std, mask } = decodeCanopyPixels(img.data, w * h);
     const tile: CachedCanopyTile = { height, std, mask, size: w };
     tileCache.set(key, tile);
     return tile;
@@ -391,4 +400,22 @@ export function downsampleCanopyRaster(
 /** Test-only. */
 export function _resetCanopyCacheForTests(): void {
   (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();
+}
+
+/** Test-only. */
+export function _canopyCacheSizeForTests(): number {
+  return (tileCache as unknown as { cache: Map<string, unknown> }).cache.size;
+}
+
+/** Test-only. Inject a cached tile without going through fetch/Canvas. */
+export function _putCanopyTileForTests(z: number, x: number, y: number, tile: CachedCanopyTile): void {
+  tileCache.set(`${z}/${x}/${y}`, tile);
+}
+
+/** Test-only. Direct byte-decode access for round-trip pixel tests. */
+export function _decodeCanopyPixelsForTests(
+  px: Uint8ClampedArray,
+  n: number,
+): { height: Uint16Array; std: Uint8Array; mask: Uint8Array } {
+  return decodeCanopyPixels(px, n);
 }

--- a/frontend/src/pages/map/canopyTiles.ts
+++ b/frontend/src/pages/map/canopyTiles.ts
@@ -1,0 +1,394 @@
+/**
+ * Canopy-height tile fetcher; tiles produced by scripts/canopy_tiles.py.
+ *
+ * Encoding:
+ *   R/G = canopy height (uint16 metres, R=high byte)
+ *   B   = std-dev (uint8 metres; 0 when the bake skipped --include-stddev)
+ *   A   = 255 valid, 0 nodata
+ *
+ * A=255 with height=0 is a real "no canopy here" measurement (clearings,
+ * fire scars); A=0 means the bake didn't cover this region and the consumer
+ * should fall back to class-nominal heights.
+ */
+import { env } from "../../env";
+import type { DEMBounds } from "./terrainDEM";
+
+const TILE_SIZE = 256;
+const MIN_ZOOM = 0;
+/** Matches the bake's default ceiling; z=12 ~= 10 m/px at lat 37, ETH is 10 m native. */
+const MAX_ZOOM = 12;
+const DEFAULT_MAX_TILES_PER_REQUEST = 256;
+
+function tileBaseUrl(): string {
+  const apiBase = env.API_BASE_URL ?? window.location.origin;
+  return `${apiBase}/tiles/canopy`;
+}
+
+function lng2tileX(lng: number, zoom: number): number {
+  return ((lng + 180) / 360) * Math.pow(2, zoom);
+}
+
+function lat2tileY(lat: number, zoom: number): number {
+  const latRad = (lat * Math.PI) / 180;
+  return (
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) *
+    Math.pow(2, zoom)
+  );
+}
+
+function tileMetersPerPixel(lat: number, zoom: number, tileSize: number): number {
+  const equatorCircumferenceM = 40_075_017;
+  return (equatorCircumferenceM * Math.cos((lat * Math.PI) / 180)) / (tileSize * Math.pow(2, zoom));
+}
+
+function tileCountForBounds(bounds: DEMBounds, zoom: number): number {
+  const xMin = Math.floor(lng2tileX(bounds.west, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.east, zoom));
+  const yMin = Math.floor(lat2tileY(bounds.north, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.south, zoom));
+  return (xMax - xMin + 1) * (yMax - yMin + 1);
+}
+
+export function selectCanopyZoom(
+  bounds: DEMBounds,
+  targetPixelSizeM: number,
+  maxTiles: number = DEFAULT_MAX_TILES_PER_REQUEST,
+): number {
+  const midLat = (bounds.north + bounds.south) / 2;
+  for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+    const res = tileMetersPerPixel(midLat, z, TILE_SIZE);
+    if (res > targetPixelSizeM) continue;
+    if (tileCountForBounds(bounds, z) <= maxTiles) return z;
+  }
+  for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+    if (tileCountForBounds(bounds, z) <= maxTiles) return z;
+  }
+  return MIN_ZOOM;
+}
+
+export interface CachedCanopyTile {
+  /** Row-major canopy heights in metres, length TILE_SIZE². 0 where mask is 0 too. */
+  height: Uint16Array;
+  /** Row-major std-dev metres; all zero if --include-stddev was off in the bake. */
+  std: Uint8Array;
+  /** Row-major valid mask: 255 = measured, 0 = nodata (fall back to class-nominal). */
+  mask: Uint8Array;
+  size: number;
+}
+
+/** Sentinel for 404'd tiles, distinct from "not yet attempted." */
+export const TILE_MISSING: CachedCanopyTile = Object.freeze({
+  height: new Uint16Array(0),
+  std: new Uint8Array(0),
+  mask: new Uint8Array(0),
+  size: TILE_SIZE,
+}) as CachedCanopyTile;
+
+class CanopyTileLRU {
+  private cache = new Map<string, CachedCanopyTile>();
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: string): CachedCanopyTile | undefined {
+    const v = this.cache.get(key);
+    if (!v) return undefined;
+    this.cache.delete(key);
+    this.cache.set(key, v);
+    return v;
+  }
+
+  set(key: string, tile: CachedCanopyTile): void {
+    if (this.cache.has(key)) this.cache.delete(key);
+    this.cache.set(key, tile);
+    while (this.cache.size > this.maxEntries) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest === undefined) break;
+      this.cache.delete(oldest);
+    }
+  }
+}
+
+// 256 tiles × 256² × (2 + 1 + 1) ≈ 64 MB worst case (height u16 + std u8 + mask u8).
+const tileCache = new CanopyTileLRU(256);
+
+export async function fetchCanopyTile(
+  z: number,
+  x: number,
+  y: number,
+): Promise<CachedCanopyTile> {
+  const key = `${z}/${x}/${y}`;
+  const hit = tileCache.get(key);
+  if (hit) return hit;
+
+  const url = `${tileBaseUrl()}/${z}/${x}/${y}.png`;
+  const res = await fetch(url);
+  if (res.status === 404) {
+    tileCache.set(key, TILE_MISSING);
+    return TILE_MISSING;
+  }
+  if (!res.ok) {
+    throw new Error(`canopy tile fetch failed ${z}/${x}/${y}: HTTP ${res.status}`);
+  }
+
+  const blob = await res.blob();
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const w = bitmap.width;
+    const h = bitmap.height;
+    if (w !== h || w !== TILE_SIZE) {
+      throw new Error(`canopy tile ${key} unexpected size ${w}x${h} (want ${TILE_SIZE})`);
+    }
+    const canvas = new OffscreenCanvas(w, h);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("OffscreenCanvas 2d context unavailable");
+    ctx.drawImage(bitmap, 0, 0);
+    const img = ctx.getImageData(0, 0, w, h);
+    const px = img.data;
+    const n = w * h;
+    const height = new Uint16Array(n);
+    const std = new Uint8Array(n);
+    const mask = new Uint8Array(n);
+    for (let i = 0; i < n; i++) {
+      const o = i * 4;
+      const valid = px[o + 3] !== 0;
+      mask[i] = valid ? 255 : 0;
+      if (valid) {
+        height[i] = (px[o] << 8) | px[o + 1];
+        std[i] = px[o + 2];
+      }
+    }
+    const tile: CachedCanopyTile = { height, std, mask, size: w };
+    tileCache.set(key, tile);
+    return tile;
+  } finally {
+    bitmap.close();
+  }
+}
+
+export interface BuildCanopyRasterOptions {
+  bounds: DEMBounds;
+  targetWidth: number;
+  targetHeight: number;
+  maxTiles?: number;
+}
+
+export interface CanopyRaster {
+  /** Row-major canopy height in metres. 0 where mask is 0 (frontend uses class-nominal then). */
+  heightM: Float32Array;
+  /** Row-major std-dev metres. 0 when bake didn't include SD or pixel is nodata. */
+  stdM: Float32Array;
+  /** Row-major 1 = measured, 0 = nodata. Float32 to keep bilinear math simple. */
+  mask: Float32Array;
+  width: number;
+  height: number;
+  bounds: DEMBounds;
+  tilesPresent: number;
+  tilesTotal: number;
+}
+
+/**
+ * Build a height raster covering `bounds` at `targetWidth × targetHeight`.
+ * Weighted bilinear over valid neighbours; missing tiles → mask = 0 and the
+ * consumer falls back to class-nominal at those pixels.
+ */
+export async function buildCanopyRaster(
+  opts: BuildCanopyRasterOptions,
+): Promise<CanopyRaster> {
+  const { bounds, targetWidth, targetHeight } = opts;
+  const maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES_PER_REQUEST;
+
+  const midLat = (bounds.north + bounds.south) / 2;
+  const bboxWidthM =
+    (bounds.east - bounds.west) * 111_320 * Math.cos((midLat * Math.PI) / 180);
+  const targetPixelSizeM = Math.max(1, bboxWidthM / targetWidth);
+  const zoom = selectCanopyZoom(bounds, targetPixelSizeM, maxTiles);
+
+  const xMin = Math.floor(lng2tileX(bounds.west, zoom));
+  const xMax = Math.floor(lng2tileX(bounds.east, zoom));
+  const yMin = Math.floor(lat2tileY(bounds.north, zoom));
+  const yMax = Math.floor(lat2tileY(bounds.south, zoom));
+  const tilesTotal = (xMax - xMin + 1) * (yMax - yMin + 1);
+
+  const tileMap = new Map<string, CachedCanopyTile>();
+  const jobs: Promise<void>[] = [];
+  for (let x = xMin; x <= xMax; x++) {
+    for (let y = yMin; y <= yMax; y++) {
+      const key = `${zoom}/${x}/${y}`;
+      jobs.push(
+        fetchCanopyTile(zoom, x, y)
+          .then((t) => void tileMap.set(key, t))
+          .catch((err) => {
+            console.warn("[canopyTiles]", err);
+            tileMap.set(key, TILE_MISSING);
+          }),
+      );
+    }
+  }
+  await Promise.all(jobs);
+
+  let tilesPresent = 0;
+  for (const t of tileMap.values()) {
+    if (t !== TILE_MISSING && t.height.length > 0) tilesPresent++;
+  }
+
+  const n = targetWidth * targetHeight;
+  const heightOut = new Float32Array(n);
+  const stdOut = new Float32Array(n);
+  const maskOut = new Float32Array(n);
+  const scale = Math.pow(2, zoom);
+
+  /** Sample (h, s, m) at a fractional tile-pixel coord. m=0 if no valid neighbour. */
+  const sampleAt = (absX: number, absY: number): [number, number, number] => {
+    const x0 = Math.floor(absX);
+    const y0 = Math.floor(absY);
+    const x1 = x0 + 1;
+    const y1 = y0 + 1;
+    const fx = absX - x0;
+    const fy = absY - y0;
+
+    const get = (ax: number, ay: number): [number, number, number] => {
+      const tileX = Math.floor(ax / TILE_SIZE);
+      const tileY = Math.floor(ay / TILE_SIZE);
+      const px = ax - tileX * TILE_SIZE;
+      const py = ay - tileY * TILE_SIZE;
+      if (px < 0 || py < 0 || px >= TILE_SIZE || py >= TILE_SIZE) return [0, 0, 0];
+      const xWrapped = ((tileX % scale) + scale) % scale;
+      const t = tileMap.get(`${zoom}/${xWrapped}/${tileY}`);
+      if (!t || t === TILE_MISSING || t.height.length === 0) return [0, 0, 0];
+      const idx = py * TILE_SIZE + px;
+      const m = t.mask[idx];
+      if (m === 0) return [0, 0, 0];
+      return [t.height[idx], t.std[idx], 1];
+    };
+
+    const [h00, s00, m00] = get(x0, y0);
+    const [h10, s10, m10] = get(x1, y0);
+    const [h01, s01, m01] = get(x0, y1);
+    const [h11, s11, m11] = get(x1, y1);
+
+    const w00 = (1 - fx) * (1 - fy) * m00;
+    const w10 = fx * (1 - fy) * m10;
+    const w01 = (1 - fx) * fy * m01;
+    const w11 = fx * fy * m11;
+    const wSum = w00 + w10 + w01 + w11;
+    if (wSum <= 0) return [0, 0, 0];
+    const h = (h00 * w00 + h10 * w10 + h01 * w01 + h11 * w11) / wSum;
+    const s = (s00 * w00 + s10 * w10 + s01 * w01 + s11 * w11) / wSum;
+    return [h, s, 1];
+  };
+
+  for (let j = 0; j < targetHeight; j++) {
+    const lat =
+      bounds.north - ((bounds.north - bounds.south) * j) / Math.max(1, targetHeight - 1);
+    const absY = lat2tileY(lat, zoom) * TILE_SIZE - 0.5;
+    for (let i = 0; i < targetWidth; i++) {
+      const lng =
+        bounds.west + ((bounds.east - bounds.west) * i) / Math.max(1, targetWidth - 1);
+      const absX = lng2tileX(lng, zoom) * TILE_SIZE - 0.5;
+      const [h, s, m] = sampleAt(absX, absY);
+      const k = j * targetWidth + i;
+      heightOut[k] = h;
+      stdOut[k] = s;
+      maskOut[k] = m;
+    }
+  }
+
+  return {
+    heightM: heightOut,
+    stdM: stdOut,
+    mask: maskOut,
+    width: targetWidth,
+    height: targetHeight,
+    bounds,
+    tilesPresent,
+    tilesTotal,
+  };
+}
+
+/**
+ * Bilinear sample of canopy height at lng/lat. Returns null only when every
+ * neighbour pixel is masked off (or the query is outside the raster). One
+ * valid neighbour is enough — canopy edge cases benefit from interpolating
+ * from any available data rather than falling back to class-nominal.
+ */
+export interface CanopySample {
+  heightM: number;
+  stdM: number;
+}
+
+export function sampleCanopyAt(
+  raster: { heightM: Float32Array; stdM: Float32Array; mask: Float32Array; width: number; height: number; bounds: DEMBounds },
+  lng: number,
+  lat: number,
+): CanopySample | null {
+  const { width, height, bounds, heightM, stdM, mask } = raster;
+  const fx = ((lng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
+  const fy = ((bounds.north - lat) / (bounds.north - bounds.south)) * (height - 1);
+  if (fx < 0 || fx > width - 1 || fy < 0 || fy > height - 1) return null;
+
+  const x0 = Math.floor(fx);
+  const y0 = Math.floor(fy);
+  const x1 = Math.min(width - 1, x0 + 1);
+  const y1 = Math.min(height - 1, y0 + 1);
+  const tx = fx - x0;
+  const ty = fy - y0;
+
+  const k00 = y0 * width + x0;
+  const k10 = y0 * width + x1;
+  const k01 = y1 * width + x0;
+  const k11 = y1 * width + x1;
+
+  const m00 = mask[k00], m10 = mask[k10], m01 = mask[k01], m11 = mask[k11];
+  const w00 = (1 - tx) * (1 - ty) * m00;
+  const w10 = tx * (1 - ty) * m10;
+  const w01 = (1 - tx) * ty * m01;
+  const w11 = tx * ty * m11;
+  const wSum = w00 + w10 + w01 + w11;
+  if (wSum <= 0) return null;
+
+  const h = (heightM[k00] * w00 + heightM[k10] * w10 + heightM[k01] * w01 + heightM[k11] * w11) / wSum;
+  const s = (stdM[k00] * w00 + stdM[k10] * w10 + stdM[k01] * w01 + stdM[k11] * w11) / wSum;
+  return { heightM: h, stdM: s };
+}
+
+/** Bilinear downsample over the same bounds. */
+export function downsampleCanopyRaster(
+  src: CanopyRaster,
+  newWidth: number,
+  newHeight: number,
+): CanopyRaster {
+  const heightOut = new Float32Array(newWidth * newHeight);
+  const stdOut = new Float32Array(newWidth * newHeight);
+  const maskOut = new Float32Array(newWidth * newHeight);
+  for (let j = 0; j < newHeight; j++) {
+    const lat =
+      src.bounds.north -
+      ((src.bounds.north - src.bounds.south) * j) / Math.max(1, newHeight - 1);
+    for (let i = 0; i < newWidth; i++) {
+      const lng =
+        src.bounds.west +
+        ((src.bounds.east - src.bounds.west) * i) / Math.max(1, newWidth - 1);
+      const k = j * newWidth + i;
+      const sample = sampleCanopyAt(src, lng, lat);
+      if (sample) {
+        heightOut[k] = sample.heightM;
+        stdOut[k] = sample.stdM;
+        maskOut[k] = 1;
+      }
+    }
+  }
+  return {
+    heightM: heightOut,
+    stdM: stdOut,
+    mask: maskOut,
+    width: newWidth,
+    height: newHeight,
+    bounds: src.bounds,
+    tilesPresent: src.tilesPresent,
+    tilesTotal: src.tilesTotal,
+  };
+}
+
+/** Test-only. */
+export function _resetCanopyCacheForTests(): void {
+  (tileCache as unknown as { cache: Map<string, unknown> }).cache.clear();
+}

--- a/frontend/src/pages/map/clutterClasses.ts
+++ b/frontend/src/pages/map/clutterClasses.ts
@@ -81,10 +81,13 @@ export function endpointClutterDb(
   cls: ClutterClass,
   antennaAGLm: number,
   freqMhz: number,
+  /** Override h_a (e.g. from a measured-height raster); falls back to cls.nominalHeightM. */
+  overrideHeightM?: number,
 ): number {
-  if (cls.nominalHeightM <= 0) return 0;
+  const haM = overrideHeightM ?? cls.nominalHeightM;
+  if (haM <= 0) return 0;
   const h = Math.max(0, antennaAGLm);
-  const ratio = h / cls.nominalHeightM;
+  const ratio = h / haM;
   const fc = freqFactor(freqMhz);
   const a =
     10.25 * fc * Math.exp(-cls.nominalDistanceKm) *

--- a/frontend/src/pages/map/clutterPath.test.ts
+++ b/frontend/src/pages/map/clutterPath.test.ts
@@ -1,18 +1,48 @@
 /** @vitest-environment node */
 import { describe, expect, it } from "vitest";
 
+import type { CanopyRaster } from "./canopyTiles";
 import {
   endpointClutterDb,
   NLCD_CLASSES,
   vegetationPathLossDb,
 } from "./clutterClasses";
 import {
+  type CanopyPathContext,
   CLUTTER_SCRATCH_LEN,
   computePathClutterLoss,
   makeClutterScratch,
 } from "./clutterPath";
+import type { DEMBounds } from "./terrainDEM";
 
 const F_915 = 915;
+
+/** Synthetic CanopyRaster with `heightM` everywhere across `bounds`. */
+function uniformCanopy(bounds: DEMBounds, heightM: number, stdM = 0): CanopyRaster {
+  const w = 4, h = 4;
+  return {
+    heightM: Float32Array.from(new Array(w * h).fill(heightM)),
+    stdM: Float32Array.from(new Array(w * h).fill(stdM)),
+    mask: Float32Array.from(new Array(w * h).fill(1)),
+    width: w,
+    height: h,
+    bounds,
+    tilesPresent: 1,
+    tilesTotal: 1,
+  };
+}
+
+/** ctx wrapping a uniform raster for an east-west path inside `bounds`. */
+function uniformCtx(heightM: number, stdM = 0): CanopyPathContext {
+  const bounds: DEMBounds = { west: -120, east: -119, south: 36, north: 37 };
+  return {
+    raster: uniformCanopy(bounds, heightM, stdM),
+    origLng: bounds.west + 0.1,
+    origLat: 36.5,
+    destLng: bounds.east - 0.1,
+    destLat: 36.5,
+  };
+}
 
 function flatProfile(
   n: number,
@@ -225,6 +255,75 @@ describe("computePathClutterLoss — raw nodata id=0 canonicalizes to default cl
       profileM, allMixed, N, 100, 2, 2, F_915, 1.0, scratch,
     );
     expect(lossInterleaved).toBeCloseTo(lossUniform, 5);
+  });
+});
+
+describe("computePathClutterLoss — measured canopy heights override class-nominal", () => {
+  it("matches the no-canopy result when the measured height equals class-nominal", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(100, 42); // evergreen, nominal 20 m
+    const lossNominal = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch,
+    );
+    const lossMeasured = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch,
+      uniformCtx(NLCD_CLASSES[42].nominalHeightM),
+    );
+    expect(lossMeasured).toBeCloseTo(lossNominal, 5);
+  });
+
+  it("a measured zero-canopy stretch suppresses MED entirely", () => {
+    // 5 km evergreen path, 2 m antennas. Without measured canopy: ~saturation
+    // ~(2x19.1 + 27) ≈ 65 dB. With measured 0 m everywhere: only the endpoint
+    // formula contributes (still ~38 dB, since the formula uses class-nominal
+    // h_a internally — Tier 3 only refines path-integrated MED).
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(100, 42);
+    const lossWithCanopy = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch,
+      uniformCtx(0),
+    );
+    const lossWithoutCanopy = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch,
+    );
+    expect(lossWithCanopy).toBeLessThan(lossWithoutCanopy - 20);
+  });
+
+  it("std-dev ≥ height blends 50/50 with class-nominal", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(100, 42); // evergreen, nominal 20 m
+    // Antennas at 5 m AGL. At 5 m measured canopy with σ=8 (high uncertainty),
+    // the loop should treat effective canopy as (5+20)/2 = 12.5 m, so the 5 m
+    // antenna sits clearly under the 12.5 m canopy and MED accumulates.
+    const lossLowConf = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 5, 5, F_915, 1.0, scratch,
+      uniformCtx(5, 8),
+    );
+    // Compare against fully-trusted measured 5 m: antennas at exactly canopy
+    // top → MED accumulates much less (zPath at 5 m = canopyTop, gate skips).
+    const lossTrusted = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 5, 5, F_915, 1.0, scratch,
+      uniformCtx(5, 0),
+    );
+    expect(lossLowConf).toBeGreaterThan(lossTrusted);
+  });
+
+  it("falls back to class-nominal when canopy raster has no coverage", () => {
+    // Out-of-bbox lng/lat → sampleCanopyAt returns null → class-nominal used.
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(100, 42);
+    const ctx: CanopyPathContext = {
+      raster: uniformCanopy({ west: 0, east: 1, south: 0, north: 1 }, 5),
+      // Path entirely outside the raster's bbox:
+      origLng: -120, origLat: 36.5, destLng: -119, destLat: 36.5,
+    };
+    const lossOutOfBox = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch, ctx,
+    );
+    const lossNoRaster = computePathClutterLoss(
+      profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch,
+    );
+    expect(lossOutOfBox).toBeCloseTo(lossNoRaster, 5);
   });
 });
 

--- a/frontend/src/pages/map/clutterPath.test.ts
+++ b/frontend/src/pages/map/clutterPath.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 import { describe, expect, it } from "vitest";
 
+import type { BuildingRaster } from "./buildingTiles";
 import type { CanopyRaster } from "./canopyTiles";
 import {
   endpointClutterDb,
@@ -8,6 +9,7 @@ import {
   vegetationPathLossDb,
 } from "./clutterClasses";
 import {
+  type BuildingPathContext,
   type CanopyPathContext,
   CLUTTER_SCRATCH_LEN,
   computePathClutterLoss,
@@ -37,6 +39,32 @@ function uniformCtx(heightM: number, stdM = 0): CanopyPathContext {
   const bounds: DEMBounds = { west: -120, east: -119, south: 36, north: 37 };
   return {
     raster: uniformCanopy(bounds, heightM, stdM),
+    origLng: bounds.west + 0.1,
+    origLat: 36.5,
+    destLng: bounds.east - 0.1,
+    destLat: 36.5,
+  };
+}
+
+/** Synthetic BuildingRaster with `heightM` everywhere across `bounds`. */
+function uniformBuildings(bounds: DEMBounds, heightM: number): BuildingRaster {
+  const w = 4, h = 4;
+  return {
+    heightM: Float32Array.from(new Array(w * h).fill(heightM)),
+    mask: Float32Array.from(new Array(w * h).fill(1)),
+    width: w,
+    height: h,
+    bounds,
+    tilesPresent: 1,
+    tilesTotal: 1,
+  };
+}
+
+/** Building ctx wrapping a uniform raster covering an east-west path. */
+function uniformBuildingCtx(heightM: number): BuildingPathContext {
+  const bounds: DEMBounds = { west: -120, east: -119, south: 36, north: 37 };
+  return {
+    raster: uniformBuildings(bounds, heightM),
     origLng: bounds.west + 0.1,
     origLat: 36.5,
     destLng: bounds.east - 0.1,
@@ -322,6 +350,70 @@ describe("computePathClutterLoss — measured canopy heights override class-nomi
     );
     const lossNoRaster = computePathClutterLoss(
       profileM, profileClasses, 100, 5000 / 99, 2, 2, F_915, 1.0, scratch,
+    );
+    expect(lossOutOfBox).toBeCloseTo(lossNoRaster, 5);
+  });
+});
+
+describe("computePathClutterLoss — measured building heights override class-nominal h_a", () => {
+  it("matches the no-buildings result when measured height equals class-nominal", () => {
+    const scratch = makeClutterScratch();
+    // Suburban (NLCD 22): nominalHeightM = 9.
+    const { profileM, profileClasses } = flatProfile(80, 22);
+    const lossNominal = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
+    );
+    const lossMeasured = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
+      null,
+      uniformBuildingCtx(NLCD_CLASSES[22].nominalHeightM),
+    );
+    expect(lossMeasured).toBeCloseTo(lossNominal, 3);
+  });
+
+  it("measured 0 m collapses developed-class endpoint loss to ~0 dB", () => {
+    // Class 22 (h_a=9) at 2 m AGL: A_h ≈ 19 dB. Override h_a = 0 → A_h = 0.
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 22);
+    const loss = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
+      null,
+      uniformBuildingCtx(0),
+    );
+    // Loss should be ~0 since h_a=0 zeros both endpoint contributions and
+    // class 22 isn't penetrable (no MED).
+    expect(loss).toBeLessThan(0.1);
+  });
+
+  it("does NOT override h_a for non-developed classes", () => {
+    // Evergreen forest (class 42, h_a=20). Building raster says 0 m, but
+    // we shouldn't replace forest h_a with 0 — trees are still there.
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 42);
+    const lossWithBuildings = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
+      null,
+      uniformBuildingCtx(0),
+    );
+    const lossWithoutBuildings = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
+    );
+    expect(lossWithBuildings).toBeCloseTo(lossWithoutBuildings, 3);
+  });
+
+  it("falls back to class-nominal when building raster has no coverage", () => {
+    const scratch = makeClutterScratch();
+    const { profileM, profileClasses } = flatProfile(80, 22);
+    // Path entirely outside the raster's bbox.
+    const ctx: BuildingPathContext = {
+      raster: uniformBuildings({ west: 0, east: 1, south: 0, north: 1 }, 25),
+      origLng: -120, origLat: 36.5, destLng: -119, destLat: 36.5,
+    };
+    const lossOutOfBox = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch, null, ctx,
+    );
+    const lossNoRaster = computePathClutterLoss(
+      profileM, profileClasses, 80, 100, 2, 2, F_915, 1.0, scratch,
     );
     expect(lossOutOfBox).toBeCloseTo(lossNoRaster, 5);
   });

--- a/frontend/src/pages/map/clutterPath.ts
+++ b/frontend/src/pages/map/clutterPath.ts
@@ -5,10 +5,13 @@
  * already covers. z_path is a linear lerp of TX/RX MSL antenna heights.
  *
  * Hot loop is alloc-free — caller allocates ClutterScratch once and reuses
- * across all per-pixel calls. When `canopyCtx` is supplied, per-sample
- * measured ETH heights replace the P.452-Table-4 nominals inside the MED
- * gate; class-nominal is the fallback.
+ * across all per-pixel calls. Optional rasters override class-nominal heights:
+ *   - canopyCtx replaces forest h_a inside the MED gate (Tier 3).
+ *   - buildingCtx replaces developed-class h_a in the P.452 endpoint formula
+ *     at TX and RX (Tier 2). Buildings also feed the ITM DSM upstream in
+ *     coverageRaster — that integration is independent of this loop.
  */
+import { type BuildingRaster, sampleBuildingAt } from "./buildingTiles";
 import { type CanopyRaster, sampleCanopyAt } from "./canopyTiles";
 import {
   classForId,
@@ -17,6 +20,9 @@ import {
   NLCD_CLASSES,
   vegetationPathLossDb,
 } from "./clutterClasses";
+
+/** NLCD developed-intensity classes that the building-height raster overrides. */
+const DEVELOPED_CLASS_IDS = new Set([21, 22, 23, 24]);
 
 /** NLCD legend max ID is 95. */
 export const CLUTTER_SCRATCH_LEN = 96;
@@ -50,6 +56,32 @@ export interface CanopyPathContext {
   destLat: number;
 }
 
+/** Same alloc-free pattern as CanopyPathContext; only the endpoints are sampled. */
+export interface BuildingPathContext {
+  raster: BuildingRaster;
+  origLng: number;
+  origLat: number;
+  destLng: number;
+  destLat: number;
+}
+
+/**
+ * Override h_a only for developed classes — replacing forest/shrub class-
+ * nominal with a buildings-raster height (often 0) would erase real
+ * tree/shrub obstruction. ANBH=0 inside a developed cell is a valid
+ * "no buildings here" reading and zeroes endpoint loss accordingly.
+ */
+function endpointHeightOverride(
+  cls: ClutterClass,
+  ctx: BuildingPathContext | null | undefined,
+  lng: number,
+  lat: number,
+): number | undefined {
+  if (!ctx || !DEVELOPED_CLASS_IDS.has(cls.id)) return undefined;
+  const sample = sampleBuildingAt(ctx.raster, lng, lat);
+  return sample === null ? undefined : sample.heightM;
+}
+
 /**
  * σ ≥ height = noisy ETH pixel; blend 50/50 with class-nominal so it can't
  * solo-drive the MED loop. σ=0 (the no-SD bake) skips the blend, which is
@@ -81,14 +113,22 @@ export function computePathClutterLoss(
   aggression: number,
   scratch: ClutterScratch,
   canopyCtx?: CanopyPathContext | null,
+  buildingCtx?: BuildingPathContext | null,
 ): number {
   if (nSamples < 2 || pointSpacingM <= 0) return 0;
 
   const txClass = classForId(profileClasses[0]);
   const rxClass = classForId(profileClasses[nSamples - 1]);
 
-  const aHTx = endpointClutterDb(txClass, txAntennaAGLm, freqMhz);
-  const aHRx = endpointClutterDb(rxClass, rxAntennaAGLm, freqMhz);
+  const txHaOverride = buildingCtx
+    ? endpointHeightOverride(txClass, buildingCtx, buildingCtx.origLng, buildingCtx.origLat)
+    : undefined;
+  const rxHaOverride = buildingCtx
+    ? endpointHeightOverride(rxClass, buildingCtx, buildingCtx.destLng, buildingCtx.destLat)
+    : undefined;
+
+  const aHTx = endpointClutterDb(txClass, txAntennaAGLm, freqMhz, txHaOverride);
+  const aHRx = endpointClutterDb(rxClass, rxAntennaAGLm, freqMhz, rxHaOverride);
 
   const txMsl = profileM[0] + txAntennaAGLm;
   const rxMsl = profileM[nSamples - 1] + rxAntennaAGLm;

--- a/frontend/src/pages/map/clutterPath.ts
+++ b/frontend/src/pages/map/clutterPath.ts
@@ -5,10 +5,14 @@
  * already covers. z_path is a linear lerp of TX/RX MSL antenna heights.
  *
  * Hot loop is alloc-free — caller allocates ClutterScratch once and reuses
- * across all per-pixel calls.
+ * across all per-pixel calls. When `canopyCtx` is supplied, per-sample
+ * measured ETH heights replace the P.452-Table-4 nominals inside the MED
+ * gate; class-nominal is the fallback.
  */
+import { type CanopyRaster, sampleCanopyAt } from "./canopyTiles";
 import {
   classForId,
+  type ClutterClass,
   endpointClutterDb,
   NLCD_CLASSES,
   vegetationPathLossDb,
@@ -35,6 +39,33 @@ export function makeClutterScratch(): ClutterScratch {
 }
 
 /**
+ * Reuse a single instance and mutate it across pixels — keeps the hot loop
+ * alloc-free at 65k+ computes per coverage frame.
+ */
+export interface CanopyPathContext {
+  raster: CanopyRaster;
+  origLng: number;
+  origLat: number;
+  destLng: number;
+  destLat: number;
+}
+
+/**
+ * σ ≥ height = noisy ETH pixel; blend 50/50 with class-nominal so it can't
+ * solo-drive the MED loop. σ=0 (the no-SD bake) skips the blend, which is
+ * the right behaviour — there's no uncertainty signal to act on.
+ */
+function effectiveCanopyHeightM(cls: ClutterClass, ctx: CanopyPathContext, lng: number, lat: number): number {
+  const sample = sampleCanopyAt(ctx.raster, lng, lat);
+  if (sample === null) return cls.nominalHeightM;
+  if (sample.heightM <= 0) return 0;
+  if (sample.stdM > 0 && sample.stdM >= sample.heightM) {
+    return 0.5 * sample.heightM + 0.5 * cls.nominalHeightM;
+  }
+  return sample.heightM;
+}
+
+/**
  * Total clutter loss in dB for one TX→RX profile.
  *
  * `profileClasses[0]` and `profileClasses[nSamples-1]` are TX/RX endpoints.
@@ -49,6 +80,7 @@ export function computePathClutterLoss(
   freqMhz: number,
   aggression: number,
   scratch: ClutterScratch,
+  canopyCtx?: CanopyPathContext | null,
 ): number {
   if (nSamples < 2 || pointSpacingM <= 0) return 0;
 
@@ -75,7 +107,13 @@ export function computePathClutterLoss(
     const t = s / lastIdx;
     const zPath = txMsl + (rxMsl - txMsl) * t;
     const zTerrain = profileM[s];
-    const canopyTop = zTerrain + cls.nominalHeightM;
+    let canopyHeightM = cls.nominalHeightM;
+    if (canopyCtx) {
+      const sLng = canopyCtx.origLng + (canopyCtx.destLng - canopyCtx.origLng) * t;
+      const sLat = canopyCtx.origLat + (canopyCtx.destLat - canopyCtx.origLat) * t;
+      canopyHeightM = effectiveCanopyHeightM(cls, canopyCtx, sLng, sLat);
+    }
+    const canopyTop = zTerrain + canopyHeightM;
 
     if (zPath >= canopyTop) continue;
     if (zPath < zTerrain) continue;

--- a/frontend/src/pages/map/coverageAnalysis.ts
+++ b/frontend/src/pages/map/coverageAnalysis.ts
@@ -138,11 +138,27 @@ export function reliabilityPreset(id: CoverageReliability): ReliabilityPreset {
 }
 
 /** Coverage computation summary (pixel stats + link-budget context). Raster lives on the Mapbox source. */
+/**
+ * Additional origin layered on the primary; painted coverage takes per-pixel
+ * max(margin) across all origins. Session-only — not persisted, since the set
+ * is contextual to one analysis.
+ */
+export interface MergeOrigin {
+  /** Node hex id, or "virtual:<lng>,<lat>" for map-pin origins. */
+  id: string;
+  label: string;
+  position: [number, number];
+  /** GPS altitude if known (node origins); null for virtual pins. */
+  altitudeM: number | null;
+}
+
 export interface CoverageResult {
   origin: [number, number];
   originHeightM: number;
   originIsFallback: boolean;
   radiusKm: number;
+  /** Count of additional merged origins (zero = single-origin compute). */
+  mergeOriginCount?: number;
   /** Pixels passing link budget with full LoS. */
   clearCount: number;
   /** Pixels passing link budget with Fresnel intrusion/diffraction loss. */

--- a/frontend/src/pages/map/coverageAnalysis.ts
+++ b/frontend/src/pages/map/coverageAnalysis.ts
@@ -157,8 +157,6 @@ export interface CoverageResult {
   originHeightM: number;
   originIsFallback: boolean;
   radiusKm: number;
-  /** Count of additional merged origins (zero = single-origin compute). */
-  mergeOriginCount?: number;
   /** Pixels passing link budget with full LoS. */
   clearCount: number;
   /** Pixels passing link budget with Fresnel intrusion/diffraction loss. */

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -134,12 +134,13 @@ export interface OutputGrid {
   height: number;
 }
 
-/** Paint `rowRange` (or full grid) of the output raster via ITM. */
+/** Paint `rowRange` (or full grid) of the output raster via ITM. With multiple
+ *  origins, each pixel keeps the max margin across all of them. */
 export function renderCoverageRaster(
   dem: DEM,
   params: RasterParams,
   itm: ItmContext,
-  origin: RasterOrigin,
+  origins: RasterOrigin[],
   rowRange?: RowRange,
   output?: OutputGrid,
   /** Optional class-ID raster aligned to the DEM bounds. Null = treat every sample as default class. */
@@ -182,16 +183,24 @@ export function renderCoverageRaster(
   const profileClassBuf = new Uint8Array(maxSamples);
   const clutterScratch = makeClutterScratch();
 
-  const [origLng, origLat] = origin.position;
+  // Pre-clamp + flatten origins so the inner loop touches Float64Arrays only.
+  const originLngs = new Float64Array(origins.length);
+  const originLats = new Float64Array(origins.length);
+  const txHeights = new Float64Array(origins.length);
+  for (let k = 0; k < origins.length; k++) {
+    originLngs[k] = origins[k].position[0];
+    originLats[k] = origins[k].position[1];
+    txHeights[k] = Math.max(0.5, Math.min(3000, origins[k].antennaHeightAboveGroundM));
+  }
+
   // Step over OUTPUT grid; terrain via bilinear sampleDEMAt is (lng,lat)-continuous
   const lonStep = (bounds.east - bounds.west) / (outputWidth - 1);
   const latStep = (bounds.north - bounds.south) / (outputHeight - 1);
 
   // Reusable input object (65k+ computes per frame → don't allocate). ITM wants AGL, clamped [0.5, 3000].
-  const txHeightAgM = Math.max(0.5, Math.min(3000, origin.antennaHeightAboveGroundM));
   const itmInput = {
-    txHeightM: txHeightAgM,
-    rxHeightM: 0, // set per-pixel
+    txHeightM: 0,
+    rxHeightM: 0,
     profileM: profileBuf,
     pointSpacingM: 0,
     climate,
@@ -229,109 +238,119 @@ export function renderCoverageRaster(
         rgba[outPxIdx * 4 + 3] = 0;
         continue;
       }
-      const distKm = haversineKm(origLng, origLat, lng, lat);
 
-      // Origin pixel — paint max-margin color
-      if (distKm < 0.01) {
-        const [r, g, b, a] = gradient(50);
-        rgba[outPxIdx * 4] = r;
-        rgba[outPxIdx * 4 + 1] = g;
-        rgba[outPxIdx * 4 + 2] = b;
-        rgba[outPxIdx * 4 + 3] = a;
-        clearCount++;
-        if (50 > maxMarginDb) maxMarginDb = 50;
-        continue;
-      }
+      let bestMargin = Number.NEGATIVE_INFINITY;
+      let anyOriginValid = false;
+      let allItmFailed = true;
 
-      // Linear lng/lat interp is within ~1% of great-circle at Meshtastic distances
-      const nSamples = profileSampleCount(distKm);
-      const lastIdx = nSamples - 1;
-      let validProfile = true;
-      for (let s = 0; s < nSamples; s++) {
-        const t = s / lastIdx;
-        const sLng = origLng + (lng - origLng) * t;
-        const sLat = origLat + (lat - origLat) * t;
-        const elev = sampleDEMAt(dem, sLng, sLat);
-        if (Number.isNaN(elev)) {
-          validProfile = false;
-          break;
+      for (let k = 0; k < origins.length; k++) {
+        const origLng = originLngs[k];
+        const origLat = originLats[k];
+        const txHeightAgM = txHeights[k];
+        const distKm = haversineKm(origLng, origLat, lng, lat);
+
+        // Origin pixel — short-circuit to max margin (50 dB).
+        if (distKm < 0.01) {
+          if (50 > bestMargin) bestMargin = 50;
+          anyOriginValid = true;
+          allItmFailed = false;
+          continue;
         }
-        // Endpoints stay bare-earth so AGL antenna heights aren't placed on
-        // top of a presumed building — that's captured by P.452 instead.
-        let dsmElev = elev;
-        if (buildings && s !== 0 && s !== lastIdx) {
-          const sample = sampleBuildingAt(buildings, sLng, sLat);
-          if (sample && sample.heightM > 0) dsmElev = elev + sample.heightM;
+
+        // Linear lng/lat interp is within ~1% of great-circle at Meshtastic distances
+        const nSamples = profileSampleCount(distKm);
+        const lastIdx = nSamples - 1;
+        let validProfile = true;
+        for (let s = 0; s < nSamples; s++) {
+          const t = s / lastIdx;
+          const sLng = origLng + (lng - origLng) * t;
+          const sLat = origLat + (lat - origLat) * t;
+          const elev = sampleDEMAt(dem, sLng, sLat);
+          if (Number.isNaN(elev)) {
+            validProfile = false;
+            break;
+          }
+          // Endpoints stay bare-earth so AGL antenna heights aren't placed on
+          // top of a presumed building — that's captured by P.452 instead.
+          let dsmElev = elev;
+          if (buildings && s !== 0 && s !== lastIdx) {
+            const sample = sampleBuildingAt(buildings, sLng, sLat);
+            if (sample && sample.heightM > 0) dsmElev = elev + sample.heightM;
+          }
+          profileBuf[s] = dsmElev;
+          profileClassBuf[s] = clutter ? sampleClutterClassAt(clutter, sLng, sLat) : 0;
         }
-        profileBuf[s] = dsmElev;
-        profileClassBuf[s] = clutter ? sampleClutterClassAt(clutter, sLng, sLat) : 0;
+        if (!validProfile) continue;
+
+        // subarray = no-copy view; slice() would allocate
+        itmInput.profileM = profileBuf.subarray(0, nSamples);
+        const pointSpacingM = (distKm * 1000) / (nSamples - 1);
+        itmInput.pointSpacingM = pointSpacingM;
+        itmInput.rxHeightM = receiverAntennaAboveGroundM;
+        itmInput.txHeightM = txHeightAgM;
+
+        const lossDb = computeP2PLossFast(itm, itmInput);
+        if (!Number.isFinite(lossDb) || lossDb <= 0) continue;
+        allItmFailed = false;
+
+        if (canopyCtx) {
+          canopyCtx.origLng = origLng;
+          canopyCtx.origLat = origLat;
+          canopyCtx.destLng = lng;
+          canopyCtx.destLat = lat;
+        }
+        if (buildingCtx) {
+          buildingCtx.origLng = origLng;
+          buildingCtx.origLat = origLat;
+          buildingCtx.destLng = lng;
+          buildingCtx.destLat = lat;
+        }
+        const clutterLossDb = computePathClutterLoss(
+          profileBuf,
+          profileClassBuf,
+          nSamples,
+          pointSpacingM,
+          txHeightAgM,
+          receiverAntennaAboveGroundM,
+          freqMhz,
+          clutterAggression,
+          clutterScratch,
+          canopyCtx,
+          buildingCtx,
+        );
+
+        const totalLossDb = lossDb + clutterLossDb + cableLossDb;
+        const rssiDbm = txDbm + txGain + rxGain - totalLossDb;
+        const marginDb = rssiDbm - rxSensitivityDbm - fadeMarginDb;
+        if (marginDb > bestMargin) bestMargin = marginDb;
+        anyOriginValid = true;
       }
-      if (!validProfile) {
+
+      if (!anyOriginValid) {
+        // Distinguish "ITM rejected every origin's path" (count as blocked)
+        // from "no DEM data here" (just leave transparent).
         rgba[outPxIdx * 4 + 3] = 0;
+        if (allItmFailed && origins.length > 0) blockedCount++;
         continue;
       }
-
-      // subarray = no-copy view; slice() would allocate
-      itmInput.profileM = profileBuf.subarray(0, nSamples);
-      const pointSpacingM = (distKm * 1000) / (nSamples - 1);
-      itmInput.pointSpacingM = pointSpacingM;
-      itmInput.rxHeightM = receiverAntennaAboveGroundM;
-
-      const lossDb = computeP2PLossFast(itm, itmInput);
-      if (!Number.isFinite(lossDb) || lossDb <= 0) {
-        // ITM failure — transparent rather than garbage color
-        rgba[outPxIdx * 4 + 3] = 0;
-        blockedCount++;
-        continue;
-      }
-
-      if (canopyCtx) {
-        canopyCtx.origLng = origLng;
-        canopyCtx.origLat = origLat;
-        canopyCtx.destLng = lng;
-        canopyCtx.destLat = lat;
-      }
-      if (buildingCtx) {
-        buildingCtx.origLng = origLng;
-        buildingCtx.origLat = origLat;
-        buildingCtx.destLng = lng;
-        buildingCtx.destLat = lat;
-      }
-      const clutterLossDb = computePathClutterLoss(
-        profileBuf,
-        profileClassBuf,
-        nSamples,
-        pointSpacingM,
-        txHeightAgM,
-        receiverAntennaAboveGroundM,
-        freqMhz,
-        clutterAggression,
-        clutterScratch,
-        canopyCtx,
-        buildingCtx,
-      );
-
-      const totalLossDb = lossDb + clutterLossDb + cableLossDb;
-      const rssiDbm = txDbm + txGain + rxGain - totalLossDb;
-      const marginDb = rssiDbm - rxSensitivityDbm - fadeMarginDb;
 
       // Record margin for blocked pixels too — contour extraction needs both sides of 0 dB
-      marginDbBuf[outPxIdx] = marginDb;
+      marginDbBuf[outPxIdx] = bestMargin;
 
-      if (marginDb < 0) {
+      if (bestMargin < 0) {
         blockedCount++;
         rgba[outPxIdx * 4 + 3] = 0;
         continue;
       }
 
-      if (marginDb >= 15) {
+      if (bestMargin >= 15) {
         clearCount++;
       } else {
         fresnelCount++;
       }
-      if (marginDb > maxMarginDb) maxMarginDb = marginDb;
+      if (bestMargin > maxMarginDb) maxMarginDb = bestMargin;
 
-      const [r, g, b, a] = gradient(marginDb);
+      const [r, g, b, a] = gradient(bestMargin);
       const o = outPxIdx * 4;
       rgba[o] = r;
       rgba[o + 1] = g;

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -241,7 +241,9 @@ export function renderCoverageRaster(
 
       let bestMargin = Number.NEGATIVE_INFINITY;
       let anyOriginValid = false;
-      let allItmFailed = true;
+      // Whether any origin built a usable terrain profile (passed DEM check) — gates
+      // blockedCount so DEM-NaN holes stay transparent rather than counted as blocked.
+      let anyOriginItmAttempted = false;
 
       for (let k = 0; k < origins.length; k++) {
         const origLng = originLngs[k];
@@ -253,7 +255,6 @@ export function renderCoverageRaster(
         if (distKm < 0.01) {
           if (50 > bestMargin) bestMargin = 50;
           anyOriginValid = true;
-          allItmFailed = false;
           continue;
         }
 
@@ -281,6 +282,7 @@ export function renderCoverageRaster(
           profileClassBuf[s] = clutter ? sampleClutterClassAt(clutter, sLng, sLat) : 0;
         }
         if (!validProfile) continue;
+        anyOriginItmAttempted = true;
 
         // subarray = no-copy view; slice() would allocate
         itmInput.profileM = profileBuf.subarray(0, nSamples);
@@ -291,7 +293,6 @@ export function renderCoverageRaster(
 
         const lossDb = computeP2PLossFast(itm, itmInput);
         if (!Number.isFinite(lossDb) || lossDb <= 0) continue;
-        allItmFailed = false;
 
         if (canopyCtx) {
           canopyCtx.origLng = origLng;
@@ -330,7 +331,7 @@ export function renderCoverageRaster(
         // Distinguish "ITM rejected every origin's path" (count as blocked)
         // from "no DEM data here" (just leave transparent).
         rgba[outPxIdx * 4 + 3] = 0;
-        if (allItmFailed && origins.length > 0) blockedCount++;
+        if (anyOriginItmAttempted) blockedCount++;
         continue;
       }
 

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -3,7 +3,9 @@
  * Hot loop is alloc-free (shared Float64 profile buffer, pre-allocated WASM ctx).
  * Profile length adapts to path length (15-96 samples, ~1.5/km).
  */
+import type { CanopyRaster } from "./canopyTiles";
 import {
+  type CanopyPathContext,
   computePathClutterLoss,
   makeClutterScratch,
 } from "./clutterPath";
@@ -140,6 +142,8 @@ export function renderCoverageRaster(
   output?: OutputGrid,
   /** Optional class-ID raster aligned to the DEM bounds. Null = treat every sample as default class. */
   clutter?: ClutterRaster | null,
+  /** Optional canopy-height raster aligned to the DEM bounds. Null = use class-nominal heights. */
+  canopy?: CanopyRaster | null,
 ): RasterResult {
   const { bounds } = dem;
   const outputWidth = output?.width ?? dem.width;
@@ -201,6 +205,11 @@ export function renderCoverageRaster(
   const txGain = txAntennaDbi;
   const rxGain = rxAntennaDbi;
 
+  // Mutated per-pixel rather than reallocated — see CanopyPathContext docstring.
+  const canopyCtx: CanopyPathContext | null = canopy
+    ? { raster: canopy, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
+
   for (let j = rowStart; j < rowEnd; j++) {
     const lat = bounds.north - j * latStep;
     const outRowOffset = (j - rowStart) * outputWidth;
@@ -260,6 +269,12 @@ export function renderCoverageRaster(
         continue;
       }
 
+      if (canopyCtx) {
+        canopyCtx.origLng = origLng;
+        canopyCtx.origLat = origLat;
+        canopyCtx.destLng = lng;
+        canopyCtx.destLat = lat;
+      }
       const clutterLossDb = computePathClutterLoss(
         profileBuf,
         profileClassBuf,
@@ -270,6 +285,7 @@ export function renderCoverageRaster(
         freqMhz,
         clutterAggression,
         clutterScratch,
+        canopyCtx,
       );
 
       const totalLossDb = lossDb + clutterLossDb + cableLossDb;

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -3,8 +3,10 @@
  * Hot loop is alloc-free (shared Float64 profile buffer, pre-allocated WASM ctx).
  * Profile length adapts to path length (15-96 samples, ~1.5/km).
  */
+import { type BuildingRaster, sampleBuildingAt } from "./buildingTiles";
 import type { CanopyRaster } from "./canopyTiles";
 import {
+  type BuildingPathContext,
   type CanopyPathContext,
   computePathClutterLoss,
   makeClutterScratch,
@@ -144,6 +146,9 @@ export function renderCoverageRaster(
   clutter?: ClutterRaster | null,
   /** Optional canopy-height raster aligned to the DEM bounds. Null = use class-nominal heights. */
   canopy?: CanopyRaster | null,
+  /** Optional building-height raster aligned to the DEM bounds. Drives the ITM
+   *  DSM (mid-path) and P.452 endpoint h_a override. Null = class-nominal. */
+  buildings?: BuildingRaster | null,
 ): RasterResult {
   const { bounds } = dem;
   const outputWidth = output?.width ?? dem.width;
@@ -209,6 +214,9 @@ export function renderCoverageRaster(
   const canopyCtx: CanopyPathContext | null = canopy
     ? { raster: canopy, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
     : null;
+  const buildingCtx: BuildingPathContext | null = buildings
+    ? { raster: buildings, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
 
   for (let j = rowStart; j < rowEnd; j++) {
     const lat = bounds.north - j * latStep;
@@ -237,9 +245,10 @@ export function renderCoverageRaster(
 
       // Linear lng/lat interp is within ~1% of great-circle at Meshtastic distances
       const nSamples = profileSampleCount(distKm);
+      const lastIdx = nSamples - 1;
       let validProfile = true;
       for (let s = 0; s < nSamples; s++) {
-        const t = s / (nSamples - 1);
+        const t = s / lastIdx;
         const sLng = origLng + (lng - origLng) * t;
         const sLat = origLat + (lat - origLat) * t;
         const elev = sampleDEMAt(dem, sLng, sLat);
@@ -247,7 +256,14 @@ export function renderCoverageRaster(
           validProfile = false;
           break;
         }
-        profileBuf[s] = elev;
+        // Endpoints stay bare-earth so AGL antenna heights aren't placed on
+        // top of a presumed building — that's captured by P.452 instead.
+        let dsmElev = elev;
+        if (buildings && s !== 0 && s !== lastIdx) {
+          const sample = sampleBuildingAt(buildings, sLng, sLat);
+          if (sample && sample.heightM > 0) dsmElev = elev + sample.heightM;
+        }
+        profileBuf[s] = dsmElev;
         profileClassBuf[s] = clutter ? sampleClutterClassAt(clutter, sLng, sLat) : 0;
       }
       if (!validProfile) {
@@ -275,6 +291,12 @@ export function renderCoverageRaster(
         canopyCtx.destLng = lng;
         canopyCtx.destLat = lat;
       }
+      if (buildingCtx) {
+        buildingCtx.origLng = origLng;
+        buildingCtx.origLat = origLat;
+        buildingCtx.destLng = lng;
+        buildingCtx.destLat = lat;
+      }
       const clutterLossDb = computePathClutterLoss(
         profileBuf,
         profileClassBuf,
@@ -286,6 +308,7 @@ export function renderCoverageRaster(
         clutterAggression,
         clutterScratch,
         canopyCtx,
+        buildingCtx,
       );
 
       const totalLossDb = lossDb + clutterLossDb + cableLossDb;

--- a/frontend/src/pages/map/coverageSliceWorker.ts
+++ b/frontend/src/pages/map/coverageSliceWorker.ts
@@ -18,6 +18,15 @@ import {
 import type { ClutterRaster } from "./landcoverTiles";
 import type { DEM, DEMBounds } from "./terrainDEM";
 
+/** Per-origin link-budget inputs; renderCoverageRaster takes max margin across all entries. */
+export interface SliceOrigin {
+  position: [number, number];
+  /** Origin MSL height (m); display/export only — ITM doesn't receive this. */
+  heightM: number;
+  /** TX antenna AGL (m); ITM txHeightM must be AGL, not MSL. */
+  antennaHeightAboveGroundM: number;
+}
+
 export interface CoverageSliceRequest {
   requestId: number;
   /** Transferable DEM buffer (main thread ships a copy per worker). */
@@ -25,10 +34,8 @@ export interface CoverageSliceRequest {
   demWidth: number;
   demHeight: number;
   bounds: DEMBounds;
-  origin: [number, number];
-  originHeightM: number;
-  /** TX antenna AGL (m); ITM txHeightM must be AGL, not MSL. */
-  originAntennaHeightAboveGroundM: number;
+  /** Primary + optional merge origins. */
+  origins: SliceOrigin[];
   params: RasterParams;
   /** rowStart/rowEnd are OUTPUT-grid indices (decoupled from DEM). */
   outputWidth: number;
@@ -158,11 +165,7 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
       dem,
       msg.params,
       itm,
-      {
-        position: msg.origin,
-        heightM: msg.originHeightM,
-        antennaHeightAboveGroundM: msg.originAntennaHeightAboveGroundM,
-      },
+      msg.origins,
       { rowStart: msg.rowStart, rowEnd: msg.rowEnd },
       { width: msg.outputWidth, height: msg.outputHeight },
       clutter,

--- a/frontend/src/pages/map/coverageSliceWorker.ts
+++ b/frontend/src/pages/map/coverageSliceWorker.ts
@@ -2,6 +2,7 @@
  * Coverage slice worker: runs ITM per pixel over a row range of a shared DEM.
  * Each worker keeps its own ITM WASM context warm across requests.
  */
+import type { CanopyRaster } from "./canopyTiles";
 import {
   type RasterParams,
   renderCoverageRaster,
@@ -37,6 +38,12 @@ export interface CoverageSliceRequest {
   clutterBuffer?: ArrayBuffer;
   clutterWidth?: number;
   clutterHeight?: number;
+  /** Optional canopy-height raster aligned to DEM bounds. Absent → class-nominal heights. */
+  canopyHeightBuffer?: ArrayBuffer;
+  canopyStdBuffer?: ArrayBuffer;
+  canopyMaskBuffer?: ArrayBuffer;
+  canopyWidth?: number;
+  canopyHeight?: number;
 }
 
 export interface CoverageSliceResponse {
@@ -116,6 +123,19 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
             tilesTotal: 0,
           }
         : null;
+    const canopy: CanopyRaster | null =
+      msg.canopyHeightBuffer && msg.canopyStdBuffer && msg.canopyMaskBuffer && msg.canopyWidth && msg.canopyHeight
+        ? {
+            heightM: new Float32Array(msg.canopyHeightBuffer),
+            stdM: new Float32Array(msg.canopyStdBuffer),
+            mask: new Float32Array(msg.canopyMaskBuffer),
+            width: msg.canopyWidth,
+            height: msg.canopyHeight,
+            bounds: msg.bounds,
+            tilesPresent: 0,
+            tilesTotal: 0,
+          }
+        : null;
     const rendered = renderCoverageRaster(
       dem,
       msg.params,
@@ -128,6 +148,7 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
       { rowStart: msg.rowStart, rowEnd: msg.rowEnd },
       { width: msg.outputWidth, height: msg.outputHeight },
       clutter,
+      canopy,
     );
     post({
       requestId: msg.requestId,

--- a/frontend/src/pages/map/coverageSliceWorker.ts
+++ b/frontend/src/pages/map/coverageSliceWorker.ts
@@ -2,6 +2,7 @@
  * Coverage slice worker: runs ITM per pixel over a row range of a shared DEM.
  * Each worker keeps its own ITM WASM context warm across requests.
  */
+import type { BuildingRaster } from "./buildingTiles";
 import type { CanopyRaster } from "./canopyTiles";
 import {
   type RasterParams,
@@ -44,6 +45,11 @@ export interface CoverageSliceRequest {
   canopyMaskBuffer?: ArrayBuffer;
   canopyWidth?: number;
   canopyHeight?: number;
+  /** Optional building-height raster aligned to DEM bounds. Absent → bare-earth + class-nominal. */
+  buildingHeightBuffer?: ArrayBuffer;
+  buildingMaskBuffer?: ArrayBuffer;
+  buildingWidth?: number;
+  buildingHeight?: number;
 }
 
 export interface CoverageSliceResponse {
@@ -136,6 +142,18 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
             tilesTotal: 0,
           }
         : null;
+    const buildings: BuildingRaster | null =
+      msg.buildingHeightBuffer && msg.buildingMaskBuffer && msg.buildingWidth && msg.buildingHeight
+        ? {
+            heightM: new Float32Array(msg.buildingHeightBuffer),
+            mask: new Float32Array(msg.buildingMaskBuffer),
+            width: msg.buildingWidth,
+            height: msg.buildingHeight,
+            bounds: msg.bounds,
+            tilesPresent: 0,
+            tilesTotal: 0,
+          }
+        : null;
     const rendered = renderCoverageRaster(
       dem,
       msg.params,
@@ -149,6 +167,7 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
       { width: msg.outputWidth, height: msg.outputHeight },
       clutter,
       canopy,
+      buildings,
     );
     post({
       requestId: msg.requestId,

--- a/frontend/src/pages/map/scanAnalysis.ts
+++ b/frontend/src/pages/map/scanAnalysis.ts
@@ -2,8 +2,9 @@
  * Best-neighbors scan: LoS + link budget from origin to each target, classified and ranked.
  * Stays on the main thread with 60 samples/ray.
  */
+import type { CanopyRaster } from "./canopyTiles";
 import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
-import { computePathClutterLoss, makeClutterScratch } from "./clutterPath";
+import { type CanopyPathContext, computePathClutterLoss, makeClutterScratch } from "./clutterPath";
 import { pathLossDb } from "./coverageAnalysis";
 import { computeP2PLossFast, type ItmContext,ModeOfVariability } from "./itm";
 import { type ClutterRaster, sampleClutterClassAt } from "./landcoverTiles";
@@ -66,6 +67,8 @@ export interface ScanInput {
   cableLossDb?: number;
   /** Optional class-ID raster aligned to bbox; absent → default class everywhere. */
   clutterRaster?: ClutterRaster | null;
+  /** Optional canopy-height raster aligned to bbox; absent → class-nominal heights. */
+  canopyRaster?: CanopyRaster | null;
   /** Scalar on the ITU clutter model output. 1.0 = calibrated baseline. */
   clutterAggression?: number;
   /** Skip targets farther than this km. Default Infinity. */
@@ -107,6 +110,7 @@ export function runScan(input: ScanInput): ScanSummary {
     fadeMarginDb = 15,
     cableLossDb = 0.5,
     clutterRaster = null,
+    canopyRaster = null,
     clutterAggression = 1.0,
     maxDistanceKm = Infinity,
   } = input;
@@ -119,6 +123,9 @@ export function runScan(input: ScanInput): ScanSummary {
   let blockedCount = 0;
 
   const clutterScratch = makeClutterScratch();
+  const canopyCtx: CanopyPathContext | null = canopyRaster
+    ? { raster: canopyRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
 
   for (const t of targets) {
     const d = haversineKm(origin, t.position);
@@ -157,6 +164,12 @@ export function runScan(input: ScanInput): ScanSummary {
     const rxAGLm = los.points.length > 0
       ? Math.max(0.5, los.toHeightM - los.points[los.points.length - 1].ground)
       : 2;
+    if (canopyCtx) {
+      canopyCtx.origLng = origin[0];
+      canopyCtx.origLat = origin[1];
+      canopyCtx.destLng = t.position[0];
+      canopyCtx.destLat = t.position[1];
+    }
     const clutterLossDb = computePathClutterLoss(
       profileM,
       profileClasses,
@@ -167,6 +180,7 @@ export function runScan(input: ScanInput): ScanSummary {
       freqMhz,
       clutterAggression,
       clutterScratch,
+      canopyCtx,
     );
 
     // Path loss: ITM (terrain-aware) when available, else FSPL + knife-edge

--- a/frontend/src/pages/map/scanAnalysis.ts
+++ b/frontend/src/pages/map/scanAnalysis.ts
@@ -2,9 +2,10 @@
  * Best-neighbors scan: LoS + link budget from origin to each target, classified and ranked.
  * Stays on the main thread with 60 samples/ray.
  */
+import { type BuildingRaster, sampleBuildingAt } from "./buildingTiles";
 import type { CanopyRaster } from "./canopyTiles";
 import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
-import { type CanopyPathContext, computePathClutterLoss, makeClutterScratch } from "./clutterPath";
+import { type BuildingPathContext, type CanopyPathContext, computePathClutterLoss, makeClutterScratch } from "./clutterPath";
 import { pathLossDb } from "./coverageAnalysis";
 import { computeP2PLossFast, type ItmContext,ModeOfVariability } from "./itm";
 import { type ClutterRaster, sampleClutterClassAt } from "./landcoverTiles";
@@ -69,6 +70,8 @@ export interface ScanInput {
   clutterRaster?: ClutterRaster | null;
   /** Optional canopy-height raster aligned to bbox; absent → class-nominal heights. */
   canopyRaster?: CanopyRaster | null;
+  /** Optional building-height raster aligned to bbox; absent → bare-earth + class-nominal. */
+  buildingRaster?: BuildingRaster | null;
   /** Scalar on the ITU clutter model output. 1.0 = calibrated baseline. */
   clutterAggression?: number;
   /** Skip targets farther than this km. Default Infinity. */
@@ -111,6 +114,7 @@ export function runScan(input: ScanInput): ScanSummary {
     cableLossDb = 0.5,
     clutterRaster = null,
     canopyRaster = null,
+    buildingRaster = null,
     clutterAggression = 1.0,
     maxDistanceKm = Infinity,
   } = input;
@@ -125,6 +129,9 @@ export function runScan(input: ScanInput): ScanSummary {
   const clutterScratch = makeClutterScratch();
   const canopyCtx: CanopyPathContext | null = canopyRaster
     ? { raster: canopyRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
+  const buildingCtx: BuildingPathContext | null = buildingRaster
+    ? { raster: buildingRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
     : null;
 
   for (const t of targets) {
@@ -143,18 +150,24 @@ export function runScan(input: ScanInput): ScanSummary {
       queryTerrainM,
     });
 
-    // LoS points only carry distanceKm; lerp lng/lat ourselves to sample classes.
+    // LoS points only carry distanceKm; lerp lng/lat ourselves to sample
+    // raster lookups. DSM endpoint-skip rationale: see coverageRaster.ts.
     const profileM = new Float64Array(los.points.map((p) => p.ground));
     const profileClasses = new Uint8Array(profileM.length);
-    if (clutterRaster) {
-      for (let s = 0; s < profileM.length; s++) {
-        const tFrac = profileM.length > 1 ? s / (profileM.length - 1) : 0;
-        const sLng = origin[0] + (t.position[0] - origin[0]) * tFrac;
-        const sLat = origin[1] + (t.position[1] - origin[1]) * tFrac;
+    const lastPathIdx = profileM.length - 1;
+    for (let s = 0; s < profileM.length; s++) {
+      const tFrac = profileM.length > 1 ? s / lastPathIdx : 0;
+      const sLng = origin[0] + (t.position[0] - origin[0]) * tFrac;
+      const sLat = origin[1] + (t.position[1] - origin[1]) * tFrac;
+      if (clutterRaster) {
         profileClasses[s] = sampleClutterClassAt(clutterRaster, sLng, sLat);
+      } else {
+        profileClasses[s] = NLCD_DEFAULT_CLASS_ID;
       }
-    } else {
-      profileClasses.fill(NLCD_DEFAULT_CLASS_ID);
+      if (buildingRaster && s !== 0 && s !== lastPathIdx) {
+        const sample = sampleBuildingAt(buildingRaster, sLng, sLat);
+        if (sample && sample.heightM > 0) profileM[s] += sample.heightM;
+      }
     }
 
     const spacingM = profileM.length > 1 ? (d * 1000) / (profileM.length - 1) : 0;
@@ -170,6 +183,12 @@ export function runScan(input: ScanInput): ScanSummary {
       canopyCtx.destLng = t.position[0];
       canopyCtx.destLat = t.position[1];
     }
+    if (buildingCtx) {
+      buildingCtx.origLng = origin[0];
+      buildingCtx.origLat = origin[1];
+      buildingCtx.destLng = t.position[0];
+      buildingCtx.destLat = t.position[1];
+    }
     const clutterLossDb = computePathClutterLoss(
       profileM,
       profileClasses,
@@ -181,6 +200,7 @@ export function runScan(input: ScanInput): ScanSummary {
       clutterAggression,
       clutterScratch,
       canopyCtx,
+      buildingCtx,
     );
 
     // Path loss: ITM (terrain-aware) when available, else FSPL + knife-edge

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -14,6 +14,9 @@ export const LS_KEYS = {
   /** Clutter model on/off. Off → aggression = 0, ITM-only path loss. */
   coverageClutterEnabled: "meshinfo.map.coverageClutterEnabled",
   scanClutterEnabled: "meshinfo.map.scanClutterEnabled",
+  /** Canopy-height tier on/off. Off → fall back to class-nominal heights. */
+  coverageCanopyEnabled: "meshinfo.map.coverageCanopyEnabled",
+  scanCanopyEnabled: "meshinfo.map.scanCanopyEnabled",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -17,6 +17,9 @@ export const LS_KEYS = {
   /** Canopy-height tier on/off. Off → fall back to class-nominal heights. */
   coverageCanopyEnabled: "meshinfo.map.coverageCanopyEnabled",
   scanCanopyEnabled: "meshinfo.map.scanCanopyEnabled",
+  /** Building-height tier on/off. Off → bare-earth DEM + class-nominal endpoint h_a. */
+  coverageBuildingsEnabled: "meshinfo.map.coverageBuildingsEnabled",
+  scanBuildingsEnabled: "meshinfo.map.scanBuildingsEnabled",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -8,6 +8,8 @@ export const LS_KEYS = {
   linkMode: "meshinfo.map.linkMode",
   myNodeId: "meshinfo.map.myNodeId",
   terrain3D: "meshinfo.map.terrain3D",
+  /** Cosmetic 3D-buildings extrusion (OpenFreeMap vector tiles). RF-independent. */
+  buildings3D: "meshinfo.map.buildings3D",
   /** AGGRESSION_STOPS index (0/1/2). Default 1 = calibrated baseline. */
   coverageAggressionIdx: "meshinfo.map.coverageAggressionIdx",
   scanAggressionIdx: "meshinfo.map.scanAggressionIdx",

--- a/scripts/README-buildings.md
+++ b/scripts/README-buildings.md
@@ -1,0 +1,123 @@
+# Building-height tile bake (operator guide)
+
+The coverage and scan tools use measured per-pixel building heights to refine
+the ITU-R P.452-17 endpoint clutter formula and to feed buildings into the
+DEM-as-DSM that the ITM propagation algorithm sees. Tiles are pre-baked from
+JRC's GHS-BUILT-H ANBH (Average Net Building Height, 2018 epoch, 100 m global,
+CC-BY-4.0) and served as static PNGs under `/tiles/buildings/{z}/{x}/{y}.png`.
+
+For the propagation model that consumes these tiles, see
+[../RF-MODEL.md](../RF-MODEL.md).
+
+## Quick start
+
+The bake auto-downloads the global ANBH GeoTIFF (~1.8 GB compressed) into
+`output/buildings-source/`, then bakes z=6..10 PNG tiles into `output/buildings/`.
+
+### Docker (recommended — no host Python deps)
+
+```bash
+docker compose --profile bake run --rm building-bake
+```
+
+### Python directly
+
+```bash
+pip install -r scripts/requirements-buildings.txt
+python scripts/building_tiles.py
+```
+
+Default scope is **global** (the source is small enough). Without building
+tiles the frontend falls back to class-nominal heights from NLCD (4/9/15/25 m
+for the four developed-intensity classes) — coverage still works, just less
+accurate in built-up regions.
+
+**First-run footprint:** ~1.8 GB zip + ~30 GB extracted GeoTIFF + ~1-2 GB
+output tiles.
+
+**Time:** ~1-3 hours total depending on CPU. Idempotent — ctrl-C and re-run
+to resume.
+
+## Sub-region bake
+
+```bash
+# CONUS only (faster, smaller output)
+python scripts/building_tiles.py --scope conus
+
+# Single state / metro
+python scripts/building_tiles.py --bbox -125 32 -113 43
+```
+
+## All flags
+
+```
+--source PATH       Use a local GHS-BUILT-H raster instead of auto-downloading.
+--scope global|conus  Convenience preset for --bbox (default: global).
+--bbox W S E N      Geographic bbox in EPSG:4326. Overrides --scope.
+--out PATH          Tile output directory (default: output/buildings).
+--zooms MIN MAX     Zoom range (default: 6 10; GHS-BUILT-H is 100 m native).
+--workers N         Parallel worker count (default: cpu_count).
+--force             Overwrite existing tiles instead of skipping.
+```
+
+## How the tiles are served
+
+The Meshinfo API mounts `output/buildings` (configurable via `buildings.tile_dir`
+in `config.toml`) at `/tiles/buildings` automatically when `buildings.enabled =
+true` (default).
+
+Both compose files bind-mount `./output:/app/output`, so tiles baked on the
+host appear at `/app/output/buildings` inside the container with no extra config.
+
+The frontend fetches via the Caddy `/api/*` proxy:
+
+```
+/api/tiles/buildings/{z}/{x}/{y}.png   →   meshinfo:9000/tiles/buildings/{z}/{x}/{y}.png
+```
+
+Tiles respond with `Cache-Control: public, max-age=86400` (1 day; new bakes
+propagate to clients within ~24 h via Starlette's built-in ETag handling).
+
+## File format
+
+Each output tile is a 256×256 RGBA PNG:
+
+- **R** = high byte of average building height in metres (uint16 packed in R/G).
+- **G** = low byte of building height.
+- **B** = 0 (reserved; std-dev is not published for GHS-BUILT-H).
+- **A** = 255 valid, 0 nodata. Frontend falls back to class-nominal on nodata.
+
+A=255 with height=0 is "valid measurement, no buildings in this 100 m cell"
+(open space, water, forest) — distinct from A=0 (the bake didn't cover this
+region).
+
+## Refreshing for a new GHS-BUILT-H release
+
+JRC publishes new GHSL releases roughly every 1-2 years. As of the 2025
+catalog, R2023A is still the latest building-height vintage (other GHSL
+products like GHS-POP have R2025A; building heights have not refreshed).
+
+To refresh: update `DEFAULT_SOURCE_URL` in
+[building_tiles.py](building_tiles.py) to the newer release, delete
+`output/buildings-source/` and `output/buildings/`, and re-run the bake.
+
+## Troubleshooting
+
+- **`Missing dependency: rasterio`** — install `scripts/requirements-buildings.txt`.
+- **Download interrupted** — re-run the same command. Resumes via HTTP Range.
+- **All tiles report `empty`** — bbox doesn't overlap the source. Check you
+  haven't passed a bbox over open ocean.
+- **Slow bake** — bump `--workers`, ensure the source GeoTIFF is on a local
+  disk (network filesystems hurt random-access reprojection).
+
+## What this models, and what it doesn't
+
+GHS-BUILT-H ANBH is a **100 m area-averaged** product — within each 100 m
+cell, ANBH gives the mean building height across the built portion. This
+captures first-order propagation physics (above-rooftop diffraction, isolated
+tall structures along a path) but smooths fine-grained building edges.
+
+For street-canyon waveguide effects and per-building precision near an antenna,
+ray-tracing or per-building vector data would be needed; both are outside the
+scope of this raster pipeline. See [../RF-MODEL.md](../RF-MODEL.md) for what
+Meshinfo does and doesn't model.

--- a/scripts/README-canopy.md
+++ b/scripts/README-canopy.md
@@ -89,7 +89,7 @@ The frontend fetches via the Caddy `/api/*` proxy:
 /api/tiles/canopy/{z}/{x}/{y}.png   →   meshinfo:9000/tiles/canopy/{z}/{x}/{y}.png
 ```
 
-Tiles respond with `Cache-Control: public, max-age=31536000, immutable`.
+Tiles respond with `Cache-Control: public, max-age=86400` (1 day).
 
 ## Troubleshooting
 

--- a/scripts/README-canopy.md
+++ b/scripts/README-canopy.md
@@ -1,0 +1,121 @@
+# Canopy-height tile bake (operator guide)
+
+The coverage and scan tools use measured per-pixel canopy heights to refine
+the ITU-R P.833-9 path-integrated vegetation loss. Tiles are pre-baked from
+the ETH Global Canopy Height 2020 dataset (Lang et al. 2023, 10 m global) and
+served as static PNGs under `/tiles/canopy/{z}/{x}/{y}.png`.
+
+For the propagation model that consumes these tiles, see
+[../RF-MODEL.md](../RF-MODEL.md).
+
+## Quick start
+
+The bake auto-downloads the relevant 3°×3° COGs from ETH's libdrive share into
+`output/canopy-source/`, then bakes z=8..12 PNG tiles into `output/canopy/`.
+
+### Docker (recommended — no host Python deps)
+
+```bash
+docker compose --profile bake run --rm canopy-bake
+```
+
+### Python directly
+
+```bash
+pip install -r scripts/requirements-canopy.txt
+python scripts/canopy_tiles.py
+```
+
+Default scope is **CONUS** (lower 48). Without canopy tiles the frontend falls
+back to class-nominal heights from NLCD (e.g. 20 m for Evergreen Forest) — the
+coverage tool still works, just less accurate over canopy variation.
+
+**First-run footprint (CONUS):** ~30 GB downloaded COGs + ~1–2 GB output tiles.
+
+**Time:** ~1–4 hours total depending on the ETH server and CPU. Idempotent —
+ctrl-C and re-run to resume.
+
+## Sub-region or non-CONUS bake
+
+```bash
+# Single state / metro
+python scripts/canopy_tiles.py --bbox -125 32 -113 43
+
+# Full Earth (~50 GB download, hours of bake time)
+python scripts/canopy_tiles.py --scope global
+
+# AK only (uses ETH coverage extent N81..S57)
+python scripts/canopy_tiles.py --bbox -170 51 -129 71
+```
+
+## Including std-dev
+
+ETH publishes a per-pixel standard-deviation file (`*_Map_SD.tif`) alongside
+each height file. The frontend can use it to weight uncertainty: where σ
+exceeds the height, the value is treated as low-confidence and the model
+falls back toward the class-nominal value.
+
+Off by default (it doubles the download). Enable with:
+
+```bash
+python scripts/canopy_tiles.py --include-stddev
+```
+
+## All flags
+
+```
+--scope conus|global    Convenience preset for --bbox (default: conus).
+--bbox W S E N          Geographic bbox in EPSG:4326. Overrides --scope.
+--src-dir PATH          Cache for downloaded COGs (default: output/canopy-source).
+--out PATH              Tile output directory (default: output/canopy).
+--zooms MIN MAX         Zoom range (default: 8 12; ETH is 10 m native).
+--workers N             Bake worker count (default: cpu_count).
+--download-workers N    Parallel ETH downloads (default: 2; max 4 — be polite).
+--include-stddev        Also download std-dev and pack into B channel.
+--force                 Overwrite existing tiles instead of skipping.
+```
+
+## How the tiles are served
+
+The Meshinfo API mounts `output/canopy` (configurable via `canopy.tile_dir` in
+`config.toml`) at `/tiles/canopy` automatically when `canopy.enabled = true`.
+
+Both compose files bind-mount `./output:/app/output`, so tiles baked on the
+host appear at `/app/output/canopy` inside the container with no extra config.
+
+The frontend fetches via the Caddy `/api/*` proxy:
+
+```
+/api/tiles/canopy/{z}/{x}/{y}.png   →   meshinfo:9000/tiles/canopy/{z}/{x}/{y}.png
+```
+
+Tiles respond with `Cache-Control: public, max-age=31536000, immutable`.
+
+## Troubleshooting
+
+- **`Missing dependency: rasterio`** — install `scripts/requirements-canopy.txt`.
+- **All cells absent** — bbox doesn't overlap any ETH-published cell. Most
+  often this means the bbox is over open ocean. Check the ETH tile index at
+  https://langnico.github.io/globalcanopyheight/.
+- **Slow downloads** — leave `--download-workers` at 2; raising it does not
+  speed things up much against a single server, and will get you rate-limited.
+- **Slow bake** — bump `--workers` once downloads are done.
+
+## File format
+
+Each output tile is a 256×256 RGBA PNG:
+
+- **R** = high byte of canopy height in metres (uint16 packed into R/G).
+- **G** = low byte of canopy height.
+- **B** = std-dev in metres (uint8); 0 if `--include-stddev` was off.
+- **A** = 255 valid, 0 nodata. Frontend falls back to NLCD class-nominal on nodata.
+
+A=255 with height=0 is "valid measurement, no canopy here" (e.g. clearing in a
+forest, fire scar) — distinct from A=0 (the bake didn't cover this region).
+
+## Refreshing for a new vintage
+
+ETH has not yet published a v2 (as of 2026). When they do, update
+`ETH_BASE_URL` and `ETH_QUERY_PATH` in
+[canopy_tiles.py](canopy_tiles.py) to point at the new share, delete
+`output/canopy-source/` and `output/canopy/`, and re-run the bake.

--- a/scripts/building_tiles.py
+++ b/scripts/building_tiles.py
@@ -1,0 +1,390 @@
+"""
+Bake JRC's GHS-BUILT-H ANBH (Average Net Building Height, 2018 epoch, 100 m
+global, CC-BY-4.0) into a {z}/{x}/{y}.png slippy tile pyramid feeding the
+P.452 endpoint formula and ITM DSM in coverageRaster / scanAnalysis.
+
+Encoding (each 256x256 RGBA PNG):
+    R = high byte of height (metres, uint16)
+    G = low byte of height
+    B = 0 (reserved; std-dev not published for GHS-BUILT-H)
+    A = 255 valid, 0 nodata (frontend falls back to class-nominal on nodata)
+
+Source: single global GeoTIFF in EPSG:54009 (Mollweide), reprojected per output
+tile to EPSG:3857. ANBH is metres, averaged only over built-area sub-pixels —
+0 means "no buildings in this 100 m cell," not nodata. The source's own nodata
+sentinel is read from the TIFF header, not hard-coded (JRC has changed it
+between releases).
+
+When run without --source, auto-downloads + extracts. Idempotent — existing
+PNG tiles skipped unless --force.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+from os import cpu_count
+from pathlib import Path
+from typing import Iterator
+
+try:
+    import mercantile
+    import numpy as np
+    import rasterio
+    from PIL import Image
+    from rasterio.warp import Resampling, reproject
+except ImportError as exc:
+    sys.stderr.write(
+        f"Missing dependency: {exc.name}.\n"
+        "Install with: pip install -r scripts/requirements-buildings.txt\n"
+    )
+    sys.exit(2)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("building_tiles")
+
+TILE_PX = 256
+
+# Web Mercator's valid latitude clip; reprojection from Mollweide blows up
+# outside this band.
+MERCATOR_LAT_LIMIT = 85.0511
+GLOBAL_BBOX = (-180.0, -MERCATOR_LAT_LIMIT, 180.0, MERCATOR_LAT_LIMIT)
+CONUS_BBOX = (-125.0, 24.0, -67.0, 49.0)
+
+# GHS-BUILT-H R2023A — anonymous-public, no auth. Update for a new release;
+# units (metres) and Mollweide CRS are stable across the R2023A family.
+DEFAULT_SOURCE_URL = (
+    "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/"
+    "GHS_BUILT_H_GLOBE_R2023A/"
+    "GHS_BUILT_H_ANBH_E2018_GLOBE_R2023A_54009_100/"
+    "V1-0/GHS_BUILT_H_ANBH_E2018_GLOBE_R2023A_54009_100_V1_0.zip"
+)
+DEFAULT_SOURCE_DIR = Path("output/buildings-source")
+
+# Outside ANBH's float32 metres range, so it disambiguates "no source coverage"
+# from the meaningful "valid 0 m height" reading (cells with no buildings).
+_DST_NODATA = 65535
+
+
+@dataclass(frozen=True)
+class TileJob:
+    z: int
+    x: int
+    y: int
+    source: str
+    out_dir: str
+    force: bool
+
+
+def _tile_path(out_dir: Path, z: int, x: int, y: int) -> Path:
+    return out_dir / str(z) / str(x) / f"{y}.png"
+
+
+def bake_tile(job: TileJob) -> str:
+    """Returns 'written', 'skipped' (already exists), or 'empty' (all nodata)."""
+    out_path = _tile_path(Path(job.out_dir), job.z, job.x, job.y)
+    if out_path.exists() and not job.force:
+        return "skipped"
+
+    bounds = mercantile.xy_bounds(job.x, job.y, job.z)
+    dst_transform = rasterio.transform.from_bounds(
+        bounds.left, bounds.bottom, bounds.right, bounds.top,
+        TILE_PX, TILE_PX,
+    )
+    contrib = np.full((TILE_PX, TILE_PX), _DST_NODATA, dtype=np.uint16)
+
+    with rasterio.open(job.source) as src:
+        # Bilinear: ANBH is already 100 m area-averaged, so cell boundaries
+        # benefit from interpolation rather than nearest-neighbor's hard cliff.
+        reproject(
+            source=rasterio.band(src, 1),
+            destination=contrib,
+            dst_transform=dst_transform,
+            dst_crs="EPSG:3857",
+            resampling=Resampling.bilinear,
+            src_nodata=src.nodata,
+            dst_nodata=_DST_NODATA,
+        )
+
+    valid = contrib != _DST_NODATA
+    if not valid.any():
+        return "empty"
+
+    height = np.where(valid, contrib, 0).astype(np.uint16)
+    rgba = np.zeros((TILE_PX, TILE_PX, 4), dtype=np.uint8)
+    rgba[..., 0] = (height >> 8) & 0xFF
+    rgba[..., 1] = height & 0xFF
+    rgba[..., 3] = np.where(valid, 255, 0)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(rgba, mode="RGBA").save(out_path, format="PNG", optimize=True)
+    return "written"
+
+
+def iter_tiles(
+    bbox: tuple[float, float, float, float],
+    zooms: range,
+) -> Iterator[mercantile.Tile]:
+    west, south, east, north = bbox
+    # mercantile.tiles emits degenerate tiles past Mercator's lat clip.
+    south = max(south, -MERCATOR_LAT_LIMIT)
+    north = min(north, MERCATOR_LAT_LIMIT)
+    for z in zooms:
+        for tile in mercantile.tiles(west, south, east, north, zooms=[z]):
+            yield tile
+
+
+def count_tiles(bbox: tuple[float, float, float, float], zooms: range) -> int:
+    return sum(1 for _ in iter_tiles(bbox, zooms))
+
+
+def _find_raster(src_dir: Path) -> Path | None:
+    for pattern in ("*.tif", "*.img"):
+        for cand in sorted(src_dir.glob(pattern)):
+            return cand
+    return None
+
+
+def _download_with_progress(url: str, dest: Path) -> None:
+    """Resumes via Range when a partial file exists and the server returns 206;
+    falls back to a fresh download if the server returns 200 instead."""
+    existing = dest.stat().st_size if dest.exists() else 0
+    headers = {"Range": f"bytes={existing}-"} if existing > 0 else {}
+    req = urllib.request.Request(url, headers=headers)
+
+    log.info("Downloading %s", url)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            status = resp.status
+            if existing > 0 and status == 206:
+                mode = "ab"
+                total = existing + int(resp.headers.get("Content-Length", 0))
+                downloaded = existing
+                log.info("Resuming from byte %d", existing)
+            else:
+                if existing > 0:
+                    log.info("Server returned %d (no Range); restarting download", status)
+                mode = "wb"
+                total = int(resp.headers.get("Content-Length", 0))
+                downloaded = 0
+
+            chunk = 1 << 16
+            last_pct = -5
+            with dest.open(mode) as f:
+                while True:
+                    buf = resp.read(chunk)
+                    if not buf:
+                        break
+                    f.write(buf)
+                    downloaded += len(buf)
+                    if total:
+                        pct = (downloaded * 100) // total
+                        if pct >= last_pct + 5:
+                            log.info("  [%3d%%]  %.1f / %.1f MB",
+                                     pct, downloaded / 1e6, total / 1e6)
+                            last_pct = pct
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Download failed: {e}. Re-run to resume.") from e
+
+    log.info("Download complete: %s (%.1f MB)", dest, dest.stat().st_size / 1e6)
+
+
+def _extract_zip(zip_path: Path, dest_dir: Path) -> None:
+    """Extracts members one at a time, validating each resolved path stays within
+    dest_dir so a malicious archive can't write outside it (zip-slip)."""
+    log.info("Extracting %s ...", zip_path.name)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    resolved_dest = dest_dir.resolve()
+    with zipfile.ZipFile(zip_path) as zf:
+        for member in zf.infolist():
+            target = (dest_dir / member.filename).resolve()
+            try:
+                target.relative_to(resolved_dest)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"Refusing to extract suspicious archive entry: {member.filename}"
+                ) from exc
+            if member.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member) as src, target.open("wb") as dst:
+                while True:
+                    chunk = src.read(1 << 20)
+                    if not chunk:
+                        break
+                    dst.write(chunk)
+    log.info("Extraction complete")
+
+
+def ensure_source(source_arg: str | None) -> Path:
+    """If --source is given, use it. Otherwise look for a raster in
+    output/buildings-source/, then a zip to extract, then download the default."""
+    if source_arg:
+        p = Path(source_arg)
+        if not p.exists():
+            raise RuntimeError(f"Source raster not found: {p}")
+        return p
+
+    DEFAULT_SOURCE_DIR.mkdir(parents=True, exist_ok=True)
+
+    raster = _find_raster(DEFAULT_SOURCE_DIR)
+    if raster:
+        log.info("Using existing raster: %s", raster)
+        return raster
+
+    zips = sorted(DEFAULT_SOURCE_DIR.glob("*.zip"))
+    if not zips:
+        zip_dest = DEFAULT_SOURCE_DIR / Path(DEFAULT_SOURCE_URL).name
+        _download_with_progress(DEFAULT_SOURCE_URL, zip_dest)
+        zips = [zip_dest]
+
+    _extract_zip(zips[0], DEFAULT_SOURCE_DIR)
+    raster = _find_raster(DEFAULT_SOURCE_DIR)
+    if not raster:
+        raise RuntimeError(
+            f"Extracted {zips[0].name} but no .tif or .img found in {DEFAULT_SOURCE_DIR}"
+        )
+    return raster
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Bake GHS-BUILT-H ANBH into a slippy tile pyramid for the building DSM model.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--source",
+        default=None,
+        help="Path to GHS-BUILT-H source raster (GeoTIFF). "
+             "Omit to auto-download the global ANBH product into output/buildings-source/.",
+    )
+    p.add_argument(
+        "--out",
+        default="output/buildings",
+        help="Output tile directory (default: output/buildings).",
+    )
+    p.add_argument(
+        "--scope",
+        choices=("global", "conus"),
+        default="global",
+        help="Convenience preset for --bbox: global (default; ~3 GB output) or conus.",
+    )
+    p.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        metavar=("WEST", "SOUTH", "EAST", "NORTH"),
+        default=None,
+        help="Geographic bbox in EPSG:4326. Overrides --scope.",
+    )
+    p.add_argument(
+        "--zooms",
+        nargs=2,
+        type=int,
+        metavar=("MIN", "MAX"),
+        default=[6, 10],
+        help="Inclusive zoom range (default: 6 10; GHS-BUILT-H is 100 m native, "
+             "z=10 ~= 38 m/px at lat 37 is the matching frontier).",
+    )
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=cpu_count() or 4,
+        help="Parallel bake workers (default: cpu_count). Memory ceiling is "
+             "GDAL_CACHEMAX × workers; the Dockerfile caps GDAL_CACHEMAX so "
+             "cpu_count fits comfortably in Docker Desktop's default 16 GB.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing tiles. Default is skip-if-exists (resumable).",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        source = ensure_source(args.source)
+    except RuntimeError as e:
+        log.error("%s", e)
+        return 1
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.bbox is not None:
+        bbox = tuple(args.bbox)
+    elif args.scope == "conus":
+        bbox = CONUS_BBOX
+    else:
+        bbox = GLOBAL_BBOX
+
+    zmin, zmax = args.zooms
+    if zmin > zmax:
+        log.error("Invalid zoom range: min %d > max %d", zmin, zmax)
+        return 1
+    zooms = range(zmin, zmax + 1)
+
+    log.info("Source:  %s", source.resolve())
+    log.info("Output:  %s", out_dir.resolve())
+    log.info("BBox:    W=%.3f S=%.3f E=%.3f N=%.3f", *bbox)
+    log.info("Zooms:   %d..%d (inclusive)", zmin, zmax)
+    log.info("Workers: %d", args.workers)
+    log.info("Force:   %s", args.force)
+
+    with rasterio.open(source) as src:
+        log.info("Source CRS: %s, size %dx%d, dtype %s, nodata %s",
+                 src.crs, src.width, src.height, src.dtypes[0], src.nodata)
+
+    log.info("Counting tiles for progress estimate...")
+    total = count_tiles(bbox, zooms)
+    log.info("Total tiles to consider: %d", total)
+
+    jobs = (
+        TileJob(t.z, t.x, t.y, str(source), str(out_dir), args.force)
+        for t in iter_tiles(bbox, zooms)
+    )
+
+    counts = {"written": 0, "skipped": 0, "empty": 0, "error": 0}
+    progress_step = max(1, total // 100)
+
+    with ProcessPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(bake_tile, job): None for job in jobs}
+        for i, fut in enumerate(as_completed(futures), 1):
+            try:
+                result = fut.result()
+                counts[result] += 1
+            except Exception as exc:
+                counts["error"] += 1
+                log.warning("Tile failed: %s", exc)
+            if i % progress_step == 0 or i == total:
+                pct = 100.0 * i / total if total else 100.0
+                log.info(
+                    "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
+                    pct, i, total,
+                    counts["written"], counts["skipped"],
+                    counts["empty"], counts["error"],
+                )
+
+    log.info(
+        "Done. written=%d skipped=%d empty=%d error=%d",
+        counts["written"], counts["skipped"], counts["empty"], counts["error"],
+    )
+    return 0 if counts["error"] == 0 else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/building_tiles.py
+++ b/scripts/building_tiles.py
@@ -26,7 +26,7 @@ import sys
 import urllib.error
 import urllib.request
 import zipfile
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
 from dataclasses import dataclass
 from os import cpu_count
 from pathlib import Path
@@ -361,23 +361,41 @@ def main() -> int:
     counts = {"written": 0, "skipped": 0, "empty": 0, "error": 0}
     progress_step = max(1, total // 100)
 
+    # Bounded streaming submission: keep ~2× workers in flight rather than
+    # materializing all futures up front. Default --scope global at z=6..10
+    # is millions of tiles; submitting all up front would burn GBs on Futures.
+    in_flight_target = max(args.workers * 2, args.workers + 1)
+
     with ProcessPoolExecutor(max_workers=args.workers) as pool:
-        futures = {pool.submit(bake_tile, job): None for job in jobs}
-        for i, fut in enumerate(as_completed(futures), 1):
+        pending = set()
+        for _ in range(in_flight_target):
             try:
-                result = fut.result()
-                counts[result] += 1
-            except Exception as exc:
-                counts["error"] += 1
-                log.warning("Tile failed: %s", exc)
-            if i % progress_step == 0 or i == total:
-                pct = 100.0 * i / total if total else 100.0
-                log.info(
-                    "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
-                    pct, i, total,
-                    counts["written"], counts["skipped"],
-                    counts["empty"], counts["error"],
-                )
+                pending.add(pool.submit(bake_tile, next(jobs)))
+            except StopIteration:
+                break
+
+        completed = 0
+        while pending:
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for fut in done:
+                completed += 1
+                try:
+                    counts[fut.result()] += 1
+                except Exception as exc:
+                    counts["error"] += 1
+                    log.warning("Tile failed: %s", exc)
+                try:
+                    pending.add(pool.submit(bake_tile, next(jobs)))
+                except StopIteration:
+                    pass
+                if completed % progress_step == 0 or completed == total:
+                    pct = 100.0 * completed / total if total else 100.0
+                    log.info(
+                        "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
+                        pct, completed, total,
+                        counts["written"], counts["skipped"],
+                        counts["empty"], counts["error"],
+                    )
 
     log.info(
         "Done. written=%d skipped=%d empty=%d error=%d",

--- a/scripts/canopy_tiles.py
+++ b/scripts/canopy_tiles.py
@@ -1,0 +1,497 @@
+"""
+Bake the ETH Global Canopy Height 2020 (Lang et al. 2023, 10 m global) into a
+{z}/{x}/{y}.png slippy tile pyramid feeding the ITU-R P.833-9 vegetation loop
+in coverageRaster / scanAnalysis.
+
+Encoding (each 256x256 RGBA PNG):
+    R = high byte of height (metres, uint16)
+    G = low byte of height
+    B = std-dev (metres, uint8) when --include-stddev; else 0
+    A = 255 valid, 0 nodata (frontend falls back to class-nominal on nodata)
+
+Source: ETH 3 deg COG tiles. See https://langnico.github.io/globalcanopyheight/.
+Only 2014 of the global ~7800 3x3 cells exist (land-only); a 404 means "no
+canopy data here," not a config error. Idempotent — existing PNG tiles are
+skipped unless --force, so an interrupted bake resumes by re-running.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from os import cpu_count
+from pathlib import Path
+from typing import Iterator
+
+try:
+    import mercantile
+    import numpy as np
+    import rasterio
+    from PIL import Image
+    from rasterio.warp import Resampling, reproject
+except ImportError as exc:
+    sys.stderr.write(
+        f"Missing dependency: {exc.name}.\n"
+        "Install with: pip install -r scripts/requirements-canopy.txt\n"
+    )
+    sys.exit(2)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("canopy_tiles")
+
+TILE_PX = 256
+
+# AK/HI/PR / non-US use --bbox or --scope.
+CONUS_BBOX = (-125.0, 24.0, -67.0, 49.0)
+# Clipped to ETH's published latitude extent (N81..S57).
+GLOBAL_BBOX = (-180.0, -57.0, 180.0, 81.0)
+
+# Single university file server — be polite (low concurrency).
+ETH_BASE_URL = "https://libdrive.ethz.ch/index.php/s/cO8or7iOe5dT2Rt/download"
+ETH_QUERY_PATH = "/3deg_cogs"
+DEFAULT_DOWNLOAD_WORKERS = 2
+DEFAULT_SOURCE_DIR = Path("output/canopy-source")
+
+CELL_DEG = 3
+
+
+@dataclass(frozen=True)
+class TileJob:
+    z: int
+    x: int
+    y: int
+    # Parallel tuples: sd_sources[i] = "" if no SD file for sources[i].
+    sources: tuple[str, ...]
+    sd_sources: tuple[str, ...]
+    out_dir: str
+    force: bool
+
+
+def _tile_path(out_dir: Path, z: int, x: int, y: int) -> Path:
+    return out_dir / str(z) / str(x) / f"{y}.png"
+
+
+def cog_basename(lat_south: int, lon_west: int) -> str:
+    """ETH naming gotcha: name uses the corner closest to the prime meridian.
+    For W tiles that's the EAST edge (e.g. N48W123 covers lon -126..-123).
+    For E tiles that's the WEST edge (lower-left, classic).
+    """
+    lat_part = f"N{lat_south:02d}" if lat_south >= 0 else f"S{abs(lat_south):02d}"
+    lon_east = lon_west + CELL_DEG
+    if lon_west >= 0:
+        lon_part = f"E{lon_west:03d}"
+    else:
+        lon_part = f"W{abs(lon_east):03d}"
+    return f"ETH_GlobalCanopyHeight_10m_2020_{lat_part}{lon_part}"
+
+
+def cells_intersecting(bbox: tuple[float, float, float, float]) -> Iterator[tuple[int, int]]:
+    """Yield (lat_south, lon_west) for every 3x3 cell whose bbox overlaps."""
+    west, south, east, north = bbox
+    lat_lo = (int(south) // CELL_DEG) * CELL_DEG
+    lat_hi = (int(north - 1e-9) // CELL_DEG) * CELL_DEG
+    lon_lo = (int(west) // CELL_DEG) * CELL_DEG
+    lon_hi = (int(east - 1e-9) // CELL_DEG) * CELL_DEG
+    for lat in range(lat_lo, lat_hi + 1, CELL_DEG):
+        for lon in range(lon_lo, lon_hi + 1, CELL_DEG):
+            yield (lat, lon)
+
+
+def eth_download_url(filename: str) -> str:
+    qs = urllib.parse.urlencode({"path": ETH_QUERY_PATH, "files": filename})
+    return f"{ETH_BASE_URL}?{qs}"
+
+
+_progress_lock = threading.Lock()
+
+
+def _download_one(url: str, dest: Path) -> str:
+    """Returns 'downloaded', 'skipped', or 'absent' (404 — no data for this cell)."""
+    if dest.exists() and dest.stat().st_size > 0:
+        return "skipped"
+
+    headers = {"User-Agent": "meshinfo-canopy-bake/1 (+https://github.com/MeshAddicts/meshinfo)"}
+    req = urllib.request.Request(url, headers=headers)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            with tmp.open("wb") as f:
+                chunk = 1 << 16
+                while True:
+                    buf = resp.read(chunk)
+                    if not buf:
+                        break
+                    f.write(buf)
+            tmp.replace(dest)
+            with _progress_lock:
+                log.info("  downloaded %s (%.1f MB)", dest.name, dest.stat().st_size / 1e6)
+            return "downloaded"
+    except urllib.error.HTTPError as e:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        if e.code == 404:
+            return "absent"
+        raise
+    except urllib.error.URLError as e:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise RuntimeError(f"Download failed for {url}: {e}. Re-run to resume.") from e
+
+
+def ensure_sources(
+    bbox: tuple[float, float, float, float],
+    src_dir: Path,
+    include_stddev: bool,
+    download_workers: int,
+) -> tuple[list[Path], list[Path | None]]:
+    """Download every ETH COG (and SD, if requested) intersecting *bbox*.
+    Returns (map_paths, sd_paths) of equal length; sd_paths[i] is None when
+    --include-stddev was off or the SD download was absent."""
+    src_dir.mkdir(parents=True, exist_ok=True)
+    cells = list(cells_intersecting(bbox))
+    log.info("Inspecting %d candidate ETH cells over bbox", len(cells))
+
+    map_paths: list[Path] = []
+    counts = {"downloaded": 0, "skipped": 0, "absent": 0, "error": 0}
+    with ThreadPoolExecutor(max_workers=download_workers) as pool:
+        jobs: dict = {}
+        for (lat, lon) in cells:
+            base = cog_basename(lat, lon)
+            path = src_dir / f"{base}_Map.tif"
+            jobs[pool.submit(_download_one, eth_download_url(path.name), path)] = path
+        for fut in as_completed(jobs):
+            path = jobs[fut]
+            try:
+                result = fut.result()
+                counts[result] += 1
+                if result in ("downloaded", "skipped"):
+                    map_paths.append(path)
+            except Exception as exc:
+                counts["error"] += 1
+                log.warning("Map download failed for %s: %s", path.name, exc)
+    log.info(
+        "Map COGs: downloaded=%d skipped=%d absent=%d error=%d (kept %d for bake)",
+        counts["downloaded"], counts["skipped"], counts["absent"],
+        counts["error"], len(map_paths),
+    )
+
+    sd_paths: list[Path | None]
+    if include_stddev:
+        sd_counts = {"downloaded": 0, "skipped": 0, "absent": 0, "error": 0}
+        sd_by_map: dict[Path, Path | None] = {}
+        with ThreadPoolExecutor(max_workers=download_workers) as pool:
+            sd_futures: dict = {}
+            for p in map_paths:
+                sd_path = src_dir / p.name.replace("_Map.tif", "_Map_SD.tif")
+                sd_futures[pool.submit(_download_one, eth_download_url(sd_path.name), sd_path)] = (p, sd_path)
+            for fut in as_completed(sd_futures):
+                (p, sd_path) = sd_futures[fut]
+                try:
+                    result = fut.result()
+                    sd_counts[result] += 1
+                    sd_by_map[p] = sd_path if result in ("downloaded", "skipped") else None
+                except Exception as exc:
+                    sd_counts["error"] += 1
+                    log.warning("SD download failed for %s: %s", sd_path.name, exc)
+                    sd_by_map[p] = None
+        log.info(
+            "SD COGs: downloaded=%d skipped=%d absent=%d error=%d",
+            sd_counts["downloaded"], sd_counts["skipped"],
+            sd_counts["absent"], sd_counts["error"],
+        )
+        sd_paths = [sd_by_map.get(p) for p in map_paths]
+    else:
+        sd_paths = [None] * len(map_paths)
+
+    if not map_paths:
+        raise RuntimeError(
+            "No ETH canopy COGs available for the requested bbox. "
+            "If this bbox is not over land (e.g. open ocean), there is nothing to bake."
+        )
+    return map_paths, sd_paths
+
+
+# Outside ETH's uint8 source range, so it disambiguates "no source coverage"
+# from the meaningful "valid 0 m canopy" reading.
+_DST_NODATA = 65535
+
+
+def _read_into_tile(
+    src_path: Path,
+    tile_bounds_3857: tuple[float, float, float, float],
+    dst: np.ndarray,
+    dst_mask: np.ndarray,
+) -> None:
+    """Reproject the relevant window of *src_path* (EPSG:4326) into *dst*
+    (EPSG:3857, TILE_PX x TILE_PX). Pixels outside this source's footprint
+    leave *dst* untouched so callers can accumulate over multiple sources.
+    """
+    dst_transform = rasterio.transform.from_bounds(
+        tile_bounds_3857[0], tile_bounds_3857[1],
+        tile_bounds_3857[2], tile_bounds_3857[3],
+        TILE_PX, TILE_PX,
+    )
+    contrib = np.full((TILE_PX, TILE_PX), _DST_NODATA, dtype=np.uint16)
+    with rasterio.open(src_path) as src:
+        # ETH nodata sentinel is 255 (uint8); 0 is a real "no canopy" reading.
+        src_nodata = src.nodata if src.nodata is not None else 255
+        reproject(
+            source=rasterio.band(src, 1),
+            destination=contrib,
+            dst_transform=dst_transform,
+            dst_crs="EPSG:3857",
+            resampling=Resampling.bilinear,
+            src_nodata=src_nodata,
+            dst_nodata=_DST_NODATA,
+        )
+
+    valid = contrib != _DST_NODATA
+    if not valid.any():
+        return
+    dst[valid] = contrib[valid]
+    dst_mask[valid] = 255
+
+
+def bake_tile(job: TileJob) -> str:
+    """Returns 'written', 'skipped', or 'empty'."""
+    out_path = _tile_path(Path(job.out_dir), job.z, job.x, job.y)
+    if out_path.exists() and not job.force:
+        return "skipped"
+
+    bounds_3857 = mercantile.xy_bounds(job.x, job.y, job.z)
+
+    height = np.zeros((TILE_PX, TILE_PX), dtype=np.uint16)
+    sd16 = np.zeros((TILE_PX, TILE_PX), dtype=np.uint16)
+    mask = np.zeros((TILE_PX, TILE_PX), dtype=np.uint8)
+
+    for src_path, sd_path in zip(job.sources, job.sd_sources):
+        _read_into_tile(Path(src_path), bounds_3857, height, mask)
+        if sd_path:
+            # SD presence alone must not validate a pixel — only height does.
+            sd_only_mask = np.zeros((TILE_PX, TILE_PX), dtype=np.uint8)
+            _read_into_tile(Path(sd_path), bounds_3857, sd16, sd_only_mask)
+
+    if not mask.any():
+        return "empty"
+
+    sd8 = np.clip(sd16, 0, 255).astype(np.uint8)
+
+    rgba = np.zeros((TILE_PX, TILE_PX, 4), dtype=np.uint8)
+    rgba[..., 0] = (height >> 8) & 0xFF
+    rgba[..., 1] = height & 0xFF
+    rgba[..., 2] = sd8
+    rgba[..., 3] = np.where(mask > 0, 255, 0)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(rgba, mode="RGBA").save(out_path, format="PNG", optimize=True)
+    return "written"
+
+
+def iter_tiles(
+    bbox: tuple[float, float, float, float],
+    zooms: range,
+) -> Iterator[mercantile.Tile]:
+    west, south, east, north = bbox
+    for z in zooms:
+        for tile in mercantile.tiles(west, south, east, north, zooms=[z]):
+            yield tile
+
+
+def count_tiles(bbox: tuple[float, float, float, float], zooms: range) -> int:
+    return sum(1 for _ in iter_tiles(bbox, zooms))
+
+
+def _bbox_intersects(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> bool:
+    return not (a[2] <= b[0] or a[0] >= b[2] or a[3] <= b[1] or a[1] >= b[3])
+
+
+def build_source_index(
+    map_paths: list[Path],
+    sd_paths: list[Path | None],
+) -> list[tuple[Path, Path | None, tuple[float, float, float, float]]]:
+    """Open each COG once to read its actual bounds (handles non-square cells
+    that ETH publishes for some clipped tiles)."""
+    out: list[tuple[Path, Path | None, tuple[float, float, float, float]]] = []
+    for p, sd in zip(map_paths, sd_paths):
+        with rasterio.open(p) as src:
+            b = src.bounds  # ETH source CRS is EPSG:4326.
+            out.append((p, sd, (b.left, b.bottom, b.right, b.top)))
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Bake ETH Global Canopy Height 2020 into a slippy tile pyramid.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--scope",
+        choices=("conus", "global"),
+        default="conus",
+        help="Convenience preset for --bbox: conus = lower 48 (default), "
+             "global = full Earth (~50 GB download, hours of bake time).",
+    )
+    p.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        metavar=("WEST", "SOUTH", "EAST", "NORTH"),
+        default=None,
+        help="Geographic bbox in EPSG:4326. Overrides --scope.",
+    )
+    p.add_argument(
+        "--src-dir",
+        type=Path,
+        default=DEFAULT_SOURCE_DIR,
+        help="Where to cache downloaded ETH COGs (default: output/canopy-source).",
+    )
+    p.add_argument(
+        "--out",
+        default="output/canopy",
+        help="Output tile directory (default: output/canopy).",
+    )
+    p.add_argument(
+        "--zooms",
+        nargs=2,
+        type=int,
+        metavar=("MIN", "MAX"),
+        default=[8, 12],
+        help="Inclusive zoom range (default: 8 12; ETH is 10 m native).",
+    )
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=cpu_count() or 4,
+        help="Parallel bake workers (default: cpu_count). Memory ceiling is "
+             "GDAL_CACHEMAX × workers; the Dockerfile caps GDAL_CACHEMAX so "
+             "cpu_count fits comfortably in Docker Desktop's default 16 GB.",
+    )
+    p.add_argument(
+        "--download-workers",
+        type=int,
+        default=DEFAULT_DOWNLOAD_WORKERS,
+        help=f"Parallel ETH downloads (default: {DEFAULT_DOWNLOAD_WORKERS}; do "
+             "not raise above 4 — be polite to the ETH file server).",
+    )
+    p.add_argument(
+        "--include-stddev",
+        action="store_true",
+        help="Also download _Map_SD.tif and pack std-dev into the B channel. "
+             "Doubles download size; useful for the uncertainty-weighted refinement.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing tiles. Default is skip-if-exists (resumable).",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.bbox is not None:
+        bbox = tuple(args.bbox)
+    elif args.scope == "global":
+        bbox = GLOBAL_BBOX
+    else:
+        bbox = CONUS_BBOX
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    zmin, zmax = args.zooms
+    if zmin > zmax:
+        log.error("Invalid zoom range: min %d > max %d", zmin, zmax)
+        return 1
+    zooms = range(zmin, zmax + 1)
+
+    log.info("Source dir: %s", args.src_dir.resolve())
+    log.info("Output:     %s", out_dir.resolve())
+    log.info("BBox:       W=%.3f S=%.3f E=%.3f N=%.3f", *bbox)
+    log.info("Zooms:      %d..%d (inclusive)", zmin, zmax)
+    log.info("Workers:    bake=%d  download=%d", args.workers, args.download_workers)
+    log.info("Include SD: %s", args.include_stddev)
+    log.info("Force:      %s", args.force)
+
+    try:
+        map_paths, sd_paths = ensure_sources(
+            bbox, args.src_dir, args.include_stddev, args.download_workers,
+        )
+    except RuntimeError as e:
+        log.error("%s", e)
+        return 1
+
+    log.info("Indexing %d source COGs...", len(map_paths))
+    src_index = build_source_index(map_paths, sd_paths)
+
+    log.info("Counting output tiles for progress estimate...")
+    total = count_tiles(bbox, zooms)
+    log.info("Total tiles to consider: %d", total)
+
+    def make_jobs() -> Iterator[TileJob]:
+        for t in iter_tiles(bbox, zooms):
+            tile_bounds = mercantile.bounds(t.x, t.y, t.z)
+            tile_geo = (tile_bounds.west, tile_bounds.south, tile_bounds.east, tile_bounds.north)
+            srcs: list[str] = []
+            sds: list[str] = []
+            for (p, sd, b) in src_index:
+                if _bbox_intersects(tile_geo, b):
+                    srcs.append(str(p))
+                    sds.append(str(sd) if sd else "")
+            if not srcs:
+                continue
+            yield TileJob(
+                z=t.z, x=t.x, y=t.y,
+                sources=tuple(srcs),
+                sd_sources=tuple(sds),
+                out_dir=str(out_dir),
+                force=args.force,
+            )
+
+    counts = {"written": 0, "skipped": 0, "empty": 0, "error": 0}
+    progress_step = max(1, total // 100)
+
+    with ProcessPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(bake_tile, job): None for job in make_jobs()}
+        n_jobs = len(futures)
+        for i, fut in enumerate(as_completed(futures), 1):
+            try:
+                result = fut.result()
+                counts[result] += 1
+            except Exception as exc:
+                counts["error"] += 1
+                log.warning("Tile failed: %s", exc)
+            if i % progress_step == 0 or i == n_jobs:
+                pct = 100.0 * i / max(1, n_jobs)
+                log.info(
+                    "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
+                    pct, i, n_jobs,
+                    counts["written"], counts["skipped"],
+                    counts["empty"], counts["error"],
+                )
+
+    log.info(
+        "Done. written=%d skipped=%d empty=%d error=%d",
+        counts["written"], counts["skipped"], counts["empty"], counts["error"],
+    )
+    return 0 if counts["error"] == 0 else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/canopy_tiles.py
+++ b/scripts/canopy_tiles.py
@@ -23,7 +23,7 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, ThreadPoolExecutor, as_completed, wait
 from dataclasses import dataclass
 from os import cpu_count
 from pathlib import Path
@@ -467,24 +467,41 @@ def main() -> int:
     counts = {"written": 0, "skipped": 0, "empty": 0, "error": 0}
     progress_step = max(1, total // 100)
 
+    # Bounded streaming submission: keep ~2× workers in flight rather than
+    # materializing all futures up front. CONUS at z=8..12 is ~200k tiles; a
+    # global bake is 10×+ that and would burn ~1 GB on Future objects alone.
+    jobs = make_jobs()
+    in_flight_target = max(args.workers * 2, args.workers + 1)
+
     with ProcessPoolExecutor(max_workers=args.workers) as pool:
-        futures = {pool.submit(bake_tile, job): None for job in make_jobs()}
-        n_jobs = len(futures)
-        for i, fut in enumerate(as_completed(futures), 1):
+        pending = set()
+        for _ in range(in_flight_target):
             try:
-                result = fut.result()
-                counts[result] += 1
-            except Exception as exc:
-                counts["error"] += 1
-                log.warning("Tile failed: %s", exc)
-            if i % progress_step == 0 or i == n_jobs:
-                pct = 100.0 * i / max(1, n_jobs)
-                log.info(
-                    "[%5.1f%%] %d/%d  written=%d skipped=%d empty=%d error=%d",
-                    pct, i, n_jobs,
-                    counts["written"], counts["skipped"],
-                    counts["empty"], counts["error"],
-                )
+                pending.add(pool.submit(bake_tile, next(jobs)))
+            except StopIteration:
+                break
+
+        completed = 0
+        while pending:
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for fut in done:
+                completed += 1
+                try:
+                    counts[fut.result()] += 1
+                except Exception as exc:
+                    counts["error"] += 1
+                    log.warning("Tile failed: %s", exc)
+                try:
+                    pending.add(pool.submit(bake_tile, next(jobs)))
+                except StopIteration:
+                    pass
+                if completed % progress_step == 0:
+                    log.info(
+                        "[%5.1f%%] %d  written=%d skipped=%d empty=%d error=%d",
+                        100.0 * completed / max(1, total), completed,
+                        counts["written"], counts["skipped"],
+                        counts["empty"], counts["error"],
+                    )
 
     log.info(
         "Done. written=%d skipped=%d empty=%d error=%d",

--- a/scripts/requirements-buildings.txt
+++ b/scripts/requirements-buildings.txt
@@ -1,0 +1,11 @@
+# Dependencies for scripts/building_tiles.py.
+# Same dep set as scripts/requirements-{landcover,canopy}.txt — kept separate
+# so each bake can be installed independently without pulling unused tooling.
+#
+# rasterio bundles its own GDAL wheels on PyPI (Linux/macOS/Windows), so no
+# system GDAL install is required for typical runs.
+
+rasterio>=1.3,<2
+mercantile>=1.2,<2
+numpy>=1.24
+Pillow>=10

--- a/scripts/requirements-canopy.txt
+++ b/scripts/requirements-canopy.txt
@@ -1,0 +1,11 @@
+# Dependencies for scripts/canopy_tiles.py.
+# Same dep set as scripts/requirements-landcover.txt — kept separate so the two
+# bakes can be installed independently without pulling unused tooling.
+#
+# rasterio bundles its own GDAL wheels on PyPI (Linux/macOS/Windows), so no
+# system GDAL install is required for typical runs.
+
+rasterio>=1.3,<2
+mercantile>=1.2,<2
+numpy>=1.24
+Pillow>=10


### PR DESCRIPTION
## Summary
- **Canopy DSM** — bake ETH global canopy heights to z6-10 PNG tiles; per-pixel heights feed P.833 vegetation loss and replace class-nominal averages. One-command bake + Docker compose profile.
- **Building DSM** — bake GHS-BUILT-H (CC-BY-4.0) to PNG tiles; per-pixel heights feed the ITM Longley-Rice profile (mid-path) and override the P.452 endpoint clutter h_a on developed NLCD classes (21/22/23/24). Bare-earth + class-nominal preserved as fallback.
- **3D buildings (cosmetic)** — MapLibre fill-extrusion sourced from OpenFreeMap vector tiles; opt-in toggle, off by default. Pairs visually with the new building RF DSM but ships independently.
- **Multi-origin coverage merge** — coverage tool now accepts additional TX origins; per-pixel reduction takes max margin across all origins. Single-origin compute remains byte-identical when the merge set is empty. Worker request shape changed: `origin` → `origins: SliceOrigin[]`.
- **Virtual map-pin merge origins** — pick non-node points on the map as merge TX origins. Draggable amber markers, ESC to cancel pick, auto-cancel on tool switch.
- **Recenter suppression** — parameter-only coverage recomputes (TX power, antenna, reliability, toggles, detail) no longer pan the view. Only origin moves trigger easeTo.
- **Status chips** — per-tool clutter/canopy/buildings tile-coverage indicators in Coverage + Scan panels.