### PR TITLE
fix: NODEINFO decoder crash, MapScanPanel hook order, generated-file lint

### DIFF
--- a/data_store.py
+++ b/data_store.py
@@ -39,8 +39,7 @@ class DataStore:
       lat_i = pos.get('latitude_i')
       lon_i = pos.get('longitude_i')
       last_geo = pos.get('last_geocoding')
-      # last_geocoding can be a datetime (just set in memory) or an ISO string
-      # (loaded from Postgres). Normalize before the freshness comparison.
+      # Normalize ISO-string last_geocoding (from DB) to datetime for comparison.
       if isinstance(last_geo, str):
         try:
           last_geo = datetime.fromisoformat(last_geo).astimezone(ZoneInfo(self.config['server']['timezone']))
@@ -57,6 +56,7 @@ class DataStore:
             logger.warning("Failed to geocode position: %s", e)
 
     # Any update reactivates the node, so a previously-pruned node comes back online.
+    # Any packet reactivates the node.
     n['active'] = True
     if isinstance(n.get('last_seen'), str):
       n['last_seen'] = datetime.fromisoformat(n['last_seen']).astimezone(ZoneInfo(self.config['server']['timezone']))
@@ -68,8 +68,7 @@ class DataStore:
     if self.pg_storage is not None and getattr(self.pg_storage, "enabled", False) and getattr(self.pg_storage, "pool", None) is not None:
       try:
         await self.pg_storage.write_node(id, n)
-        # Only refresh the cache on a confirmed successful write so a failed
-        # write doesn't leave the cache ahead of the DB.
+        # Refresh cache only after a confirmed write.
         self.pg_storage.cache_node_set(id, n)
       except Exception as e:
         logger.error("Failed to write node %s to Postgres: %s", id, e)
@@ -168,9 +167,7 @@ class DataStore:
     node = await self.pg_storage.get_node_cached(node_id)
     if node is None:
       return
-    # Enrichment is a name lookup, not a packet from the node — don't go
-    # through update_node, which would force `active=True` and reset
-    # `last_seen`. Persist only the name fields.
+    # Bypass update_node to avoid touching active/last_seen on a name lookup.
     if short:
       node['shortname'] = short
     if long_:

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -44,6 +44,6 @@ export default tseslint.config(
   prettier,
 
   {
-    ignores: ["dist", "scripts", ".yarn"],
+    ignores: ["dist", "scripts", ".yarn", "src/generated/**"],
   },
 );

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -262,10 +262,7 @@ export const Stats = () => {
       tone?: "good" | "warn" | "info";
     }> = [];
 
-    // Active ratio. The "known" count includes nodes only ever seen as stubs
-    // (gateways/recipients), so a healthy mesh routinely sits in the 25–50% band.
-    // Phrasing avoids a fixed window since the backend prune threshold is
-    // configurable via server.node_activity_prune_threshold.
+    // Active ratio. "Known" includes stub-only nodes, so a healthy mesh sits in the 25-50% band.
     if (derived.nodes > 0) {
       const pct = Math.round(derived.activeRatio * 100);
       if (pct >= 50) {

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, type MergeOrigin, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
+import { COVERAGE_DETAIL_SIZE,type CoverageDetail } from "./coverageDetail";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
 
@@ -21,25 +22,6 @@ function parseLatLng(input: string): [number, number] | null {
   if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null;
   return [lng, lat];
 }
-
-/** Coverage paint resolution. Standard=instant, Survey=2048² (1:1 with DEM, 4× Ultra cost). */
-export type CoverageDetail = "standard" | "high" | "ultra" | "survey";
-
-export const COVERAGE_DETAIL_SIZE: Record<CoverageDetail, number> = {
-  standard: 512,
-  high: 768,
-  ultra: 1024,
-  survey: 2048,
-};
-
-/** Per-Detail DEM tile cap. Higher = finer native zoom at smaller radii. Standard
- *  matches the Tilezen LRU size so default-tier repeats hit cache 100%. */
-export const COVERAGE_DETAIL_MAX_TILES: Record<CoverageDetail, number> = {
-  standard: 256,
-  high: 512,
-  ultra: 768,
-  survey: 1024,
-};
 
 /** Info icon with hover tooltip. `align` picks the edge it anchors to. */
 function InfoTip({ children, align = "right" }: { children: React.ReactNode; align?: "left" | "right" }) {

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -155,6 +155,42 @@ export function MapScanPanel({
   reliability: CoverageReliability;
   onReliabilityChange: (r: CoverageReliability) => void;
 }) {
+  // null = show all; click active filter to toggle off
+  const [filter, setFilter] = useState<ScanClass | null>(null);
+  const [expandedSettingsRow, setExpandedSettingsRow] = useState<SettingsRowKey | null>(null);
+  const [minimized, setMinimized] = useState(false);
+
+  // Without a snapshot, unchecking "Same as transmitter" would be a visual
+  // no-op — rxMatchesTx is derived, so the values still match TX.
+  const rxSnapshotRef = useRef<{ hw: number; ant: number } | null>(null);
+
+  const sheet = useBottomSheetGesture(onClose);
+
+  useEffect(() => {
+    const onDocMouseDown = (e: MouseEvent) => {
+      const root = sheet.sheetRef.current;
+      if (!root) return;
+      if (root.contains(e.target as Node)) return;
+      root.querySelectorAll<HTMLDetailsElement>("details[open]").forEach((d) => {
+        d.removeAttribute("open");
+      });
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [sheet.sheetRef]);
+
+  // Text-mode input; commit on blur/Enter, blank → 2 m default.
+  const [heightInput, setHeightInput] = useState(String(antennaHeightM));
+  useEffect(() => { setHeightInput(String(antennaHeightM)); }, [antennaHeightM]);
+
+  const displayResults: ScanResult[] = useMemo(() => {
+    if (!summary) return [];
+    const filtered = filter
+      ? summary.results.filter((r) => r.cls === filter)
+      : summary.results;
+    return [...filtered].sort((a, b) => b.marginDb - a.marginDb);
+  }, [summary, filter]);
+
   if (terrainNeeded && onEnableTerrain) {
     return (
       <div className="fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl
@@ -183,41 +219,15 @@ export function MapScanPanel({
     );
   }
 
-  // null = show all; click active filter to toggle off
-  const [filter, setFilter] = useState<ScanClass | null>(null);
   const toggleFilter = (cls: ScanClass) =>
     setFilter((prev) => (prev === cls ? null : cls));
 
-  const [expandedSettingsRow, setExpandedSettingsRow] = useState<SettingsRowKey | null>(null);
   const toggleSettingsRow = (k: SettingsRowKey) =>
     setExpandedSettingsRow((cur) => (cur === k ? null : k));
 
-  const [minimized, setMinimized] = useState(false);
-
-  // Without a snapshot, unchecking "Same as transmitter" would be a visual
-  // no-op — rxMatchesTx is derived, so the values still match TX.
-  const rxSnapshotRef = useRef<{ hw: number; ant: number } | null>(null);
-
-  const sheet = useBottomSheetGesture(onClose);
   const isCustomHardware = COMMON_HARDWARE[hardwareIdx]?.isCustom ?? false;
   const isCustomPreset = MESHTASTIC_PRESETS[presetIdx]?.isCustom ?? false;
 
-  useEffect(() => {
-    const onDocMouseDown = (e: MouseEvent) => {
-      const root = sheet.sheetRef.current;
-      if (!root) return;
-      if (root.contains(e.target as Node)) return;
-      root.querySelectorAll<HTMLDetailsElement>("details[open]").forEach((d) => {
-        d.removeAttribute("open");
-      });
-    };
-    document.addEventListener("mousedown", onDocMouseDown);
-    return () => document.removeEventListener("mousedown", onDocMouseDown);
-  }, [sheet.sheetRef]);
-
-  // Text-mode input; commit on blur/Enter, blank → 2 m default.
-  const [heightInput, setHeightInput] = useState(String(antennaHeightM));
-  useEffect(() => { setHeightInput(String(antennaHeightM)); }, [antennaHeightM]);
   const commitHeight = () => {
     const trimmed = heightInput.trim();
     if (trimmed === "") { onAntennaHeightChange(2); setHeightInput("2"); return; }
@@ -255,14 +265,6 @@ export function MapScanPanel({
     return r ? `${r.time}/${r.location}/${r.situation}` : "";
   })();
   const accSummaryStr = `${reliabilityLabel} · ${reliabilityPctStr}`;
-
-  const displayResults: ScanResult[] = useMemo(() => {
-    if (!summary) return [];
-    const filtered = filter
-      ? summary.results.filter((r) => r.cls === filter)
-      : summary.results;
-    return [...filtered].sort((a, b) => b.marginDb - a.marginDb);
-  }, [summary, filter]);
 
   return (
     <div

--- a/frontend/src/pages/map/coverageDetail.ts
+++ b/frontend/src/pages/map/coverageDetail.ts
@@ -1,0 +1,18 @@
+/** Coverage paint resolution. Standard=instant, Survey=2048² (1:1 with DEM, 4× Ultra cost). */
+export type CoverageDetail = "standard" | "high" | "ultra" | "survey";
+
+export const COVERAGE_DETAIL_SIZE: Record<CoverageDetail, number> = {
+  standard: 512,
+  high: 768,
+  ultra: 1024,
+  survey: 2048,
+};
+
+/** Per-Detail DEM tile cap. Higher = finer native zoom at smaller radii. Standard
+ *  matches the Tilezen LRU size so default-tier repeats hit cache 100%. */
+export const COVERAGE_DETAIL_MAX_TILES: Record<CoverageDetail, number> = {
+  standard: 256,
+  high: 512,
+  ultra: 768,
+  survey: 1024,
+};

--- a/frontend/src/pages/map/useCoverageCompute.ts
+++ b/frontend/src/pages/map/useCoverageCompute.ts
@@ -9,6 +9,7 @@ import { buildBuildingRaster, type BuildingRaster, downsampleBuildingRaster } fr
 import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./canopyTiles";
 import { AGGRESSION_STOPS, type MergeOrigin, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./coverageAnalysis";
 import { type ContourFeatureCollection, extractCoverageContours } from "./coverageContours";
+import { COVERAGE_DETAIL_MAX_TILES, COVERAGE_DETAIL_SIZE } from "./coverageDetail";
 import { exportCoverage } from "./coverageExport";
 import type { RasterParams } from "./coverageRaster";
 import { extractCoverageRays, type VisibilityRayFeatureCollection } from "./coverageRays";
@@ -16,7 +17,6 @@ import type { CoverageSliceRequest, SliceOrigin } from "./coverageSliceWorker";
 import { CoverageWorkerPool } from "./coverageWorkerPool";
 import { queryTerrainElevationMSL } from "./helpers";
 import { buildClutterRaster, type ClutterRaster, downsampleClutterRaster } from "./landcoverTiles";
-import { COVERAGE_DETAIL_MAX_TILES, COVERAGE_DETAIL_SIZE } from "./MapCoveragePanel";
 import { type DEM, type DEMBounds, demBoundsAround, downsampleDEM, sampleDEMAt } from "./terrainDEM";
 import { buildDem, fetchElevationAt } from "./terrainRgb";
 import type { IMapNode } from "./types";

--- a/frontend/src/pages/map/useCoverageState.ts
+++ b/frontend/src/pages/map/useCoverageState.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX, effectiveSensitivityDbm, MESHTASTIC_PRESETS } from "./coverageAnalysis";
+import type { CoverageDetail } from "./coverageDetail";
 import { clampAggressionIdx } from "./helpers";
-import type { CoverageDetail } from "./MapCoveragePanel";
 import { LS_KEYS, readJson, writeJson } from "./storage";
 import type { DemSource } from "./terrainRgb";
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -193,13 +193,19 @@ class MQTT:
                     try:
                         info = mesh_pb2.User().FromString(mp.decoded.payload)
                         out = json.loads(MessageToJson(info, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
-                        if isinstance(out['id'], int):
-                            out["id"] = utils.convert_node_id_from_int_to_hex(out['id'])
-                        out["id"] = out['id'].replace('!', '')
-                        outs["type"] = "nodeinfo"
-                        outs["payload"] = out
-                        logger.debug("Decoded protobuf message: nodeinfo: %s", outs)
-                        await self.handle_nodeinfo(outs)
+                        # Some senders broadcast NODEINFO without setting User.id;
+                        # the MeshPacket `from` field identifies the same node.
+                        nid = out.get('id', outs.get('from'))
+                        if nid is None:
+                            logger.debug("NODEINFO packet missing identity; skipping: %s", out)
+                        else:
+                            if isinstance(nid, int):
+                                nid = utils.convert_node_id_from_int_to_hex(nid)
+                            out["id"] = str(nid).replace('!', '')
+                            outs["type"] = "nodeinfo"
+                            outs["payload"] = out
+                            logger.debug("Decoded protobuf message: nodeinfo: %s", outs)
+                            await self.handle_nodeinfo(outs)
                     except UnicodeDecodeError as e:
                         logger.debug("Unicode decoding error: text: %s", e)
                     except DecodeError as e:

--- a/mqtt.py
+++ b/mqtt.py
@@ -193,8 +193,7 @@ class MQTT:
                     try:
                         info = mesh_pb2.User().FromString(mp.decoded.payload)
                         out = json.loads(MessageToJson(info, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
-                        # Some senders broadcast NODEINFO without setting User.id;
-                        # the MeshPacket `from` field identifies the same node.
+                        # Fall back to MeshPacket `from` when User.id is unset.
                         nid = out.get('id', outs.get('from'))
                         if nid is None:
                             logger.debug("NODEINFO packet missing identity; skipping: %s", out)

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -84,13 +84,9 @@ class PostgresStorage:
         # Optional: enable to make migrations "honest" (fail fast / count failures correctly)
         self.raise_on_write_error = bool(self.pg_config.get("raise_on_write_error", False))
 
-        # Node read cache. Stores live references to node dicts — callers that
-        # mutate the returned dict (the MQTT handlers do; that's the read-modify-
-        # write pattern) directly update the cache. Writes via `cache_node_set`
-        # keep cache and DB in lockstep. Eviction is LRU by insertion/access order.
+        # LRU node cache. Stores live refs so read-modify-write callers update
+        # the cache directly; pair mutations with cache_node_set after a write.
         self._node_lru: "OrderedDict[str, dict]" = OrderedDict()
-        # Floor at 1 so a misconfigured non-positive value can't crash the
-        # eviction loop on its first popitem.
         self._node_lru_max = max(1, int(self.pg_config.get("node_cache_size", 10000)))
 
     async def connect(self) -> bool:
@@ -1593,7 +1589,7 @@ class PostgresStorage:
         return nodes.get(node_id)
 
     # ───────────────────────────────────────────────────────────────────
-    # Node cache (replaces the old in-memory `data.nodes` dict)
+    # Node cache
     # ───────────────────────────────────────────────────────────────────
 
     def cache_node_set(self, node_id: str, node: Optional[Dict[str, Any]]) -> None:
@@ -1613,12 +1609,7 @@ class PostgresStorage:
         self._node_lru.clear()
 
     async def get_node_cached(self, node_id: str) -> Optional[Dict[str, Any]]:
-        """Get a single node, hitting LRU cache first then PostgreSQL.
-
-        Returns the live cache reference — callers that mutate the dict directly
-        update the cache. Pair mutations with a `write_node` + `cache_node_set`
-        so the persisted state matches.
-        """
+        """Get a single node, hitting LRU cache first then PostgreSQL. Returns the live cache ref."""
         cached = self._node_lru.get(node_id)
         if cached is not None:
             self._node_lru.move_to_end(node_id)
@@ -1663,10 +1654,7 @@ class PostgresStorage:
             return None
 
     async def find_nodes_needing_enrichment(self, limit: int = 200) -> Dict[str, Dict[str, Any]]:
-        """Return nodes whose name fields look unenriched (Unknown/UNK or NULL).
-
-        Replaces the old in-memory walk of `data.nodes`. Cached via `get_node_cached`.
-        """
+        """Return nodes whose name fields look unenriched (Unknown/UNK or NULL)."""
         if not self._ready("find_nodes_needing_enrichment"):
             return {}
         try:
@@ -1695,12 +1683,7 @@ class PostgresStorage:
         return result
 
     async def mark_nodes_inactive_by_age(self, threshold_seconds: int) -> int:
-        """Bulk-mark stale nodes as inactive. Returns the number of rows updated.
-
-        Replaces the per-node dict walk in `mqtt.prune_expired_nodes`. Affected
-        node entries are evicted from the cache so the next read sees the new
-        `active=False` state.
-        """
+        """Bulk-mark stale nodes inactive and evict them from cache. Returns rows updated."""
         if not self._ready("mark_nodes_inactive_by_age") or threshold_seconds <= 0:
             return 0
         try:
@@ -2093,11 +2076,7 @@ class PostgresStorage:
             return []
 
     async def query_stats(self) -> Dict[str, Any]:
-        """Query statistics from PostgreSQL.
-
-        Most fields are integer counters. `session_by_modem_preset` is a nested
-        dict (preset → count) so the overall return is `Dict[str, Any]`.
-        """
+        """Query statistics from PostgreSQL."""
         if not self.enabled or not self.pool:
             return {}
 
@@ -2114,11 +2093,7 @@ class PostgresStorage:
                 stats["total_telemetry"] = await conn.fetchval("SELECT COUNT(*) FROM telemetry")
                 stats["total_traceroutes"] = await conn.fetchval("SELECT COUNT(*) FROM traceroutes")
 
-                # mqtt_messages can be huge and is under constant write load — an exact
-                # COUNT(*) can be slow enough to hit statement_timeout. The planner
-                # estimate is instant and accurate to within a few percent, which is
-                # plenty for a stats counter. Isolate so a failure here can't blank
-                # the rest of the response.
+                # Planner estimate; exact COUNT(*) can hit statement_timeout on this table.
                 try:
                     approx = await conn.fetchval(
                         "SELECT reltuples::bigint FROM pg_class WHERE relname = 'mqtt_messages'"
@@ -2130,9 +2105,7 @@ class PostgresStorage:
                 stats["total_messages"] = mqtt_count
                 stats["total_mqtt_messages"] = mqtt_count
 
-                # Topic-preset split over the last 24h. The Meshtastic topic format is
-                # `msh/<region(s)>/2/e/<preset>/!<node>`, so the preset is the segment
-                # immediately after `/2/e/`. Isolated try so a failure can't blank stats.
+                # 24h topic-preset split. Topic format: msh/<region>/2/e/<preset>/!<node>.
                 preset_split: Dict[str, int] = {}
                 try:
                     rows = await conn.fetch(


### PR DESCRIPTION
## Summary

Three small fixes that surfaced while reviewing the post-merge in-memory refactor PR. Independent of each other; grouped because they're all under the same review pass.

## What changed

### 1. MQTT decoder no longer crashes on malformed NODEINFO ([mqtt.py:192-211](mqtt.py#L192-L211)) (#465)

NODEINFO packets that omit `User.id` were raising `KeyError` on `out['id']`. The surrounding try/except only caught `UnicodeDecodeError` / `DecodeError`, so the error escaped and the supervisor restarted the MQTT loop on a 5s backoff — losing a small window of packets every time.

Fall back to `outs['from']` (the MeshPacket `from` field, same node identity). Skip with a debug log if both are missing.

### 2. MapScanPanel rules-of-hooks violation ([MapScanPanel.tsx](frontend/src/pages/map/MapScanPanel.tsx))

`useState`/`useRef`/`useEffect`/`useMemo` were called **after** an early return for the "Scanning requires 3D terrain" prompt. React relies on hooks being called in the same order every render; this would have produced inconsistent state or `Rendered fewer hooks than expected` errors depending on terrain mode.

Moved all hook calls above the conditional return. Derived constants and event handlers stay below.

Also extracted `COVERAGE_DETAIL_SIZE`, `COVERAGE_DETAIL_MAX_TILES`, and `CoverageDetail` from `MapCoveragePanel.tsx` into [coverageDetail.ts](frontend/src/pages/map/coverageDetail.ts) — these were causing `react-refresh/only-export-components` warnings because the file mixed components and constants.

### 3. ESLint ignores generated files ([eslint.config.js](frontend/eslint.config.js))

`frontend/src/generated/itm/itm.js` is the WASM build's compiled output but lint was scanning it as source, producing 19 errors. Added `src/generated/**` to the existing `ignores` array.