### PR TITLE
fix(caddy): add /tiles/* routes so frontend can reach baked clutter tiles

### DIFF
--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -5,6 +5,15 @@
 http://localhost {
 	encode gzip
 
+	# Tile API (land-cover / canopy / buildings)
+	handle_path /api/tiles/* {
+		rewrite * /tiles{uri}
+		reverse_proxy meshinfo:9000
+	}
+	handle /tiles/* {
+		reverse_proxy meshinfo:9000
+	}
+
 	handle_path /api/* {
 		reverse_proxy meshinfo:9000
 	}

--- a/Caddyfile.sample
+++ b/Caddyfile.sample
@@ -6,6 +6,15 @@ YOUR_FQDN_OR_HOSTNAME {
 		output file /var/log/caddy.log
 	}
 
+	# --- Tile API (land-cover / canopy / buildings) ---
+	handle_path /api/tiles/* {
+		rewrite * /tiles{uri}
+		reverse_proxy meshinfo:9000
+	}
+	handle /tiles/* {
+		reverse_proxy meshinfo:9000
+	}
+
 	# --- API ---
 	handle_path /api/* {
 		reverse_proxy meshinfo:9000


### PR DESCRIPTION
## Summary

Adds two routes to both Caddyfiles, ordered so `/tiles/*` and `/api/tiles/*` match before the generic `/api/*` handler:

- `handle /tiles/*` — direct fetches when `VITE_API_BASE_URL` is unset (frontend falls back to `window.location.origin`).
- `handle_path /api/tiles/* { rewrite * /tiles{uri} }` — for deployments that set `VITE_API_BASE_URL=/api`. Tiles are mounted outside `/v1` on the API, so the rewrite strips `/api/tiles` and re-prefixes `/tiles` instead of going through the generic `/api/* → /v1/...` rewrite some deployments use.