### PR TITLE
feat(frontend): redesign navigation as a unified collapsible glass rail

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -230,6 +230,10 @@ channels = ["31"]
 name = "Central Valley Mesh"
 shortname = "CVM"
 description = "Serving Meshtastic to the California Central Valley and surrounding areas."
+# Optional logo shown in the collapsed (slim) nav rail. Path or URL; falls back
+# to the mesh name's first letter when empty. Drop a file in public/images and
+# point here, e.g. "/images/logo.svg", or use a full https:// URL.
+icon = ""
 url = "https://CVME.sh"
 contact = "https://CVME.sh"
 country = "US"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,36 +5,9 @@ import { Menu } from "./Menu";
 
 export const Layout = ({ children }: { children: React.ReactNode }) => {
   const { pathname } = useLocation();
-  const [isDark, setIsDark] = useState(false);
-  const [navCollapsed, setNavCollapsed] = useState(() => {
-    try {
-      return localStorage.getItem("meshinfo.nav.collapsed") === "1";
-    } catch {
-      return false;
-    }
-  });
-
-  const toggleNav = () =>
-    setNavCollapsed((c) => {
-      const next = !c;
-      try {
-        localStorage.setItem("meshinfo.nav.collapsed", next ? "1" : "0");
-      } catch {
-        // ignore storage failures (private mode, etc.)
-      }
-      return next;
-    });
-
-  // Single source of truth for the rail width + content offset (see index.css
-  // .nav-offset). The rail reads the same var so the two never drift.
-  useEffect(() => {
-    document.documentElement.style.setProperty(
-      "--nav-w",
-      navCollapsed ? "4.5rem" : "15rem",
-    );
-  }, [navCollapsed]);
-
   const isMap = pathname === "/map";
+  const [isDark, setIsDark] = useState(false);
+
   const isChat = pathname === "/chat";
   const isLog = pathname === "/log" || pathname === "/logs";
   const isTraceroutes = pathname === "/traceroutes";
@@ -99,12 +72,10 @@ const isFullBleed = isMap || isChat || isLog || isTraceroutes || isTelemetry || 
         isDark={isDark}
         onDarkChange={(dark) => setIsDark(dark)}
         overlayMode={isMap}
-        collapsed={navCollapsed}
-        onCollapseToggle={toggleNav}
       />
 
       <div
-        className={`${isMap ? "" : "nav-offset"} dark:bg-gray-950 dark:text-gray-100 lg:pt-0
+        className={`${isMap ? "nav-offset-map" : "nav-offset"} dark:bg-gray-950 dark:text-gray-100 lg:pt-0
           ${isFullBleed ? "pt-0 h-full overflow-hidden" : "pt-14"}`}
       >
         <main className={isFullBleed ? "h-full" : "py-1"}>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,33 @@ import { Menu } from "./Menu";
 export const Layout = ({ children }: { children: React.ReactNode }) => {
   const { pathname } = useLocation();
   const [isDark, setIsDark] = useState(false);
+  const [navCollapsed, setNavCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem("meshinfo.nav.collapsed") === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  const toggleNav = () =>
+    setNavCollapsed((c) => {
+      const next = !c;
+      try {
+        localStorage.setItem("meshinfo.nav.collapsed", next ? "1" : "0");
+      } catch {
+        // ignore storage failures (private mode, etc.)
+      }
+      return next;
+    });
+
+  // Single source of truth for the rail width + content offset (see index.css
+  // .nav-offset). The rail reads the same var so the two never drift.
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--nav-w",
+      navCollapsed ? "4.5rem" : "15rem",
+    );
+  }, [navCollapsed]);
 
   const isMap = pathname === "/map";
   const isChat = pathname === "/chat";
@@ -68,10 +95,16 @@ const isFullBleed = isMap || isChat || isLog || isTraceroutes || isTelemetry || 
 
   return (
     <div className={isFullBleed ? "h-dvh overflow-hidden" : ""}>
-      <Menu isDark={isDark} onDarkChange={(dark) => setIsDark(dark)} overlayMode={isMap} />
+      <Menu
+        isDark={isDark}
+        onDarkChange={(dark) => setIsDark(dark)}
+        overlayMode={isMap}
+        collapsed={navCollapsed}
+        onCollapseToggle={toggleNav}
+      />
 
       <div
-        className={`${isMap ? "" : "lg:pl-60"} dark:bg-gray-950 dark:text-gray-100 lg:pt-0
+        className={`${isMap ? "" : "nav-offset"} dark:bg-gray-950 dark:text-gray-100 lg:pt-0
           ${isFullBleed ? "pt-0 h-full overflow-hidden" : "pt-14"}`}
       >
         <main className={isFullBleed ? "h-full" : "py-1"}>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,8 +15,9 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
   const isNodes = pathname === "/nodes";
   const isNeighbors = pathname === "/neighbors";
   const isStats = pathname === "/stats";
+  const isGraph = pathname === "/graph";
 
-const isFullBleed = isMap || isChat || isLog || isTraceroutes || isTelemetry || isNodes || isNeighbors || isStats;
+const isFullBleed = isMap || isChat || isLog || isTraceroutes || isTelemetry || isNodes || isNeighbors || isStats || isGraph;
 
   // make sure the root element is updated with the dark class
   //  move this out eventually

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 
 import { useGetConfigQuery } from "../slices/apiSlice";
 import {
   ChevronDoubleLeftIcon,
   DEFAULT_TOOLS,
-  EllipsisIcon,
   type ExternalLinkDef,
   ExternalLinkIcon,
   GitHubIcon,
@@ -157,77 +156,6 @@ function ExternalRow({
   );
 }
 
-/** Collapsed-rail "More" popover holding the off-site Tools + Addons. */
-function MoreMenu({
-  tools,
-  addons,
-}: {
-  tools: ExternalLinkDef[];
-  addons: ExternalLinkDef[];
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        title="More links"
-        aria-label="More links"
-        aria-expanded={open}
-        className={`w-full flex items-center justify-center p-2.5 rounded-lg transition-colors ${
-          open
-            ? "bg-cyan-500/15 text-cyan-600 dark:text-cyan-300"
-            : "text-gray-400 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 hover:text-gray-600 dark:hover:text-gray-200"
-        }`}
-      >
-        <EllipsisIcon className="w-5 h-5" />
-      </button>
-      {open && (
-        <div className="absolute left-full bottom-0 ml-2 w-56 z-50 rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-gray-900/95 dark:backdrop-blur-xl shadow-2xl p-2 space-y-2">
-          <div className="space-y-0.5">
-            <h3 className={`${sectionHeader} px-2 pt-1 pb-1`}>Tools</h3>
-            {tools.map((t, i) => (
-              <ExternalRow
-                key={`more-tool-${i}`}
-                link={t}
-                collapsed={false}
-                onNavigate={() => setOpen(false)}
-              />
-            ))}
-          </div>
-          <div className="space-y-0.5">
-            <h3 className={`${sectionHeader} px-2 pt-1 pb-1`}>Addons</h3>
-            {addons.map((t, i) => (
-              <ExternalRow
-                key={`more-addon-${i}`}
-                link={t}
-                collapsed={false}
-                onNavigate={() => setOpen(false)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
 function ThemeToggle({
   isDark,
   onToggle,
@@ -252,25 +180,27 @@ export const Menu = ({
   isDark,
   onDarkChange,
   overlayMode = false,
-  collapsed = false,
-  onCollapseToggle,
 }: {
   isDark: boolean;
   onDarkChange: (dark: boolean) => void;
   overlayMode?: boolean;
-  collapsed?: boolean;
-  onCollapseToggle?: () => void;
 }) => {
   const { data: config } = useGetConfigQuery();
+  const { pathname } = useLocation();
   const [showMenu, setShowMenu] = useState(false);
+  // The desktop rail rests slim; expanding flies it out OVER the content as a
+  // transient overlay (the page never reflows). Auto-retracts on navigate,
+  // outside-click, or Escape, so it never lingers covering the page.
+  const [expanded, setExpanded] = useState(false);
+  const collapsed = !expanded;
+  const asideRef = useRef<HTMLElement>(null);
 
   const tools = config?.mesh?.tools?.length
     ? (config.mesh.tools as ExternalLinkDef[])
     : DEFAULT_TOOLS;
   const addons = MESHTASTIC_ADDONS;
   const closeDrawer = () => setShowMenu(false);
-  // On the map the rail runs as an overlay — close it after navigating.
-  const railNavigate = overlayMode ? closeDrawer : undefined;
+  const collapseRail = () => setExpanded(false);
 
   useEffect(() => {
     if (!showMenu) return;
@@ -281,6 +211,29 @@ export const Menu = ({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [showMenu]);
 
+  // Retract the expanded rail when the route changes (e.g. a nav click).
+  useEffect(() => {
+    setExpanded(false);
+  }, [pathname]);
+
+  // While expanded, retract on outside-click or Escape (flyout behavior).
+  useEffect(() => {
+    if (!expanded) return;
+    const onDown = (e: MouseEvent) => {
+      if (asideRef.current && !asideRef.current.contains(e.target as Node))
+        setExpanded(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [expanded]);
+
   const handleDarkChange = (dark: boolean) => {
     onDarkChange(dark);
     localStorage.setItem("theme", dark ? "dark" : "light");
@@ -288,10 +241,11 @@ export const Menu = ({
 
   return (
     <>
-      {/* Hamburger — always visible in overlay mode (map), mobile-only otherwise */}
+      {/* Hamburger — small screens only (every page incl. map). At lg the
+          persistent rail replaces it. Sits left on the map, right elsewhere. */}
       <button
         type="button"
-        className={`${overlayMode ? "" : "lg:hidden"} fixed z-50 top-4 ${
+        className={`lg:hidden fixed z-50 top-4 ${
           overlayMode ? "left-4" : "right-4 left-auto"
         } p-2 rounded-lg shadow-lg backdrop-blur-xs border transition-all duration-200 ${
           showMenu
@@ -337,17 +291,16 @@ export const Menu = ({
         </div>
       </button>
 
-      {/* Backdrop for the drawer */}
+      {/* Backdrop for the mobile drawer (small screens only). */}
       <div
-        className={`${overlayMode ? "" : "lg:hidden"} fixed inset-0 bg-black/20 backdrop-blur-xs z-40 transition-opacity duration-200 ${
+        className={`lg:hidden fixed inset-0 bg-black/20 backdrop-blur-xs z-40 transition-opacity duration-200 ${
           showMenu ? "opacity-100" : "opacity-0 pointer-events-none"
         }`}
         onClick={() => setShowMenu(false)}
       />
 
       {/* Mobile drawer — small screens only, every page. At lg the persistent
-          rail (below) takes over, including on the map where it opens as an
-          overlay, so the map nav matches the rest of the site. */}
+          rail (below) takes over on every page, including the map. */}
       <div
         className={`lg:hidden fixed inset-y-0 left-0 z-50 w-80 max-w-[80vw] flex flex-col bg-white dark:bg-gray-900 shadow-xl border-r border-gray-200 dark:border-gray-700 ${
           showMenu ? "" : "hidden"
@@ -413,17 +366,13 @@ export const Menu = ({
         </div>
       </div>
 
-      {/* Desktop rail (lg+). On normal pages it's persistent; on the map it
-          runs as an overlay toggled by the hamburger, so the map gets the same
-          rail — collapse button and all. Width tracks the --nav-w CSS var. */}
+      {/* Desktop rail (lg+) — rests slim in a fixed gutter on every page; when
+          expanded it grows to w-60 OVER the content (overlay, z above the map
+          panels) without moving the page. z-[1200] clears the map's z-1100 pills. */}
       <aside
-        style={{ width: "var(--nav-w)" }}
-        className={`hidden lg:fixed lg:inset-y-0 lg:left-0 lg:flex-col overflow-hidden bg-gray-50 dark:bg-gray-900/80 dark:backdrop-blur-xl border-r border-gray-200 dark:border-white/10 transition-[width] duration-200 ${
-          overlayMode
-            ? showMenu
-              ? "lg:flex lg:z-50 lg:shadow-2xl"
-              : "lg:hidden"
-            : "lg:flex lg:z-40"
+        ref={asideRef}
+        className={`hidden lg:flex lg:fixed lg:inset-y-0 lg:left-0 lg:z-1200 lg:flex-col overflow-hidden bg-gray-50 dark:bg-gray-900/80 dark:backdrop-blur-xl border-r border-gray-200 dark:border-white/10 transition-[width] duration-200 ${
+          collapsed ? "lg:w-18" : "lg:w-60 lg:shadow-2xl"
         }`}
       >
           {/* Brand / collapse toggle */}
@@ -431,7 +380,7 @@ export const Menu = ({
             {collapsed ? (
               <button
                 type="button"
-                onClick={onCollapseToggle}
+                onClick={() => setExpanded((v) => !v)}
                 title="Expand sidebar"
                 aria-label="Expand sidebar"
                 className="flex items-center justify-center w-full h-16 text-lg font-bold text-gray-800 dark:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
@@ -442,7 +391,7 @@ export const Menu = ({
               <div className="relative px-4 pt-4 pb-3">
                 <button
                   type="button"
-                  onClick={onCollapseToggle}
+                  onClick={() => setExpanded((v) => !v)}
                   title="Collapse sidebar"
                   aria-label="Collapse sidebar"
                   className="absolute top-3 right-3 p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
@@ -470,11 +419,9 @@ export const Menu = ({
                     key={item.to}
                     item={item}
                     collapsed
-                    onNavigate={railNavigate}
+                    onNavigate={collapseRail}
                   />
                 ))}
-                <div className="mx-2 my-2 h-px bg-gray-200 dark:bg-white/10" />
-                <MoreMenu tools={tools} addons={addons} />
               </div>
             ) : (
               <div className="space-y-4">
@@ -485,14 +432,19 @@ export const Menu = ({
                       key={item.to}
                       item={item}
                       collapsed={false}
-                      onNavigate={railNavigate}
+                      onNavigate={collapseRail}
                     />
                   ))}
                 </div>
                 <div className="space-y-0.5">
                   <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>Tools</h3>
                   {tools.map((t, i) => (
-                    <ExternalRow key={`tool-${i}`} link={t} collapsed={false} />
+                    <ExternalRow
+                      key={`tool-${i}`}
+                      link={t}
+                      collapsed={false}
+                      onNavigate={collapseRail}
+                    />
                   ))}
                 </div>
                 <div className="space-y-0.5">
@@ -500,7 +452,12 @@ export const Menu = ({
                     Meshtastic Addons
                   </h3>
                   {addons.map((t, i) => (
-                    <ExternalRow key={`addon-${i}`} link={t} collapsed={false} />
+                    <ExternalRow
+                      key={`addon-${i}`}
+                      link={t}
+                      collapsed={false}
+                      onNavigate={collapseRail}
+                    />
                   ))}
                 </div>
               </div>

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -255,13 +255,11 @@ export const Menu = ({
 
   return (
     <>
-      {/* Hamburger — small screens only (every page incl. map). At lg the
-          persistent rail replaces it. Sits left on the map, right elsewhere. */}
+      {/* Hamburger — small screens only (every page incl. map); top-right on
+          every page (overlays the header). At lg the persistent rail replaces it. */}
       <button
         type="button"
-        className={`lg:hidden fixed z-50 top-4 ${
-          overlayMode ? "left-4" : "right-4 left-auto"
-        } p-2 rounded-lg shadow-lg backdrop-blur-xs border transition-all duration-200 ${
+        className={`lg:hidden fixed z-50 top-4 right-4 p-2 rounded-lg shadow-lg backdrop-blur-xs border transition-all duration-200 ${
           showMenu
             ? "bg-gray-800 dark:bg-gray-200 border-gray-600 dark:border-gray-400"
             : overlayMode

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -1,35 +1,282 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router";
+import { useEffect, useRef, useState } from "react";
+import { NavLink } from "react-router";
 
 import { useGetConfigQuery } from "../slices/apiSlice";
+import {
+  ChevronDoubleLeftIcon,
+  DEFAULT_TOOLS,
+  EllipsisIcon,
+  type ExternalLinkDef,
+  ExternalLinkIcon,
+  GitHubIcon,
+  MESH_NAV,
+  MESHTASTIC_ADDONS,
+  MoonIcon,
+  type NavItemDef,
+  SunIcon,
+} from "./navConfig";
 
-const defaultTools = [
-  { name: "Armooo's MeshView", url: "https://meshview.armooo.net" },
-  { name: "Liam's Meshtastic Map", url: "https://meshtastic.liamcottle.net" },
-  { name: "MeshMap", url: "https://meshmap.net" },
-  { name: "Bay Mesh Explorer", url: "https://app.bayme.sh" },
-  { name: "HWT Path Profiler", url: "https://heywhatsthat.com/profiler.html" },
-];
+// Shared tokens — keep the rail and the drawer reading from one place.
+const sectionHeader =
+  "text-[10px] font-bold text-cyan-600 dark:text-cyan-500 uppercase tracking-widest";
+const rowBase =
+  "relative group flex items-center rounded-lg transition-colors";
+const rowActive = "bg-cyan-500/15 text-cyan-700 dark:text-cyan-200";
+const rowIdle =
+  "text-gray-700 dark:text-gray-300 hover:bg-gray-500/10 dark:hover:bg-gray-700/50";
+const GITHUB_URL = "https://github.com/MeshAddicts/meshinfo";
+
+/** Mesh name with the first letter of each word emphasized, rest muted. */
+function MeshName({ name, className }: { name?: string; className?: string }) {
+  if (!name) return null;
+  return (
+    <div className={className}>
+      {name.split(" ").map((word, i) => (
+        <div key={i} className="leading-tight dark:text-gray-50">
+          {word[0]}
+          <span className="text-gray-500 dark:text-gray-400 font-normal">
+            {word.slice(1)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Brand header content shared by the rail and the drawer so their vertical
+ *  metrics stay identical — no nav shift when moving between map and other pages. */
+function BrandBlock({
+  name,
+  description,
+  url,
+}: {
+  name?: string;
+  description?: string;
+  url?: string;
+}) {
+  return (
+    <>
+      <MeshName name={name} className="text-xl font-bold" />
+      {description && (
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 leading-relaxed line-clamp-3">
+          {description}
+        </p>
+      )}
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 inline-block text-xs text-cyan-600 dark:text-cyan-400 hover:underline"
+        >
+          Website
+        </a>
+      )}
+    </>
+  );
+}
+
+/** Internal route row — NavLink drives the cyan active state + aria-current. */
+function NavRow({
+  item,
+  collapsed,
+  onNavigate,
+}: {
+  item: NavItemDef;
+  collapsed: boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <NavLink
+      to={item.to}
+      onClick={onNavigate}
+      title={collapsed ? item.label : undefined}
+      className={({ isActive }) =>
+        `${rowBase} ${collapsed ? "justify-center p-2.5" : "gap-3 px-3 py-2.5"} ${
+          isActive ? rowActive : rowIdle
+        }`
+      }
+    >
+      {({ isActive }) => (
+        <>
+          {isActive && (
+            <span className="absolute left-0 top-1.5 bottom-1.5 w-0.75 rounded-full bg-cyan-500" />
+          )}
+          <span className="relative shrink-0">
+            <item.Icon
+              className={`w-5 h-5 ${
+                isActive
+                  ? "text-cyan-600 dark:text-cyan-300"
+                  : "text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-200"
+              }`}
+            />
+            {collapsed && item.badge && (
+              <span className="absolute -right-1 -top-1 w-2 h-2 rounded-full bg-amber-500" />
+            )}
+          </span>
+          {!collapsed && (
+            <span className="text-sm font-medium">{item.label}</span>
+          )}
+          {!collapsed && item.badge && (
+            <span className="ml-auto text-[10px] bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded-sm">
+              {item.badge}
+            </span>
+          )}
+        </>
+      )}
+    </NavLink>
+  );
+}
+
+/** External (off-site) link row — opens in a new tab. */
+function ExternalRow({
+  link,
+  collapsed,
+  onNavigate,
+}: {
+  link: ExternalLinkDef;
+  collapsed: boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <a
+      href={link.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={onNavigate}
+      title={collapsed ? link.name : undefined}
+      className={`${rowBase} ${rowIdle} ${
+        collapsed ? "justify-center p-2.5" : "gap-3 px-3 py-2.5"
+      }`}
+    >
+      <ExternalLinkIcon className="w-5 h-5 shrink-0 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-200" />
+      {!collapsed && (
+        <span className="text-sm font-medium truncate">{link.name}</span>
+      )}
+    </a>
+  );
+}
+
+/** Collapsed-rail "More" popover holding the off-site Tools + Addons. */
+function MoreMenu({
+  tools,
+  addons,
+}: {
+  tools: ExternalLinkDef[];
+  addons: ExternalLinkDef[];
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="More links"
+        aria-label="More links"
+        aria-expanded={open}
+        className={`w-full flex items-center justify-center p-2.5 rounded-lg transition-colors ${
+          open
+            ? "bg-cyan-500/15 text-cyan-600 dark:text-cyan-300"
+            : "text-gray-400 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 hover:text-gray-600 dark:hover:text-gray-200"
+        }`}
+      >
+        <EllipsisIcon className="w-5 h-5" />
+      </button>
+      {open && (
+        <div className="absolute left-full bottom-0 ml-2 w-56 z-50 rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-gray-900/95 dark:backdrop-blur-xl shadow-2xl p-2 space-y-2">
+          <div className="space-y-0.5">
+            <h3 className={`${sectionHeader} px-2 pt-1 pb-1`}>Tools</h3>
+            {tools.map((t, i) => (
+              <ExternalRow
+                key={`more-tool-${i}`}
+                link={t}
+                collapsed={false}
+                onNavigate={() => setOpen(false)}
+              />
+            ))}
+          </div>
+          <div className="space-y-0.5">
+            <h3 className={`${sectionHeader} px-2 pt-1 pb-1`}>Addons</h3>
+            {addons.map((t, i) => (
+              <ExternalRow
+                key={`more-addon-${i}`}
+                link={t}
+                collapsed={false}
+                onNavigate={() => setOpen(false)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ThemeToggle({
+  isDark,
+  onToggle,
+}: {
+  isDark: boolean;
+  onToggle: (dark: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(!isDark)}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="flex items-center justify-center w-9 h-9 rounded-lg text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
+    >
+      {isDark ? <SunIcon className="w-5 h-5" /> : <MoonIcon className="w-5 h-5" />}
+    </button>
+  );
+}
 
 export const Menu = ({
   isDark,
   onDarkChange,
   overlayMode = false,
+  collapsed = false,
+  onCollapseToggle,
 }: {
   isDark: boolean;
   onDarkChange: (dark: boolean) => void;
   overlayMode?: boolean;
+  collapsed?: boolean;
+  onCollapseToggle?: () => void;
 }) => {
   const { data: config } = useGetConfigQuery();
   const [showMenu, setShowMenu] = useState(false);
 
+  const tools = config?.mesh?.tools?.length
+    ? (config.mesh.tools as ExternalLinkDef[])
+    : DEFAULT_TOOLS;
+  const addons = MESHTASTIC_ADDONS;
+  const closeDrawer = () => setShowMenu(false);
+  // On the map the rail runs as an overlay — close it after navigating.
+  const railNavigate = overlayMode ? closeDrawer : undefined;
+
   useEffect(() => {
     if (!showMenu) return;
-
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setShowMenu(false);
     };
-
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [showMenu]);
@@ -41,10 +288,12 @@ export const Menu = ({
 
   return (
     <>
-      {/* Hamburger Button — always visible in overlay mode, mobile-only otherwise */}
+      {/* Hamburger — always visible in overlay mode (map), mobile-only otherwise */}
       <button
         type="button"
-        className={`${overlayMode ? "" : "lg:hidden"} fixed z-50 top-4 ${overlayMode ? "left-4" : "right-4 left-auto"} p-2 rounded-lg shadow-lg backdrop-blur-xs border transition-all duration-200 ${
+        className={`${overlayMode ? "" : "lg:hidden"} fixed z-50 top-4 ${
+          overlayMode ? "left-4" : "right-4 left-auto"
+        } p-2 rounded-lg shadow-lg backdrop-blur-xs border transition-all duration-200 ${
           showMenu
             ? "bg-gray-800 dark:bg-gray-200 border-gray-600 dark:border-gray-400"
             : overlayMode
@@ -57,28 +306,38 @@ export const Menu = ({
       >
         <div className="w-5 h-5 flex flex-col justify-center items-center">
           {showMenu ? (
-            <svg 
-              className="w-4 h-4 text-white dark:text-gray-800" 
-              fill="none" 
-              stroke="currentColor" 
+            <svg
+              className="w-4 h-4 text-white dark:text-gray-800"
+              fill="none"
+              stroke="currentColor"
               viewBox="0 0 24 24"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           ) : (
-            <svg 
-              className="w-4 h-4 text-gray-700 dark:text-gray-200" 
-              fill="none" 
-              stroke="currentColor" 
+            <svg
+              className="w-4 h-4 text-gray-700 dark:text-gray-200"
+              fill="none"
+              stroke="currentColor"
               viewBox="0 0 24 24"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
             </svg>
           )}
         </div>
       </button>
 
-      {/* Backdrop — always available in overlay mode, mobile-only otherwise */}
+      {/* Backdrop for the drawer */}
       <div
         className={`${overlayMode ? "" : "lg:hidden"} fixed inset-0 bg-black/20 backdrop-blur-xs z-40 transition-opacity duration-200 ${
           showMenu ? "opacity-100" : "opacity-0 pointer-events-none"
@@ -86,423 +345,210 @@ export const Menu = ({
         onClick={() => setShowMenu(false)}
       />
 
-      {/* Navigation Panel */}
+      {/* Mobile drawer — small screens only, every page. At lg the persistent
+          rail (below) takes over, including on the map where it opens as an
+          overlay, so the map nav matches the rest of the site. */}
       <div
-        className={`w-full ${overlayMode ? "" : "lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-60 lg:flex-col"} ${
+        className={`lg:hidden fixed inset-y-0 left-0 z-50 w-80 max-w-[80vw] flex flex-col bg-white dark:bg-gray-900 shadow-xl border-r border-gray-200 dark:border-gray-700 ${
           showMenu ? "" : "hidden"
-        } dark:text-gray-100 z-0 ${overlayMode ? "" : "lg:z-50"}`}
+        }`}
       >
-        {/* Drawer (mobile always, desktop when overlayMode) */}
-        <div className={`${overlayMode ? "" : "lg:hidden"} fixed inset-y-0 left-0 z-50 w-80 max-w-[80vw] bg-white dark:bg-gray-900 shadow-xl border-r border-gray-200 dark:border-gray-700`}>
-          <div className="flex flex-col h-full overflow-hidden">
-            {/* Mobile Header */}
-            <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-              <div className="mb-2">
-                {config?.mesh?.name?.split(" ").map((word, index) => (
-                  <div
-                    className="text-xl font-bold dark:text-gray-50"
-                    key={`mobile-meshname-${index}`}
-                  >
-                    {word[0]}
-                    <span className="text-gray-500 dark:text-gray-400 font-normal">
-                      {word.slice(1)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              {config?.mesh?.description && (
-                <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
-                  {config.mesh.description}
-                </p>
-              )}
-            </div>
-
-            {/* Mobile Navigation */}
-            <div className="flex-1 overflow-y-auto px-2 py-3 space-y-4">
-              <div className="space-y-0.5">
-                <h3 className="text-[10px] font-bold text-cyan-600 dark:text-cyan-500 uppercase tracking-widest px-3 pt-2 pb-1">Mesh</h3>
-                <Link to="/chat" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Chat</span>
-                  </div>
-                </Link>
-                <Link to="/map" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Map</span>
-                  </div>
-                </Link>
-                <Link to="/graph" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Graph</span>
-                    <span className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded-sm">Experimental</span>
-                  </div>
-                </Link>
-                <Link to="/nodes" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Nodes</span>
-                  </div>
-                </Link>
-                <Link to="/neighbors" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Node Neighbors</span>
-                  </div>
-                </Link>
-                <Link to="/stats" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Stats</span>
-                  </div>
-                </Link>
-                <Link to="/telemetry" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Telemetry</span>
-                  </div>
-                </Link>
-                <Link to="/traceroutes" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Traceroutes</span>
-                  </div>
-                </Link>
-                <Link to="/logs" onClick={() => setShowMenu(false)} className="block">
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Logs</span>
-                  </div>
-                </Link>
-              </div>
-
-              <div className="space-y-0.5">
-                <h3 className="text-[10px] font-bold text-cyan-600 dark:text-cyan-500 uppercase tracking-widest px-3 pt-2 pb-1">Tools</h3>
-                {(config?.mesh?.tools ?? defaultTools).map((tool, index) => (
-                  <a
-                    key={`mobile-tools-${index}`}
-                    href={tool.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => setShowMenu(false)}
-                    className="block"
-                  >
-                    <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                      <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{tool.name}</span>
-                    </div>
-                  </a>
-                ))}
-              </div>
-
-              <div className="space-y-0.5">
-                <h3 className="text-[10px] font-bold text-cyan-600 dark:text-cyan-500 uppercase tracking-widest px-3 pt-2 pb-1">Meshtastic Addons</h3>
-                <a
-                  href="https://github.com/armooo/meshtastic_dopewars"
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={() => setShowMenu(false)}
-                  className="block"
-                >
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">DopeWars</span>
-                  </div>
-                </a>
-                <a
-                  href="https://github.com/TheCommsChannel/TC2-BBS-mesh"
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={() => setShowMenu(false)}
-                  className="block"
-                >
-                  <div className="flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700/50">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">TheCommsChannel BBS</span>
-                  </div>
-                </a>
-              </div>
-            </div>
-
-            {/* Mobile Footer */}
-            <div className="p-4 border-t border-gray-200 dark:border-gray-700">
-              <button
-                onClick={() => handleDarkChange(!isDark)}
-                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-              >
-                {isDark ? "🌞" : "🌙"}
-              </button>
-            </div>
-          </div>
+        <div className="px-4 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700">
+          <BrandBlock
+            name={config?.mesh?.name}
+            description={config?.mesh?.description}
+            url={config?.mesh?.url}
+          />
         </div>
 
-        {/* Desktop Sidebar — hidden in overlay mode */}
-        <div className={`${overlayMode ? "hidden" : "hidden lg:flex lg:flex-col"} px-6 pb-4 overflow-y-auto bg-gray-300 dark:bg-gray-800 border-r-2 grow gap-y-5 border-r-cyan-600`}>
-          <div className="flex items-center h-24 mt-4 shrink-0">
-            <div className="text-2xl">
-              {config?.mesh?.name?.split(" ").map((word, index) => (
-                <div
-                  className="p-0 m-0 dark:text-gray-50"
-                  key={`meshname-${index}`}
-                >
-                  {word[0]}
-                  <span className="text-gray-500 dark:text-gray-400">
-                    {word.slice(1)}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div>{config?.mesh?.description}</div>
-
-          <div>
-            <a
-              href={config?.mesh?.url}
-              className="text-xs text-gray-900 dark:text-gray-50"
-            >
-              Website
-            </a>
-          </div>
-
-          <nav className="flex flex-col flex-1">
-            <h3 className="font-bold">Mesh</h3>
-            <div className="mb-1">
-              <Link
-                to="/chat"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/chat.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="chat icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Chat
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/map"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/map.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="map icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Map
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/graph"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/graph.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="graph icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Graph
-                <span className="ml-1 text-xs text-amber-600 dark:text-amber-400">
-                  Experimental
-                </span>
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/nodes"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/node.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="node icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Nodes
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/neighbors"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/neighbors.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="neighbors icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Node Neighbors
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/stats"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/stats.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="stats icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Stats
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/telemetry"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/telemetry.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="telemetry icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Telemetry
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/traceroutes"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/route2.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="traceroutes icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Traceroutes
-              </Link>
-            </div>
-            <div className="mb-1">
-              <Link
-                to="/logs"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                <img
-                  src={`${import.meta.env.BASE_URL}images/icons/logs.svg`}
-                  width="20"
-                  height="20"
-                  className="inline-block mr-2 dark:invert"
-                  alt="logs icon"
-                  style={{ verticalAlign: "middle" }}
-                />
-                Logs
-              </Link>
-            </div>
-          </nav>
-
-          <nav className="flex flex-col flex-1">
-            <h3 className="font-bold">Tools</h3>
-            {(config?.mesh?.tools ?? defaultTools).map((tool, index) => (
-              <div key={`tools-${index}`} className="mb-1">
-                <a
-                  href={tool.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-                >
-                  {tool.name}
-                </a>
-              </div>
+        <nav
+          className="flex-1 overflow-y-auto px-2 py-3 space-y-4"
+          aria-label="Primary"
+        >
+          <div className="space-y-0.5">
+            <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>Mesh</h3>
+            {MESH_NAV.map((item) => (
+              <NavRow
+                key={item.to}
+                item={item}
+                collapsed={false}
+                onNavigate={closeDrawer}
+              />
             ))}
-          </nav>
-
-          <nav className="flex flex-col flex-1">
-            <h3 className="font-bold">Meshtastic Addons</h3>
-            <div className="mb-1">
-              <a
-                href="https://github.com/armooo/meshtastic_dopewars"
-                target="_blank"
-                rel="noreferrer"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                DopeWars
-              </a>
-            </div>
-            <div className="mb-1">
-              <a
-                href="https://github.com/TheCommsChannel/TC2-BBS-mesh"
-                target="_blank"
-                rel="noreferrer"
-                className="dark:text-indigo-400 dark:visited:text-indigo-400 dark:hover:text-indigo-500"
-              >
-                TheCommsChannel BBS
-              </a>
-            </div>
-          </nav>
-
-          <div className="grow" />
-
-          <div className="flex flex-col">
-            <h5 className="mb-2">
-              Powered by MeshInfo{" "}
-              <span className="text-xs text-gray-500">
-                {config?.server?.version_info?.refName}
-              </span>
-            </h5>
-            <div className="flex">
-              <a
-                href="https://github.com/MeshAddicts/meshinfo"
-                className="text-xs text-gray-500"
-              >
-                <img
-                  src="https://img.shields.io/github/stars/MeshAddicts/meshinfo?style=social"
-                  alt="GitHub Stars"
-                />
-              </a>
-              {isDark ? (
-                <div
-                  role="button"
-                  onClick={() => handleDarkChange(false)}
-                  onKeyDown={() => handleDarkChange(false)}
-                  tabIndex={0}
-                >
-                  <img
-                    src={`${import.meta.env.BASE_URL}images/icons/light-mode.svg`}
-                    width="20"
-                    height="20"
-                    className="inline-block ml-2 dark:invert cursor-pointer"
-                    alt="light mode icon"
-                    title="Switch to Light Mode"
-                  />
-                </div>
-              ) : (
-                <div
-                  role="button"
-                  onClick={() => handleDarkChange(true)}
-                  onKeyDown={() => handleDarkChange(true)}
-                  tabIndex={0}
-                >
-                  <img
-                    src={`${import.meta.env.BASE_URL}images/icons/dark-mode.svg`}
-                    width="20"
-                    height="20"
-                    className="inline-block ml-2 dark:invert cursor-pointer"
-                    alt="light mode icon"
-                    title="Switch to Dark Mode"
-                  />
-                </div>
-              )}
-            </div>
           </div>
+          <div className="space-y-0.5">
+            <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>Tools</h3>
+            {tools.map((t, i) => (
+              <ExternalRow
+                key={`tool-${i}`}
+                link={t}
+                collapsed={false}
+                onNavigate={closeDrawer}
+              />
+            ))}
+          </div>
+          <div className="space-y-0.5">
+            <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>
+              Meshtastic Addons
+            </h3>
+            {addons.map((t, i) => (
+              <ExternalRow
+                key={`addon-${i}`}
+                link={t}
+                collapsed={false}
+                onNavigate={closeDrawer}
+              />
+            ))}
+          </div>
+        </nav>
+
+        <div className="p-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            MeshInfo{" "}
+            <span className="text-gray-400 dark:text-gray-500">
+              {config?.server?.version_info?.refName}
+            </span>
+          </span>
+          <ThemeToggle isDark={isDark} onToggle={handleDarkChange} />
         </div>
       </div>
+
+      {/* Desktop rail (lg+). On normal pages it's persistent; on the map it
+          runs as an overlay toggled by the hamburger, so the map gets the same
+          rail — collapse button and all. Width tracks the --nav-w CSS var. */}
+      <aside
+        style={{ width: "var(--nav-w)" }}
+        className={`hidden lg:fixed lg:inset-y-0 lg:left-0 lg:flex-col overflow-hidden bg-gray-50 dark:bg-gray-900/80 dark:backdrop-blur-xl border-r border-gray-200 dark:border-white/10 transition-[width] duration-200 ${
+          overlayMode
+            ? showMenu
+              ? "lg:flex lg:z-50 lg:shadow-2xl"
+              : "lg:hidden"
+            : "lg:flex lg:z-40"
+        }`}
+      >
+          {/* Brand / collapse toggle */}
+          <div className="shrink-0 border-b border-gray-200 dark:border-white/10">
+            {collapsed ? (
+              <button
+                type="button"
+                onClick={onCollapseToggle}
+                title="Expand sidebar"
+                aria-label="Expand sidebar"
+                className="flex items-center justify-center w-full h-16 text-lg font-bold text-gray-800 dark:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
+              >
+                {config?.mesh?.name?.[0] ?? "≡"}
+              </button>
+            ) : (
+              <div className="relative px-4 pt-4 pb-3">
+                <button
+                  type="button"
+                  onClick={onCollapseToggle}
+                  title="Collapse sidebar"
+                  aria-label="Collapse sidebar"
+                  className="absolute top-3 right-3 p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  <ChevronDoubleLeftIcon className="w-4 h-4" />
+                </button>
+                <BrandBlock
+                  name={config?.mesh?.name}
+                  description={config?.mesh?.description}
+                  url={config?.mesh?.url}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Nav */}
+          <nav
+            className="flex-1 overflow-y-auto no-scrollbar px-2 py-3"
+            aria-label="Primary"
+          >
+            {collapsed ? (
+              <div className="space-y-1">
+                {MESH_NAV.map((item) => (
+                  <NavRow
+                    key={item.to}
+                    item={item}
+                    collapsed
+                    onNavigate={railNavigate}
+                  />
+                ))}
+                <div className="mx-2 my-2 h-px bg-gray-200 dark:bg-white/10" />
+                <MoreMenu tools={tools} addons={addons} />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-0.5">
+                  <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>Mesh</h3>
+                  {MESH_NAV.map((item) => (
+                    <NavRow
+                      key={item.to}
+                      item={item}
+                      collapsed={false}
+                      onNavigate={railNavigate}
+                    />
+                  ))}
+                </div>
+                <div className="space-y-0.5">
+                  <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>Tools</h3>
+                  {tools.map((t, i) => (
+                    <ExternalRow key={`tool-${i}`} link={t} collapsed={false} />
+                  ))}
+                </div>
+                <div className="space-y-0.5">
+                  <h3 className={`${sectionHeader} px-3 pt-1 pb-1`}>
+                    Meshtastic Addons
+                  </h3>
+                  {addons.map((t, i) => (
+                    <ExternalRow key={`addon-${i}`} link={t} collapsed={false} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </nav>
+
+          {/* Footer — version, GitHub stars, theme toggle */}
+          <div className="shrink-0 border-t border-gray-200 dark:border-white/10 p-3">
+            {collapsed ? (
+              <div className="flex flex-col items-center gap-1">
+                <ThemeToggle isDark={isDark} onToggle={handleDarkChange} />
+                <a
+                  href={GITHUB_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  title="MeshInfo on GitHub"
+                  aria-label="MeshInfo on GitHub"
+                  className="flex items-center justify-center w-9 h-9 rounded-lg text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  <GitHubIcon className="w-5 h-5" />
+                </a>
+              </div>
+            ) : (
+              <div className="flex items-end justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    Powered by MeshInfo{" "}
+                    <span className="text-gray-400 dark:text-gray-500">
+                      {config?.server?.version_info?.refName}
+                    </span>
+                  </div>
+                  <a
+                    href={GITHUB_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-1.5 inline-block"
+                  >
+                    <img
+                      src="https://img.shields.io/github/stars/MeshAddicts/meshinfo?style=social"
+                      alt="GitHub Stars"
+                    />
+                  </a>
+                </div>
+                <ThemeToggle isDark={isDark} onToggle={handleDarkChange} />
+              </div>
+            )}
+          </div>
+        </aside>
     </>
   );
 };

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -42,6 +42,20 @@ function MeshName({ name, className }: { name?: string; className?: string }) {
   );
 }
 
+/** Collapsed-rail brand: the deployer's logo (mesh.icon) if set, else the
+ *  mesh name's first letter. */
+function BrandMark({ icon, name }: { icon?: string; name?: string }) {
+  if (icon)
+    return (
+      <img
+        src={icon}
+        alt={name ? `${name} logo` : "Logo"}
+        className="w-7 h-7 object-contain"
+      />
+    );
+  return <>{name?.[0] ?? "≡"}</>;
+}
+
 /** Brand header content shared by the rail and the drawer so their vertical
  *  metrics stay identical — no nav shift when moving between map and other pages. */
 function BrandBlock({
@@ -385,7 +399,10 @@ export const Menu = ({
                 aria-label="Expand sidebar"
                 className="flex items-center justify-center w-full h-16 text-lg font-bold text-gray-800 dark:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
               >
-                {config?.mesh?.name?.[0] ?? "≡"}
+                <BrandMark
+                  icon={config?.mesh?.icon}
+                  name={config?.mesh?.name}
+                />
               </button>
             ) : (
               <div className="relative px-4 pt-4 pb-3">

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -104,6 +104,7 @@ function NavRow({
       to={item.to}
       onClick={onNavigate}
       title={collapsed ? item.label : undefined}
+      aria-label={collapsed ? item.label : undefined}
       className={({ isActive }) =>
         `${rowBase} ${collapsed ? "justify-center p-2.5" : "gap-3 px-3 py-2.5"} ${
           isActive ? rowActive : rowIdle
@@ -120,7 +121,7 @@ function NavRow({
               className={`w-5 h-5 ${
                 isActive
                   ? "text-cyan-600 dark:text-cyan-300"
-                  : "text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-200"
+                  : "text-gray-500 dark:text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-200"
               }`}
             />
             {collapsed && item.badge && (
@@ -158,11 +159,12 @@ function ExternalRow({
       rel="noopener noreferrer"
       onClick={onNavigate}
       title={collapsed ? link.name : undefined}
+      aria-label={collapsed ? link.name : undefined}
       className={`${rowBase} ${rowIdle} ${
         collapsed ? "justify-center p-2.5" : "gap-3 px-3 py-2.5"
       }`}
     >
-      <ExternalLinkIcon className="w-5 h-5 shrink-0 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-200" />
+      <ExternalLinkIcon className="w-5 h-5 shrink-0 text-gray-500 dark:text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-200" />
       {!collapsed && (
         <span className="text-sm font-medium truncate">{link.name}</span>
       )}
@@ -208,6 +210,10 @@ export const Menu = ({
   const [expanded, setExpanded] = useState(false);
   const collapsed = !expanded;
   const asideRef = useRef<HTMLElement>(null);
+  const expandBtnRef = useRef<HTMLButtonElement>(null);
+  // True when a keyboard action retracts the rail, so focus returns to the
+  // expand button instead of falling to <body> as the flyout unmounts.
+  const restoreFocusRef = useRef(false);
 
   const tools = config?.mesh?.tools?.length
     ? (config.mesh.tools as ExternalLinkDef[])
@@ -230,6 +236,14 @@ export const Menu = ({
     setExpanded(false);
   }, [pathname]);
 
+  // After a keyboard retract, return focus to the expand button.
+  useEffect(() => {
+    if (!expanded && restoreFocusRef.current) {
+      restoreFocusRef.current = false;
+      expandBtnRef.current?.focus();
+    }
+  }, [expanded]);
+
   // While expanded, retract on outside-click or Escape (flyout behavior).
   useEffect(() => {
     if (!expanded) return;
@@ -238,7 +252,10 @@ export const Menu = ({
         setExpanded(false);
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
+      if (e.key === "Escape") {
+        restoreFocusRef.current = true;
+        setExpanded(false);
+      }
     };
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
@@ -383,6 +400,7 @@ export const Menu = ({
           panels) without moving the page. z-[1200] clears the map's z-1100 pills. */}
       <aside
         ref={asideRef}
+        id="nav-rail"
         className={`hidden lg:flex lg:fixed lg:inset-y-0 lg:left-0 lg:z-1200 lg:flex-col overflow-hidden bg-gray-50 dark:bg-gray-900/80 dark:backdrop-blur-xl border-r border-gray-200 dark:border-white/10 transition-[width] duration-200 ${
           collapsed ? "lg:w-18" : "lg:w-60 lg:shadow-2xl"
         }`}
@@ -391,10 +409,13 @@ export const Menu = ({
           <div className="shrink-0 border-b border-gray-200 dark:border-white/10">
             {collapsed ? (
               <button
+                ref={expandBtnRef}
                 type="button"
-                onClick={() => setExpanded((v) => !v)}
+                onClick={() => setExpanded(true)}
                 title="Expand sidebar"
                 aria-label="Expand sidebar"
+                aria-expanded={expanded}
+                aria-controls="nav-rail"
                 className="flex items-center justify-center w-full h-16 text-lg font-bold text-gray-800 dark:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
               >
                 <BrandMark
@@ -406,9 +427,14 @@ export const Menu = ({
               <div className="relative px-4 pt-4 pb-3">
                 <button
                   type="button"
-                  onClick={() => setExpanded((v) => !v)}
+                  onClick={() => {
+                    restoreFocusRef.current = true;
+                    setExpanded(false);
+                  }}
                   title="Collapse sidebar"
                   aria-label="Collapse sidebar"
+                  aria-expanded={expanded}
+                  aria-controls="nav-rail"
                   className="absolute top-3 right-3 p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-100 hover:bg-gray-500/10 dark:hover:bg-gray-700/50 transition-colors"
                 >
                   <ChevronDoubleLeftIcon className="w-4 h-4" />

--- a/frontend/src/components/navConfig.tsx
+++ b/frontend/src/components/navConfig.tsx
@@ -1,0 +1,164 @@
+// Single source of truth for the primary nav. Both the persistent desktop rail
+// and the mobile/overlay drawer render from MESH_NAV, so the two can never drift.
+// Icons are inline stroke="currentColor" SVGs (matching the map-panel idiom) so
+// they tint with the active/hover text color — no icon-library dependency.
+/* eslint-disable react-refresh/only-export-components */
+import type { ReactElement, ReactNode } from "react";
+
+export type IconProps = { className?: string };
+export type IconComponent = (props: IconProps) => ReactElement;
+
+// Outline icon factory — shared stroke geometry, paths supplied per icon.
+function strokeIcon(children: ReactNode): IconComponent {
+  return function Icon({ className }: IconProps) {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.75}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={className}
+        aria-hidden="true"
+      >
+        {children}
+      </svg>
+    );
+  };
+}
+
+// --- Route icons ---
+export const ChatIcon = strokeIcon(
+  <>
+    <path d="M7.5 8.25h9m-9 3.75h6" />
+    <path d="M7.1 18.16 3 21V5.25A2.25 2.25 0 0 1 5.25 3h13.5A2.25 2.25 0 0 1 21 5.25v9A2.25 2.25 0 0 1 18.75 16.5H8.69a2.25 2.25 0 0 0-1.59.66Z" />
+  </>,
+);
+export const MapIcon = strokeIcon(
+  <>
+    <circle cx="12" cy="10.5" r="2.5" />
+    <path d="M19.5 10.5c0 6-7.5 10.5-7.5 10.5S4.5 16.5 4.5 10.5a7.5 7.5 0 0 1 15 0Z" />
+  </>,
+);
+export const GraphIcon = strokeIcon(
+  <>
+    <circle cx="6" cy="12" r="2.25" />
+    <circle cx="18" cy="6" r="2.25" />
+    <circle cx="18" cy="18" r="2.25" />
+    <path d="m8.05 11.05 7.9-3.95M8.05 12.95l7.9 3.95" />
+  </>,
+);
+export const NodesIcon = strokeIcon(
+  <>
+    <rect x="6" y="6" width="12" height="12" rx="1.5" />
+    <rect x="9.25" y="9.25" width="5.5" height="5.5" rx="0.75" />
+    <path d="M9 3v1.75M12 3v1.75M15 3v1.75M9 19.25V21M12 19.25V21M15 19.25V21M3 9h1.75M3 12h1.75M3 15h1.75M19.25 9H21M19.25 12H21M19.25 15H21" />
+  </>,
+);
+export const NeighborsIcon = strokeIcon(
+  <>
+    <circle cx="9" cy="8" r="3" />
+    <path d="M3.5 19a5.5 5.5 0 0 1 11 0" />
+    <path d="M16 5.2a3 3 0 0 1 0 5.6" />
+    <path d="M17.5 13.4a5.5 5.5 0 0 1 3 4.9" />
+  </>,
+);
+export const StatsIcon = strokeIcon(
+  <>
+    <path d="M3.5 20.5h17" />
+    <rect x="5" y="11" width="3.4" height="7.5" rx="0.6" />
+    <rect x="10.3" y="6.5" width="3.4" height="12" rx="0.6" />
+    <rect x="15.6" y="14" width="3.4" height="4.5" rx="0.6" />
+  </>,
+);
+export const TelemetryIcon = strokeIcon(
+  <path d="M3 12h3.2l2.4-7 4 14 2.4-7H21" />,
+);
+export const TraceroutesIcon = strokeIcon(
+  <>
+    <circle cx="6" cy="6" r="2" />
+    <circle cx="18" cy="18" r="2" />
+    <path d="M8 6h6a3 3 0 0 1 0 6h-4a3 3 0 0 0 0 6h6" />
+  </>,
+);
+export const LogsIcon = strokeIcon(
+  <>
+    <path d="M8.5 7h9M8.5 12h9M8.5 17h6" />
+    <path d="M4.75 7h.01M4.75 12h.01M4.75 17h.01" />
+  </>,
+);
+
+// --- UI chrome icons ---
+export const ChevronDoubleLeftIcon = strokeIcon(
+  <path d="m18 6-6 6 6 6M12 6l-6 6 6 6" />,
+);
+export const ExternalLinkIcon = strokeIcon(
+  <>
+    <path d="M14 5h5v5" />
+    <path d="M19 5 11.5 12.5" />
+    <path d="M19 13.5V18a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4.5" />
+  </>,
+);
+export const SunIcon = strokeIcon(
+  <>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+  </>,
+);
+export const MoonIcon = strokeIcon(
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />,
+);
+
+// Filled marks (dots / logo) — currentColor fill, no stroke.
+export const EllipsisIcon = ({ className }: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <circle cx="5" cy="12" r="1.6" />
+    <circle cx="12" cy="12" r="1.6" />
+    <circle cx="19" cy="12" r="1.6" />
+  </svg>
+);
+export const GitHubIcon = ({ className }: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.46-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05A9.34 9.34 0 0 1 12 6.84c.85 0 1.71.12 2.51.34 1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.81 0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" />
+  </svg>
+);
+
+export interface NavItemDef {
+  to: string;
+  label: string;
+  Icon: IconComponent;
+  badge?: string;
+}
+
+export interface ExternalLinkDef {
+  name: string;
+  url: string;
+}
+
+// Primary in-app destinations. Order preserved from the legacy sidebar.
+export const MESH_NAV: NavItemDef[] = [
+  { to: "/chat", label: "Chat", Icon: ChatIcon },
+  { to: "/map", label: "Map", Icon: MapIcon },
+  { to: "/graph", label: "Graph", Icon: GraphIcon, badge: "Experimental" },
+  { to: "/nodes", label: "Nodes", Icon: NodesIcon },
+  { to: "/neighbors", label: "Node Neighbors", Icon: NeighborsIcon },
+  { to: "/stats", label: "Stats", Icon: StatsIcon },
+  { to: "/telemetry", label: "Telemetry", Icon: TelemetryIcon },
+  { to: "/traceroutes", label: "Traceroutes", Icon: TraceroutesIcon },
+  { to: "/logs", label: "Logs", Icon: LogsIcon },
+];
+
+// Falls back here when config.mesh.tools is absent.
+export const DEFAULT_TOOLS: ExternalLinkDef[] = [
+  { name: "Armooo's MeshView", url: "https://meshview.armooo.net" },
+  { name: "Liam's Meshtastic Map", url: "https://meshtastic.liamcottle.net" },
+  { name: "MeshMap", url: "https://meshmap.net" },
+  { name: "Bay Mesh Explorer", url: "https://app.bayme.sh" },
+  { name: "HWT Path Profiler", url: "https://heywhatsthat.com/profiler.html" },
+];
+
+export const MESHTASTIC_ADDONS: ExternalLinkDef[] = [
+  { name: "DopeWars", url: "https://github.com/armooo/meshtastic_dopewars" },
+  { name: "TheCommsChannel BBS", url: "https://github.com/TheCommsChannel/TC2-BBS-mesh" },
+];

--- a/frontend/src/components/navConfig.tsx
+++ b/frontend/src/components/navConfig.tsx
@@ -110,14 +110,6 @@ export const MoonIcon = strokeIcon(
   <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />,
 );
 
-// Filled marks (dots / logo) — currentColor fill, no stroke.
-export const EllipsisIcon = ({ className }: IconProps) => (
-  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
-    <circle cx="5" cy="12" r="1.6" />
-    <circle cx="12" cy="12" r="1.6" />
-    <circle cx="19" cy="12" r="1.6" />
-  </svg>
-);
 export const GitHubIcon = ({ className }: IconProps) => (
   <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
     <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.46-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05A9.34 9.34 0 0 1 12 6.84c.85 0 1.71.12 2.51.34 1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.81 0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,10 +2,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/*
-  Tailwind v4 uses oklch colors which shift the indigo palette more blue.
-  Override with v3 hex values to preserve the original softer indigo look.
-*/
 @theme {
   --color-indigo-300: #a5b4fc;
   --color-indigo-400: #818cf8;
@@ -16,16 +12,10 @@
   --z-index-1050: 1050;
   --z-index-1060: 1060;
   --z-index-1100: 1100;
+  /* Expanded nav rail floats above the map's overlay stack. */
+  --z-index-1200: 1200;
 }
 
-/*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
 @layer base {
   *,
   ::after,
@@ -36,11 +26,6 @@
   }
 }
 
-/*
-  Tailwind v4 puts utilities in @layer, which loses to unlayered styles.
-  External CSS (ol.css, mapbox-gl.css) sets link colors outside layers,
-  overriding dark mode utilities. These unlayered rules fix dark mode links.
-*/
 .dark a {
   color: #818cf8;
 }
@@ -55,18 +40,11 @@
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
 
-/*
-  Persistent nav rail width. --nav-w is the single source of truth, set by
-  Layout (expanded vs collapsed); both the rail's width and the page's left
-  offset read it so they can never drift. Only offsets at lg+ (where the rail
-  is shown); the mobile drawer needs no gutter.
-*/
-:root { --nav-w: 15rem; }
+:root { --nav-rail: 4.5rem; --map-pad: 0px; }
 @media (min-width: 1024px) {
-  .nav-offset {
-    padding-left: var(--nav-w);
-    transition: padding-left 200ms ease;
-  }
+  .nav-offset { padding-left: var(--nav-rail); }
+  .nav-offset-map { margin-left: var(--nav-rail); }
+  :root { --map-pad: var(--nav-rail); }
 }
 
 /* Disable iOS pull-to-refresh — the app has no content feed to refresh. */
@@ -89,9 +67,6 @@ html, body {
   border-top-color: rgba(0, 0, 0, 0.85);
 }
 
-/* Link hover card. Compound `.maplibregl-popup.map-link-tooltip` selector wins
- *  over MapLibre's default popup styles. All four border-*-color slots set so
- *  the tip stays dark at any anchor direction. */
 .maplibregl-popup.map-link-tooltip .maplibregl-popup-content {
   background: rgba(0, 0, 0, 0.85);
   color: white;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,15 @@
   :root { --map-pad: var(--nav-rail); }
 }
 
+/* Respect the OS "reduce motion" preference. */
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 /* Disable iOS pull-to-refresh — the app has no content feed to refresh. */
 html, body {
   overscroll-behavior-y: none;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,6 +55,20 @@
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
 
+/*
+  Persistent nav rail width. --nav-w is the single source of truth, set by
+  Layout (expanded vs collapsed); both the rail's width and the page's left
+  offset read it so they can never drift. Only offsets at lg+ (where the rail
+  is shown); the mobile drawer needs no gutter.
+*/
+:root { --nav-w: 15rem; }
+@media (min-width: 1024px) {
+  .nav-offset {
+    padding-left: var(--nav-w);
+    transition: padding-left 200ms ease;
+  }
+}
+
 /* Disable iOS pull-to-refresh — the app has no content feed to refresh. */
 html, body {
   overscroll-behavior-y: none;

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1237,7 +1237,7 @@ export const Chat = () => {
     return (
       <div className="w-full h-dvh overflow-hidden flex flex-col">
         <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-          <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
             <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
               <div>
                 <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -1330,7 +1330,7 @@ export const Chat = () => {
       />
 
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -557,7 +557,7 @@ export const Log = () => {
   return (
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -2246,7 +2246,7 @@ export function Map() {
       {/* Live terrain elevation under the cursor — helps sanity-check coverage
           paints. Only renders when 3D terrain is on and we got a valid sample. */}
       {terrain3D && hoverElevationM != null && (
-        <div className="fixed top-3 left-120 sm:left-135 z-30 px-2.5 py-1 rounded-full text-[11px] font-medium border border-white/10 bg-gray-900/80 backdrop-blur-xl text-gray-300 shadow-2xl pointer-events-none select-none flex items-center gap-1.5">
+        <div className="fixed top-3 left-[calc(var(--map-pad)+30rem)] sm:left-[calc(var(--map-pad)+33.75rem)] z-30 px-2.5 py-1 rounded-full text-[11px] font-medium border border-white/10 bg-gray-900/80 backdrop-blur-xl text-gray-300 shadow-2xl pointer-events-none select-none flex items-center gap-1.5">
           <svg className="w-3 h-3 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 21l6-6 4 4 8-8" />
           </svg>

--- a/frontend/src/pages/Neighbors.tsx
+++ b/frontend/src/pages/Neighbors.tsx
@@ -918,7 +918,7 @@ export const Neighbors = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -701,7 +701,7 @@ export const Nodes = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header */}
       <div data-no-clear-selection className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -327,7 +327,7 @@ export const Stats = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* ── Sticky header (matches Nodes) ── */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/Telemetry.tsx
+++ b/frontend/src/pages/Telemetry.tsx
@@ -632,7 +632,7 @@ export const Telemetry = () => {
     return (
       <div className="w-full h-dvh overflow-hidden flex flex-col">
         <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-          <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
             <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
               Telemetry
             </h1>
@@ -650,7 +650,7 @@ export const Telemetry = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header (Chat-style) */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -724,7 +724,7 @@ export const Traceroutes = () => {
     return (
       <div className="w-full h-dvh overflow-hidden flex flex-col">
         <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-          <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
             <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
               Traceroutes
             </h1>
@@ -742,7 +742,7 @@ export const Traceroutes = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header (Chat-style) */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] pl-3 pr-14 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/frontend/src/pages/map/FiltersResetPill.tsx
+++ b/frontend/src/pages/map/FiltersResetPill.tsx
@@ -100,7 +100,7 @@ export function FiltersResetPill({
   return (
     <div
       ref={ref}
-      className={`fixed bottom-4 left-4 z-1100 ${hidden ? "max-sm:hidden" : ""}`}
+      className={`fixed bottom-4 left-[calc(var(--map-pad)+1rem)] z-1100 transition-[left] duration-200 ${hidden ? "max-sm:hidden" : ""}`}
     >
       {open && hasFilters && (
         <div className="mb-2 w-56 rounded-xl p-2 space-y-1

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -351,7 +351,7 @@ export function MapCoveragePanel({
     return (
       <div className="fixed z-1050 shadow-2xl border border-amber-500/30 bg-gray-900/90 backdrop-blur-xl
         inset-x-0 bottom-0 rounded-t-2xl p-4 pb-6 max-h-[75dvh] overflow-y-auto
-        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
+        sm:inset-x-auto sm:bottom-3 sm:left-[calc(50%+var(--map-pad)/2)] sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
         sm:rounded-xl sm:pb-4 sm:max-h-none sm:overflow-visible">
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1">
@@ -393,7 +393,7 @@ export function MapCoveragePanel({
       return (
         <div className="fixed z-1050 shadow-2xl border border-red-500/40 bg-gray-900/90 backdrop-blur-xl
           inset-x-0 bottom-0 rounded-t-2xl p-3 pb-5
-          sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
+          sm:inset-x-auto sm:bottom-3 sm:left-[calc(50%+var(--map-pad)/2)] sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
           sm:rounded-xl sm:pb-3">
           <div className="flex items-start justify-between gap-3">
             <div className="flex-1 min-w-0">
@@ -434,7 +434,7 @@ export function MapCoveragePanel({
     return (
       <div className="fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl
         inset-x-0 bottom-0 rounded-t-2xl p-3 pb-5
-        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
+        sm:inset-x-auto sm:bottom-3 sm:left-[calc(50%+var(--map-pad)/2)] sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
         sm:rounded-xl sm:pb-3">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-xs text-gray-400 min-w-0">
@@ -519,7 +519,7 @@ export function MapCoveragePanel({
       className="fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl
         inset-x-0 bottom-0 rounded-t-2xl max-h-[78dvh] flex flex-col
         animate-[slideInUp_200ms_ease-out]
-        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(560px,calc(100vw-2rem))]
+        sm:inset-x-auto sm:bottom-3 sm:left-[calc(50%+var(--map-pad)/2)] sm:-translate-x-1/2 sm:w-[min(560px,calc(100vw-2rem))]
         sm:rounded-xl sm:max-h-[calc(100dvh-2rem)] sm:flex sm:flex-col"
     >
       <div

--- a/frontend/src/pages/map/MapSearchBar.tsx
+++ b/frontend/src/pages/map/MapSearchBar.tsx
@@ -85,7 +85,7 @@ export function MapSearchBar({
 
   return (
     <div
-      className="fixed top-3 left-14 z-30 transition-[width] duration-200
+      className="fixed top-3 left-[calc(var(--map-pad)+3.5rem)] z-30 transition-[left,width] duration-200
         w-28 sm:w-64
         focus-within:w-[calc(100vw-4.5rem)] focus-within:z-50
         sm:focus-within:w-64 sm:focus-within:z-30"

--- a/frontend/src/pages/map/MapSearchBar.tsx
+++ b/frontend/src/pages/map/MapSearchBar.tsx
@@ -87,7 +87,7 @@ export function MapSearchBar({
     <div
       className="fixed top-3 left-[calc(var(--map-pad)+1rem)] z-30 transition-[left,width] duration-200
         w-36 sm:w-64
-        focus-within:w-[calc(100vw-4.5rem)] focus-within:z-50
+        focus-within:w-[calc(100vw-2rem)] focus-within:z-50
         sm:focus-within:w-64 sm:focus-within:z-30"
     >
       <div className="relative">

--- a/frontend/src/pages/map/MapSearchBar.tsx
+++ b/frontend/src/pages/map/MapSearchBar.tsx
@@ -85,8 +85,8 @@ export function MapSearchBar({
 
   return (
     <div
-      className="fixed top-3 left-[calc(var(--map-pad)+3.5rem)] z-30 transition-[left,width] duration-200
-        w-28 sm:w-64
+      className="fixed top-3 left-[calc(var(--map-pad)+1rem)] z-30 transition-[left,width] duration-200
+        w-36 sm:w-64
         focus-within:w-[calc(100vw-4.5rem)] focus-within:z-50
         sm:focus-within:w-64 sm:focus-within:z-30"
     >

--- a/frontend/src/pages/map/MapToolsDrawer.tsx
+++ b/frontend/src/pages/map/MapToolsDrawer.tsx
@@ -102,7 +102,10 @@ export function MapToolsDrawer({
   const pillIdle = "bg-gray-900/80 border-white/10 text-gray-300 hover:bg-gray-900/90 hover:border-white/20 hover:text-gray-100";
 
   return (
-    <div ref={ref} className="fixed top-3 left-44 sm:left-81 z-30">
+    <div
+      ref={ref}
+      className="fixed top-3 left-[calc(var(--map-pad)+11rem)] sm:left-[calc(var(--map-pad)+20.25rem)] z-30 transition-[left] duration-200"
+    >
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -64,6 +64,9 @@ export interface Mesh {
   name?: string;
   shortname?: string;
   description?: string;
+  /** Optional logo (path or URL) shown in the collapsed nav rail; falls back
+   *  to the mesh name's first letter when unset. */
+  icon?: string;
   url?: string;
   contact?: string;
   country?: string;


### PR DESCRIPTION
## What & why
Replaces the legacy desktop sidebar and the map's separate overlay drawer with a single navigation rail used across the entire site. Brings the modern map-drawer aesthetic everywhere, adds the first active-route indicator, and makes collapse/expand never reflow the page.

## Highlights
- **One source of truth:** `NAV_SECTIONS` + inline `currentColor` SVG icons
  (no new deps). The same `NavRow`/`BrandBlock` render the desktop rail and the
  mobile drawer, so they can't drift.
- **Active-route state** via `NavLink` — cyan left-bar + `aria-current`.
- **Slim rail by default; expand overlays.** Expanding flies the labeled rail
  out *over* the content as a transient flyout (auto-retracts on navigate,
  outside-click, or Esc). The page reserves a fixed `--nav-rail` gutter, so
  collapse/expand never reflows content — on any page, including the map.
- **Map stays full-bleed;** its left controls track the rail via `--map-pad`.
- **Mobile:** hamburger unified to the top-right on every page and overlays the
  header (no more `pr-14` content shift); map search widened/re-anchored.
- **Deployer logo:** new `[mesh] icon` config renders in the slim rail with a
  first-letter fallback; flows through `server_config`.

## Accessibility
- `aria-current` on the active route; `aria-label` on the collapsed icon-only
  links; `aria-expanded` + `aria-controls` on the rail toggles; focus returns
  to the expand button after a keyboard retract; idle icons meet WCAG 1.4.11
  contrast in light mode; `prefers-reduced-motion` is respected.

## Also
- `/graph` added to the full-bleed set so the Experimental graph gets the
  full-height layout.
- `MapCoveragePanel` sheets now center on the offset map area, not the viewport.