### PR TITLE
Map RF tools: panel redesign, scan accuracy parity, and scan-from-coverage overlay

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -331,8 +331,8 @@ export function Map() {
   // total === 0 means idle / drag preview / terrain fetch
   const [coverageProgress, setCoverageProgress] = useState<{ completed: number; total: number }>({ completed: 0, total: 0 });
   const [coverageDemSource, setCoverageDemSource] = useState<DemSource | null>(null);
-  // True while a "Scan visible nodes" overlay is active from the coverage panel —
-  // keeps the coverage paint visible even though activeTool has switched to "scan".
+  // Keeps the coverage paint up across the activeTool flip when the user
+  // launches a Scan-from-here overlay from the coverage panel.
   const [keepCoveragePaint, setKeepCoveragePaint] = useState(false);
   // Drives the land-cover status chip in each panel.
   const [coverageClutterStatus, setCoverageClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
@@ -528,8 +528,8 @@ export function Map() {
   const [scanDemSource, setScanDemSource] = useState<DemSource | null>(null);
   /** Monotonic request id — stale worker replies are dropped. */
   const coverageRequestIdRef = useRef(0);
-  // Set on overlay enter/exit so the coverage compute effect doesn't kick off
-  // a redundant recompute when activeTool flips but the params are unchanged.
+  // Suppresses the redundant coverage recompute the activeTool flip would
+  // otherwise trigger on Scan-from-here overlay enter/exit.
   const skipNextCoverageComputeRef = useRef(false);
   /** Lazily-created coverage worker pool; terminated on unmount. */
   const coveragePoolRef = useRef<CoverageWorkerPool | null>(null);
@@ -1575,9 +1575,8 @@ export function Map() {
           return;
         }
         const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
-        // Match coverage's 2048² DEM (~97 m/px over 200 km) so per-target ITM
-        // sees the same terrain detail the painted prediction does. Same goes
-        // for the clutter/canopy/building rasters.
+        // 2048² rasters match coverage's resolution so per-target ITM sees
+        // the same terrain detail the painted prediction does.
         const [{ dem, source: demSourceUsedForScan }, scanClutter, scanCanopy, scanBuildings] = await Promise.all([
           buildDem({
             bounds: scanBounds,
@@ -1668,9 +1667,8 @@ export function Map() {
                 polarization: 1 /* Vertical */,
                 groundDielectric: 15,
                 groundConductivity: 0.005,
-                // Match coverage's reliability semantics. Without these, the
-                // scan defaulted to 50/50/50 (median), which was ~10–15 dB
-                // more optimistic than the user's painted prediction.
+                // Without these, scanAnalysis falls back to 50/50/50 — much
+                // more optimistic than coverage's 90/50/70 default.
                 timePct: reliabilityPreset(scanReliability).time,
                 locationPct: reliabilityPreset(scanReliability).location,
                 situationPct: reliabilityPreset(scanReliability).situation,
@@ -1754,14 +1752,12 @@ export function Map() {
     }
   }, [scanHoverId, scanSummary]);
 
-  // Coverage prediction — runs when Coverage tool reaches result step, OR
-  // while a Scan-from-here overlay is active (so coverage-setting tweaks made
-  // through the minimized coverage panel still trigger a fresh paint).
+  // Coverage prediction — also runs while a Scan-from-here overlay is active
+  // so coverage-setting tweaks through the minimized panel still recompute.
   useEffect(() => {
     if ((activeTool !== "coverage" && !keepCoveragePaint) || toolStep !== "result") {
-      // Scan-from-here overlay holds onto the result so the painted layer
-      // stays visible and the minimized coverage panel keeps showing the
-      // reachable summary instead of flipping back into the loading state.
+      // Overlay holds onto the result so the paint stays up and the
+      // minimized panel keeps showing the reachable summary.
       if (!keepCoveragePaint) setCoverageResult(null);
       setIsComputingCoverage(false);
       setIsFetchingCoverageTerrain(false);
@@ -1770,9 +1766,7 @@ export function Map() {
       lastRecenteredOriginRef.current = null;
       return;
     }
-    // Skip recomputes triggered solely by overlay enter/exit transitions —
-    // the params are unchanged so the result would be identical (and the
-    // brief "Recomputing…" pill feels like a glitch).
+    // Suppress the redundant recompute on overlay enter/exit (params unchanged).
     if (skipNextCoverageComputeRef.current) {
       skipNextCoverageComputeRef.current = false;
       return;
@@ -2158,10 +2152,8 @@ export function Map() {
     };
   }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageMergeOrigins, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce, keepCoveragePaint]);
 
-  // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry.
-  // When keepCoveragePaint is set (Scan-from-here overlay), leave the paint
-  // visible across the activeTool switch so the user sees both the coverage
-  // raster and the scan-link overlay together.
+  // Hide coverage layers when leaving tool; sources/layers stay for fast
+  // re-entry. keepCoveragePaint exempts the Scan-from-here overlay.
   useEffect(() => {
     const mb = mbMapRef.current;
     if (!mb) return;
@@ -4353,8 +4345,8 @@ export function Map() {
         />
       )}
 
-      {/* Floating Coverage panel — also stays mounted (forced-minimized) during a
-           Scan-from-here overlay so the user knows coverage is paused, not closed. */}
+      {/* Stays mounted (force-minimized) during a Scan-from-here overlay so
+          the user knows coverage is paused, not closed. */}
       {((activeTool === "coverage") || keepCoveragePaint) && toolStep === "result" && (toolFromId || toolVirtualPos) && (
         <MapCoveragePanel
           overlayMode={keepCoveragePaint}
@@ -4446,9 +4438,9 @@ export function Map() {
             mbMapRef.current?.easeTo({ center: lngLat, duration: 600 });
           }}
           onScanFromHere={() => {
-            // Mirror coverage's RF settings into scan so the scan results match
-            // the painted prediction the user is looking at. toolFromId /
-            // toolVirtualPos are shared, so the origin already lines up.
+            // Mirror coverage's RF settings so the scan results match the
+            // painted prediction. Origin (toolFromId / toolVirtualPos) is
+            // already shared between the tools.
             setScanHardwareIdx(coverageHardwareIdx);
             setScanAntennaIdx(coverageAntennaIdx);
             setScanAntennaHeightM(coverageAntennaHeightM);
@@ -4462,8 +4454,6 @@ export function Map() {
             setScanCanopyEnabled(coverageCanopyEnabled);
             setScanBuildingsEnabled(coverageBuildingsEnabled);
             setScanReliability(coverageReliability);
-            // Coverage params didn't change — skip the recompute the
-            // activeTool flip would otherwise trigger.
             skipNextCoverageComputeRef.current = true;
             setKeepCoveragePaint(true);
             setActiveTool("scan");
@@ -4502,13 +4492,9 @@ export function Map() {
           terrainNeeded={!terrain3D}
           onEnableTerrain={() => setTerrain3D(true)}
           onClose={() => {
-            // If scan was opened as an overlay from the coverage panel,
-            // closing it returns the user to the coverage view (paint stays
-            // visible because keepCoveragePaint kept it through the switch).
-            // Otherwise it's a standalone scan and full reset is correct.
+            // Overlay close returns to the coverage view; standalone close
+            // does a full reset.
             if (keepCoveragePaint) {
-              // Coverage params didn't change while in overlay — skip the
-              // recompute the activeTool flip would otherwise trigger.
               skipNextCoverageComputeRef.current = true;
               setKeepCoveragePaint(false);
               setActiveTool("coverage");

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -331,6 +331,9 @@ export function Map() {
   // total === 0 means idle / drag preview / terrain fetch
   const [coverageProgress, setCoverageProgress] = useState<{ completed: number; total: number }>({ completed: 0, total: 0 });
   const [coverageDemSource, setCoverageDemSource] = useState<DemSource | null>(null);
+  // True while a "Scan visible nodes" overlay is active from the coverage panel —
+  // keeps the coverage paint visible even though activeTool has switched to "scan".
+  const [keepCoveragePaint, setKeepCoveragePaint] = useState(false);
   // Drives the land-cover status chip in each panel.
   const [coverageClutterStatus, setCoverageClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
   const [scanClutterStatus, setScanClutterStatus] = useState<{ tilesPresent: number; tilesTotal: number } | null>(null);
@@ -412,6 +415,7 @@ export function Map() {
   // Antenna AGL (m); overrides GPS altitude on node-anchored origins
   const [coverageAntennaHeightM, setCoverageAntennaHeightM] = useState(2);
   const [coverageReliability, setCoverageReliability] = useState<CoverageReliability>("typical");
+  const [scanReliability, setScanReliability] = useState<CoverageReliability>("typical");
   // Ref mirror so the drag-preview closure sees latest without re-binding
   const coverageAntennaHeightMRef = useRef(2);
   useEffect(() => {
@@ -524,6 +528,9 @@ export function Map() {
   const [scanDemSource, setScanDemSource] = useState<DemSource | null>(null);
   /** Monotonic request id — stale worker replies are dropped. */
   const coverageRequestIdRef = useRef(0);
+  // Set on overlay enter/exit so the coverage compute effect doesn't kick off
+  // a redundant recompute when activeTool flips but the params are unchanged.
+  const skipNextCoverageComputeRef = useRef(false);
   /** Lazily-created coverage worker pool; terminated on unmount. */
   const coveragePoolRef = useRef<CoverageWorkerPool | null>(null);
   const ensureCoveragePool = useCallback((): CoverageWorkerPool => {
@@ -1160,6 +1167,7 @@ export function Map() {
     losHoverMarkerRef.current = null;
     setLosResult(null);
     setCoverageResult(null);
+    setKeepCoveragePaint(false);
     setScanSummary(null);
     setIsComputingCoverage(false);
     setIsFetchingCoverageTerrain(false);
@@ -1567,33 +1575,36 @@ export function Map() {
           return;
         }
         const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
+        // Match coverage's 2048² DEM (~97 m/px over 200 km) so per-target ITM
+        // sees the same terrain detail the painted prediction does. Same goes
+        // for the clutter/canopy/building rasters.
         const [{ dem, source: demSourceUsedForScan }, scanClutter, scanCanopy, scanBuildings] = await Promise.all([
           buildDem({
             bounds: scanBounds,
-            targetWidth: 1024,
-            targetHeight: 1024,
+            targetWidth: 2048,
+            targetHeight: 2048,
             token: mapboxToken,
           }),
           // Skip individual fetches when their respective models are toggled off.
           scanClutterEnabled
             ? buildClutterRaster({
                 bounds: scanBounds,
-                targetWidth: 1024,
-                targetHeight: 1024,
+                targetWidth: 2048,
+                targetHeight: 2048,
               })
             : Promise.resolve(null),
           scanCanopyEnabled
             ? buildCanopyRaster({
                 bounds: scanBounds,
-                targetWidth: 1024,
-                targetHeight: 1024,
+                targetWidth: 2048,
+                targetHeight: 2048,
               })
             : Promise.resolve(null),
           scanBuildingsEnabled
             ? buildBuildingRaster({
                 bounds: scanBounds,
-                targetWidth: 1024,
-                targetHeight: 1024,
+                targetWidth: 2048,
+                targetHeight: 2048,
               })
             : Promise.resolve(null),
         ]);
@@ -1657,6 +1668,12 @@ export function Map() {
                 polarization: 1 /* Vertical */,
                 groundDielectric: 15,
                 groundConductivity: 0.005,
+                // Match coverage's reliability semantics. Without these, the
+                // scan defaulted to 50/50/50 (median), which was ~10–15 dB
+                // more optimistic than the user's painted prediction.
+                timePct: reliabilityPreset(scanReliability).time,
+                locationPct: reliabilityPreset(scanReliability).location,
+                situationPct: reliabilityPreset(scanReliability).situation,
               }
             : undefined,
         });
@@ -1677,7 +1694,7 @@ export function Map() {
     return () => { cancelled = true; };
   }, [activeTool, toolStep, toolFromId, toolVirtualPos, provider, terrain3D, nodes,
       scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
-      scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled, scanAntennaHeightM]);
+      scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled, scanAntennaHeightM, scanReliability]);
 
   // Per-class map visibility filter (compute still runs for hidden classes).
   useEffect(() => {
@@ -1737,15 +1754,27 @@ export function Map() {
     }
   }, [scanHoverId, scanSummary]);
 
-  // Coverage prediction — runs when Coverage tool reaches result step.
+  // Coverage prediction — runs when Coverage tool reaches result step, OR
+  // while a Scan-from-here overlay is active (so coverage-setting tweaks made
+  // through the minimized coverage panel still trigger a fresh paint).
   useEffect(() => {
-    if (activeTool !== "coverage" || toolStep !== "result") {
-      setCoverageResult(null);
+    if ((activeTool !== "coverage" && !keepCoveragePaint) || toolStep !== "result") {
+      // Scan-from-here overlay holds onto the result so the painted layer
+      // stays visible and the minimized coverage panel keeps showing the
+      // reachable summary instead of flipping back into the loading state.
+      if (!keepCoveragePaint) setCoverageResult(null);
       setIsComputingCoverage(false);
       setIsFetchingCoverageTerrain(false);
       setCoverageError(null);
       setCoverageProgress({ completed: 0, total: 0 });
       lastRecenteredOriginRef.current = null;
+      return;
+    }
+    // Skip recomputes triggered solely by overlay enter/exit transitions —
+    // the params are unchanged so the result would be identical (and the
+    // brief "Recomputing…" pill feels like a glitch).
+    if (skipNextCoverageComputeRef.current) {
+      skipNextCoverageComputeRef.current = false;
       return;
     }
     if (!terrain3D) {
@@ -2127,13 +2156,16 @@ export function Map() {
     return () => {
       cancelled = true;
     };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageMergeOrigins, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, coverageAntennaDbi, coverageRxAntennaDbi, coverageRxHeightM, coverageTxDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageMergeOrigins, coverageSensitivityDbm, coverageDetail, coverageAntennaHeightM, coverageReliability, provider, terrain3D, nodes, coverageRetryNonce, keepCoveragePaint]);
 
-  // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry
+  // Hide coverage raster when leaving tool; sources/layers stay for fast re-entry.
+  // When keepCoveragePaint is set (Scan-from-here overlay), leave the paint
+  // visible across the activeTool switch so the user sees both the coverage
+  // raster and the scan-link overlay together.
   useEffect(() => {
     const mb = mbMapRef.current;
     if (!mb) return;
-    if (activeTool !== "coverage") {
+    if (activeTool !== "coverage" && !keepCoveragePaint) {
       try {
         if (mb.getLayer("coverage-raster")) {
           mb.setLayoutProperty("coverage-raster", "visibility", "none");
@@ -2146,7 +2178,7 @@ export function Map() {
         }
       } catch {}
     }
-  }, [activeTool]);
+  }, [activeTool, keepCoveragePaint]);
 
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -2156,10 +2188,10 @@ export function Map() {
       mb.setLayoutProperty(
         "coverage-contours-line",
         "visibility",
-        activeTool === "coverage" && showCoverageContours ? "visible" : "none",
+        (activeTool === "coverage" || keepCoveragePaint) && showCoverageContours ? "visible" : "none",
       );
     } catch {}
-  }, [activeTool, showCoverageContours, coverageResult]);
+  }, [activeTool, showCoverageContours, coverageResult, keepCoveragePaint]);
 
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -2169,10 +2201,10 @@ export function Map() {
       mb.setLayoutProperty(
         "coverage-rays-line",
         "visibility",
-        activeTool === "coverage" && showCoverageRays ? "visible" : "none",
+        (activeTool === "coverage" || keepCoveragePaint) && showCoverageRays ? "visible" : "none",
       );
     } catch {}
-  }, [activeTool, showCoverageRays, coverageResult]);
+  }, [activeTool, showCoverageRays, coverageResult, keepCoveragePaint]);
 
   /** Cluster donut + count text dim. Combines the tool-active dim (when an RF
    *  tool is in result step, so the raster reads clearly) with focus-on-hover
@@ -4321,9 +4353,11 @@ export function Map() {
         />
       )}
 
-      {/* Floating Coverage panel */}
-      {activeTool === "coverage" && toolStep === "result" && (toolFromId || toolVirtualPos) && (
+      {/* Floating Coverage panel — also stays mounted (forced-minimized) during a
+           Scan-from-here overlay so the user knows coverage is paused, not closed. */}
+      {((activeTool === "coverage") || keepCoveragePaint) && toolStep === "result" && (toolFromId || toolVirtualPos) && (
         <MapCoveragePanel
+          overlayMode={keepCoveragePaint}
           result={coverageResult}
           originLabel={
             toolFromId
@@ -4411,6 +4445,29 @@ export function Map() {
             setToolVirtualPos(lngLat);
             mbMapRef.current?.easeTo({ center: lngLat, duration: 600 });
           }}
+          onScanFromHere={() => {
+            // Mirror coverage's RF settings into scan so the scan results match
+            // the painted prediction the user is looking at. toolFromId /
+            // toolVirtualPos are shared, so the origin already lines up.
+            setScanHardwareIdx(coverageHardwareIdx);
+            setScanAntennaIdx(coverageAntennaIdx);
+            setScanAntennaHeightM(coverageAntennaHeightM);
+            setScanCustomTxDbm(coverageCustomTxDbm);
+            setScanRxHardwareIdx(coverageRxHardwareIdx);
+            setScanRxAntennaIdx(coverageRxAntennaIdx);
+            setScanPresetIdx(coveragePresetIdx);
+            setScanCustomSensDbm(coverageCustomSensDbm);
+            setScanAggressionIdx(coverageAggressionIdx);
+            setScanClutterEnabled(coverageClutterEnabled);
+            setScanCanopyEnabled(coverageCanopyEnabled);
+            setScanBuildingsEnabled(coverageBuildingsEnabled);
+            setScanReliability(coverageReliability);
+            // Coverage params didn't change — skip the recompute the
+            // activeTool flip would otherwise trigger.
+            skipNextCoverageComputeRef.current = true;
+            setKeepCoveragePaint(true);
+            setActiveTool("scan");
+          }}
         />
       )}
 
@@ -4444,7 +4501,21 @@ export function Map() {
           demSource={scanDemSource}
           terrainNeeded={!terrain3D}
           onEnableTerrain={() => setTerrain3D(true)}
-          onClose={resetTool}
+          onClose={() => {
+            // If scan was opened as an overlay from the coverage panel,
+            // closing it returns the user to the coverage view (paint stays
+            // visible because keepCoveragePaint kept it through the switch).
+            // Otherwise it's a standalone scan and full reset is correct.
+            if (keepCoveragePaint) {
+              // Coverage params didn't change while in overlay — skip the
+              // recompute the activeTool flip would otherwise trigger.
+              skipNextCoverageComputeRef.current = true;
+              setKeepCoveragePaint(false);
+              setActiveTool("coverage");
+            } else {
+              resetTool();
+            }
+          }}
           onSelectResult={(id) => {
             // Fly to the target, then open its details panel.
             const n = nodes[id] ?? nodes[`!${id}`];
@@ -4507,6 +4578,8 @@ export function Map() {
           onPresetIdxChange={setScanPresetIdx}
           customSensitivityDbm={scanCustomSensDbm}
           onCustomSensitivityChange={setScanCustomSensDbm}
+          reliability={scanReliability}
+          onReliabilityChange={setScanReliability}
         />
       )}
 

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -772,15 +772,21 @@ export function MapCoveragePanel({
           const noTerrainData = terrainCoverage < 0.05;
           const noLinkBudget = !noTerrainData && reachablePx === 0;
           return (
-            <div className="px-2.5 py-2 rounded-lg bg-white/5">
+            <div className={`px-2.5 py-2 rounded-lg bg-white/5 transition-shadow ${isComputing ? "shadow-[inset_0_0_0_1px_rgba(34,211,238,0.45)]" : ""}`}>
               <div className="flex items-center gap-2 text-[10px]">
                 <span className="text-gray-500 uppercase tracking-wider">Reachable</span>
-                <span className="text-emerald-300 font-medium tabular-nums">
+                <span className={`text-emerald-300 font-medium tabular-nums transition-opacity ${isComputing ? "opacity-50" : ""}`}>
                   ~{fmt(reachableKm2)} km²
                 </span>
-                <span className="text-gray-500 tabular-nums">
+                <span className={`text-gray-500 tabular-nums transition-opacity ${isComputing ? "opacity-50" : ""}`}>
                   ({Math.round(pct)}% of {fmt(scannedKm2)} km²)
                 </span>
+                {isComputing && (
+                  <span className="inline-flex items-center gap-1 text-cyan-300 font-medium">
+                    <span className="w-2 h-2 border border-cyan-400 border-t-transparent rounded-full animate-spin" />
+                    Updating…
+                  </span>
+                )}
                 <span className="ml-auto inline-flex items-center gap-1.5">
                   {onScanFromHere && (
                     <button
@@ -1182,7 +1188,9 @@ export function MapCoveragePanel({
           onToggle={() => toggleRow("rx")}
         >
           <div className="flex items-center justify-between gap-2">
-            <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
+            {/* px/-mx pair gives the active-flash some real estate without
+                changing the rendered layout. */}
+            <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none px-1.5 py-0.5 -mx-1.5 -my-0.5 rounded transition-colors active:bg-cyan-500/20">
               <input
                 type="checkbox"
                 checked={rxMatchesTx}

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -165,6 +165,8 @@ export function MapCoveragePanel({
   onShowRaysChange,
   onExport,
   onOriginChange,
+  onScanFromHere,
+  overlayMode = false,
 }: {
   result: CoverageResult | null;
   originLabel: string;
@@ -244,6 +246,13 @@ export function MapCoveragePanel({
   onExport: (format: "geojson" | "kml") => void;
   /** Custom coord typed into the origin label. Caller detaches any anchor and moves the pin. */
   onOriginChange?: (lngLat: [number, number]) => void;
+  /** Desktop-only: open the Scan tool with the same origin + settings, leaving the
+   *  coverage paint visible underneath as a sanity check against real nodes in view. */
+  onScanFromHere?: () => void;
+  /** True while the Scan-from-here overlay owns the screen — the panel still
+   *  renders so the user knows coverage is paused (not closed), but is forced
+   *  minimized to keep the map clear. */
+  overlayMode?: boolean;
 }) {
   const isCustomHardware = COMMON_HARDWARE[hardwareIdx]?.isCustom ?? false;
   const isCustomPreset = MESHTASTIC_PRESETS[presetIdx]?.isCustom ?? false;
@@ -334,6 +343,18 @@ export function MapCoveragePanel({
       setMinimized(true);
     }
   }, [result]);
+
+  // Force minimize on entering Scan-from-here overlay so the map stays clear.
+  const prevOverlayRef = useRef(overlayMode);
+  useEffect(() => {
+    if (overlayMode && !prevOverlayRef.current) setMinimized(true);
+    prevOverlayRef.current = overlayMode;
+  }, [overlayMode]);
+
+  // Snapshot of pre-check RX values so unchecking "Same as transmitter" can
+  // restore whatever the user had before. Without this the uncheck looks like
+  // a no-op because rxMatchesTx is derived from the values still matching.
+  const rxSnapshotRef = useRef<{ hw: number; ant: number; height: number } | null>(null);
 
   const sheet = useBottomSheetGesture(onClose);
 
@@ -760,7 +781,20 @@ export function MapCoveragePanel({
                 <span className="text-gray-500 tabular-nums">
                   ({Math.round(pct)}% of {fmt(scannedKm2)} km²)
                 </span>
-                <span className="ml-auto">
+                <span className="ml-auto inline-flex items-center gap-1.5">
+                  {onScanFromHere && (
+                    <button
+                      type="button"
+                      onClick={onScanFromHere}
+                      className="hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-cyan-500/30 bg-cyan-500/10 text-[10px] font-medium text-cyan-300 hover:bg-cyan-500/20 hover:border-cyan-500/50 transition-colors"
+                      title="Run a Line-of-Sight scan against every node in range from this same origin — coverage paint stays visible underneath"
+                    >
+                      <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M7 12h10M10 18h4" />
+                      </svg>
+                      Scan nodes
+                    </button>
+                  )}
                   <details className="text-[10px] text-gray-500 relative">
                     <summary className="cursor-pointer hover:text-gray-300 select-none list-none inline-flex items-center" title="What does this mean?">
                       <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1154,11 +1188,30 @@ export function MapCoveragePanel({
                 checked={rxMatchesTx}
                 onChange={(e) => {
                   if (e.target.checked) {
+                    // Save the current RX so unchecking can restore it.
+                    rxSnapshotRef.current = {
+                      hw: rxHardwareIdx,
+                      ant: rxAntennaIdx,
+                      height: rxHeightM,
+                    };
                     onRxHardwareIdxChange(hardwareIdx);
                     onRxAntennaIdxChange(antennaIdx);
                     onRxHeightChange(antennaHeightM);
+                  } else {
+                    // Restore the previous RX. If there isn't one (RX was
+                    // already matching when the panel opened), fall back to
+                    // the stock handheld so the toggle is at least meaningful.
+                    const snap = rxSnapshotRef.current;
+                    if (snap) {
+                      onRxHardwareIdxChange(snap.hw);
+                      onRxAntennaIdxChange(snap.ant);
+                      onRxHeightChange(snap.height);
+                    } else {
+                      onRxHardwareIdxChange(4); // Heltec V3
+                      onRxAntennaIdxChange(0);  // rubber duck
+                      onRxHeightChange(2);
+                    }
                   }
-                  // unchecking: keep current RX values; user will edit below
                 }}
                 className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
               />

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -59,6 +59,51 @@ function InfoTip({ children, align = "right" }: { children: React.ReactNode; ali
   );
 }
 
+/** Collapsible row: header summarizes current state, body holds inline editors. */
+function Row({
+  icon,
+  title,
+  summary,
+  expanded,
+  onToggle,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  summary: React.ReactNode;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg bg-white/5 border border-white/5 overflow-hidden">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2 px-2.5 py-2 hover:bg-white/3 transition-colors text-left"
+      >
+        <span className="text-gray-400 shrink-0 w-4 h-4 inline-flex items-center justify-center">{icon}</span>
+        <span className="text-[11px] font-medium text-gray-200 shrink-0">{title}</span>
+        <span className="text-[10px] text-gray-500 truncate flex-1 min-w-0 text-right">{summary}</span>
+        <svg
+          className={`w-3.5 h-3.5 text-gray-500 transition-transform shrink-0 ${expanded ? "rotate-90" : ""}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="px-2.5 pb-2.5 pt-2 border-t border-white/5 space-y-2.5">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type RowKey = "tx" | "rx" | "env" | "acc" | "ov";
+
 export function MapCoveragePanel({
   result,
   originLabel,
@@ -267,10 +312,32 @@ export function MapCoveragePanel({
       .slice(0, 12);
   }, [mergeOriginSearch, mergeOrigins, mergeNodeOptions]);
 
-  // Lets the header "custom RX" pill open the advanced-settings <details>
-  const gearRef = useRef<HTMLDetailsElement>(null);
+  // Single-expand accordion. Auto-expand RX whenever it becomes asymmetric so
+  // the user can see what changed; never auto-collapse.
+  const [expandedRow, setExpandedRow] = useState<RowKey | null>(null);
+  const toggleRow = (k: RowKey) => setExpandedRow((cur) => (cur === k ? null : k));
+
+  // Minimized = header-only. Tool keeps computing in the background; the
+  // user can restore to inspect or tweak. Mobile drag-handle still works.
+  const [minimized, setMinimized] = useState(false);
+
+  // Auto-minimize on the FIRST result for each new origin (so the user can see
+  // the painted coverage on the map). Recomputes for the same origin — e.g.,
+  // changing detail or hardware — leave the panel alone so the user keeps
+  // seeing what they're tweaking.
+  const lastAutoMinKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!result) return;
+    const key = `${result.origin[0]},${result.origin[1]}`;
+    if (lastAutoMinKeyRef.current !== key) {
+      lastAutoMinKeyRef.current = key;
+      setMinimized(true);
+    }
+  }, [result]);
+
   const sheet = useBottomSheetGesture(onClose);
 
+  // Close any open <details> popovers (the ⋯ menu) on outside-click.
   useEffect(() => {
     const onDocMouseDown = (e: MouseEvent) => {
       const root = sheet.sheetRef.current;
@@ -412,6 +479,43 @@ export function MapCoveragePanel({
     );
   }
 
+  // Derived summaries for collapsed row headers
+  const txHardware = COMMON_HARDWARE[hardwareIdx]?.label ?? "Custom";
+  const txAntDbi = COMMON_ANTENNAS[antennaIdx]?.dbi ?? 0;
+  const txPreset = MESHTASTIC_PRESETS[presetIdx]?.label ?? "Custom";
+  const rxMatchesTx =
+    rxHardwareIdx === hardwareIdx &&
+    rxAntennaIdx === antennaIdx &&
+    rxHeightM === antennaHeightM;
+  const rxHardware = COMMON_HARDWARE[rxHardwareIdx]?.label ?? "Custom";
+  const rxAntDbi = COMMON_ANTENNAS[rxAntennaIdx]?.dbi ?? 0;
+  const reliabilityLabel = RELIABILITY_PRESETS.find((p) => p.id === reliability)?.label ?? "Typical";
+
+  const txSummary = (
+    <>
+      {txHardware} · {txAntDbi} dBi · {antennaHeightM}m · {txPreset}
+      {mergeOrigins.length > 0 && (
+        <span className="text-cyan-300 ml-1">+{mergeOrigins.length}</span>
+      )}
+    </>
+  );
+
+  const rxSummary = rxMatchesTx
+    ? <span>Same as TX</span>
+    : <span className="text-cyan-300">{rxHardware} · {rxAntDbi} dBi · {rxHeightM}m</span>;
+
+  const envParts: string[] = [];
+  if (clutterEnabled) envParts.push("clutter");
+  if (canopyEnabled) envParts.push("canopy");
+  if (buildingsEnabled) envParts.push("buildings");
+  const envSummary = envParts.length === 0 ? "All off · bare earth" : envParts.join(" · ");
+
+  const accSummary = `${reliabilityLabel} · ${COVERAGE_DETAIL_SIZE[detail]} px`;
+
+  const ovParts: string[] = [];
+  if (showContours) ovParts.push("contours");
+  if (showRays) ovParts.push("rays");
+  const ovSummary = ovParts.length === 0 ? "None" : ovParts.join(" · ");
 
   return (
     <div
@@ -419,16 +523,8 @@ export function MapCoveragePanel({
       className="fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl
         inset-x-0 bottom-0 rounded-t-2xl max-h-[78dvh] flex flex-col
         animate-[slideInUp_200ms_ease-out]
-        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(640px,calc(100vw-2rem))]
-        sm:rounded-xl sm:max-h-none sm:block"
-      onClick={(e) => {
-        // Close any open <details> popover when clicking elsewhere in the panel
-        const target = e.target as Node;
-        const openDetails = e.currentTarget.querySelectorAll<HTMLDetailsElement>("details[open]");
-        openDetails.forEach((d) => {
-          if (!d.contains(target)) d.removeAttribute("open");
-        });
-      }}
+        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(560px,calc(100vw-2rem))]
+        sm:rounded-xl sm:max-h-[calc(100dvh-2rem)] sm:flex sm:flex-col"
     >
       <div
         className="sm:hidden flex justify-center pt-2 pb-1 cursor-grab active:cursor-grabbing touch-none shrink-0"
@@ -485,6 +581,7 @@ export function MapCoveragePanel({
         );
       })()}
 
+      {/* Header: badge · origin editor · ⋯ menu · close */}
       <div
         className="flex items-center justify-between gap-3 px-3 py-2 border-b border-white/5 shrink-0 max-sm:touch-none"
         onTouchStart={sheet.onTouchStart}
@@ -563,47 +660,42 @@ export function MapCoveragePanel({
             <span className="text-gray-500 shrink-0">
               {Math.round(result.originHeightM)}m{result.originIsFallback ? "~" : ""}
             </span>
-            {(() => {
-              // Header pill surfaces asymmetric RX; click toggles the gear popover
-              const rxMatchesTx =
-                rxHardwareIdx === hardwareIdx &&
-                rxAntennaIdx === antennaIdx &&
-                rxHeightM === antennaHeightM;
-              if (rxMatchesTx) return null;
-              const hwLabel = COMMON_HARDWARE[rxHardwareIdx]?.label ?? "custom";
-              const antDbi = COMMON_ANTENNAS[rxAntennaIdx]?.dbi ?? 3;
-              return (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    // stopPropagation so the panel's outside-click handler doesn't re-close
-                    e.stopPropagation();
-                    if (gearRef.current) {
-                      gearRef.current.open = !gearRef.current.open;
-                    }
-                  }}
-                  className="ml-1 shrink-0 px-1.5 py-0 rounded bg-cyan-500/15 border border-cyan-500/30 text-[9px] text-cyan-200 font-medium whitespace-nowrap hover:bg-cyan-500/25 hover:border-cyan-500/50 transition-colors cursor-pointer"
-                  title={`Custom RX: ${hwLabel} with ${antDbi} dBi antenna at ${rxHeightM} m · click to edit`}
-                >
-                  RX {antDbi} dBi @ {rxHeightM}m
-                </button>
-              );
-            })()}
           </div>
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          {/* Export dropdown; opens upward. */}
-          <details className="text-[10px] text-gray-400 relative group">
+          <button
+            type="button"
+            onClick={() => setMinimized((m) => !m)}
+            className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+            aria-label={minimized ? "Expand panel" : "Minimize panel"}
+            aria-expanded={!minimized}
+            title={minimized ? "Expand — coverage tool is still running" : "Minimize — keep tool running, hide controls"}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {minimized ? (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 9l7 7 7-7" />
+              )}
+            </svg>
+          </button>
+          {/* ⋯ menu: export options */}
+          <details className="text-[10px] text-gray-400 relative">
             <summary
-              className="cursor-pointer list-none p-1 rounded-md hover:text-gray-200 hover:bg-white/5 transition-colors flex items-center gap-1"
-              aria-label="Export coverage"
-              title="Export coverage"
+              className="cursor-pointer list-none p-1 rounded-md hover:text-gray-200 hover:bg-white/5 transition-colors flex items-center"
+              aria-label="More options"
+              title="More options"
             >
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3" />
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <circle cx="5" cy="12" r="1.6" />
+                <circle cx="12" cy="12" r="1.6" />
+                <circle cx="19" cy="12" r="1.6" />
               </svg>
             </summary>
-            <div className="absolute right-0 bottom-full mb-1 w-40 p-1 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl z-50 flex flex-col">
+            <div className="absolute right-0 top-full mt-1 w-44 p-1 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl z-50 flex flex-col">
+              <div className="px-2 pt-1 pb-0.5 text-[9px] uppercase tracking-wider text-gray-500 font-medium">
+                Export
+              </div>
               <button
                 type="button"
                 onClick={(e) => {
@@ -628,519 +720,6 @@ export function MapCoveragePanel({
               </button>
             </div>
           </details>
-          <details className="text-[10px] text-gray-500 relative">
-            <summary className="cursor-pointer hover:text-gray-400 select-none list-none p-1">
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </summary>
-            <div className="fixed z-50 overflow-y-auto p-2.5 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl text-gray-400 leading-relaxed space-y-1
-              inset-x-3 top-4 bottom-4 w-auto max-w-none
-              sm:absolute sm:inset-auto sm:right-0 sm:bottom-full sm:top-auto sm:mb-1 sm:w-85 sm:max-w-[calc(100vw-1rem)] sm:max-h-none sm:overflow-visible">
-              <div>Pixel color shows predicted <strong>link margin</strong> (RSSI minus sensitivity and fade margin). Cyan = very reliable, orange = marginal, magenta = at threshold. Unpainted terrain is below sensitivity.</div>
-              <div className="pt-1 border-t border-white/5">
-                <div className="text-gray-300 font-medium">Reliability</div>
-                <div className="mt-0.5">
-                  {RELIABILITY_PRESETS.find((p) => p.id === reliability)?.desc}
-                </div>
-              </div>
-              <div className="pt-1 border-t border-white/5">
-                <div className="text-gray-300 font-medium">Propagation model</div>
-                <div className="font-mono text-[9px] text-gray-500 mt-0.5">
-                  Longley-Rice v1.4 (ITS) via WASM
-                </div>
-                <div className="mt-1">
-                  Per-pixel basic transmission loss from{" "}
-                  <a
-                    href="https://its.ntia.gov/software/itm"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-cyan-300/80 hover:text-cyan-200 underline decoration-dotted"
-                  >NTIA's Irregular Terrain Model</a>,
-                  reference C++ ported to WebAssembly. Handles line-of-sight,
-                  multi-edge diffraction, and troposcatter with 4/3 earth
-                  refraction.
-                </div>
-              </div>
-
-              <div className="pt-1 border-t border-white/5">
-                <div className="text-gray-300 font-medium">Terrain data</div>
-                <div className="font-mono text-[9px] text-gray-500 mt-0.5">
-                  {demSource === "tilezen"
-                    ? "Tilezen terrarium · USGS 3DEP (US) / SRTM (global)"
-                    : demSource === "mapbox-terrain-rgb"
-                      ? "Mapbox terrain-rgb v1 · global ~30 m"
-                      : "awaiting first compute…"}
-                </div>
-                <div className="mt-1">
-                  {demSource === "tilezen" ? (
-                    <>
-                      DEM fetched from{" "}
-                      <a
-                        href="https://registry.opendata.aws/terrain-tiles/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-cyan-300/80 hover:text-cyan-200 underline decoration-dotted"
-                      >AWS Open Data Registry</a>{" "}
-                      (Tilezen). In the US this is USGS 3DEP at ~10 m native
-                      through z=15 — the same dataset RF tools
-                      like SPLAT! and Radio Mobile use. Outside the US it
-                      falls back to SRTM 30 m.
-                    </>
-                  ) : demSource === "mapbox-terrain-rgb" ? (
-                    <>
-                      DEM fetched from Mapbox's legacy{" "}
-                      <code className="bg-white/10 px-1 rounded-sm">terrain-rgb</code>{" "}
-                      tileset via the v4 Tiles API. Fallback path — the
-                      preferred Tilezen source wasn't reachable for this
-                      compute. Can under-read mountain peaks by 100-200 m
-                      vs. 3DEP data.
-                    </>
-                  ) : (
-                    <>
-                      Once the first compute completes this will show which
-                      tile source was used (Tilezen 3DEP preferred, Mapbox
-                      terrain-rgb fallback).
-                    </>
-                  )}
-                </div>
-              </div>
-              <div className="pt-1 border-t border-white/5">
-                <div className="text-gray-300 font-medium">Link budget</div>
-                <div className="mt-0.5">
-                  {(() => {
-                    const rp = RELIABILITY_PRESETS.find((p) => p.id === reliability) ?? RELIABILITY_PRESETS[1];
-                    return (
-                      <>
-                        Climate: <strong>Continental Temperate</strong> ·
-                        Reliability: <strong>{rp.time} / {rp.location} / {rp.situation} %</strong>{" "}
-                        (time / location / situation) · Cable loss: <strong>0.5 dB</strong> ·
-                        Fade margin: <strong>15 dB</strong> ·
-                        TX antenna: <strong>{result.txAntennaDbi} dBi</strong> ·
-                        RX antenna: <strong>{result.rxAntennaDbi} dBi</strong> @
-                        <strong> {Math.round(result.rxAntennaHeightAboveGroundM)} m</strong> AGL ·
-                        RX sensitivity: <strong>{result.rxSensitivityDbm} dBm</strong>{" "}
-                        (real-world; SX1262 datasheet is ~3 dB more sensitive).
-                      </>
-                    );
-                  })()}
-                </div>
-              </div>
-              <div className="text-amber-300/80 pt-1 border-t border-white/5 mt-1">
-                <strong>Caveats:</strong> RX sensitivity uses real-world typical
-                values (~3 dB worse than datasheet) and adjusts down another
-                ~2 dB for SX1276-based boards (Heltec v2). ITM does not model
-                buildings or foliage; the <em>Environment</em> selector adds a
-                flat clutter loss as a rough compensation. RX hardware,
-                antenna, and height live in the gear popover (the TX side is
-                configured in the main panel above); the default RX models a
-                stock Heltec V3 with the rubber-duck antenna at 2 m, so
-                out-of-box results show what a typical handheld would hear. Analysis area is capped at{" "}
-                <strong>200 km radius</strong> so the DEM at the pin stays fine
-                enough to capture actual peaks — use the LOS tool for specific
-                longer-range point-to-point links.
-              </div>
-            </div>
-          </details>
-
-          {/* Advanced-settings gear popover (environment, reliability, detail, contours, RX). */}
-          <details ref={gearRef} className="text-[10px] text-gray-400 relative">
-            <summary
-              className="cursor-pointer list-none p-1 rounded-md hover:text-gray-200 hover:bg-white/5 transition-colors"
-              aria-label="Advanced settings"
-              title="Advanced settings"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            </summary>
-            {/* xl+: fixed to right of panel so status pill isn't blocked; below xl: opens upward. */}
-            <div className="fixed z-50 overflow-y-auto p-3 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl space-y-3
-              inset-x-3 top-4 bottom-4 w-auto max-w-none
-              sm:absolute sm:inset-auto sm:right-0 sm:bottom-full sm:top-auto sm:mb-1 sm:w-90 sm:max-w-[calc(100vw-1rem)] sm:max-h-none sm:overflow-visible
-              xl:fixed xl:bottom-3 xl:top-auto xl:right-auto xl:mb-0 xl:w-96
-              xl:left-[calc(50%+332px)] xl:overflow-visible">
-              <div className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
-                Advanced settings
-              </div>
-
-              {/* Receiver — asymmetric RX. Non-default values surface as a header pill. */}
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
-                    <span>Receiver</span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      // Heltec V3 + rubber duck @ 2 m
-                      onRxHardwareIdxChange(4);
-                      onRxAntennaIdxChange(0);
-                      onRxHeightChange(2);
-                    }}
-                    className="text-[9px] text-cyan-400/70 hover:text-cyan-300 transition-colors"
-                    title="Reset RX to stock handheld (Heltec V3, rubber duck, 2 m)"
-                  >
-                    Reset to handheld
-                  </button>
-                </div>
-                <div className="grid grid-cols-2 gap-2">
-                  <div>
-                    <label htmlFor="coverage-rx-hw" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
-                      <span>Hardware</span>
-                      <InfoTip align="left">
-                        RX hardware drives the chipset-aware sensitivity
-                        correction (SX1276 boards get an additional ~2 dB
-                        penalty over SX1262). TX power is unused on this
-                        side — ITM treats RX as a passive receiver.
-                      </InfoTip>
-                    </label>
-                    <select
-                      id="coverage-rx-hw"
-                      value={rxHardwareIdx}
-                      onChange={(e) => onRxHardwareIdxChange(Number(e.target.value))}
-                      className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                        focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                        [&>option]:bg-gray-800 [&>option]:text-gray-200"
-                    >
-                      {COMMON_HARDWARE.map((h, i) => (
-                        <option key={i} value={i}>{h.label}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label htmlFor="coverage-rx-ant" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                      Antenna
-                    </label>
-                    <select
-                      id="coverage-rx-ant"
-                      value={rxAntennaIdx}
-                      onChange={(e) => onRxAntennaIdxChange(Number(e.target.value))}
-                      className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                        focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                        [&>option]:bg-gray-800 [&>option]:text-gray-200"
-                    >
-                      {COMMON_ANTENNAS.map((a, i) => (
-                        <option key={i} value={i}>{a.label}</option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="coverage-rx-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
-                    <span>Height above ground</span>
-                    <InfoTip align="left">
-                      RX antenna height over local terrain (m). 2 m =
-                      handheld default. Use 6-10 m for a typical rooftop
-                      station, 30 m+ for tower-mounted receivers.
-                    </InfoTip>
-                  </label>
-                  <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-24">
-                    <input
-                      id="coverage-rx-height"
-                      type="text"
-                      inputMode="decimal"
-                      value={rxHeightInput}
-                      onChange={(e) => setRxHeightInput(e.target.value)}
-                      onBlur={commitRxHeight}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          (e.currentTarget as HTMLInputElement).blur();
-                        } else if (e.key === "Escape") {
-                          setRxHeightInput(String(rxHeightM));
-                          (e.currentTarget as HTMLInputElement).blur();
-                        }
-                      }}
-                      aria-label="RX antenna height above ground (meters)"
-                      title="RX height above local terrain (m). Blank = 2 m default."
-                      className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center focus:outline-hidden"
-                    />
-                    <span className="text-[10px] text-gray-500 shrink-0">m</span>
-                  </div>
-                </div>
-              </div>
-
-              {/* Multi-origin merge. */}
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between gap-2">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
-                    <span>Merged origins{mergeOrigins.length > 0 && ` (${mergeOrigins.length})`}</span>
-                    <InfoTip align="left">
-                      Add other nodes to layer on top of the primary origin —
-                      the painted coverage takes the per-pixel best signal
-                      across all origins. Useful for asking "where can my mesh
-                      reach if any of these nodes works?" without picking
-                      one as primary. Session-only — not persisted.
-                    </InfoTip>
-                  </label>
-                  {mergeOrigins.length > 0 && (
-                    <button
-                      type="button"
-                      onClick={onClearMergeOrigins}
-                      className="text-[10px] text-gray-500 hover:text-red-300"
-                    >
-                      Clear
-                    </button>
-                  )}
-                </div>
-                {mergeOrigins.length > 0 && (
-                  <div className="flex flex-col gap-1">
-                    {mergeOrigins.map((o) => (
-                      <div
-                        key={o.id}
-                        className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-white/5 text-[10px] text-gray-300"
-                      >
-                        <span className="truncate min-w-0 flex-1">{o.label}</span>
-                        <button
-                          type="button"
-                          onClick={() => onRemoveMergeOrigin(o.id)}
-                          className="text-gray-500 hover:text-red-300 shrink-0"
-                          aria-label={`Remove ${o.label} from merged origins`}
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <div className="flex items-center gap-1.5">
-                  <input
-                    type="text"
-                    value={mergeOriginSearch}
-                    onChange={(e) => setMergeOriginSearch(e.target.value)}
-                    placeholder="Search nodes to merge…"
-                    className="flex-1 min-w-0 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-[10px] text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-cyan-500/50"
-                  />
-                  <button
-                    type="button"
-                    onClick={pickingMergeOrigin ? onCancelPickMergeOrigin : onStartPickMergeOrigin}
-                    title={pickingMergeOrigin ? "Cancel pick (or press Esc)" : "Click on the map to drop a pin"}
-                    className={`px-2 py-1 rounded-md border text-[10px] whitespace-nowrap shrink-0 transition-colors ${
-                      pickingMergeOrigin
-                        ? "bg-amber-500/20 border-amber-500/40 text-amber-200"
-                        : "bg-white/5 border-white/10 text-gray-300 hover:bg-white/10"
-                    }`}
-                  >
-                    {pickingMergeOrigin ? "Click map…" : "+ Pin"}
-                  </button>
-                </div>
-                {mergeOriginSearch.trim() !== "" && (
-                  <div className="max-h-32 overflow-y-auto rounded-md bg-black/20 border border-white/5 divide-y divide-white/5">
-                    {mergeOriginCandidates.length === 0 ? (
-                      <div className="text-[10px] text-gray-500 px-2 py-1.5">No matches.</div>
-                    ) : (
-                      mergeOriginCandidates.map((n) => (
-                        <button
-                          key={n.id}
-                          type="button"
-                          onClick={() => {
-                            onAddMergeOriginById(n.id);
-                            setMergeOriginSearch("");
-                          }}
-                          className="w-full text-left px-2 py-1 text-[10px] text-gray-300 hover:bg-white/5 truncate"
-                        >
-                          <span className="text-cyan-300/80 mr-1">+</span>
-                          {n.shortname ?? n.longname ?? n.id}
-                          {n.shortname && n.longname && (
-                            <span className="text-gray-500 ml-1.5">{n.longname}</span>
-                          )}
-                        </button>
-                      ))
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Clutter (per-pixel ITU model + aggression scaler). */}
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between gap-2">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
-                    <span>Clutter</span>
-                    <InfoTip align="left">
-                      Per-pixel building / vegetation loss from USGS NLCD land
-                      cover, applied via ITU-R P.452-17 (endpoint clutter) and
-                      P.833-9 (path-traversed vegetation). Toggle off for
-                      ITM-only bare-earth predictions.
-                    </InfoTip>
-                  </label>
-                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
-                    <input
-                      type="checkbox"
-                      checked={clutterEnabled}
-                      onChange={(e) => onClutterEnabledChange(e.target.checked)}
-                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
-                    />
-                    <span>Enabled</span>
-                  </label>
-                </div>
-                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
-                <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
-                <ClassLegend />
-                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
-                    <span>Canopy heights</span>
-                    <InfoTip align="left">
-                      Per-pixel measured canopy heights from ETH Global Canopy
-                      Height 2020 (Lang et al. 2023, 10 m). Replaces class-nominal
-                      heights in ITU-R P.833-9 vegetation loss for forest classes.
-                      Toggle off to fall back to class-nominal heights everywhere.
-                    </InfoTip>
-                  </label>
-                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
-                    <input
-                      type="checkbox"
-                      checked={canopyEnabled}
-                      onChange={(e) => onCanopyEnabledChange(e.target.checked)}
-                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
-                    />
-                    <span>Enabled</span>
-                  </label>
-                </div>
-                <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
-                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
-                    <span>Building heights</span>
-                    <InfoTip align="left">
-                      Per-pixel measured building heights from JRC GHS-BUILT-H
-                      ANBH (100 m global). Adds rooftops as DSM obstacles for
-                      ITM diffraction along the propagation path, and replaces
-                      class-nominal h_a in the ITU-R P.452 endpoint formula for
-                      developed-class pixels. Toggle off for bare-earth DEM and
-                      class-nominal heights.
-                    </InfoTip>
-                  </label>
-                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
-                    <input
-                      type="checkbox"
-                      checked={buildingsEnabled}
-                      onChange={(e) => onBuildingsEnabledChange(e.target.checked)}
-                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
-                    />
-                    <span>Enabled</span>
-                  </label>
-                </div>
-                <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
-              </div>
-
-              {/* Reliability (ITM TLS preset) */}
-              <div>
-                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
-                  <span>Reliability</span>
-                  <InfoTip align="left">
-                    ITM's time / location / situation percentages. Higher =
-                    "works most of the time" instead of "works half the time."
-                    Typical (90/50/70) is the industry planning default.
-                    Median matches Radio&nbsp;Mobile / SPLAT!; Conservative is
-                    for mission-critical links.
-                  </InfoTip>
-                </label>
-                <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
-                  {RELIABILITY_PRESETS.map((p) => {
-                    const active = reliability === p.id;
-                    return (
-                      <button
-                        key={p.id}
-                        type="button"
-                        onClick={() => onReliabilityChange(p.id)}
-                        title={p.desc}
-                        className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
-                          active
-                            ? "bg-cyan-500/20 text-cyan-200"
-                            : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
-                        }`}
-                      >
-                        <div>{p.label}</div>
-                        <div className="text-[9px] text-gray-500 font-normal">
-                          {p.time}/{p.location}/{p.situation}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Detail (output raster resolution). */}
-              <div>
-                <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
-                  <span>Detail</span>
-                  <InfoTip align="left">
-                    Output raster resolution (painted pixels). Higher detail
-                    = crisper edges around terrain features when zoomed in,
-                    but slower to compute. Standard feels instant; Ultra is
-                    a one-off survey. Survey matches the 2048² DEM 1:1 — the
-                    sharpest possible output, 4× the compute of Ultra.
-                  </InfoTip>
-                </label>
-                <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
-                  {([
-                    { key: "standard", label: "Std",    sub: "512 px" },
-                    { key: "high",     label: "High",   sub: "768 px" },
-                    { key: "ultra",    label: "Ultra",  sub: "1024 px" },
-                    { key: "survey",   label: "Survey", sub: "2048 px" },
-                  ] as const).map((opt) => {
-                    const active = detail === opt.key;
-                    return (
-                      <button
-                        key={opt.key}
-                        type="button"
-                        onClick={() => onDetailChange(opt.key)}
-                        className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
-                          active
-                            ? "bg-cyan-500/20 text-cyan-200"
-                            : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
-                        }`}
-                      >
-                        <div>{opt.label}</div>
-                        <div className="text-[9px] text-gray-500 font-normal">{opt.sub}</div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Overlay toggles (contours + rays); both extracted from margin grid, no recompute. */}
-              <div className="flex items-center justify-between gap-3">
-                <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={showContours}
-                    onChange={(e) => onShowContoursChange(e.target.checked)}
-                    className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
-                  />
-                  <span className="inline-flex items-center gap-1 min-w-0">
-                    Iso-margin contours
-                    <InfoTip align="left">
-                      Overlay iso-margin lines at 0 dB (magenta — edge of
-                      coverage), +10 dB (cyan — reliable), and +20 dB (deep
-                      cyan — strong signal).
-                    </InfoTip>
-                  </span>
-                </label>
-
-                <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none shrink-0">
-                  <input
-                    type="checkbox"
-                    checked={showRays}
-                    onChange={(e) => onShowRaysChange(e.target.checked)}
-                    className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
-                  />
-                  <span className="inline-flex items-center gap-1 min-w-0">
-                    Visibility rays
-                    <InfoTip align="left">
-                      Draws a fan of per-azimuth sightlines from the origin
-                      — the HeyWhatsThat-style view. Each ray shows where
-                      the link budget stays above threshold along that
-                      bearing. Useful for spotting specific paths that
-                      punch through to distant ridges (which the smooth
-                      coverage raster averages away).
-                    </InfoTip>
-                  </span>
-                </label>
-              </div>
-            </div>
-          </details>
 
           <button
             type="button"
@@ -1155,203 +734,755 @@ export function MapCoveragePanel({
         </div>
       </div>
 
-      <div className="p-3 pb-5 space-y-3 overflow-y-auto overscroll-contain min-h-0 flex-1 sm:pb-3 sm:overflow-visible">
-        {/* Reachability summary + RSSI gradient legend */}
+      {/* Body: result strip + accordion rows. Hidden when minimized. */}
+      <div className={`p-3 pb-5 space-y-2 overflow-y-auto overscroll-contain min-h-0 flex-1 sm:pb-3 ${minimized ? "hidden" : ""}`}>
+        {/* Reachability summary + RSSI gradient legend + diagnostics + help */}
         {(() => {
           const reachablePx = result.clearCount + result.fresnelCount;
           const totalPx = reachablePx + result.blockedCount;
           const pct = totalPx > 0 ? (reachablePx / totalPx) * 100 : 0;
-          // DEM bbox padded 5% each side → (2·r·1.05)²
           const scannedKm2 = (2 * result.radiusKm * 1.05) ** 2;
           const reachableKm2 = scannedKm2 * (totalPx > 0 ? reachablePx / totalPx : 0);
           const fmt = (n: number) => n >= 100 ? Math.round(n).toLocaleString() : n.toFixed(1);
 
-          // Diagnostics: <5% terrain coverage → tile source issue; 0 reachable → link budget fails
           const terrainCoverage = result.scannedPixels > 0
             ? totalPx / result.scannedPixels
             : 0;
           const noTerrainData = terrainCoverage < 0.05;
           const noLinkBudget = !noTerrainData && reachablePx === 0;
           return (
-            <div className="flex items-center gap-3 px-2 py-1.5 rounded-lg bg-white/5">
-              <div className="flex-1">
-                <div className="flex items-center gap-2 text-[10px]">
-                  <span className="text-gray-500 uppercase tracking-wider inline-flex items-center gap-1">
-                    Reachable
-                    <InfoTip align="left">
-                      Estimated area where the link budget succeeds (RSSI above
-                      sensitivity + fade margin). Computed from the
-                      {" "}{reachablePx.toLocaleString()} of {totalPx.toLocaleString()}{" "}
-                      grid cells that passed.
-                    </InfoTip>
-                  </span>
-                  <span className="text-emerald-300 font-medium tabular-nums">
-                    ~{fmt(reachableKm2)} km²
-                  </span>
-                  <span className="text-gray-500 tabular-nums">
-                    ({Math.round(pct)}% of {fmt(scannedKm2)} km²)
-                  </span>
-                </div>
-                <div className="mt-1 h-2 rounded-full overflow-hidden" style={{
-                  background: "linear-gradient(to right, #d946ef 0%, #f97316 20%, #06b6d4 55%, #0891b2 100%)",
-                }} />
-                <div className="flex items-center justify-between text-[9px] text-gray-500 mt-0.5 font-mono">
-                  <span>0 dB</span>
-                  <span>+5</span>
-                  <span>+15</span>
-                  <span>+25 dB margin</span>
-                </div>
-                {(noTerrainData || noLinkBudget) && (
-                  <div className="mt-1.5 px-2 py-1 rounded bg-amber-500/10 border border-amber-500/30 text-[10px] text-amber-300 leading-snug">
-                    {noTerrainData ? (
-                      <>
-                        <strong>No terrain data</strong> delivered for the pin
-                        area. Usually a transient network issue with the
-                        terrain tile source — click Retry, or try a different
-                        location.
-                      </>
-                    ) : (
-                      <>
-                        <strong>Link budget fails everywhere</strong> within range.
-                        Try a slower modem preset (LongFast or LongSlow),
-                        more TX power, a higher-gain antenna, or a smaller
-                        analysis range.
-                      </>
-                    )}
-                  </div>
-                )}
+            <div className="px-2.5 py-2 rounded-lg bg-white/5">
+              <div className="flex items-center gap-2 text-[10px]">
+                <span className="text-gray-500 uppercase tracking-wider">Reachable</span>
+                <span className="text-emerald-300 font-medium tabular-nums">
+                  ~{fmt(reachableKm2)} km²
+                </span>
+                <span className="text-gray-500 tabular-nums">
+                  ({Math.round(pct)}% of {fmt(scannedKm2)} km²)
+                </span>
+                <span className="ml-auto">
+                  <details className="text-[10px] text-gray-500 relative">
+                    <summary className="cursor-pointer hover:text-gray-300 select-none list-none inline-flex items-center" title="What does this mean?">
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    </summary>
+                    <div className="fixed z-50 overflow-y-auto p-2.5 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl text-gray-400 leading-relaxed space-y-1 text-[10px]
+                      inset-x-3 top-4 bottom-4 w-auto max-w-none
+                      sm:absolute sm:inset-auto sm:right-0 sm:top-full sm:mt-1 sm:bottom-auto sm:w-85 sm:max-w-[calc(100vw-1rem)] sm:max-h-[60dvh]">
+                      <div>Pixel color shows predicted <strong>link margin</strong> (RSSI minus sensitivity and fade margin). Cyan = very reliable, orange = marginal, magenta = at threshold. Unpainted terrain is below sensitivity.</div>
+                      <div className="pt-1 border-t border-white/5">
+                        <div className="text-gray-300 font-medium">Reliability</div>
+                        <div className="mt-0.5">
+                          {RELIABILITY_PRESETS.find((p) => p.id === reliability)?.desc}
+                        </div>
+                      </div>
+                      <div className="pt-1 border-t border-white/5">
+                        <div className="text-gray-300 font-medium">Propagation model</div>
+                        <div className="font-mono text-[9px] text-gray-500 mt-0.5">
+                          Longley-Rice v1.4 (ITS) via WASM
+                        </div>
+                        <div className="mt-1">
+                          Per-pixel basic transmission loss from{" "}
+                          <a
+                            href="https://its.ntia.gov/software/itm"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-cyan-300/80 hover:text-cyan-200 underline decoration-dotted"
+                          >NTIA's Irregular Terrain Model</a>,
+                          reference C++ ported to WebAssembly. Handles line-of-sight,
+                          multi-edge diffraction, and troposcatter with 4/3 earth
+                          refraction.
+                        </div>
+                      </div>
+                      <div className="pt-1 border-t border-white/5">
+                        <div className="text-gray-300 font-medium">Terrain data</div>
+                        <div className="font-mono text-[9px] text-gray-500 mt-0.5">
+                          {demSource === "tilezen"
+                            ? "Tilezen terrarium · USGS 3DEP (US) / SRTM (global)"
+                            : demSource === "mapbox-terrain-rgb"
+                              ? "Mapbox terrain-rgb v1 · global ~30 m"
+                              : "awaiting first compute…"}
+                        </div>
+                        <div className="mt-1">
+                          {demSource === "tilezen" ? (
+                            <>
+                              DEM fetched from{" "}
+                              <a
+                                href="https://registry.opendata.aws/terrain-tiles/"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-cyan-300/80 hover:text-cyan-200 underline decoration-dotted"
+                              >AWS Open Data Registry</a>{" "}
+                              (Tilezen). In the US this is USGS 3DEP at ~10 m native
+                              through z=15 — the same dataset RF tools
+                              like SPLAT! and Radio Mobile use. Outside the US it
+                              falls back to SRTM 30 m.
+                            </>
+                          ) : demSource === "mapbox-terrain-rgb" ? (
+                            <>
+                              DEM fetched from Mapbox's legacy{" "}
+                              <code className="bg-white/10 px-1 rounded-sm">terrain-rgb</code>{" "}
+                              tileset via the v4 Tiles API. Fallback path — the
+                              preferred Tilezen source wasn't reachable for this
+                              compute. Can under-read mountain peaks by 100-200 m
+                              vs. 3DEP data.
+                            </>
+                          ) : (
+                            <>
+                              Once the first compute completes this will show which
+                              tile source was used (Tilezen 3DEP preferred, Mapbox
+                              terrain-rgb fallback).
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <div className="pt-1 border-t border-white/5">
+                        <div className="text-gray-300 font-medium">Link budget</div>
+                        <div className="mt-0.5">
+                          {(() => {
+                            const rp = RELIABILITY_PRESETS.find((p) => p.id === reliability) ?? RELIABILITY_PRESETS[1];
+                            return (
+                              <>
+                                Climate: <strong>Continental Temperate</strong> ·
+                                Reliability: <strong>{rp.time} / {rp.location} / {rp.situation} %</strong>{" "}
+                                (time / location / situation) · Cable loss: <strong>0.5 dB</strong> ·
+                                Fade margin: <strong>15 dB</strong> ·
+                                TX antenna: <strong>{result.txAntennaDbi} dBi</strong> ·
+                                RX antenna: <strong>{result.rxAntennaDbi} dBi</strong> @
+                                <strong> {Math.round(result.rxAntennaHeightAboveGroundM)} m</strong> AGL ·
+                                RX sensitivity: <strong>{result.rxSensitivityDbm} dBm</strong>{" "}
+                                (real-world; SX1262 datasheet is ~3 dB more sensitive).
+                              </>
+                            );
+                          })()}
+                        </div>
+                      </div>
+                      <div className="text-amber-300/80 pt-1 border-t border-white/5 mt-1">
+                        <strong>Caveats:</strong> RX sensitivity uses real-world typical
+                        values (~3 dB worse than datasheet) and adjusts down another
+                        ~2 dB for SX1276-based boards (Heltec v2). ITM does not model
+                        buildings or foliage; the <em>Environment</em> row adds a
+                        flat clutter loss as a rough compensation. Analysis area is
+                        capped at <strong>200 km radius</strong> so the DEM at the
+                        pin stays fine enough to capture actual peaks — use the
+                        LOS tool for specific longer-range point-to-point links.
+                      </div>
+                    </div>
+                  </details>
+                </span>
               </div>
+              <div className="mt-1 h-2 rounded-full overflow-hidden" style={{
+                background: "linear-gradient(to right, #d946ef 0%, #f97316 20%, #06b6d4 55%, #0891b2 100%)",
+              }} />
+              <div className="flex items-center justify-between text-[9px] text-gray-500 mt-0.5 font-mono">
+                <span>0 dB</span>
+                <span>+5</span>
+                <span>+15</span>
+                <span>+25 dB margin</span>
+              </div>
+              {(noTerrainData || noLinkBudget) && (
+                <div className="mt-1.5 px-2 py-1 rounded bg-amber-500/10 border border-amber-500/30 text-[10px] text-amber-300 leading-snug">
+                  {noTerrainData ? (
+                    <>
+                      <strong>No terrain data</strong> delivered for the pin
+                      area. Usually a transient network issue with the
+                      terrain tile source — click Retry, or try a different
+                      location.
+                    </>
+                  ) : (
+                    <>
+                      <strong>Link budget fails everywhere</strong> within range.
+                      Try a slower modem preset (LongFast or LongSlow),
+                      more TX power, a higher-gain antenna, or a smaller
+                      analysis range.
+                    </>
+                  )}
+                </div>
+              )}
             </div>
           );
         })()}
 
-        {/* Primary controls (hardware, modem, antenna); advanced settings live in the gear popover */}
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <label htmlFor="coverage-hardware" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-              Hardware
-            </label>
-            <div className="flex gap-1">
-              <select
-                id="coverage-hardware"
-                value={hardwareIdx}
-                onChange={(e) => onHardwareIdxChange(Number(e.target.value))}
-                className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                  focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                  [&>option]:bg-gray-800 [&>option]:text-gray-200"
-              >
-                {COMMON_HARDWARE.map((h, i) => (
-                  <option key={i} value={i}>
-                    {h.label}{h.isCustom ? "" : ` (${h.txDbm} dBm)`}
-                  </option>
-                ))}
-              </select>
-              {isCustomHardware && (
-                <input
-                  type="number"
-                  value={customTxDbm}
-                  onChange={(e) => onCustomTxDbmChange(Number(e.target.value))}
-                  min={10}
-                  max={35}
-                  step={1}
-                  aria-label="Custom TX power (dBm)"
-                  title="TX power in dBm"
-                  className="w-12 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
-                    focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
-                />
-              )}
+        {/* Transmitter row */}
+        <Row
+          icon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.7} d="M5 12a7 7 0 0114 0M2 12a10 10 0 0120 0M9 12a3 3 0 116 0M12 12v9" />
+            </svg>
+          }
+          title="Transmitter"
+          summary={txSummary}
+          expanded={expandedRow === "tx"}
+          onToggle={() => toggleRow("tx")}
+        >
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label htmlFor="coverage-hardware" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                Hardware
+              </label>
+              <div className="flex gap-1">
+                <select
+                  id="coverage-hardware"
+                  value={hardwareIdx}
+                  onChange={(e) => onHardwareIdxChange(Number(e.target.value))}
+                  className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                    focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                    [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                >
+                  {COMMON_HARDWARE.map((h, i) => (
+                    <option key={i} value={i}>
+                      {h.label}{h.isCustom ? "" : ` (${h.txDbm} dBm)`}
+                    </option>
+                  ))}
+                </select>
+                {isCustomHardware && (
+                  <input
+                    type="number"
+                    value={customTxDbm}
+                    onChange={(e) => onCustomTxDbmChange(Number(e.target.value))}
+                    min={10}
+                    max={35}
+                    step={1}
+                    aria-label="Custom TX power (dBm)"
+                    title="TX power in dBm"
+                    className="w-12 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
+                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
+                  />
+                )}
+              </div>
+            </div>
+            <div>
+              <label htmlFor="coverage-preset" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                Modem Preset
+              </label>
+              <div className="flex gap-1">
+                <select
+                  id="coverage-preset"
+                  value={presetIdx}
+                  onChange={(e) => onPresetIdxChange(Number(e.target.value))}
+                  className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                    focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                    [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                >
+                  {MESHTASTIC_PRESETS.map((p, i) => (
+                    <option key={i} value={i}>
+                      {p.label}{p.isCustom ? "" : ` · ${p.sensitivityDbm} dBm`}
+                    </option>
+                  ))}
+                </select>
+                {isCustomPreset && (
+                  <input
+                    type="number"
+                    value={customSensitivityDbm}
+                    onChange={(e) => onCustomSensitivityChange(Number(e.target.value))}
+                    min={-150}
+                    max={-100}
+                    step={1}
+                    aria-label="Custom RX sensitivity (dBm)"
+                    title="RX sensitivity in dBm (e.g. −133)"
+                    className="w-14 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
+                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
+                  />
+                )}
+              </div>
             </div>
           </div>
-          <div>
-            <label htmlFor="coverage-preset" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-              Modem Preset
-            </label>
-            <div className="flex gap-1">
-              <select
-                id="coverage-preset"
-                value={presetIdx}
-                onChange={(e) => onPresetIdxChange(Number(e.target.value))}
-                className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                  focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                  [&>option]:bg-gray-800 [&>option]:text-gray-200"
-              >
-                {MESHTASTIC_PRESETS.map((p, i) => (
-                  <option key={i} value={i}>
-                    {p.label}{p.isCustom ? "" : ` · ${p.sensitivityDbm} dBm`}
-                  </option>
-                ))}
-              </select>
-              {isCustomPreset && (
-                <input
-                  type="number"
-                  value={customSensitivityDbm}
-                  onChange={(e) => onCustomSensitivityChange(Number(e.target.value))}
-                  min={-150}
-                  max={-100}
-                  step={1}
-                  aria-label="Custom RX sensitivity (dBm)"
-                  title="RX sensitivity in dBm (e.g. −133)"
-                  className="w-14 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
-                    focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
-                />
-              )}
-            </div>
-          </div>
-        </div>
 
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <label htmlFor="coverage-antenna" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-              Antenna Gain
-            </label>
-            <select
-              id="coverage-antenna"
-              value={antennaIdx}
-              onChange={(e) => onAntennaIdxChange(Number(e.target.value))}
-              className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                [&>option]:bg-gray-800 [&>option]:text-gray-200"
-            >
-              {COMMON_ANTENNAS.map((a, i) => (
-                <option key={i} value={i}>{a.label}</option>
-              ))}
-            </select>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label htmlFor="coverage-antenna" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                Antenna Gain
+              </label>
+              <select
+                id="coverage-antenna"
+                value={antennaIdx}
+                onChange={(e) => onAntennaIdxChange(Number(e.target.value))}
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                  focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                  [&>option]:bg-gray-800 [&>option]:text-gray-200"
+              >
+                {COMMON_ANTENNAS.map((a, i) => (
+                  <option key={i} value={i}>{a.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="coverage-antenna-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
+                <span>Antenna Height</span>
+                <InfoTip align="right">
+                  Height of the antenna above the pin location. For a
+                  node-anchored pin, height stacks on top of the node's GPS
+                  altitude. Defaults to 2 m (handheld).
+                </InfoTip>
+              </label>
+              <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-20">
+                <input
+                  id="coverage-antenna-height"
+                  type="text"
+                  inputMode="decimal"
+                  value={heightInput}
+                  onChange={(e) => setHeightInput(e.target.value)}
+                  onBlur={commitHeight}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      (e.currentTarget as HTMLInputElement).blur();
+                    } else if (e.key === "Escape") {
+                      setHeightInput(String(antennaHeightM));
+                      (e.currentTarget as HTMLInputElement).blur();
+                    }
+                  }}
+                  aria-label="Antenna height above the pin (meters)"
+                  title="Antenna height above the pin (m). Blank = 2 m default."
+                  className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center focus:outline-hidden"
+                />
+                <span className="text-[10px] text-gray-500 shrink-0">m</span>
+              </div>
+            </div>
           </div>
+
+          {/* Additional origins (multi-origin merge) */}
+          <div className="space-y-1.5 pt-1 border-t border-white/5">
+            <div className="flex items-center justify-between gap-2">
+              <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                <span>Additional origins{mergeOrigins.length > 0 && ` (${mergeOrigins.length})`}</span>
+                <InfoTip align="left">
+                  Add other nodes to layer on top of the primary origin —
+                  the painted coverage takes the per-pixel best signal
+                  across all origins. Useful for asking "where can my mesh
+                  reach if any of these nodes works?" without picking
+                  one as primary. Session-only — not persisted.
+                </InfoTip>
+              </label>
+              {mergeOrigins.length > 0 && (
+                <button
+                  type="button"
+                  onClick={onClearMergeOrigins}
+                  className="text-[10px] text-gray-500 hover:text-red-300"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            {mergeOrigins.length > 0 && (
+              <div className="flex flex-col gap-1">
+                {mergeOrigins.map((o) => (
+                  <div
+                    key={o.id}
+                    className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-white/5 text-[10px] text-gray-300"
+                  >
+                    <span className="truncate min-w-0 flex-1">{o.label}</span>
+                    <button
+                      type="button"
+                      onClick={() => onRemoveMergeOrigin(o.id)}
+                      className="text-gray-500 hover:text-red-300 shrink-0"
+                      aria-label={`Remove ${o.label} from merged origins`}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="flex items-center gap-1.5">
+              <input
+                type="text"
+                value={mergeOriginSearch}
+                onChange={(e) => setMergeOriginSearch(e.target.value)}
+                placeholder="Search nodes to add…"
+                className="flex-1 min-w-0 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-[10px] text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-cyan-500/50"
+              />
+              <button
+                type="button"
+                onClick={pickingMergeOrigin ? onCancelPickMergeOrigin : onStartPickMergeOrigin}
+                title={pickingMergeOrigin ? "Cancel pick (or press Esc)" : "Click on the map to drop a pin"}
+                className={`px-2 py-1 rounded-md border text-[10px] whitespace-nowrap shrink-0 transition-colors ${
+                  pickingMergeOrigin
+                    ? "bg-amber-500/20 border-amber-500/40 text-amber-200"
+                    : "bg-white/5 border-white/10 text-gray-300 hover:bg-white/10"
+                }`}
+              >
+                {pickingMergeOrigin ? "Click map…" : "+ Pin"}
+              </button>
+            </div>
+            {mergeOriginSearch.trim() !== "" && (
+              <div className="max-h-32 overflow-y-auto rounded-md bg-black/20 border border-white/5 divide-y divide-white/5">
+                {mergeOriginCandidates.length === 0 ? (
+                  <div className="text-[10px] text-gray-500 px-2 py-1.5">No matches.</div>
+                ) : (
+                  mergeOriginCandidates.map((n) => (
+                    <button
+                      key={n.id}
+                      type="button"
+                      onClick={() => {
+                        onAddMergeOriginById(n.id);
+                        setMergeOriginSearch("");
+                      }}
+                      className="w-full text-left px-2 py-1 text-[10px] text-gray-300 hover:bg-white/5 truncate"
+                    >
+                      <span className="text-cyan-300/80 mr-1">+</span>
+                      {n.shortname ?? n.longname ?? n.id}
+                      {n.shortname && n.longname && (
+                        <span className="text-gray-500 ml-1.5">{n.longname}</span>
+                      )}
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </Row>
+
+        {/* Receiver row — defaults to Same as TX, single toggle to customize */}
+        <Row
+          icon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <rect x="7" y="2" width="10" height="20" rx="2" strokeWidth={1.7} />
+              <line x1="11" y1="18" x2="13" y2="18" strokeWidth={1.7} strokeLinecap="round" />
+            </svg>
+          }
+          title="Receiver"
+          summary={rxSummary}
+          expanded={expandedRow === "rx"}
+          onToggle={() => toggleRow("rx")}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={rxMatchesTx}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onRxHardwareIdxChange(hardwareIdx);
+                    onRxAntennaIdxChange(antennaIdx);
+                    onRxHeightChange(antennaHeightM);
+                  }
+                  // unchecking: keep current RX values; user will edit below
+                }}
+                className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
+              />
+              <span>Same as transmitter</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => {
+                // Heltec V3 + rubber duck @ 2 m
+                onRxHardwareIdxChange(4);
+                onRxAntennaIdxChange(0);
+                onRxHeightChange(2);
+              }}
+              className="text-[10px] text-cyan-400/70 hover:text-cyan-300 transition-colors"
+              title="Set RX to a stock handheld (Heltec V3, rubber duck, 2 m) — typical 'who can hear me?' setup"
+            >
+              Use handheld
+            </button>
+          </div>
+
+          {!rxMatchesTx && (
+            <>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label htmlFor="coverage-rx-hw" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
+                    <span>Hardware</span>
+                    <InfoTip align="left">
+                      RX hardware drives the chipset-aware sensitivity
+                      correction (SX1276 boards get an additional ~2 dB
+                      penalty over SX1262). TX power is unused on this
+                      side — ITM treats RX as a passive receiver.
+                    </InfoTip>
+                  </label>
+                  <select
+                    id="coverage-rx-hw"
+                    value={rxHardwareIdx}
+                    onChange={(e) => onRxHardwareIdxChange(Number(e.target.value))}
+                    className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                      [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                  >
+                    {COMMON_HARDWARE.map((h, i) => (
+                      <option key={i} value={i}>{h.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="coverage-rx-ant" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                    Antenna
+                  </label>
+                  <select
+                    id="coverage-rx-ant"
+                    value={rxAntennaIdx}
+                    onChange={(e) => onRxAntennaIdxChange(Number(e.target.value))}
+                    className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                      [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                  >
+                    {COMMON_ANTENNAS.map((a, i) => (
+                      <option key={i} value={i}>{a.label}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label htmlFor="coverage-rx-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
+                  <span>Height above ground</span>
+                  <InfoTip align="left">
+                    RX antenna height over local terrain (m). 2 m =
+                    handheld default. Use 6-10 m for a typical rooftop
+                    station, 30 m+ for tower-mounted receivers.
+                  </InfoTip>
+                </label>
+                <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-24">
+                  <input
+                    id="coverage-rx-height"
+                    type="text"
+                    inputMode="decimal"
+                    value={rxHeightInput}
+                    onChange={(e) => setRxHeightInput(e.target.value)}
+                    onBlur={commitRxHeight}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        (e.currentTarget as HTMLInputElement).blur();
+                      } else if (e.key === "Escape") {
+                        setRxHeightInput(String(rxHeightM));
+                        (e.currentTarget as HTMLInputElement).blur();
+                      }
+                    }}
+                    aria-label="RX antenna height above ground (meters)"
+                    title="RX height above local terrain (m). Blank = 2 m default."
+                    className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center focus:outline-hidden"
+                  />
+                  <span className="text-[10px] text-gray-500 shrink-0">m</span>
+                </div>
+              </div>
+            </>
+          )}
+        </Row>
+
+        {/* Environment row (clutter + canopy + buildings) */}
+        <Row
+          icon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.7} d="M12 3l4 6h-2.5L17 15h-3l3 5H7l3-5H7l3-6H7.5L12 3z" />
+            </svg>
+          }
+          title="Environment"
+          summary={envSummary}
+          expanded={expandedRow === "env"}
+          onToggle={() => toggleRow("env")}
+        >
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                <span>Clutter (NLCD)</span>
+                <InfoTip align="left">
+                  Per-pixel building / vegetation loss from USGS NLCD land
+                  cover, applied via ITU-R P.452-17 (endpoint clutter) and
+                  P.833-9 (path-traversed vegetation). Toggle off for
+                  ITM-only bare-earth predictions.
+                </InfoTip>
+              </label>
+              <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                <input
+                  type="checkbox"
+                  checked={clutterEnabled}
+                  onChange={(e) => onClutterEnabledChange(e.target.checked)}
+                  className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                />
+                <span>Enabled</span>
+              </label>
+            </div>
+            <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
+            <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
+            <ClassLegend />
+          </div>
+          <div className="space-y-1.5 pt-1.5 border-t border-white/5">
+            <div className="flex items-center justify-between gap-2">
+              <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                <span>Canopy heights (ETH)</span>
+                <InfoTip align="left">
+                  Per-pixel measured canopy heights from ETH Global Canopy
+                  Height 2020 (Lang et al. 2023, 10 m). Replaces class-nominal
+                  heights in ITU-R P.833-9 vegetation loss for forest classes.
+                  Toggle off to fall back to class-nominal heights everywhere.
+                </InfoTip>
+              </label>
+              <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                <input
+                  type="checkbox"
+                  checked={canopyEnabled}
+                  onChange={(e) => onCanopyEnabledChange(e.target.checked)}
+                  className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                />
+                <span>Enabled</span>
+              </label>
+            </div>
+            <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
+          </div>
+          <div className="space-y-1.5 pt-1.5 border-t border-white/5">
+            <div className="flex items-center justify-between gap-2">
+              <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
+                <span>Building heights (JRC)</span>
+                <InfoTip align="left">
+                  Per-pixel measured building heights from JRC GHS-BUILT-H
+                  ANBH (100 m global). Adds rooftops as DSM obstacles for
+                  ITM diffraction along the propagation path, and replaces
+                  class-nominal h_a in the ITU-R P.452 endpoint formula for
+                  developed-class pixels. Toggle off for bare-earth DEM and
+                  class-nominal heights.
+                </InfoTip>
+              </label>
+              <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                <input
+                  type="checkbox"
+                  checked={buildingsEnabled}
+                  onChange={(e) => onBuildingsEnabledChange(e.target.checked)}
+                  className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                />
+                <span>Enabled</span>
+              </label>
+            </div>
+            <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
+          </div>
+        </Row>
+
+        {/* Accuracy row (reliability + detail) */}
+        <Row
+          icon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="9" strokeWidth={1.7} />
+              <circle cx="12" cy="12" r="5" strokeWidth={1.7} />
+              <circle cx="12" cy="12" r="1.5" strokeWidth={1.7} fill="currentColor" />
+            </svg>
+          }
+          title="Accuracy"
+          summary={accSummary}
+          expanded={expandedRow === "acc"}
+          onToggle={() => toggleRow("acc")}
+        >
           <div>
-            <label htmlFor="coverage-antenna-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
-              <span>Antenna Height</span>
-              <InfoTip align="right">
-                Height of the antenna above the pin location. For a
-                node-anchored pin, height stacks on top of the node's GPS
-                altitude. Defaults to 2 m (handheld).
+            <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
+              <span>Reliability</span>
+              <InfoTip align="left">
+                ITM's time / location / situation percentages. Higher =
+                "works most of the time" instead of "works half the time."
+                Typical (90/50/70) is the industry planning default.
+                Median matches Radio&nbsp;Mobile / SPLAT!; Conservative is
+                for mission-critical links.
               </InfoTip>
             </label>
-            <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-20">
-              <input
-                id="coverage-antenna-height"
-                type="text"
-                inputMode="decimal"
-                value={heightInput}
-                onChange={(e) => setHeightInput(e.target.value)}
-                onBlur={commitHeight}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    (e.currentTarget as HTMLInputElement).blur();
-                  } else if (e.key === "Escape") {
-                    setHeightInput(String(antennaHeightM));
-                    (e.currentTarget as HTMLInputElement).blur();
-                  }
-                }}
-                aria-label="Antenna height above the pin (meters)"
-                title="Antenna height above the pin (m). Blank = 2 m default."
-                className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center
-                  focus:outline-hidden"
-              />
-              <span className="text-[10px] text-gray-500 shrink-0">m</span>
+            <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
+              {RELIABILITY_PRESETS.map((p) => {
+                const active = reliability === p.id;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => onReliabilityChange(p.id)}
+                    title={p.desc}
+                    className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
+                      active
+                        ? "bg-cyan-500/20 text-cyan-200"
+                        : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
+                    }`}
+                  >
+                    <div>{p.label}</div>
+                    <div className="text-[9px] text-gray-500 font-normal">
+                      {p.time}/{p.location}/{p.situation}
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </div>
-        </div>
+          <div>
+            <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 flex items-center gap-1">
+              <span>Detail</span>
+              <InfoTip align="left">
+                Output raster resolution (painted pixels). Higher detail
+                = crisper edges around terrain features when zoomed in,
+                but slower to compute. Standard feels instant; Ultra is
+                a one-off survey. Survey matches the 2048² DEM 1:1 — the
+                sharpest possible output, 4× the compute of Ultra.
+              </InfoTip>
+            </label>
+            <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
+              {([
+                { key: "standard", label: "Std",    sub: "512 px" },
+                { key: "high",     label: "High",   sub: "768 px" },
+                { key: "ultra",    label: "Ultra",  sub: "1024 px" },
+                { key: "survey",   label: "Survey", sub: "2048 px" },
+              ] as const).map((opt) => {
+                const active = detail === opt.key;
+                return (
+                  <button
+                    key={opt.key}
+                    type="button"
+                    onClick={() => onDetailChange(opt.key)}
+                    className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
+                      active
+                        ? "bg-cyan-500/20 text-cyan-200"
+                        : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
+                    }`}
+                  >
+                    <div>{opt.label}</div>
+                    <div className="text-[9px] text-gray-500 font-normal">{opt.sub}</div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </Row>
+
+        {/* Overlays row (contours + rays) */}
+        <Row
+          icon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.7} d="M12 3l9 5-9 5-9-5 9-5zM3 13l9 5 9-5M3 17l9 5 9-5" />
+            </svg>
+          }
+          title="Overlays"
+          summary={ovSummary}
+          expanded={expandedRow === "ov"}
+          onToggle={() => toggleRow("ov")}
+        >
+          <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showContours}
+              onChange={(e) => onShowContoursChange(e.target.checked)}
+              className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
+            />
+            <span className="inline-flex items-center gap-1 min-w-0">
+              Iso-margin contours
+              <InfoTip align="left">
+                Overlay iso-margin lines at 0 dB (magenta — edge of
+                coverage), +10 dB (cyan — reliable), and +20 dB (deep
+                cyan — strong signal).
+              </InfoTip>
+            </span>
+          </label>
+          <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showRays}
+              onChange={(e) => onShowRaysChange(e.target.checked)}
+              className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
+            />
+            <span className="inline-flex items-center gap-1 min-w-0">
+              Visibility rays
+              <InfoTip align="left">
+                Draws a fan of per-azimuth sightlines from the origin
+                — the HeyWhatsThat-style view. Each ray shows where
+                the link budget stays above threshold along that
+                bearing. Useful for spotting specific paths that
+                punch through to distant ridges (which the smooth
+                coverage raster averages away).
+              </InfoTip>
+            </span>
+          </label>
+        </Row>
       </div>
     </div>
   );

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -246,12 +246,11 @@ export function MapCoveragePanel({
   onExport: (format: "geojson" | "kml") => void;
   /** Custom coord typed into the origin label. Caller detaches any anchor and moves the pin. */
   onOriginChange?: (lngLat: [number, number]) => void;
-  /** Desktop-only: open the Scan tool with the same origin + settings, leaving the
-   *  coverage paint visible underneath as a sanity check against real nodes in view. */
+  /** Desktop-only: open the Scan tool against the same origin + settings,
+   *  leaving the coverage paint visible underneath. */
   onScanFromHere?: () => void;
-  /** True while the Scan-from-here overlay owns the screen — the panel still
-   *  renders so the user knows coverage is paused (not closed), but is forced
-   *  minimized to keep the map clear. */
+  /** True while a Scan-from-here overlay is active. Forces the panel to
+   *  stay minimized so the map stays clear. */
   overlayMode?: boolean;
 }) {
   const isCustomHardware = COMMON_HARDWARE[hardwareIdx]?.isCustom ?? false;
@@ -321,19 +320,14 @@ export function MapCoveragePanel({
       .slice(0, 12);
   }, [mergeOriginSearch, mergeOrigins, mergeNodeOptions]);
 
-  // Single-expand accordion. Auto-expand RX whenever it becomes asymmetric so
-  // the user can see what changed; never auto-collapse.
   const [expandedRow, setExpandedRow] = useState<RowKey | null>(null);
   const toggleRow = (k: RowKey) => setExpandedRow((cur) => (cur === k ? null : k));
 
-  // Minimized = header-only. Tool keeps computing in the background; the
-  // user can restore to inspect or tweak. Mobile drag-handle still works.
   const [minimized, setMinimized] = useState(false);
 
-  // Auto-minimize on the FIRST result for each new origin (so the user can see
-  // the painted coverage on the map). Recomputes for the same origin — e.g.,
-  // changing detail or hardware — leave the panel alone so the user keeps
-  // seeing what they're tweaking.
+  // Auto-minimize on the first result for each new origin so the painted
+  // coverage is visible on the map. Recomputes for the same origin leave
+  // the panel state alone so the user keeps seeing what they're tweaking.
   const lastAutoMinKeyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!result) return;
@@ -344,16 +338,15 @@ export function MapCoveragePanel({
     }
   }, [result]);
 
-  // Force minimize on entering Scan-from-here overlay so the map stays clear.
+  // Force-minimize on entering Scan-from-here overlay so the map stays clear.
   const prevOverlayRef = useRef(overlayMode);
   useEffect(() => {
     if (overlayMode && !prevOverlayRef.current) setMinimized(true);
     prevOverlayRef.current = overlayMode;
   }, [overlayMode]);
 
-  // Snapshot of pre-check RX values so unchecking "Same as transmitter" can
-  // restore whatever the user had before. Without this the uncheck looks like
-  // a no-op because rxMatchesTx is derived from the values still matching.
+  // Without a snapshot, unchecking "Same as transmitter" would be a visual
+  // no-op — rxMatchesTx is derived, so the values still match TX.
   const rxSnapshotRef = useRef<{ hw: number; ant: number; height: number } | null>(null);
 
   const sheet = useBottomSheetGesture(onClose);
@@ -602,7 +595,6 @@ export function MapCoveragePanel({
         );
       })()}
 
-      {/* Header: badge · origin editor · ⋯ menu · close */}
       <div
         className="flex items-center justify-between gap-3 px-3 py-2 border-b border-white/5 shrink-0 max-sm:touch-none"
         onTouchStart={sheet.onTouchStart}
@@ -646,9 +638,8 @@ export function MapCoveragePanel({
                   }
                 }}
                 onBlur={() => {
-                  // Commit silently if valid, otherwise just close. A
-                  // bad value on blur is treated as a cancel so an
-                  // accidental click-away doesn't blow up.
+                  // Treat a bad value on blur as a cancel so a click-away
+                  // doesn't reset the pin to nonsense.
                   const parsed = parseLatLng(originDraft);
                   setEditingOrigin(false);
                   setOriginDraftError(false);
@@ -665,8 +656,6 @@ export function MapCoveragePanel({
               <button
                 type="button"
                 onClick={() => {
-                  // Pre-fill with current pin coordinates (works whether the
-                  // origin is a node anchor or a virtual placement).
                   const [lng, lat] = result.origin;
                   setOriginDraft(`${lat.toFixed(5)}, ${lng.toFixed(5)}`);
                   setEditingOrigin(true);
@@ -700,7 +689,6 @@ export function MapCoveragePanel({
               )}
             </svg>
           </button>
-          {/* ⋯ menu: export options */}
           <details className="text-[10px] text-gray-400 relative">
             <summary
               className="cursor-pointer list-none p-1 rounded-md hover:text-gray-200 hover:bg-white/5 transition-colors flex items-center"
@@ -755,9 +743,7 @@ export function MapCoveragePanel({
         </div>
       </div>
 
-      {/* Body: result strip + accordion rows. Hidden when minimized. */}
       <div className={`p-3 pb-5 space-y-2 overflow-y-auto overscroll-contain min-h-0 flex-1 sm:pb-3 ${minimized ? "hidden" : ""}`}>
-        {/* Reachability summary + RSSI gradient legend + diagnostics + help */}
         {(() => {
           const reachablePx = result.clearCount + result.fresnelCount;
           const totalPx = reachablePx + result.blockedCount;
@@ -944,7 +930,6 @@ export function MapCoveragePanel({
           );
         })()}
 
-        {/* Transmitter row */}
         <Row
           icon={
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1082,7 +1067,6 @@ export function MapCoveragePanel({
             </div>
           </div>
 
-          {/* Additional origins (multi-origin merge) */}
           <div className="space-y-1.5 pt-1 border-t border-white/5">
             <div className="flex items-center justify-between gap-2">
               <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 flex items-center gap-1">
@@ -1174,7 +1158,6 @@ export function MapCoveragePanel({
           </div>
         </Row>
 
-        {/* Receiver row — defaults to Same as TX, single toggle to customize */}
         <Row
           icon={
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1196,7 +1179,6 @@ export function MapCoveragePanel({
                 checked={rxMatchesTx}
                 onChange={(e) => {
                   if (e.target.checked) {
-                    // Save the current RX so unchecking can restore it.
                     rxSnapshotRef.current = {
                       hw: rxHardwareIdx,
                       ant: rxAntennaIdx,
@@ -1206,15 +1188,15 @@ export function MapCoveragePanel({
                     onRxAntennaIdxChange(antennaIdx);
                     onRxHeightChange(antennaHeightM);
                   } else {
-                    // Restore the previous RX. If there isn't one (RX was
-                    // already matching when the panel opened), fall back to
-                    // the stock handheld so the toggle is at least meaningful.
                     const snap = rxSnapshotRef.current;
                     if (snap) {
                       onRxHardwareIdxChange(snap.hw);
                       onRxAntennaIdxChange(snap.ant);
                       onRxHeightChange(snap.height);
                     } else {
+                      // No snapshot = RX already matched TX when the panel
+                      // opened. Fall back to handheld so the toggle isn't a
+                      // no-op.
                       onRxHardwareIdxChange(4); // Heltec V3
                       onRxAntennaIdxChange(0);  // rubber duck
                       onRxHeightChange(2);
@@ -1321,7 +1303,6 @@ export function MapCoveragePanel({
           )}
         </Row>
 
-        {/* Environment row (clutter + canopy + buildings) */}
         <Row
           icon={
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1408,7 +1389,6 @@ export function MapCoveragePanel({
           </div>
         </Row>
 
-        {/* Accuracy row (reliability + detail) */}
         <Row
           icon={
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1496,7 +1476,6 @@ export function MapCoveragePanel({
           </div>
         </Row>
 
-        {/* Overlays row (contours + rays) */}
         <Row
           icon={
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -188,18 +188,15 @@ export function MapScanPanel({
   const toggleFilter = (cls: ScanClass) =>
     setFilter((prev) => (prev === cls ? null : cls));
 
-  // Single-expand settings rows inside the gear popover
   const [expandedSettingsRow, setExpandedSettingsRow] = useState<SettingsRowKey | null>(null);
   const toggleSettingsRow = (k: SettingsRowKey) =>
     setExpandedSettingsRow((cur) => (cur === k ? null : k));
 
-  // Minimized = header-only. Scan keeps running in the background; user can
-  // restore to inspect results or tweak settings.
   const [minimized, setMinimized] = useState(false);
 
-  // Auto-minimize on the FIRST scan result for each new origin (so the user
-  // can see their hits on the map). Recomputes for the same origin leave the
-  // panel alone so the user keeps seeing results they're tweaking against.
+  // Auto-minimize on the first result for each new origin so the user can see
+  // their hits on the map. Recomputes for the same origin leave panel state
+  // alone so the user keeps seeing results they're tweaking against.
   const lastAutoMinKeyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!summary) return;
@@ -209,9 +206,8 @@ export function MapScanPanel({
     }
   }, [summary, originLabel]);
 
-  // Snapshot of pre-check RX so unchecking "Same as transmitter" restores
-  // whatever the user had before, instead of being a no-op (rxMatchesTx is
-  // derived from the values still matching, so no state change = no UI change).
+  // Without a snapshot, unchecking "Same as transmitter" would be a visual
+  // no-op — rxMatchesTx is derived, so the values still match TX.
   const rxSnapshotRef = useRef<{ hw: number; ant: number } | null>(null);
 
   const sheet = useBottomSheetGesture(onClose);
@@ -368,7 +364,6 @@ export function MapScanPanel({
                 Scan settings
               </div>
 
-              {/* Transmitter row */}
               <SettingsRow
                 title="Transmitter"
                 summary={txSummaryStr}
@@ -492,7 +487,6 @@ export function MapScanPanel({
                 </div>
               </SettingsRow>
 
-              {/* Receiver row — defaults to Same as TX, single toggle to customize */}
               <SettingsRow
                 title="Receiver"
                 summary={rxMatchesTx ? rxSummaryStr : <span className="text-cyan-300">{rxSummaryStr}</span>}
@@ -578,7 +572,6 @@ export function MapScanPanel({
                 )}
               </SettingsRow>
 
-              {/* Environment row (clutter + canopy + buildings) */}
               <SettingsRow
                 title="Environment"
                 summary={envSummaryStr}
@@ -640,7 +633,6 @@ export function MapScanPanel({
                 </div>
               </SettingsRow>
 
-              {/* Accuracy row (ITM reliability — time/location/situation %) */}
               <SettingsRow
                 title="Accuracy"
                 summary={accSummaryStr}

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -1,11 +1,53 @@
 /** Scan-results panel: ranked LoS from origin to every node in view. */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, MESHTASTIC_PRESETS } from "./coverageAnalysis";
 import type { ScanClass, ScanResult,ScanSummary } from "./scanAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
+
+/** Collapsible settings row: header summarizes current state, body holds inline editors. */
+function SettingsRow({
+  title,
+  summary,
+  expanded,
+  onToggle,
+  children,
+}: {
+  title: string;
+  summary: React.ReactNode;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg bg-white/5 border border-white/5 overflow-hidden">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2 px-2.5 py-2 hover:bg-white/3 transition-colors text-left"
+      >
+        <span className="text-[10px] font-medium uppercase tracking-wider text-gray-400 shrink-0">{title}</span>
+        <span className="text-[10px] text-gray-500 truncate flex-1 min-w-0 text-right">{summary}</span>
+        <svg
+          className={`w-3.5 h-3.5 text-gray-500 transition-transform shrink-0 ${expanded ? "rotate-90" : ""}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="px-2.5 pb-2.5 pt-2 border-t border-white/5 space-y-2.5">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SettingsRowKey = "tx" | "rx" | "env";
 
 const CLASS_STYLES: Record<ScanClass, { bg: string; text: string; border: string; label: string }> = {
   clear:      { bg: "bg-cyan-500/15",    text: "text-cyan-300",    border: "border-cyan-500/30",    label: "Clear" },
@@ -139,6 +181,27 @@ export function MapScanPanel({
   const toggleFilter = (cls: ScanClass) =>
     setFilter((prev) => (prev === cls ? null : cls));
 
+  // Single-expand settings rows inside the gear popover
+  const [expandedSettingsRow, setExpandedSettingsRow] = useState<SettingsRowKey | null>(null);
+  const toggleSettingsRow = (k: SettingsRowKey) =>
+    setExpandedSettingsRow((cur) => (cur === k ? null : k));
+
+  // Minimized = header-only. Scan keeps running in the background; user can
+  // restore to inspect results or tweak settings.
+  const [minimized, setMinimized] = useState(false);
+
+  // Auto-minimize on the FIRST scan result for each new origin (so the user
+  // can see their hits on the map). Recomputes for the same origin leave the
+  // panel alone so the user keeps seeing results they're tweaking against.
+  const lastAutoMinKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!summary) return;
+    if (lastAutoMinKeyRef.current !== originLabel) {
+      lastAutoMinKeyRef.current = originLabel;
+      setMinimized(true);
+    }
+  }, [summary, originLabel]);
+
   const sheet = useBottomSheetGesture(onClose);
   const isCustomHardware = COMMON_HARDWARE[hardwareIdx]?.isCustom ?? false;
   const isCustomPreset = MESHTASTIC_PRESETS[presetIdx]?.isCustom ?? false;
@@ -174,6 +237,22 @@ export function MapScanPanel({
     ? summary.clearCount + summary.fresnelCount + summary.diffractedCount
     : 0;
 
+  // Derived summaries for collapsed settings-row headers
+  const txHardware = COMMON_HARDWARE[hardwareIdx]?.label ?? "Custom";
+  const txAntDbi = COMMON_ANTENNAS[antennaIdx]?.dbi ?? 0;
+  const txPreset = MESHTASTIC_PRESETS[presetIdx]?.label ?? "Custom";
+  const rxMatchesTx = rxHardwareIdx === hardwareIdx && rxAntennaIdx === antennaIdx;
+  const rxHardware = COMMON_HARDWARE[rxHardwareIdx]?.label ?? "Custom";
+  const rxAntDbi = COMMON_ANTENNAS[rxAntennaIdx]?.dbi ?? 0;
+
+  const txSummaryStr = `${txHardware} · ${txAntDbi} dBi · ${antennaHeightM}m · ${txPreset}`;
+  const rxSummaryStr = rxMatchesTx ? "Same as TX" : `${rxHardware} · ${rxAntDbi} dBi`;
+  const envParts: string[] = [];
+  if (clutterEnabled) envParts.push("clutter");
+  if (canopyEnabled) envParts.push("canopy");
+  if (buildingsEnabled) envParts.push("buildings");
+  const envSummaryStr = envParts.length === 0 ? "All off · bare earth" : envParts.join(" · ");
+
   const displayResults: ScanResult[] = useMemo(() => {
     if (!summary) return [];
     const filtered = filter
@@ -185,12 +264,13 @@ export function MapScanPanel({
   return (
     <div
       ref={sheet.sheetRef}
-      className="fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl flex flex-col
+      className={`fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl flex flex-col
         inset-x-0 bottom-0 rounded-t-2xl max-h-[78dvh]
         animate-[slideInUp_200ms_ease-out]
-        sm:inset-x-auto sm:left-3 sm:top-16 sm:bottom-16 sm:w-85 sm:max-w-[calc(100vw-1.5rem)]
+        sm:inset-x-auto sm:left-3 sm:top-16 sm:w-85 sm:max-w-[calc(100vw-1.5rem)]
         sm:rounded-xl sm:max-h-none
-        sm:animate-[slideInLeft_220ms_ease-out]"
+        sm:animate-[slideInLeft_220ms_ease-out]
+        ${minimized ? "sm:bottom-auto" : "sm:bottom-16"}`}
       onClick={(e) => {
         const target = e.target as Node;
         const openDetails = e.currentTarget.querySelectorAll<HTMLDetailsElement>("details[open]");
@@ -234,6 +314,22 @@ export function MapScanPanel({
           </div>
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => setMinimized((m) => !m)}
+            className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+            aria-label={minimized ? "Expand panel" : "Minimize panel"}
+            aria-expanded={!minimized}
+            title={minimized ? "Expand — scan tool is still running" : "Minimize — keep tool running, hide results"}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {minimized ? (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 9l7 7 7-7" />
+              )}
+            </svg>
+          </button>
           <details className="text-[10px] text-gray-400 relative">
             <summary
               className="cursor-pointer list-none p-1 rounded-md hover:text-gray-200 hover:bg-white/5 transition-colors"
@@ -246,176 +342,97 @@ export function MapScanPanel({
               </svg>
             </summary>
             {/* Fixed so it escapes the side-panel's overflow. */}
-            <div className="fixed z-1060 overflow-y-auto p-3 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl space-y-3
+            <div className="fixed z-1060 overflow-y-auto p-2 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl space-y-2
               inset-x-3 top-4 bottom-4 w-auto max-w-none
               sm:inset-auto sm:top-16 sm:left-90 sm:w-90 sm:max-h-[calc(100vh-8rem)]">
-              <div className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
+              <div className="text-[10px] uppercase tracking-wider text-gray-500 font-medium px-0.5 pb-0.5">
                 Scan settings
               </div>
 
-              {/* TX block */}
-              <div className="grid grid-cols-2 gap-2">
-                <div>
-                  <label htmlFor="scan-hardware" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                    TX Hardware
-                  </label>
-                  <div className="flex gap-1">
-                    <select
-                      id="scan-hardware"
-                      value={hardwareIdx}
-                      onChange={(e) => onHardwareIdxChange(Number(e.target.value))}
-                      className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                        focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                        [&>option]:bg-gray-800 [&>option]:text-gray-200"
-                    >
-                      {COMMON_HARDWARE.map((h, i) => (
-                        <option key={i} value={i}>
-                          {h.label}{h.isCustom ? "" : ` (${h.txDbm} dBm)`}
-                        </option>
-                      ))}
-                    </select>
-                    {isCustomHardware && (
-                      <input
-                        type="number"
-                        value={customTxDbm}
-                        onChange={(e) => onCustomTxDbmChange(Number(e.target.value))}
-                        min={10} max={35} step={1}
-                        aria-label="Custom TX power (dBm)"
-                        title="TX power in dBm"
-                        className="w-12 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
-                          focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
-                      />
-                    )}
+              {/* Transmitter row */}
+              <SettingsRow
+                title="Transmitter"
+                summary={txSummaryStr}
+                expanded={expandedSettingsRow === "tx"}
+                onToggle={() => toggleSettingsRow("tx")}
+              >
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label htmlFor="scan-hardware" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                      Hardware
+                    </label>
+                    <div className="flex gap-1">
+                      <select
+                        id="scan-hardware"
+                        value={hardwareIdx}
+                        onChange={(e) => onHardwareIdxChange(Number(e.target.value))}
+                        className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                          focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                          [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                      >
+                        {COMMON_HARDWARE.map((h, i) => (
+                          <option key={i} value={i}>
+                            {h.label}{h.isCustom ? "" : ` (${h.txDbm} dBm)`}
+                          </option>
+                        ))}
+                      </select>
+                      {isCustomHardware && (
+                        <input
+                          type="number"
+                          value={customTxDbm}
+                          onChange={(e) => onCustomTxDbmChange(Number(e.target.value))}
+                          min={10} max={35} step={1}
+                          aria-label="Custom TX power (dBm)"
+                          title="TX power in dBm"
+                          className="w-12 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
+                            focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
+                        />
+                      )}
+                    </div>
                   </div>
-                </div>
-                <div>
-                  <label htmlFor="scan-antenna" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                    TX Antenna
-                  </label>
-                  <select
-                    id="scan-antenna"
-                    value={antennaIdx}
-                    onChange={(e) => onAntennaIdxChange(Number(e.target.value))}
-                    className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                      [&>option]:bg-gray-800 [&>option]:text-gray-200"
-                  >
-                    {COMMON_ANTENNAS.map((a, i) => (
-                      <option key={i} value={i}>{a.label}</option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              {/* TX antenna height AGL — overrides GPS altitude. */}
-              <div>
-                <label htmlFor="scan-tx-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                  TX Antenna Height
-                </label>
-                <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-20">
-                  <input
-                    id="scan-tx-height"
-                    type="text"
-                    inputMode="decimal"
-                    value={heightInput}
-                    onChange={(e) => setHeightInput(e.target.value)}
-                    onBlur={commitHeight}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        (e.currentTarget as HTMLInputElement).blur();
-                      } else if (e.key === "Escape") {
-                        setHeightInput(String(antennaHeightM));
-                        (e.currentTarget as HTMLInputElement).blur();
-                      }
-                    }}
-                    aria-label="TX antenna height above the origin (meters)"
-                    title="TX antenna height above the origin terrain (m). Blank = 2 m default."
-                    className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center focus:outline-hidden"
-                  />
-                  <span className="text-[10px] text-gray-500 shrink-0">m</span>
-                </div>
-              </div>
-
-              {/* Modem preset */}
-              <div>
-                <label htmlFor="scan-preset" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                  Modem Preset
-                </label>
-                <div className="flex gap-1">
-                  <select
-                    id="scan-preset"
-                    value={presetIdx}
-                    onChange={(e) => onPresetIdxChange(Number(e.target.value))}
-                    className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                      [&>option]:bg-gray-800 [&>option]:text-gray-200"
-                  >
-                    {MESHTASTIC_PRESETS.map((p, i) => (
-                      <option key={i} value={i}>
-                        {p.label}{p.isCustom ? "" : ` · ${p.sensitivityDbm} dBm`}
-                      </option>
-                    ))}
-                  </select>
-                  {isCustomPreset && (
-                    <input
-                      type="number"
-                      value={customSensitivityDbm}
-                      onChange={(e) => onCustomSensitivityChange(Number(e.target.value))}
-                      min={-150} max={-100} step={1}
-                      aria-label="Custom RX sensitivity (dBm)"
-                      title="RX sensitivity in dBm"
-                      className="w-14 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
-                        focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
-                    />
-                  )}
-                </div>
-              </div>
-
-              {/* RX block */}
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
-                    <span>Receiver (modeled)</span>
+                  <div>
+                    <label htmlFor="scan-preset" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                      Modem Preset
+                    </label>
+                    <div className="flex gap-1">
+                      <select
+                        id="scan-preset"
+                        value={presetIdx}
+                        onChange={(e) => onPresetIdxChange(Number(e.target.value))}
+                        className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                          focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                          [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                      >
+                        {MESHTASTIC_PRESETS.map((p, i) => (
+                          <option key={i} value={i}>
+                            {p.label}{p.isCustom ? "" : ` · ${p.sensitivityDbm} dBm`}
+                          </option>
+                        ))}
+                      </select>
+                      {isCustomPreset && (
+                        <input
+                          type="number"
+                          value={customSensitivityDbm}
+                          onChange={(e) => onCustomSensitivityChange(Number(e.target.value))}
+                          min={-150} max={-100} step={1}
+                          aria-label="Custom RX sensitivity (dBm)"
+                          title="RX sensitivity in dBm"
+                          className="w-14 rounded-lg border border-white/10 bg-white/5 px-1 py-1 text-xs text-gray-200 text-center
+                            focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50"
+                        />
+                      )}
+                    </div>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onRxHardwareIdxChange(4); // Heltec V3
-                      onRxAntennaIdxChange(0);  // rubber duck
-                    }}
-                    className="text-[9px] text-cyan-400/70 hover:text-cyan-300 transition-colors"
-                    title="Reset RX to stock handheld (Heltec V3, rubber duck)"
-                  >
-                    Reset to handheld
-                  </button>
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   <div>
-                    <label htmlFor="scan-rx-hw" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
-                      Hardware
-                    </label>
-                    <select
-                      id="scan-rx-hw"
-                      value={rxHardwareIdx}
-                      onChange={(e) => onRxHardwareIdxChange(Number(e.target.value))}
-                      className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
-                        focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
-                        [&>option]:bg-gray-800 [&>option]:text-gray-200"
-                    >
-                      {COMMON_HARDWARE.map((h, i) => (
-                        <option key={i} value={i}>{h.label}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label htmlFor="scan-rx-ant" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                    <label htmlFor="scan-antenna" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
                       Antenna
                     </label>
                     <select
-                      id="scan-rx-ant"
-                      value={rxAntennaIdx}
-                      onChange={(e) => onRxAntennaIdxChange(Number(e.target.value))}
+                      id="scan-antenna"
+                      value={antennaIdx}
+                      onChange={(e) => onAntennaIdxChange(Number(e.target.value))}
                       className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
                         focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
                         [&>option]:bg-gray-800 [&>option]:text-gray-200"
@@ -425,61 +442,175 @@ export function MapScanPanel({
                       ))}
                     </select>
                   </div>
+                  <div>
+                    <label htmlFor="scan-tx-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                      Antenna Height
+                    </label>
+                    <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-20">
+                      <input
+                        id="scan-tx-height"
+                        type="text"
+                        inputMode="decimal"
+                        value={heightInput}
+                        onChange={(e) => setHeightInput(e.target.value)}
+                        onBlur={commitHeight}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            (e.currentTarget as HTMLInputElement).blur();
+                          } else if (e.key === "Escape") {
+                            setHeightInput(String(antennaHeightM));
+                            (e.currentTarget as HTMLInputElement).blur();
+                          }
+                        }}
+                        aria-label="TX antenna height above the origin (meters)"
+                        title="TX antenna height above the origin terrain (m). Blank = 2 m default."
+                        className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center focus:outline-hidden"
+                      />
+                      <span className="text-[10px] text-gray-500 shrink-0">m</span>
+                    </div>
+                  </div>
                 </div>
-              </div>
+              </SettingsRow>
 
-              {/* Clutter (per-pixel ITU model + aggression scaler). */}
-              <div className="space-y-1.5">
+              {/* Receiver row — defaults to Same as TX, single toggle to customize */}
+              <SettingsRow
+                title="Receiver"
+                summary={rxMatchesTx ? rxSummaryStr : <span className="text-cyan-300">{rxSummaryStr}</span>}
+                expanded={expandedSettingsRow === "rx"}
+                onToggle={() => toggleSettingsRow("rx")}
+              >
                 <div className="flex items-center justify-between gap-2">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
-                    Clutter
-                  </label>
-                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                  <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
                     <input
                       type="checkbox"
-                      checked={clutterEnabled}
-                      onChange={(e) => onClutterEnabledChange(e.target.checked)}
-                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                      checked={rxMatchesTx}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          onRxHardwareIdxChange(hardwareIdx);
+                          onRxAntennaIdxChange(antennaIdx);
+                        }
+                        // unchecking: keep current RX values; user will edit below
+                      }}
+                      className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
                     />
-                    <span>Enabled</span>
+                    <span>Same as transmitter</span>
                   </label>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onRxHardwareIdxChange(4); // Heltec V3
+                      onRxAntennaIdxChange(0);  // rubber duck
+                    }}
+                    className="text-[10px] text-cyan-400/70 hover:text-cyan-300 transition-colors"
+                    title="Set RX to a stock handheld (Heltec V3, rubber duck) — typical 'who can hear me?' setup"
+                  >
+                    Use handheld
+                  </button>
                 </div>
-                <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
-                <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
-                <ClassLegend />
-                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
-                    Canopy heights
-                  </label>
-                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
-                    <input
-                      type="checkbox"
-                      checked={canopyEnabled}
-                      onChange={(e) => onCanopyEnabledChange(e.target.checked)}
-                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
-                    />
-                    <span>Enabled</span>
-                  </label>
-                </div>
-                <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
-                <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-white/5">
-                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
-                    Building heights
-                  </label>
-                  <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
-                    <input
-                      type="checkbox"
-                      checked={buildingsEnabled}
-                      onChange={(e) => onBuildingsEnabledChange(e.target.checked)}
-                      className="w-3 h-3 accent-cyan-500 cursor-pointer"
-                    />
-                    <span>Enabled</span>
-                  </label>
-                </div>
-                <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
-              </div>
+                {!rxMatchesTx && (
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label htmlFor="scan-rx-hw" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                        Hardware
+                      </label>
+                      <select
+                        id="scan-rx-hw"
+                        value={rxHardwareIdx}
+                        onChange={(e) => onRxHardwareIdxChange(Number(e.target.value))}
+                        className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                          focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                          [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                      >
+                        {COMMON_HARDWARE.map((h, i) => (
+                          <option key={i} value={i}>{h.label}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="scan-rx-ant" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                        Antenna
+                      </label>
+                      <select
+                        id="scan-rx-ant"
+                        value={rxAntennaIdx}
+                        onChange={(e) => onRxAntennaIdxChange(Number(e.target.value))}
+                        className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                          focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                          [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                      >
+                        {COMMON_ANTENNAS.map((a, i) => (
+                          <option key={i} value={i}>{a.label}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                )}
+              </SettingsRow>
 
-              <div className="pt-2 border-t border-white/5 text-[10px] text-gray-500 leading-relaxed">
+              {/* Environment row (clutter + canopy + buildings) */}
+              <SettingsRow
+                title="Environment"
+                summary={envSummaryStr}
+                expanded={expandedSettingsRow === "env"}
+                onToggle={() => toggleSettingsRow("env")}
+              >
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                      Clutter (NLCD)
+                    </label>
+                    <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                      <input
+                        type="checkbox"
+                        checked={clutterEnabled}
+                        onChange={(e) => onClutterEnabledChange(e.target.checked)}
+                        className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                      />
+                      <span>Enabled</span>
+                    </label>
+                  </div>
+                  <AggressionSlider aggressionIdx={aggressionIdx} onChange={onAggressionIdxChange} enabled={clutterEnabled} />
+                  <ClutterStatusChip status={clutterStatus} enabled={clutterEnabled} />
+                  <ClassLegend />
+                </div>
+                <div className="space-y-1.5 pt-1.5 border-t border-white/5">
+                  <div className="flex items-center justify-between gap-2">
+                    <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                      Canopy heights (ETH)
+                    </label>
+                    <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                      <input
+                        type="checkbox"
+                        checked={canopyEnabled}
+                        onChange={(e) => onCanopyEnabledChange(e.target.checked)}
+                        className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                      />
+                      <span>Enabled</span>
+                    </label>
+                  </div>
+                  <CanopyStatusChip status={canopyStatus} enabled={canopyEnabled} />
+                </div>
+                <div className="space-y-1.5 pt-1.5 border-t border-white/5">
+                  <div className="flex items-center justify-between gap-2">
+                    <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 block">
+                      Building heights (JRC)
+                    </label>
+                    <label className="flex items-center gap-1.5 text-[10px] text-gray-300 cursor-pointer select-none shrink-0">
+                      <input
+                        type="checkbox"
+                        checked={buildingsEnabled}
+                        onChange={(e) => onBuildingsEnabledChange(e.target.checked)}
+                        className="w-3 h-3 accent-cyan-500 cursor-pointer"
+                      />
+                      <span>Enabled</span>
+                    </label>
+                  </div>
+                  <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
+                </div>
+              </SettingsRow>
+
+              <div className="pt-1.5 px-0.5 text-[10px] text-gray-500 leading-relaxed">
                 <span className="font-medium text-gray-400">Terrain data:</span>{" "}
                 {demSource === "tilezen"
                   ? "Tilezen terrarium (USGS 3DEP / SRTM) via AWS Open Data"
@@ -501,7 +632,7 @@ export function MapScanPanel({
         </div>
       </div>
 
-      <div className="overflow-y-auto overscroll-contain flex-1">
+      <div className={`overflow-y-auto overscroll-contain flex-1 ${minimized ? "hidden" : ""}`}>
         {isScanning && (
           <div className="px-3 py-6 text-center text-[11px] text-gray-400">
             <div className="inline-flex items-center gap-2">

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -500,7 +500,9 @@ export function MapScanPanel({
                 onToggle={() => toggleSettingsRow("rx")}
               >
                 <div className="flex items-center justify-between gap-2">
-                  <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
+                  {/* px/-mx pair gives the active-flash some real estate without
+                      changing the rendered layout. */}
+                  <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none px-1.5 py-0.5 -mx-1.5 -my-0.5 rounded transition-colors active:bg-cyan-500/20">
                     <input
                       type="checkbox"
                       checked={rxMatchesTx}

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
-import { COMMON_ANTENNAS, COMMON_HARDWARE, MESHTASTIC_PRESETS } from "./coverageAnalysis";
+import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import type { ScanClass, ScanResult,ScanSummary } from "./scanAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
@@ -47,7 +47,7 @@ function SettingsRow({
   );
 }
 
-type SettingsRowKey = "tx" | "rx" | "env";
+type SettingsRowKey = "tx" | "rx" | "env" | "acc";
 
 const CLASS_STYLES: Record<ScanClass, { bg: string; text: string; border: string; label: string }> = {
   clear:      { bg: "bg-cyan-500/15",    text: "text-cyan-300",    border: "border-cyan-500/30",    label: "Clear" },
@@ -96,6 +96,8 @@ export function MapScanPanel({
   onPresetIdxChange,
   customSensitivityDbm,
   onCustomSensitivityChange,
+  reliability,
+  onReliabilityChange,
 }: {
   summary: ScanSummary | null;
   originLabel: string;
@@ -147,6 +149,11 @@ export function MapScanPanel({
   onPresetIdxChange: (idx: number) => void;
   customSensitivityDbm: number;
   onCustomSensitivityChange: (dbm: number) => void;
+  /** ITM reliability preset (time/location/situation %). Matches coverage's
+   *  control so a scan from coverage's origin uses the same statistical
+   *  threshold the painted prediction does. */
+  reliability: CoverageReliability;
+  onReliabilityChange: (r: CoverageReliability) => void;
 }) {
   if (terrainNeeded && onEnableTerrain) {
     return (
@@ -202,6 +209,11 @@ export function MapScanPanel({
     }
   }, [summary, originLabel]);
 
+  // Snapshot of pre-check RX so unchecking "Same as transmitter" restores
+  // whatever the user had before, instead of being a no-op (rxMatchesTx is
+  // derived from the values still matching, so no state change = no UI change).
+  const rxSnapshotRef = useRef<{ hw: number; ant: number } | null>(null);
+
   const sheet = useBottomSheetGesture(onClose);
   const isCustomHardware = COMMON_HARDWARE[hardwareIdx]?.isCustom ?? false;
   const isCustomPreset = MESHTASTIC_PRESETS[presetIdx]?.isCustom ?? false;
@@ -252,6 +264,13 @@ export function MapScanPanel({
   if (canopyEnabled) envParts.push("canopy");
   if (buildingsEnabled) envParts.push("buildings");
   const envSummaryStr = envParts.length === 0 ? "All off · bare earth" : envParts.join(" · ");
+
+  const reliabilityLabel = RELIABILITY_PRESETS.find((p) => p.id === reliability)?.label ?? "Typical";
+  const reliabilityPctStr = (() => {
+    const r = RELIABILITY_PRESETS.find((p) => p.id === reliability);
+    return r ? `${r.time}/${r.location}/${r.situation}` : "";
+  })();
+  const accSummaryStr = `${reliabilityLabel} · ${reliabilityPctStr}`;
 
   const displayResults: ScanResult[] = useMemo(() => {
     if (!summary) return [];
@@ -487,10 +506,19 @@ export function MapScanPanel({
                       checked={rxMatchesTx}
                       onChange={(e) => {
                         if (e.target.checked) {
+                          rxSnapshotRef.current = { hw: rxHardwareIdx, ant: rxAntennaIdx };
                           onRxHardwareIdxChange(hardwareIdx);
                           onRxAntennaIdxChange(antennaIdx);
+                        } else {
+                          const snap = rxSnapshotRef.current;
+                          if (snap) {
+                            onRxHardwareIdxChange(snap.hw);
+                            onRxAntennaIdxChange(snap.ant);
+                          } else {
+                            onRxHardwareIdxChange(4); // Heltec V3
+                            onRxAntennaIdxChange(0);  // rubber duck
+                          }
                         }
-                        // unchecking: keep current RX values; user will edit below
                       }}
                       className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
                     />
@@ -607,6 +635,47 @@ export function MapScanPanel({
                     </label>
                   </div>
                   <BuildingStatusChip status={buildingsStatus} enabled={buildingsEnabled} />
+                </div>
+              </SettingsRow>
+
+              {/* Accuracy row (ITM reliability — time/location/situation %) */}
+              <SettingsRow
+                title="Accuracy"
+                summary={accSummaryStr}
+                expanded={expandedSettingsRow === "acc"}
+                onToggle={() => toggleSettingsRow("acc")}
+              >
+                <div>
+                  <label className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                    Reliability
+                  </label>
+                  <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-0.5 text-[10px] font-medium">
+                    {RELIABILITY_PRESETS.map((p) => {
+                      const active = reliability === p.id;
+                      return (
+                        <button
+                          key={p.id}
+                          type="button"
+                          onClick={() => onReliabilityChange(p.id)}
+                          title={p.desc}
+                          className={`flex-1 rounded-md px-1.5 py-1 transition-colors ${
+                            active
+                              ? "bg-cyan-500/20 text-cyan-200"
+                              : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
+                          }`}
+                        >
+                          <div>{p.label}</div>
+                          <div className="text-[9px] text-gray-500 font-normal">
+                            {p.time}/{p.location}/{p.situation}
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="text-[9px] text-gray-500 mt-1 leading-relaxed">
+                    Higher = "works most of the time" instead of "works half the time."
+                    Typical (90/50/70) matches the coverage panel default.
+                  </div>
                 </div>
               </SettingsRow>
 


### PR DESCRIPTION
## Summary
- **Coverage and Scan panel redesign** — both panels now use a 5-row (coverage) / 4-row (scan) accordion layout with one-line state summaries on each collapsed header, replacing the gear-popover-of-everything pattern. Adds a minimize button + auto-minimize-on-first-result so the painted coverage stays visible while the panel gets out of the way.
- **Scan accuracy parity with coverage** — scan was silently using ITM defaults of 50/50/50 (median) instead of coverage's user-configurable reliability, and a 1024² DEM instead of 2048². Fixed both: scan now passes its own configurable Reliability preset (defaulting to Typical 90/50/70, matching coverage), uses 2048² for DEM/clutter/canopy/building rasters, and ships a Reliability accordion row in its settings popover.
- **Scan-from-coverage overlay** — new "Scan nodes" button in the coverage result strip (desktop-only). Click copies all coverage RF settings into scan, switches to the scan tool, and keeps the coverage paint visible underneath. Closing the scan panel returns to the coverage view rather than fully resetting. Coverage panel stays force-minimized during the overlay so the user can still see it's paused.
- **Bug fixes from testing the overlay flow** — coverage now recomputes on setting changes while the overlay is active (was bailing because activeTool was "scan"); the "Same as transmitter" checkbox now actually reverts to a snapshot on uncheck instead of being a no-op (rxMatchesTx is derived from value-matching, so the previous handler did nothing visible).
- **Click feedback polish** — `:active` CSS press state on the receiver toggle gives instant tactile feedback on click; an "Updating…" pill appears inline in the coverage result strip while computing.