### PR TITLE
feat(frontend): spiderfy overlapping nodes when clustering is off (#475)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -28,12 +28,16 @@ import { MapToolPrompt, MapToolsDrawer } from "./map/MapToolsDrawer";
 import { MapTraceroutePanel } from "./map/MapTraceroutePanel";
 import { findPathsBetween } from "./map/pathAnalysis";
 import {
+  autoSpiderfyOverlappingPlainNodes,
   autoSpiderfyVisibleClusters,
+  dismissPlainSpiderfy,
+  isSpiderfied,
   removeSpiderfyLayers,
   spiderfy,
   SPIDERFY_LAYER_LABELS,
   SPIDERFY_LAYER_NODES,
   SPIDERFY_SOURCE_NODES,
+  spiderfyFeatures,
   unspiderfy,
   updateSpiderfyPositions,
 } from "./map/spiderfy";
@@ -1668,6 +1672,29 @@ export function Map() {
       // Cluster hover cursor (donut icons are GL-native, no HTML to highlight)
       bindHover("clusters");
 
+      // Distinct plain nodes whose circles overlap near `point` (clustering off).
+      // Circle radius is 8px, so a one-radius box catches genuinely-stacked nodes.
+      const OVERLAP_PX = 8;
+      const findOverlappingPlainNodes = (
+        point: maplibregl.Point,
+      ): GeoJSON.Feature<GeoJSON.Point>[] => {
+        if (!map.getLayer("plain-nodes")) return [];
+        const bbox: [maplibregl.PointLike, maplibregl.PointLike] = [
+          [point.x - OVERLAP_PX, point.y - OVERLAP_PX],
+          [point.x + OVERLAP_PX, point.y + OVERLAP_PX],
+        ];
+        const feats = map.queryRenderedFeatures(bbox, { layers: ["plain-nodes"] });
+        const seen = new Set<string>();
+        const out: GeoJSON.Feature<GeoJSON.Point>[] = [];
+        for (const f of feats) {
+          const id = (f.properties?.id ?? "") as string;
+          if (!id || seen.has(id) || f.geometry?.type !== "Point") continue;
+          seen.add(id);
+          out.push(f as unknown as GeoJSON.Feature<GeoJSON.Point>);
+        }
+        return out;
+      };
+
       const onNodeLayerClick = (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }) => {
         const feature = e.features?.[0];
         if (!feature) return;
@@ -1694,6 +1721,21 @@ export function Map() {
           setToolStep("result");
           map.getCanvas().style.cursor = "";
           return;
+        }
+
+        // Clustering OFF: co-located nodes stack so only the top one is
+        // clickable. If several overlap at the click, fan them out instead of
+        // selecting whichever rendered on top. (#475)
+        if (!clusterEnabledRef.current && !isSpiderfied(map)) {
+          const overlap = findOverlappingPlainNodes(e.point);
+          if (overlap.length >= 2) {
+            const center: [number, number] = [
+              overlap.reduce((s, f) => s + f.geometry.coordinates[0], 0) / overlap.length,
+              overlap.reduce((s, f) => s + f.geometry.coordinates[1], 0) / overlap.length,
+            ];
+            void spiderfyFeatures(map, center, overlap as any, map.getZoom(), true);
+            return;
+          }
         }
 
         void handleNodeClick(id);
@@ -1744,7 +1786,11 @@ export function Map() {
           map.queryRenderedFeatures(e.point, { layers: ["clusters"] }).length > 0;
         if (hitNode || hitCluster) return;
 
-        void unspiderfy(map);
+        // Clustering off: fans are automatic, so dismiss-and-remember (the auto
+        // pass won't immediately re-open the same set). Clustering on: a cluster
+        // donut stays put, so a plain collapse is fine.
+        if (clusterEnabledRef.current) void unspiderfy(map);
+        else dismissPlainSpiderfy(map);
         clearMapboxSelectionAndOverlays();
       });
 
@@ -1753,19 +1799,24 @@ export function Map() {
         updateSpiderfyPositions(map);
       });
 
-      // Auto-spiderfy clusters whose children can't be separated by further zoom.
+      // Auto-spiderfy stacked nodes once zoomed in. Clustering ON: fan clusters
+      // whose children can't be separated by further zoom. Clustering OFF: fan
+      // the largest group of plain nodes whose circles overlap at this zoom.
       // Driven by moveend (reliable, independent of GL render state) with `idle`
       // as a backup and a one-shot on `load` for the initial view. Debounced so
       // a single gesture doesn't run multiple passes.
       let spiderfyDebounce: number | null = null;
       const triggerAutoSpiderfy = () => {
-        if (!clusterEnabledRef.current) return;
         if (spiderfyDebounce != null) window.clearTimeout(spiderfyDebounce);
         spiderfyDebounce = window.setTimeout(() => {
           spiderfyDebounce = null;
-          const pool = buildNodesGeoJSON(nodesRef.current, recentDaysRef.current, getFilters()).features
-            .filter((f) => f.geometry?.type === "Point") as any;
-          void autoSpiderfyVisibleClusters(map, pool);
+          if (clusterEnabledRef.current) {
+            const pool = buildNodesGeoJSON(nodesRef.current, recentDaysRef.current, getFilters()).features
+              .filter((f) => f.geometry?.type === "Point") as any;
+            void autoSpiderfyVisibleClusters(map, pool);
+          } else {
+            void autoSpiderfyOverlappingPlainNodes(map);
+          }
         }, 150);
       };
       map.on("moveend", triggerAutoSpiderfy);

--- a/frontend/src/pages/map/spiderfy.ts
+++ b/frontend/src/pages/map/spiderfy.ts
@@ -23,16 +23,31 @@ const ANIMATE_MS = 320;
 const GOLDEN_ANGLE = 2.399963229728653; // 137.508°
 const AUTO_SPIDERFY_MIN_ZOOM = 14;
 
-interface SpiderfyState {
+/** One fanned-out cluster of co-located nodes. */
+interface SpiderfyGroup {
   center: [number, number];
   leaves: GeoFeature<GeoPoint, GeoJsonProperties>[];
+}
+
+interface SpiderfyState {
+  groups: SpiderfyGroup[];
   lastZoom: number;
 }
 
 let activeState: SpiderfyState | null = null;
 
-export function getActiveSpiderfyState(): SpiderfyState | null {
-  return activeState;
+// Signature of a fan set the user explicitly dismissed (clustering-off). The
+// auto pass refuses to re-fan exactly this set until it changes, so dismissing
+// sticks instead of popping straight back open on the next pan.
+let dismissedSignature: string | null = null;
+
+/** Stable signature of a set of fanned node ids (order-independent). */
+function groupsSignature(groups: SpiderfyGroup[]): string {
+  return groups
+    .flatMap((g) => g.leaves.map((l) => l.properties?.id as string | undefined))
+    .filter(Boolean)
+    .sort()
+    .join(",");
 }
 
 function pixelsToDegrees(pixels: number, zoom: number): number {
@@ -81,33 +96,56 @@ function interpolatePositions(
   ]);
 }
 
-function nodesGeoJSON(
-  leaves: GeoFeature<GeoPoint, GeoJsonProperties>[],
-  positions: [number, number][],
-): FeatureCollection<GeoPoint, GeoJsonProperties> {
+/** Combined node + leg GeoJSON for every active group at animation progress `t`
+ *  (t≥1 = fully fanned). Groups render into one source pair so any number of
+ *  stacks can be fanned at once. */
+function composeData(
+  groups: SpiderfyGroup[],
+  zoom: number,
+  t: number,
+): {
+  nodes: FeatureCollection<GeoPoint, GeoJsonProperties>;
+  legs: FeatureCollection<GeoLineString, GeoJsonProperties>;
+} {
+  const nodeFeatures: GeoFeature<GeoPoint, GeoJsonProperties>[] = [];
+  const legFeatures: GeoFeature<GeoLineString, GeoJsonProperties>[] = [];
+
+  groups.forEach((group, gi) => {
+    const targets = fanPositions(group.center, group.leaves.length, zoom);
+    const positions = t >= 1 ? targets : interpolatePositions(group.center, targets, t);
+
+    group.leaves.forEach((leaf, i) => {
+      nodeFeatures.push({
+        type: "Feature",
+        id: leaf.properties?.id ?? `spider-${gi}-${i}`,
+        properties: { ...leaf.properties, _spiderfied: true },
+        geometry: { type: "Point", coordinates: positions[i] },
+      });
+      legFeatures.push({
+        type: "Feature",
+        properties: { index: i, centerLng: group.center[0], centerLat: group.center[1] },
+        geometry: { type: "LineString", coordinates: [group.center, positions[i]] },
+      });
+    });
+  });
+
   return {
-    type: "FeatureCollection",
-    features: leaves.map((leaf, i) => ({
-      type: "Feature" as const,
-      id: leaf.properties?.id ?? `spider-${i}`,
-      properties: { ...leaf.properties, _spiderfied: true },
-      geometry: { type: "Point" as const, coordinates: positions[i] },
-    })),
+    nodes: { type: "FeatureCollection", features: nodeFeatures },
+    legs: { type: "FeatureCollection", features: legFeatures },
   };
 }
 
-function legsGeoJSON(
-  center: [number, number],
-  positions: [number, number][],
-): FeatureCollection<GeoLineString, GeoJsonProperties> {
-  return {
-    type: "FeatureCollection",
-    features: positions.map((pos, i) => ({
-      type: "Feature" as const,
-      properties: { index: i, centerLng: center[0], centerLat: center[1] },
-      geometry: { type: "LineString" as const, coordinates: [center, pos] },
-    })),
-  };
+/** Push composed data to the spiderfy sources; false if they've been removed. */
+function applyData(
+  map: MlMap,
+  data: ReturnType<typeof composeData>,
+): boolean {
+  const nodeSrc = map.getSource(SPIDERFY_SOURCE_NODES) as MlGeoJSONSource | undefined;
+  const legSrc = map.getSource(SPIDERFY_SOURCE_LEGS) as MlGeoJSONSource | undefined;
+  if (!nodeSrc || !legSrc) return false;
+  nodeSrc.setData(data.nodes);
+  legSrc.setData(data.legs);
+  return true;
 }
 
 /** getClusterLeaves with a timeout; returns [] if the cluster_id is stale or the callback never fires. */
@@ -171,6 +209,7 @@ export function isSpiderfied(map: MlMap): boolean {
 
 export function removeSpiderfyLayers(map: MlMap): void {
   activeState = null;
+  dismissedSignature = null; // teardown clears any remembered dismissal...
   for (const id of [SPIDERFY_LAYER_LABELS, SPIDERFY_LAYER_NODES, SPIDERFY_LAYER_LEGS, SPIDERFY_LAYER_LEGS_SHADOW]) {
     if (map.getLayer(id)) map.removeLayer(id);
   }
@@ -258,6 +297,41 @@ function addSpiderfyLayers(map: MlMap): void {
   });
 }
 
+/** Shared render core: fan every group out around its center. When the layers
+ *  are already present (a reconcile/update) the data is just swapped — sources
+ *  are kept so feature-state (selection) survives. `animate` only applies to a
+ *  fresh fan; updates render instantly. Assumes `groups` is non-empty. */
+function renderSpiderfy(
+  map: MlMap,
+  groups: SpiderfyGroup[],
+  zoom: number,
+  animate: boolean,
+): Promise<void> {
+  const fresh = !isSpiderfied(map);
+  activeState = { groups, lastZoom: zoom };
+  if (fresh) addSpiderfyLayers(map);
+
+  if (!animate || !fresh) {
+    applyData(map, composeData(groups, zoom, 1));
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    const start = performance.now();
+    function frame(now: number) {
+      const t = Math.min((now - start) / ANIMATE_MS, 1);
+      if (!applyData(map, composeData(groups, zoom, t))) {
+        removeSpiderfyLayers(map);
+        resolve();
+        return;
+      }
+      if (t < 1) requestAnimationFrame(frame);
+      else resolve();
+    }
+    requestAnimationFrame(frame);
+  });
+}
+
 export async function spiderfy(
   map: MlMap,
   clusterId: number,
@@ -282,58 +356,34 @@ export async function spiderfy(
 
   if (leaves.length === 0) return;
 
-  activeState = { center, leaves, lastZoom: zoom };
-  const finalPositions = fanPositions(center, leaves.length, zoom);
+  return renderSpiderfy(map, [{ center, leaves }], zoom, animate);
+}
 
-  addSpiderfyLayers(map);
-
-  const nodeSrc = map.getSource(SPIDERFY_SOURCE_NODES) as MlGeoJSONSource;
-  const legSrc = map.getSource(SPIDERFY_SOURCE_LEGS) as MlGeoJSONSource;
-
-  if (!animate) {
-    nodeSrc.setData(nodesGeoJSON(leaves, finalPositions));
-    legSrc.setData(legsGeoJSON(center, finalPositions));
-    return;
-  }
-
-  return new Promise<void>((resolve) => {
-    const start = performance.now();
-    function frame(now: number) {
-      const t = Math.min((now - start) / ANIMATE_MS, 1);
-      const pos = interpolatePositions(center, finalPositions, t);
-      try {
-        nodeSrc.setData(nodesGeoJSON(leaves, pos));
-        legSrc.setData(legsGeoJSON(center, pos));
-      } catch {
-        removeSpiderfyLayers(map);
-        resolve();
-        return;
-      }
-      if (t < 1) requestAnimationFrame(frame);
-      else resolve();
-    }
-    requestAnimationFrame(frame);
-  });
+/** Spiderfy an explicit set of co-located features. Used when clustering is OFF
+ *  and the user clicks a spot where several plain nodes overlap — there is no
+ *  cluster to query, so the caller supplies the stacked leaves directly. */
+export async function spiderfyFeatures(
+  map: MlMap,
+  center: [number, number],
+  leaves: GeoFeature<GeoPoint, GeoJsonProperties>[],
+  zoom: number,
+  animate = true,
+): Promise<void> {
+  removeSpiderfyLayers(map);
+  if (leaves.length === 0) return;
+  return renderSpiderfy(map, [{ center, leaves }], zoom, animate);
 }
 
 export async function unspiderfy(map: MlMap): Promise<void> {
   if (!isSpiderfied(map)) return;
 
   const state = activeState;
-  const nodeSrc = map.getSource(SPIDERFY_SOURCE_NODES) as MlGeoJSONSource | undefined;
-  const legSrc = map.getSource(SPIDERFY_SOURCE_LEGS) as MlGeoJSONSource | undefined;
-
-  if (!nodeSrc || !legSrc || !state) {
+  if (!state || !map.getSource(SPIDERFY_SOURCE_NODES)) {
     removeSpiderfyLayers(map);
     return;
   }
-  // Bind narrowed non-null values for the inner frame() closure (TS loses
-  // the outer control-flow narrowing across the Promise boundary).
-  const s = state;
-  const ns = nodeSrc;
-  const ls = legSrc;
-
-  const positions = fanPositions(s.center, s.leaves.length, map.getZoom());
+  const groups = state.groups;
+  const zoom = map.getZoom();
   activeState = null;
 
   return new Promise<void>((resolve) => {
@@ -341,11 +391,7 @@ export async function unspiderfy(map: MlMap): Promise<void> {
     const duration = ANIMATE_MS * 0.7;
     function frame(now: number) {
       const t = Math.min((now - start) / duration, 1);
-      const pos = interpolatePositions(s.center, positions, 1 - t);
-      try {
-        ns.setData(nodesGeoJSON(s.leaves, pos));
-        ls.setData(legsGeoJSON(s.center, pos));
-      } catch {
+      if (!applyData(map, composeData(groups, zoom, 1 - t))) {
         removeSpiderfyLayers(map);
         resolve();
         return;
@@ -357,6 +403,14 @@ export async function unspiderfy(map: MlMap): Promise<void> {
   });
 }
 
+/** Dismiss the active fans and remember the set so the clustering-off auto pass
+ *  won't immediately re-open exactly what the user just closed. */
+export function dismissPlainSpiderfy(map: MlMap): void {
+  const sig = activeState ? groupsSignature(activeState.groups) : null;
+  removeSpiderfyLayers(map); // clears dismissedSignature...
+  dismissedSignature = sig; // ...then record what was dismissed
+}
+
 export function updateSpiderfyPositions(map: MlMap): void {
   if (!activeState || !isSpiderfied(map)) return;
 
@@ -366,16 +420,9 @@ export function updateSpiderfyPositions(map: MlMap): void {
     return;
   }
 
-  const { center, leaves } = activeState;
   activeState.lastZoom = zoom;
-  const positions = fanPositions(center, leaves.length, zoom);
-
   try {
-    const nodeSrc = map.getSource(SPIDERFY_SOURCE_NODES) as MlGeoJSONSource | undefined;
-    const legSrc = map.getSource(SPIDERFY_SOURCE_LEGS) as MlGeoJSONSource | undefined;
-    if (!nodeSrc || !legSrc) return;
-    nodeSrc.setData(nodesGeoJSON(leaves, positions));
-    legSrc.setData(legsGeoJSON(center, positions));
+    applyData(map, composeData(activeState.groups, zoom, 1));
   } catch { /* sources may have been removed */ }
 }
 
@@ -428,4 +475,86 @@ export async function autoSpiderfyVisibleClusters(
       return;
     }
   }
+}
+
+// Plain-node circle radius (px) — must match the "plain-nodes" layer paint.
+const PLAIN_NODE_RADIUS_PX = 8;
+
+/** Build a centered group from member feature indices into `pts`. */
+function groupFromIndices(
+  indices: number[],
+  pts: { f: GeoFeature<GeoPoint, GeoJsonProperties> }[],
+): SpiderfyGroup {
+  const leaves = indices.map((k) => pts[k].f);
+  let lng = 0, lat = 0;
+  for (const lf of leaves) {
+    const c = (lf.geometry as GeoPoint).coordinates;
+    lng += c[0];
+    lat += c[1];
+  }
+  return { center: [lng / leaves.length, lat / leaves.length], leaves };
+}
+
+/** Clustering-OFF analogue of autoSpiderfyVisibleClusters: there is no cluster
+ *  source, so detect every group of plain nodes whose circles overlap at the
+ *  current zoom (single-linkage by screen distance) and fan them ALL out.
+ *  Reconciles on each call — new stacks fan in, separated ones collapse — and
+ *  skips re-rendering when the set is unchanged or was just dismissed. */
+export async function autoSpiderfyOverlappingPlainNodes(map: MlMap): Promise<void> {
+  if (!map.getLayer("plain-nodes")) return;
+
+  const currentZoom = map.getZoom();
+  if (currentZoom < AUTO_SPIDERFY_MIN_ZOOM) {
+    if (activeState) removeSpiderfyLayers(map);
+    return;
+  }
+
+  const feats = map.queryRenderedFeatures({ layers: ["plain-nodes"] });
+
+  // Dedupe by node id (tiling repeats features) and record screen position.
+  const seen = new Set<string>();
+  const pts: { f: GeoFeature<GeoPoint, GeoJsonProperties>; x: number; y: number }[] = [];
+  for (const f of feats) {
+    const id = f.properties?.id as string | undefined;
+    if (!id || seen.has(id) || f.geometry?.type !== "Point") continue;
+    seen.add(id);
+    const c = (f.geometry as GeoPoint).coordinates;
+    const p = map.project([c[0], c[1]]);
+    pts.push({ f: f as GeoFeature<GeoPoint, GeoJsonProperties>, x: p.x, y: p.y });
+  }
+
+  // Single-linkage grouping by screen distance; keep every group of 2+.
+  // Circles overlap when their centers are within one diameter.
+  const t2 = (PLAIN_NODE_RADIUS_PX * 2) ** 2;
+  const used = new Array(pts.length).fill(false);
+  const groups: SpiderfyGroup[] = [];
+  for (let i = 0; i < pts.length; i++) {
+    if (used[i]) continue;
+    const member = [i];
+    used[i] = true;
+    for (let g = 0; g < member.length; g++) {
+      const a = pts[member[g]];
+      for (let j = 0; j < pts.length; j++) {
+        if (used[j]) continue;
+        const dx = a.x - pts[j].x;
+        const dy = a.y - pts[j].y;
+        if (dx * dx + dy * dy <= t2) { used[j] = true; member.push(j); }
+      }
+    }
+    if (member.length >= 2) groups.push(groupFromIndices(member, pts));
+  }
+
+  const nextSig = groupsSignature(groups);
+  const currentSig = activeState ? groupsSignature(activeState.groups) : "";
+  if (nextSig === currentSig) return; // already showing exactly this set
+  if (nextSig === dismissedSignature) return; // user just dismissed this set
+
+  dismissedSignature = null; // the overlap set changed — old dismissal is stale
+  if (groups.length === 0) {
+    removeSpiderfyLayers(map);
+    return;
+  }
+  // Animate only the first fan; later reconciles swap data in place so existing
+  // fans don't re-expand and the selection highlight survives.
+  await renderSpiderfy(map, groups, currentZoom, !activeState);
 }

--- a/frontend/src/pages/map/utils.ts
+++ b/frontend/src/pages/map/utils.ts
@@ -132,7 +132,7 @@ export function applyClusterVisibility(map: MlMap, enabled: boolean): void {
   set("plain-nodes", !enabled);
   set("plain-labels", !enabled);
 
-  if (!enabled) {
-    removeSpiderfyLayers(map);
-  }
+  // Either toggle direction invalidates the current fans (they belong to the
+  // mode we're leaving); the matching auto-spiderfy pass re-creates them.
+  removeSpiderfyLayers(map);
 }


### PR DESCRIPTION
## What & why

Closes #475. With clustering **off**, two nodes at (near-)identical
coordinates stacked on top of each other — only the top one was clickable,
so the others were impossible to select. Clustering-on already solved this
via spiderfy (fan the stack out with leader lines); this brings the same
behavior to clustering-off.

## Behavior

- **Click** a stack of overlapping plain nodes → they fan out so each is
  individually clickable.
- **Zoom in** (z14+, same threshold as the cluster auto-spiderfy) → every
  overlapping stack in view fans out automatically, and the set is
  reconciled as you pan/zoom (new stacks fan in, ones separated by zoom
  collapse out).
- **Dismiss** by clicking empty space — and it stays dismissed; the auto
  pass won't immediately re-open the same set until the overlap actually
  changes.

## Changes

- **`spiderfy.ts`** — reworked the single-fan state into **multi-group**:
  all fans render into one source pair via `composeData()`, so any number
  of stacks can be open at once. Reconcile updates swap data in place, 
  so existing fans don't re-animate and the selection highlight survives.
- **`autoSpiderfyOverlappingPlainNodes()`** — new clustering-off analogue
  of `autoSpiderfyVisibleClusters`: single-linkage groups plain nodes whose
  circles overlap (by screen distance) and fans them all, signature-gated to
  skip no-op re-renders.
- **`dismissPlainSpiderfy()`** — remembers the dismissed set so it doesn't
  pop back open.
- **`Map.tsx`** — overlap detection on plain-node click; auto-spiderfy
  trigger now branches by cluster mode instead of bailing when off.
- **`utils.ts`** — `applyClusterVisibility` clears fans on either toggle
  direction (was off-only).

The clustering-on cluster/spiderfy path is unchanged.