### PR TITLE
feat(caddy): add maintenance mode landing page with toggle script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules/
 backups/*
 caddy
 Caddyfile
+
+# Maintenance-mode toggle flag — runtime state, never commit it enabled.
+public/maintenance/ON
 output/*
 mosquitto/data/*
 mosquitto/config/mosquitto.conf

--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -5,25 +5,46 @@
 http://localhost {
 	encode gzip
 
-	# Tile API (land-cover / canopy / buildings)
-	handle_path /api/tiles/* {
-		rewrite * /tiles{uri}
-		reverse_proxy meshinfo:9000
-	}
-	handle /tiles/* {
-		reverse_proxy meshinfo:9000
+	# ---- Maintenance mode ----
+	# Toggle with `scripts/maintenance.sh on|off`, or create/delete the flag
+	# file ./public/maintenance/ON directly. The `file` matcher is checked
+	# per-request, so toggling needs no reload.
+	@maintenance file {
+		root /srv/maintenance
+		try_files ON
 	}
 
-	handle_path /api/* {
-		reverse_proxy meshinfo:9000
-	}
-	handle /next {
-		respond "Gone" 410
-	}
-	handle /next/* {
-		respond "Gone" 410
-	}
-	handle {
-		reverse_proxy frontend:5173
+	route {
+		handle @maintenance {
+			root * /srv/maintenance
+			rewrite * /index.html
+			header Retry-After "3600"
+			header Cache-Control "no-store"
+			file_server {
+				status 503
+			}
+		}
+
+		# Tile API (land-cover / canopy / buildings)
+		handle_path /api/tiles/* {
+			rewrite * /tiles{uri}
+			reverse_proxy meshinfo:9000
+		}
+		handle /tiles/* {
+			reverse_proxy meshinfo:9000
+		}
+
+		handle_path /api/* {
+			reverse_proxy meshinfo:9000
+		}
+		handle /next {
+			respond "Gone" 410
+		}
+		handle /next/* {
+			respond "Gone" 410
+		}
+		handle {
+			reverse_proxy frontend:5173
+		}
 	}
 }

--- a/Caddyfile.sample
+++ b/Caddyfile.sample
@@ -6,27 +6,52 @@ YOUR_FQDN_OR_HOSTNAME {
 		output file /var/log/caddy.log
 	}
 
-	# --- Tile API (land-cover / canopy / buildings) ---
-	handle_path /api/tiles/* {
-		rewrite * /tiles{uri}
-		reverse_proxy meshinfo:9000
-	}
-	handle /tiles/* {
-		reverse_proxy meshinfo:9000
-	}
-
-	# --- API ---
-	handle_path /api/* {
-		reverse_proxy meshinfo:9000
+	# --- Maintenance mode ---
+	# Toggle with `scripts/maintenance.sh on|off`, or create/delete the flag
+	# file ./public/maintenance/ON directly. The `file` matcher is evaluated
+	# per-request, so flipping it takes effect immediately — no reload needed.
+	# Requires the ./public/maintenance:/srv/maintenance mount on the caddy
+	# service (already set in docker-compose.yml).
+	@maintenance file {
+		root /srv/maintenance
+		try_files ON
 	}
 
-	# --- API (direct /v1/* access, used by the SPA) ---
-	handle /v1/* {
-		reverse_proxy meshinfo:9000
-	}
+	route {
+		# When the flag is present, the maintenance page takes over every
+		# path and returns 503 so clients know the outage is temporary.
+		handle @maintenance {
+			root * /srv/maintenance
+			rewrite * /index.html
+			header Retry-After "3600"
+			header Cache-Control "no-store"
+			file_server {
+				status 503
+			}
+		}
 
-	# --- Frontend ---
-	handle {
-		reverse_proxy frontend:80
+		# --- Tile API (land-cover / canopy / buildings) ---
+		handle_path /api/tiles/* {
+			rewrite * /tiles{uri}
+			reverse_proxy meshinfo:9000
+		}
+		handle /tiles/* {
+			reverse_proxy meshinfo:9000
+		}
+
+		# --- API ---
+		handle_path /api/* {
+			reverse_proxy meshinfo:9000
+		}
+
+		# --- API (direct /v1/* access, used by the SPA) ---
+		handle /v1/* {
+			reverse_proxy meshinfo:9000
+		}
+
+		# --- Frontend ---
+		handle {
+			reverse_proxy frontend:80
+		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ The included `Caddyfile.sample` routes `/api/*` and `/v1/*` to the backend and e
 
 If you use a different reverse proxy, point `/api/*` and `/v1/*` at the backend container (port 9000) and `/` at the frontend container (port 80).
 
+### Maintenance Mode
+
+When you need to take the stack down — for example to upgrade PostgreSQL — Caddy can serve a branded maintenance page instead of a broken site. Caddy and the page itself stay up the whole time, so visitors get a clean "we'll be back shortly" landing page rather than a connection error.
+
+```sh
+scripts/maintenance.sh on       # show the maintenance page
+# ... perform the upgrade ...
+scripts/maintenance.sh off      # back to normal
+scripts/maintenance.sh status   # check current state
+```
+
+On Windows, use the PowerShell port instead — `scripts\maintenance.ps1 on|off|status`.
+
+The toggle creates/removes the flag file `public/maintenance/ON`. Caddy checks for it on every request, so it takes effect immediately — no reload or restart. While enabled, every path (including `/api/*`) returns the page with HTTP `503` and a `Retry-After` header. The page auto-refreshes every 60 seconds, so visitors land on the live site automatically once you turn it off.
+
+A typical database upgrade then looks like:
+
+```sh
+scripts/maintenance.sh on
+docker compose stop meshinfo postgres
+# ... upgrade / migrate ...
+docker compose up -d meshinfo postgres
+scripts/maintenance.sh off
+```
+
+Customize the look by editing [public/maintenance/index.html](public/maintenance/index.html) — it is a single self-contained file.
+
 ### Map Providers
 
 MeshInfo supports two map providers, configured in `frontend/.env`:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,6 +7,8 @@ services:
       - ./caddy/data:/data/caddy
       - ./Caddyfile.dev:/etc/caddy/Caddyfile
       - ./public/images:/srv/images
+      # Maintenance landing page + toggle flag (see scripts/maintenance.sh).
+      - ./public/maintenance:/srv/maintenance:ro
     environment:
       - CADDY_AGREE=true
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       - ./caddy/data:/data/caddy
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./public/images:/srv/images
+      # Maintenance landing page + toggle flag (see scripts/maintenance.sh).
+      - ./public/maintenance:/srv/maintenance:ro
     environment:
       - CADDY_AGREE=true
     restart: unless-stopped

--- a/public/maintenance/index.html
+++ b/public/maintenance/index.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="robots" content="noindex" />
+    <!-- Auto-retry: once maintenance mode is turned off, the next refresh
+         lands the visitor straight on the live site. -->
+    <meta http-equiv="refresh" content="60" />
+    <title>Under Maintenance &middot; MeshInfo</title>
+    <style>
+      :root {
+        --cyan: #06b6d4;
+        --cyan-bright: #22d3ee;
+        --text: #e5e7eb;
+        --muted: #94a3b8;
+        --faint: #64748b;
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        color: var(--text);
+        background:
+          radial-gradient(ellipse 120% 90% at 50% -10%, #1e293b 0%, transparent 60%),
+          radial-gradient(ellipse 100% 80% at 50% 110%, #0e2a33 0%, transparent 55%),
+          #0b1120;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        -webkit-font-smoothing: antialiased;
+      }
+      .card {
+        width: 100%;
+        max-width: 520px;
+        text-align: center;
+        padding: 44px 36px 36px;
+        border: 1px solid rgba(6, 182, 212, 0.22);
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.6);
+        box-shadow:
+          0 0 0 1px rgba(255, 255, 255, 0.02) inset,
+          0 30px 80px -20px rgba(0, 0, 0, 0.7);
+      }
+
+      /* --- Animated radio-wave mesh motif --- */
+      .mesh { width: 168px; height: 168px; margin: 0 auto 28px; display: block; }
+      .ring {
+        transform-origin: 110px 110px;
+        animation: pulse 3s ease-out infinite;
+      }
+      .ring:nth-of-type(2) { animation-delay: 1s; }
+      .ring:nth-of-type(3) { animation-delay: 2s; }
+      @keyframes pulse {
+        0%   { transform: scale(0.25); opacity: 0.9; }
+        80%  { opacity: 0; }
+        100% { transform: scale(1); opacity: 0; }
+      }
+      .node { animation: blink 2.4s ease-in-out infinite; }
+      .node:nth-of-type(5) { animation-delay: 0.4s; }
+      .node:nth-of-type(6) { animation-delay: 0.8s; }
+      .node:nth-of-type(7) { animation-delay: 1.2s; }
+      .node:nth-of-type(8) { animation-delay: 1.6s; }
+      @keyframes blink {
+        0%, 100% { opacity: 0.35; }
+        50%      { opacity: 1; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .ring, .node { animation: none; }
+        .ring { opacity: 0.18; }
+      }
+
+      h1 {
+        margin: 0 0 14px;
+        font-size: 22px;
+        letter-spacing: 0.04em;
+        color: #f8fafc;
+      }
+      .accent { color: var(--cyan-bright); }
+      p {
+        margin: 0 auto 14px;
+        max-width: 38ch;
+        font-size: 13.5px;
+        line-height: 1.7;
+        color: var(--muted);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 6px;
+        padding: 7px 14px;
+        font-size: 12px;
+        color: var(--cyan-bright);
+        border: 1px solid rgba(6, 182, 212, 0.3);
+        border-radius: 999px;
+        background: rgba(6, 182, 212, 0.07);
+      }
+      .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--cyan-bright);
+        box-shadow: 0 0 8px var(--cyan-bright);
+        animation: blink 1.8s ease-in-out infinite;
+      }
+      .footer {
+        margin-top: 30px;
+        padding-top: 18px;
+        border-top: 1px solid rgba(148, 163, 184, 0.12);
+        font-size: 11px;
+        color: var(--faint);
+        letter-spacing: 0.03em;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <!-- Radio-wave mesh: a central node broadcasting to its neighbors. -->
+      <svg class="mesh" viewBox="0 0 220 220" fill="none" aria-hidden="true">
+        <!-- expanding signal rings -->
+        <circle class="ring" cx="110" cy="110" r="100" stroke="#22d3ee" stroke-width="2" />
+        <circle class="ring" cx="110" cy="110" r="100" stroke="#22d3ee" stroke-width="2" />
+        <circle class="ring" cx="110" cy="110" r="100" stroke="#22d3ee" stroke-width="2" />
+        <!-- links from the hub to each neighbor -->
+        <g stroke="#0e7490" stroke-width="2">
+          <line x1="110" y1="110" x2="40"  y2="58" />
+          <line x1="110" y1="110" x2="182" y2="74" />
+          <line x1="110" y1="110" x2="170" y2="170" />
+          <line x1="110" y1="110" x2="52"  y2="166" />
+        </g>
+        <!-- neighbor nodes -->
+        <circle class="node" cx="40"  cy="58"  r="7" fill="#0891b2" />
+        <circle class="node" cx="182" cy="74"  r="7" fill="#0891b2" />
+        <circle class="node" cx="170" cy="170" r="7" fill="#0891b2" />
+        <circle class="node" cx="52"  cy="166" r="7" fill="#0891b2" />
+        <!-- central hub -->
+        <circle cx="110" cy="110" r="11" fill="#22d3ee" />
+        <circle cx="110" cy="110" r="11" fill="none" stroke="#0b1120" stroke-width="3" />
+      </svg>
+
+      <!-- Customize the copy below for your mesh if you like. -->
+      <h1>We&rsquo;re <span class="accent">briefly offline</span></h1>
+      <p>MeshInfo is undergoing maintenance.</p>
+      <p>Thanks for your patience. We&rsquo;ll be back shortly.</p>
+
+      <div class="status">
+        <span class="dot"></span>
+        This page checks for you every 60&nbsp;seconds
+      </div>
+
+      <div class="footer">Powered by MeshInfo</div>
+    </main>
+  </body>
+</html>

--- a/scripts/maintenance.ps1
+++ b/scripts/maintenance.ps1
@@ -1,0 +1,44 @@
+#!/usr/bin/env pwsh
+
+# Toggle MeshInfo maintenance mode (PowerShell port of maintenance.sh).
+#
+# When enabled, Caddy serves public/maintenance/index.html (HTTP 503) for
+# every request instead of proxying to the app -- useful while taking the
+# backend or database down for an upgrade.
+#
+# Caddy checks the flag file per-request, so on/off takes effect on the
+# very next request. No 'caddy reload' or container restart is needed.
+#
+# Usage:
+#   scripts\maintenance.ps1 on        # show the maintenance page
+#   scripts\maintenance.ps1 off       # back to normal
+#   scripts\maintenance.ps1 status    # report current state (default)
+
+param(
+    [ValidateSet('on', 'off', 'status')]
+    [string]$Action = 'status'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Flag file lives in the dir bind-mounted into the caddy container.
+$flag = Join-Path $PSScriptRoot '..\public\maintenance\ON'
+
+switch ($Action) {
+    'on' {
+        if (-not (Test-Path $flag)) { New-Item -ItemType File -Path $flag | Out-Null }
+        Write-Host 'Maintenance mode ENABLED  -- visitors now see the maintenance page.' -ForegroundColor Yellow
+    }
+    'off' {
+        if (Test-Path $flag) { Remove-Item $flag }
+        Write-Host 'Maintenance mode DISABLED -- site is live.' -ForegroundColor Green
+    }
+    'status' {
+        if (Test-Path $flag) {
+            Write-Host 'Maintenance mode is ON' -ForegroundColor Yellow
+        }
+        else {
+            Write-Host 'Maintenance mode is OFF' -ForegroundColor Green
+        }
+    }
+}

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Toggle MeshInfo maintenance mode.
+#
+# When enabled, Caddy serves public/maintenance/index.html (HTTP 503) for
+# every request instead of proxying to the app — useful while taking the
+# backend or database down for an upgrade.
+#
+# Caddy checks the flag file per-request, so on/off takes effect on the
+# very next request. No `caddy reload` or container restart is needed.
+#
+# Usage:
+#   scripts/maintenance.sh on        # show the maintenance page
+#   scripts/maintenance.sh off       # back to normal
+#   scripts/maintenance.sh status    # report current state (default)
+
+set -euo pipefail
+
+# Flag file lives in the dir bind-mounted into the caddy container.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FLAG="$REPO_ROOT/public/maintenance/ON"
+
+case "${1:-status}" in
+  on)
+    touch "$FLAG"
+    printf '\xF0\x9F\x9B\xA0  Maintenance mode ENABLED — visitors now see the maintenance page.\n'
+    ;;
+  off)
+    rm -f "$FLAG"
+    printf '\xE2\x9C\x85 Maintenance mode DISABLED — site is live.\n'
+    ;;
+  status)
+    if [ -e "$FLAG" ]; then
+      printf '\xF0\x9F\x9B\xA0  Maintenance mode is ON\n'
+    else
+      printf '\xE2\x9C\x85 Maintenance mode is OFF\n'
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [on|off|status]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
### Summary

Adds an opt-in maintenance mode so visitors see a branded landing page instead of a broken or unreachable site when the stack is taken down.

A per-request `file` matcher checks for a flag file; when present, Caddy serves a static maintenance page (HTTP `503` + `Retry-After`) for **every** path instead of proxying. Because the matcher is evaluated per request, toggling needs no reload or restart.

### How to use

```sh
scripts/maintenance.sh on       # show the maintenance page
scripts/maintenance.sh off      # back to live
scripts/maintenance.sh status   # check state
```

Windows: `scripts\maintenance.ps1 on|off|status`.

### Changes

- **New** `public/maintenance/index.html` — self-contained, dark-themed landing page matching the dashboard (animated radio-wave mesh motif, auto-refreshes every 60 s so visitors return to the live site automatically)
- **New** `scripts/maintenance.sh` / `scripts/maintenance.ps1` — on/off/status toggle; creates/removes the `public/maintenance/ON` flag
- **Caddy** — `Caddyfile.dev` and `Caddyfile.sample` get a `@maintenance` `file` matcher inside a `route` block; the handler returns the page with `503` + `Retry-After` + `Cache-Control: no-store`
- **Compose** — the `caddy` service mounts `./public/maintenance:/srv/maintenance:ro` (prod and dev)
- **`.gitignore`** — ignores the runtime `ON` flag so it's never committed enabled
- **README** — new "Maintenance Mode" section

### Notes

- After merging, recreate the `caddy` container once to pick up the new volume mount: `docker compose up -d --force-recreate caddy`.