### PR TITLE
chore(postgres)!: upgrade to PostgreSQL 18 with dump/restore migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing! MeshInfo is open source under the [GPL
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
 - Python 3.14+ (for backend development without Docker)
 - Node.js 22+ and Yarn 4 via Corepack (for frontend development)
-- A running PostgreSQL 16 instance (Docker Compose provides one)
+- A running PostgreSQL 18 instance (Docker Compose provides one)
 
 ### Development Setup
 

--- a/POSTGRES.md
+++ b/POSTGRES.md
@@ -160,11 +160,16 @@ Notes:
   before** recreating the volume — that file is your recovery artifact.
 - It is a no-op on fresh installs and when the volume is already current, so
   it is safe to run unconditionally as part of an update.
+- On Windows, run it from **Git Bash** (bundled with Git) — `bash
+  scripts/migrate-postgres.sh`. The script is MSYS-path-safe, so the single
+  bash version covers every platform.
 - Set `KEEP_VOLUME_BACKUP=1` to also snapshot the old data volume to
   `<volume>_oldpg_backup` for an instant rollback (uses extra disk; delete it
   once the upgrade is verified).
-- Roll back from the dump by restoring it into a container of the old version:
-  `gzip -dc backups/<dump>.sql.gz | psql -U postgres -d meshinfo`.
+- To roll back from the SQL dump: set the `postgres` image (and volume mount)
+  in your compose file back to the old version, remove the data volume so it
+  re-initialises empty, `docker compose up -d postgres`, then restore —
+  `gzip -dc backups/<dump>.sql.gz | docker compose exec -T postgres psql -U postgres -d meshinfo`.
 
 ## Security
 

--- a/POSTGRES.md
+++ b/POSTGRES.md
@@ -124,6 +124,48 @@ docker exec -it meshinfo-meshinfo-1 python3 scripts/migrate_json_to_postgres.py
 
 This reads your existing JSON data files and imports them into PostgreSQL. Once complete, update your config to the new PostgreSQL-only format (see `config.toml.sample`) and restart.
 
+## Upgrading PostgreSQL major versions
+
+PostgreSQL major versions (16 → 18, etc.) use **incompatible on-disk storage
+formats**. A newer `postgres` container will refuse to start against a data
+volume initialised by an older one, failing with:
+
+```
+FATAL: database files are incompatible with server
+DETAIL: The data directory was initialized by PostgreSQL version 16,
+        which is not compatible with this version 18.x.
+```
+
+When a MeshInfo release bumps the `postgres` image major version, run the
+included migration script once. It dumps the database with a temporary
+container of the *old* version, recreates the volume, and restores into the
+*new* version — using only official `postgres` images.
+
+```sh
+git pull
+docker compose pull               # fetch the new postgres image
+bash scripts/migrate-postgres.sh  # one-time: dump old → restore new
+docker compose up -d
+```
+
+For a development stack, point the script at the dev compose file:
+
+```sh
+COMPOSE_FILE=docker-compose-dev.yml bash scripts/migrate-postgres.sh
+```
+
+Notes:
+
+- The script writes a compressed SQL dump to `backups/` and **verifies it
+  before** recreating the volume — that file is your recovery artifact.
+- It is a no-op on fresh installs and when the volume is already current, so
+  it is safe to run unconditionally as part of an update.
+- Set `KEEP_VOLUME_BACKUP=1` to also snapshot the old data volume to
+  `<volume>_oldpg_backup` for an instant rollback (uses extra disk; delete it
+  once the upgrade is verified).
+- Roll back from the dump by restoring it into a container of the old version:
+  `gzip -dc backups/<dump>.sql.gz | psql -U postgres -d meshinfo`.
+
 ## Security
 
 - Use strong passwords for PostgreSQL

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See a live instance at [Central Valley Mesh](https://meshinfo.cvme.sh).
 ```
 MQTT Broker(s)  -->  MeshInfo Backend (Python / FastAPI / uvicorn)
                           |
-                     PostgreSQL 16
+                     PostgreSQL 18
                           |
                      MeshInfo Frontend (React 19 / TypeScript / Vite)
                           |
@@ -94,6 +94,11 @@ MeshInfo will be available at `https://your-domain` (or `http://localhost` if us
 git pull && docker compose pull && docker compose down && docker compose up -d
 ```
 
+> **PostgreSQL major version bumps:** if a release changes the `postgres` image
+> to a new major version (e.g. 16 → 18), run the one-time migration **before**
+> the final `up -d` — `docker compose pull` then `bash scripts/migrate-postgres.sh`.
+> See [POSTGRES.md](POSTGRES.md#upgrading-postgresql-major-versions).
+
 ### Configuration
 
 The main configuration file is `config.toml`. Key sections:
@@ -135,7 +140,7 @@ MeshInfo supports two map providers, configured in `frontend/.env`:
 
 ### Backend
 
-Requires Python 3.14+ and a running PostgreSQL 16 instance.
+Requires Python 3.14+ and a running PostgreSQL 18 instance.
 
 ```sh
 pip install -r requirements.txt

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,7 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: postgres:16
+    image: postgres:18
     restart: unless-stopped
     environment:
       POSTGRES_DB: meshinfo
@@ -21,7 +21,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - meshinfo_pgdata:/var/lib/postgresql/data
+      # postgres:18+ stores data in a version-specific subdir; mount the
+      # parent (/var/lib/postgresql), not /data. See POSTGRES.md.
+      - meshinfo_pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d meshinfo"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     restart: unless-stopped
     environment:
       POSTGRES_DB: meshinfo
@@ -9,7 +9,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - meshinfo_pgdata:/var/lib/postgresql/data
+      # postgres:18+ stores data in a version-specific subdir; mount the
+      # parent (/var/lib/postgresql), not /data. See POSTGRES.md.
+      - meshinfo_pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d meshinfo"]
       interval: 5s

--- a/scripts/migrate-postgres.sh
+++ b/scripts/migrate-postgres.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# migrate-postgres.sh — upgrade the MeshInfo Postgres data volume to a new
+# PostgreSQL major version.
+#
+# PostgreSQL major versions use incompatible on-disk storage formats, so a
+# newer postgres container cannot start against a volume initialised by an
+# older one. This script:
+#
+#   1. Dumps the existing database with a temporary container running the
+#      OLD PostgreSQL version (read from the volume's PG_VERSION file).
+#   2. Verifies the dump, then recreates the volume empty.
+#   3. Starts the NEW postgres version (from docker-compose.yml) and restores.
+#
+# Run this ONCE, after pulling the release that bumps the postgres image and
+# BEFORE `docker compose up -d`:
+#
+#   git pull
+#   docker compose pull
+#   ./scripts/migrate-postgres.sh
+#   docker compose up -d
+#
+# The compressed SQL dump in ./backups/ is your recovery artifact — it is
+# written and integrity-checked before the volume is touched. If the restore
+# fails, your data is still safe in that file (and in the backup volume when
+# KEEP_VOLUME_BACKUP=1).
+#
+# Environment overrides:
+#   COMPOSE_FILE         compose file to use (e.g. docker-compose-dev.yml)
+#   PGDATA_VOLUME        Docker volume name (default: auto-detected)
+#   POSTGRES_DB/USER/PASSWORD   database credentials (defaults: meshinfo/postgres/password)
+#   KEEP_VOLUME_BACKUP=1 also snapshot the old volume to <volume>_oldpg_backup
+#
+set -euo pipefail
+
+# Stop MSYS/Git-Bash (Windows) from rewriting container paths like `/v` or
+# `/var/lib/postgresql/data` into Windows paths. Harmless no-op on Linux/macOS.
+export MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'
+
+DB_NAME="${POSTGRES_DB:-meshinfo}"
+DB_USER="${POSTGRES_USER:-postgres}"
+DB_PASSWORD="${POSTGRES_PASSWORD:-password}"
+TMP_PG="meshinfo-pg-migrate"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DUMP_DIR="${REPO_ROOT}/backups"
+DUMP_FILE="${DUMP_DIR}/meshinfo-pg-$(date +%Y%m%d-%H%M%S).sql.gz"
+
+log()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m warn:\033[0m %s\n' "$*" >&2; }
+err()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; }
+cleanup() { docker rm -f "$TMP_PG" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+cd "$REPO_ROOT"
+
+# --- Pre-flight --------------------------------------------------------------
+command -v docker >/dev/null 2>&1 || { err "docker not found on PATH"; exit 1; }
+
+VOLUME="${PGDATA_VOLUME:-}"
+if [ -z "$VOLUME" ]; then
+  VOLUME="$(docker volume ls -q | grep -E '_meshinfo_pgdata$' | head -n1 || true)"
+  VOLUME="${VOLUME:-meshinfo_meshinfo_pgdata}"
+fi
+
+if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+  log "Volume '$VOLUME' does not exist — fresh install, nothing to migrate."
+  log "Just run: docker compose up -d"
+  exit 0
+fi
+
+# On-disk catalog version of the existing cluster. postgres images ≤17 keep
+# the cluster at the volume root; 18+ images use a version subdir (…/<major>/
+# docker), so probe both layouts.
+OLD_VER="$(docker run --rm -v "$VOLUME":/v:ro alpine sh -c \
+  'cat /v/PG_VERSION 2>/dev/null || cat /v/*/docker/PG_VERSION 2>/dev/null' \
+  2>/dev/null | tr -cd '0-9' || true)"
+if [ -z "$OLD_VER" ]; then
+  log "Volume '$VOLUME' has no initialised cluster — nothing to migrate."
+  log "Just run: docker compose up -d"
+  exit 0
+fi
+
+# Target version declared in the compose file.
+NEW_VER="$(docker compose config 2>/dev/null | grep -oE 'postgres:[0-9]+' | head -n1 | cut -d: -f2 || true)"
+if [ -z "$NEW_VER" ]; then
+  err "Could not read the target postgres version from the compose file."
+  err "Check the 'postgres' service image, or set COMPOSE_FILE."
+  exit 1
+fi
+
+if [ "$OLD_VER" = "$NEW_VER" ]; then
+  log "Volume '$VOLUME' is already at PostgreSQL ${NEW_VER} — migration not needed."
+  exit 0
+fi
+if [ "$OLD_VER" -gt "$NEW_VER" ]; then
+  err "Volume is PostgreSQL ${OLD_VER}, newer than the target ${NEW_VER}. Refusing to downgrade."
+  exit 1
+fi
+
+log "Migrating volume '$VOLUME': PostgreSQL ${OLD_VER} → ${NEW_VER}"
+mkdir -p "$DUMP_DIR"
+
+# --- 1. Stop the stack (volumes preserved) -----------------------------------
+log "Stopping the MeshInfo stack…"
+docker compose down --remove-orphans 2>/dev/null || true
+
+# --- 2. Dump from a temporary old-version container --------------------------
+log "Starting a temporary PostgreSQL ${OLD_VER} container to read the old data…"
+cleanup
+# postgres ≤17 expects the volume at /var/lib/postgresql/data; 18+ at the parent.
+OLD_MOUNT="/var/lib/postgresql/data"
+[ "$OLD_VER" -ge 18 ] && OLD_MOUNT="/var/lib/postgresql"
+docker run -d --name "$TMP_PG" \
+  -v "$VOLUME":"$OLD_MOUNT" \
+  -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+  "postgres:${OLD_VER}" >/dev/null
+
+log "Waiting for PostgreSQL ${OLD_VER} to accept connections…"
+for i in $(seq 1 60); do
+  docker exec "$TMP_PG" pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1 && break
+  if [ "$i" -eq 60 ]; then
+    err "PostgreSQL ${OLD_VER} did not become ready."
+    docker logs --tail 30 "$TMP_PG" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+log "Dumping database '${DB_NAME}' → ${DUMP_FILE}"
+if ! docker exec -e PGPASSWORD="$DB_PASSWORD" "$TMP_PG" \
+       pg_dump -U "$DB_USER" -d "$DB_NAME" --no-owner --no-privileges \
+     | gzip > "$DUMP_FILE"; then
+  err "pg_dump failed — the volume has NOT been modified."
+  docker logs --tail 30 "$TMP_PG" >&2 || true
+  exit 1
+fi
+
+# The dump is the recovery artifact: integrity-check it before anything destructive.
+if [ ! -s "$DUMP_FILE" ] || ! gzip -t "$DUMP_FILE" 2>/dev/null; then
+  err "Dump file is empty or corrupt — aborting before touching the volume."
+  exit 1
+fi
+log "Dump complete and verified ($(du -h "$DUMP_FILE" | cut -f1))."
+
+cleanup
+
+# --- 3. Recreate the volume empty --------------------------------------------
+if [ "${KEEP_VOLUME_BACKUP:-0}" = "1" ]; then
+  BACKUP_VOLUME="${VOLUME}_oldpg_backup"
+  log "Snapshotting old volume → '${BACKUP_VOLUME}'…"
+  docker volume rm "$BACKUP_VOLUME" >/dev/null 2>&1 || true
+  docker volume create "$BACKUP_VOLUME" >/dev/null
+  docker run --rm -v "$VOLUME":/from:ro -v "$BACKUP_VOLUME":/to \
+    alpine sh -c 'cp -a /from/. /to/'
+fi
+
+log "Removing the old volume so PostgreSQL ${NEW_VER} can initialise fresh…"
+docker volume rm "$VOLUME" >/dev/null
+# docker compose recreates the named volume on the next `up`.
+
+# --- 4. Start the new version and restore ------------------------------------
+log "Starting PostgreSQL ${NEW_VER}…"
+docker compose up -d postgres
+
+log "Waiting for PostgreSQL ${NEW_VER} to accept connections…"
+for i in $(seq 1 60); do
+  docker compose exec -T postgres pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1 && break
+  if [ "$i" -eq 60 ]; then
+    err "PostgreSQL ${NEW_VER} did not become ready."
+    docker compose logs --tail 30 postgres >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+log "Restoring the dump into PostgreSQL ${NEW_VER}…"
+if ! gzip -dc "$DUMP_FILE" \
+     | docker compose exec -T -e PGPASSWORD="$DB_PASSWORD" postgres \
+         psql -v ON_ERROR_STOP=1 -U "$DB_USER" -d "$DB_NAME" -q >/dev/null; then
+  err "Restore failed. Your data is safe in: ${DUMP_FILE}"
+  err "Investigate, then re-run the restore manually:"
+  err "  gzip -dc '${DUMP_FILE}' | docker compose exec -T postgres psql -U ${DB_USER} -d ${DB_NAME}"
+  exit 1
+fi
+
+log "Migration complete — PostgreSQL ${OLD_VER} → ${NEW_VER}. 🎉"
+echo
+echo "  SQL dump kept at : ${DUMP_FILE}"
+[ "${KEEP_VOLUME_BACKUP:-0}" = "1" ] && echo "  Volume backup    : docker volume '${VOLUME}_oldpg_backup'"
+echo
+echo "Start the full stack:  docker compose up -d"

--- a/scripts/migrate-postgres.sh
+++ b/scripts/migrate-postgres.sh
@@ -10,14 +10,14 @@
 #   1. Dumps the existing database with a temporary container running the
 #      OLD PostgreSQL version (read from the volume's PG_VERSION file).
 #   2. Verifies the dump, then recreates the volume empty.
-#   3. Starts the NEW postgres version (from docker-compose.yml) and restores.
+#   3. Starts the NEW postgres version (from the compose file) and restores.
 #
 # Run this ONCE, after pulling the release that bumps the postgres image and
 # BEFORE `docker compose up -d`:
 #
 #   git pull
 #   docker compose pull
-#   ./scripts/migrate-postgres.sh
+#   bash scripts/migrate-postgres.sh
 #   docker compose up -d
 #
 # The compressed SQL dump in ./backups/ is your recovery artifact — it is
@@ -56,11 +56,27 @@ cd "$REPO_ROOT"
 
 # --- Pre-flight --------------------------------------------------------------
 command -v docker >/dev/null 2>&1 || { err "docker not found on PATH"; exit 1; }
+docker compose version >/dev/null 2>&1 || {
+  err "docker compose (v2) is required — install the Compose plugin or upgrade Docker."
+  exit 1
+}
 
 VOLUME="${PGDATA_VOLUME:-}"
 if [ -z "$VOLUME" ]; then
-  VOLUME="$(docker volume ls -q | grep -E '_meshinfo_pgdata$' | head -n1 || true)"
-  VOLUME="${VOLUME:-meshinfo_meshinfo_pgdata}"
+  # Auto-detect the compose pgdata volume. Refuse to guess when a host runs
+  # several MeshInfo deployments — picking the wrong one here destroys data.
+  MATCHES="$(docker volume ls -q | grep -E '_meshinfo_pgdata$' || true)"
+  COUNT="$(printf '%s\n' "$MATCHES" | grep -c . || true)"
+  if [ "$COUNT" -gt 1 ]; then
+    err "Multiple candidate pgdata volumes found:"
+    printf '       %s\n' $MATCHES >&2
+    err "Set PGDATA_VOLUME=<name> to choose which one to migrate."
+    exit 1
+  elif [ "$COUNT" -eq 1 ]; then
+    VOLUME="$MATCHES"
+  else
+    VOLUME="meshinfo_meshinfo_pgdata"
+  fi
 fi
 
 if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Upgrades the PostgreSQL service from 16 to 18 in both compose files, and adds a
one-time migration script so existing deployments can move their data without loss.

This implements the `postgres` portion of #404 — which Renovate bundled with an
emsdk bump and which has sat on hold pending a migration strategy. #404 can be
re-scoped to just the emsdk update or closed.

## ⚠️ Breaking change — action required for existing deployments

Deployments using the bundled `postgres` compose service must run a one-time
migration. PostgreSQL 18's on-disk format and the `postgres:18` image's data
directory layout are both incompatible with 16, so the normal update flow
(`docker compose pull && up -d`) will leave Postgres unable to start until
the data is migrated:

    git pull
    docker compose pull
    bash scripts/migrate-postgres.sh   # one-time
    docker compose up -d

`postgres:18` refuses to start with a clear error and
leaves the 16 data untouched — but the stack is down until the migration
runs. Fresh installs and external (non-compose) Postgres are unaffected.

## Notes

Two incompatibilities have to be handled:

1. **On-disk format** — as with every PostgreSQL major version, an 18 container
   cannot start against a 16 data directory.
2. **The `postgres:18` image moved its data directory.** 18+ images store the
   cluster in a version-specific subdirectory and expect the volume mounted at
   `/var/lib/postgresql`, not `/var/lib/postgresql/data`
   (docker-library/postgres#1259). Both compose files are updated accordingly.

## What's included

- `postgres:16` → `postgres:18` in `docker-compose.yml` and
  `docker-compose-dev.yml`, with the volume remounted at `/var/lib/postgresql`.
- **`scripts/migrate-postgres.sh`** — dumps the existing cluster with a temporary
  old-version container, recreates the volume, and restores into 18. It reads the old
  version from the volume and the target from the compose file, so it is not
  pinned to 16→18; it is layout-aware, idempotent, no-ops on fresh installs, and
  sets `MSYS_NO_PATHCONV` so it also runs under Git Bash on Windows.
- Docs: a new "Upgrading PostgreSQL major versions" section in `POSTGRES.md`, a
  note in the README update steps, and version bumps in `README.md` /
  `CONTRIBUTING.md`.

## Upgrading an existing deployment

```sh
git pull
docker compose pull
bash scripts/migrate-postgres.sh
docker compose up -d
