### PR TITLE
chore(frontend): clear Tailwind & ESLint warnings (canonical classes, toast store split, import sort)

### DIFF
--- a/frontend/src/components/toast.tsx
+++ b/frontend/src/components/toast.tsx
@@ -1,28 +1,6 @@
 import { useEffect, useState } from "react";
 
-export type ToastKind = "info" | "error" | "success";
-
-interface ToastItem {
-  id: number;
-  message: string;
-  kind: ToastKind;
-  duration: number;
-}
-
-type Listener = (t: ToastItem) => void;
-const listeners = new Set<Listener>();
-let nextId = 1;
-
-/** Fire a transient toast. No-op if no <ToastHost> is mounted. */
-export function toast(message: string, opts?: { kind?: ToastKind; duration?: number }): void {
-  const item: ToastItem = {
-    id: nextId++,
-    message,
-    kind: opts?.kind ?? "info",
-    duration: opts?.duration ?? 4500,
-  };
-  listeners.forEach((l) => l(item));
-}
+import { subscribeToasts, type ToastItem, type ToastKind } from "./toastStore";
 
 const KIND_CLASS: Record<ToastKind, string> = {
   info: "bg-gray-900/85 border-white/10 text-gray-200",
@@ -35,12 +13,10 @@ export function ToastHost() {
   const [items, setItems] = useState<ToastItem[]>([]);
 
   useEffect(() => {
-    const onToast: Listener = (t) => {
+    return subscribeToasts((t) => {
       setItems((prev) => [...prev, t]);
       window.setTimeout(() => setItems((prev) => prev.filter((x) => x.id !== t.id)), t.duration);
-    };
-    listeners.add(onToast);
-    return () => { listeners.delete(onToast); };
+    });
   }, []);
 
   if (items.length === 0) return null;

--- a/frontend/src/components/toastStore.ts
+++ b/frontend/src/components/toastStore.ts
@@ -1,0 +1,31 @@
+export type ToastKind = "info" | "error" | "success";
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  duration: number;
+}
+
+type Listener = (t: ToastItem) => void;
+const listeners = new Set<Listener>();
+let nextId = 1;
+
+/** Fire a transient toast. No-op if no <ToastHost> is mounted. */
+export function toast(message: string, opts?: { kind?: ToastKind; duration?: number }): void {
+  const item: ToastItem = {
+    id: nextId++,
+    message,
+    kind: opts?.kind ?? "info",
+    duration: opts?.duration ?? 4500,
+  };
+  listeners.forEach((l) => l(item));
+}
+
+/** Subscribe a host to fired toasts; returns an unsubscribe. */
+export function subscribeToasts(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -83,7 +83,7 @@ function MobileSheet({
         onClick={onClose}
       />
       <div className="absolute inset-x-0 bottom-0">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="rounded-t-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-2xl overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-800">
               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
@@ -1237,7 +1237,7 @@ export const Chat = () => {
     return (
       <div className="w-full h-dvh overflow-hidden flex flex-col">
         <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+          <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
             <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
               <div>
                 <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -1262,13 +1262,13 @@ export const Chat = () => {
 
             {/* Skeleton search bar */}
             <div className="mt-3">
-              <div className="animate-pulse rounded-md border border-gray-300/40 dark:border-gray-700/40 bg-gray-200/30 dark:bg-gray-800/30 h-[38px] w-full" />
+              <div className="animate-pulse rounded-md border border-gray-300/40 dark:border-gray-700/40 bg-gray-200/30 dark:bg-gray-800/30 h-9.5 w-full" />
             </div>
           </div>
         </div>
 
         <div className="flex-1 overflow-hidden flex flex-col">
-          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+          <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 h-full min-h-0">
               {/* Skeleton message list */}
               <div className="lg:col-span-2 min-h-0 flex flex-col">
@@ -1330,7 +1330,7 @@ export const Chat = () => {
       />
 
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -1498,7 +1498,7 @@ export const Chat = () => {
 
           {/* Toolbar row: mobile keeps ONLY search; desktop keeps full controls */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
-            <div className="flex-1 min-w-0 lg:min-w-[260px]">
+            <div className="flex-1 min-w-0 lg:min-w-65">
               <input
                 ref={searchInputRef}
                 value={qInput}
@@ -1609,7 +1609,7 @@ export const Chat = () => {
               </button>
 
               <div className="flex items-center gap-2">
-                <span className="min-w-[88px] text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                <span className="min-w-22 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
                   {hasFilters
                     ? `${activeFilterCount} filter${
                         activeFilterCount > 1 ? "s" : ""
@@ -1635,7 +1635,7 @@ export const Chat = () => {
           </div>
 
           {/* Status chips: desktop only, always rendered (mobile uses Controls Badge) */}
-          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-[30px]">
+          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-7.5">
             <StatusChip
               label={`Range: ${urlRange}`}
               active={urlRange !== "24h"}
@@ -1734,7 +1734,7 @@ export const Chat = () => {
       </div>
 
       <div className="flex-1 overflow-hidden flex flex-col">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 h-full min-h-0">
             <div className="lg:col-span-2 min-h-0 flex flex-col">
               <MessageList
@@ -1791,7 +1791,7 @@ export const Chat = () => {
 
       {/* Mobile bottom nav */}
       <div className="fixed inset-x-0 bottom-0 z-30 lg:hidden">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="mb-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm shadow-xs overflow-hidden">
             <div className="grid grid-cols-3 divide-x divide-gray-200 dark:divide-gray-800">
               <button

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -160,7 +160,7 @@ export const Graph = () => {
                 <div className="text-xs font-semibold text-gray-300">Top hubs</div>
                 <div className="text-[11px] text-gray-500">click to select</div>
               </div>
-              <div className="space-y-0.5 max-h-[200px] overflow-auto">
+              <div className="space-y-0.5 max-h-50 overflow-auto">
                 {nodes.slice(0, 10).map((n) => (
                   <button key={n.id} type="button" onClick={() => setSelectedId(n.id)}
                     className={`w-full flex items-center justify-between px-2 py-1 rounded text-left transition ${
@@ -213,7 +213,7 @@ export const Graph = () => {
                   {selectedEdges.length > 0 && (
                     <div>
                       <div className="text-[11px] text-gray-500 mb-1">Connected to ({selectedEdges.length}):</div>
-                      <div className="space-y-0.5 max-h-[180px] overflow-auto">
+                      <div className="space-y-0.5 max-h-45 overflow-auto">
                         {selectedEdges.map((e, i) => {
                           const peerId = e.a === selected.id ? e.b : e.a;
                           const peer = nodeById.get(peerId);

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -151,7 +151,7 @@ function MobileSheet({
         onClick={onClose}
       />
       <div className="absolute inset-x-0 bottom-0">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="rounded-t-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-2xl overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-800">
               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
@@ -557,7 +557,7 @@ export const Log = () => {
   return (
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -650,7 +650,7 @@ export const Log = () => {
 
           {/* Search + range controls */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
-            <div className="flex-1 min-w-0 lg:min-w-[260px]">
+            <div className="flex-1 min-w-0 lg:min-w-65">
               <input
                 ref={searchInputRef}
                 value={qInput}
@@ -698,7 +698,7 @@ export const Log = () => {
                 />
               </label>
 
-              <span className="min-w-[88px] text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+              <span className="min-w-22 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
                 {hasFilters
                   ? `${activeFilterCount} filter${activeFilterCount > 1 ? "s" : ""}`
                   : "no filters"}
@@ -719,7 +719,7 @@ export const Log = () => {
       </div>
 
       <div className="flex-1 overflow-hidden flex flex-col">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           {/* Deeplinked packet */}
           {hasPacketLink ? (
             <div className="mb-3 rounded-xl border border-indigo-300/70 dark:border-indigo-800/70 bg-indigo-50/50 dark:bg-indigo-950/20 overflow-hidden">
@@ -827,7 +827,7 @@ export const Log = () => {
 
       {/* Mobile controls */}
       <div className="fixed inset-x-0 bottom-0 z-30 lg:hidden">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="mb-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm shadow-xs overflow-hidden">
             <button
               type="button"

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -6,7 +6,7 @@ import maplibregl, {
 } from "maplibre-gl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { toast } from "../components/toast";
+import { toast } from "../components/toastStore";
 import { env } from "../env";
 import { reverseGeocode } from "../maps/geocoder";
 import { buildMapStyle, ensureBuildings3D, ensureTerrain, isDarkBasemap, type OsmBasemap, removeBuildings3D, removeTerrain } from "../maps/mapStyle";

--- a/frontend/src/pages/Neighbors.tsx
+++ b/frontend/src/pages/Neighbors.tsx
@@ -90,7 +90,7 @@ function MobileSheet({
         onClick={onClose}
       />
       <div className="absolute inset-x-0 bottom-0">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="rounded-t-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-2xl overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-800">
               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
@@ -918,7 +918,7 @@ export const Neighbors = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -1023,7 +1023,7 @@ export const Neighbors = () => {
 
           {/* Toolbar */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
-            <div className="flex-1 min-w-0 lg:min-w-[260px]">
+            <div className="flex-1 min-w-0 lg:min-w-65">
               <input
                 id="neighbors-search"
                 value={qInput}
@@ -1080,7 +1080,7 @@ export const Neighbors = () => {
           </div>
 
           {/* Status chips: desktop */}
-          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-[30px]">
+          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-7.5">
             <StatusChip
               label={`Sort: ${sortBy}/${sortDir}`}
               active={sortBy !== "seen" || sortDir !== "desc"}
@@ -1116,7 +1116,7 @@ export const Neighbors = () => {
 
       {/* Main body */}
       <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0">
             {/* Left: list */}
             <div className="lg:col-span-2 min-h-0 flex flex-col h-full">
@@ -1176,7 +1176,7 @@ export const Neighbors = () => {
 
       {/* Mobile bottom nav */}
       <div className="fixed inset-x-0 bottom-0 z-30 lg:hidden">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="mb-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm shadow-xs overflow-hidden">
             <div className="grid grid-cols-2 divide-x divide-gray-200 dark:divide-gray-800">
               <button

--- a/frontend/src/pages/Nodes.tsx
+++ b/frontend/src/pages/Nodes.tsx
@@ -60,7 +60,7 @@ function MobileSheet({
         onClick={onClose}
       />
       <div className="absolute inset-x-0 bottom-0">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="rounded-t-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-2xl overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-800">
               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
@@ -701,7 +701,7 @@ export const Nodes = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header */}
       <div data-no-clear-selection className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -886,7 +886,7 @@ export const Nodes = () => {
 
           {/* Toolbar */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
-            <div className="flex-1 min-w-0 lg:min-w-[260px]">
+            <div className="flex-1 min-w-0 lg:min-w-65">
               <input
                 id="nodes-search"
                 value={qInput}
@@ -951,7 +951,7 @@ export const Nodes = () => {
               </button>
 
               <div className="flex items-center gap-2">
-                <span className="min-w-[88px] text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                <span className="min-w-22 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
                   {hasFilters
                     ? `${activeFilterCount} filter${
                         activeFilterCount > 1 ? "s" : ""
@@ -977,7 +977,7 @@ export const Nodes = () => {
           </div>
 
           {/* Status chips: desktop only */}
-          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-[30px]">
+          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-7.5">
             <StatusChip
               label={`Range: ${urlRange}`}
               active={urlRange !== "all"}
@@ -1030,7 +1030,7 @@ export const Nodes = () => {
 
       {/* Main body */}
       <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0">
             {/* Left: list */}
             <div ref={listContainerRef} className="lg:col-span-2 min-h-0 flex flex-col h-full">
@@ -1077,7 +1077,7 @@ export const Nodes = () => {
 
       {/* Mobile bottom nav */}
       <div className="fixed inset-x-0 bottom-0 z-30 lg:hidden">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pb-[env(safe-area-inset-bottom)]">
           <div className="mb-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm shadow-xs overflow-hidden">
             <div className="grid grid-cols-2 divide-x divide-gray-200 dark:divide-gray-800">
               <button

--- a/frontend/src/pages/RouteError.tsx
+++ b/frontend/src/pages/RouteError.tsx
@@ -125,7 +125,7 @@ export function RouteError() {
     <div className="min-h-dvh bg-white dark:bg-gray-950">
       {/* simple “in-app-ish” header */}
       <div className="sticky top-0 z-10 border-b border-gray-200 dark:border-gray-800 bg-white/85 dark:bg-gray-900/70 backdrop-blur-sm">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-3 flex items-center justify-between gap-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-3 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 min-w-0">
             <span className="text-indigo-600 dark:text-indigo-400">
               <BrokenNodeArt />
@@ -165,7 +165,7 @@ export function RouteError() {
         </div>
       </div>
 
-      <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-6">
+      <div className="mx-auto max-w-400 px-3 sm:px-5 py-6">
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xs overflow-hidden">
           <div className="p-5 sm:p-6">
             <div className="flex items-start gap-4">

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -327,7 +327,7 @@ export const Stats = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* ── Sticky header (matches Nodes) ── */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -493,7 +493,7 @@ export const Stats = () => {
 
       {/* ── Scrollable body ── */}
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="mx-auto max-w-[1600px] px-4 py-5 lg:px-8 lg:py-6">
+        <div className="mx-auto max-w-400 px-4 py-5 lg:px-8 lg:py-6">
           {/* Hero */}
           <div>
             <Panel className="relative overflow-hidden">

--- a/frontend/src/pages/Telemetry.tsx
+++ b/frontend/src/pages/Telemetry.tsx
@@ -632,7 +632,7 @@ export const Telemetry = () => {
     return (
       <div className="w-full h-dvh overflow-hidden flex flex-col">
         <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+          <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
             <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
               Telemetry
             </h1>
@@ -650,7 +650,7 @@ export const Telemetry = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header (Chat-style) */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -779,7 +779,7 @@ export const Telemetry = () => {
 
           {/* Toolbar row */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
-            <div className="flex-1 min-w-0 lg:min-w-[260px]">
+            <div className="flex-1 min-w-0 lg:min-w-65">
               <input
                 ref={searchInputRef}
                 value={qInput}
@@ -844,7 +844,7 @@ export const Telemetry = () => {
           </div>
 
           {/* Status chips (desktop only) */}
-          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-[30px]">
+          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-7.5">
             <StatusChip
               label={`Range: ${range}`}
               active={range !== DEFAULT_RANGE}
@@ -882,7 +882,7 @@ export const Telemetry = () => {
 
       {/* Main body */}
       <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0">
             {/* List */}
             <div className="min-h-0 flex flex-col h-full">

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -724,7 +724,7 @@ export const Traceroutes = () => {
     return (
       <div className="w-full h-dvh overflow-hidden flex flex-col">
         <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-          <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+          <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
             <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
               Traceroutes
             </h1>
@@ -742,7 +742,7 @@ export const Traceroutes = () => {
     <div className="w-full h-dvh overflow-hidden flex flex-col">
       {/* Sticky header (Chat-style) */}
       <div className="sticky top-0 z-20 shrink-0 bg-white/90 dark:bg-gray-900/85 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 py-2 sm:py-3">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 py-2 sm:py-3">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -871,7 +871,7 @@ export const Traceroutes = () => {
 
           {/* Toolbar row */}
           <div className="mt-3 flex flex-col lg:flex-row gap-2 lg:items-center lg:justify-between">
-            <div className="flex-1 min-w-0 lg:min-w-[260px]">
+            <div className="flex-1 min-w-0 lg:min-w-65">
               <input
                 ref={searchInputRef}
                 value={qInput}
@@ -934,7 +934,7 @@ export const Traceroutes = () => {
           </div>
 
           {/* Status chips (desktop only) */}
-          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-[30px]">
+          <div className="mt-2 hidden lg:flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] min-h-7.5">
             <StatusChip
               label={`Range: ${range}`}
               active={range !== DEFAULT_RANGE}
@@ -968,7 +968,7 @@ export const Traceroutes = () => {
 
       {/* Main body */}
       <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <div className="mx-auto max-w-[1600px] px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
+        <div className="mx-auto max-w-400 px-3 sm:px-5 pt-3 pb-20 lg:pb-0 flex-1 min-h-0 w-full flex flex-col">
           {/* Telemetry-style layout: list 1 col, details 2 col */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0">
             {/* List */}

--- a/frontend/src/pages/map/FilterDropup.tsx
+++ b/frontend/src/pages/map/FilterDropup.tsx
@@ -112,7 +112,7 @@ export function FilterDropup<T extends string | number | null>({
             maxHeight,
             zIndex: 2000,
           }}
-          className="min-w-[160px] max-w-[280px] rounded-xl overflow-y-auto
+          className="min-w-40 max-w-70 rounded-xl overflow-y-auto
             bg-gray-900/95 backdrop-blur-xl border border-white/10 shadow-2xl py-1"
         >
           {options.map((opt) => {

--- a/frontend/src/pages/map/MapHealthWidget.tsx
+++ b/frontend/src/pages/map/MapHealthWidget.tsx
@@ -95,7 +95,7 @@ export function MapHealthWidget({ nodes }: { nodes: Record<string, IMapNode> }) 
       </button>
 
       {expanded && health && (
-        <div id="mesh-health-panel" className="mt-2 min-w-[220px] rounded-xl p-3
+        <div id="mesh-health-panel" className="mt-2 min-w-55 rounded-xl p-3
           bg-gray-900/90 backdrop-blur-xl border border-white/10 shadow-2xl
           space-y-2 text-xs">
           <div className="flex items-center justify-between">

--- a/frontend/src/pages/map/spiderfy.ts
+++ b/frontend/src/pages/map/spiderfy.ts
@@ -10,10 +10,10 @@ import type {
   LineString as GeoLineString,
   Point as GeoPoint,
 } from "geojson";
+import type { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl";
 
 import { mbRoleColorExpr } from "../../palette";
 import { prefersReducedMotion } from "../../reducedMotion";
-import type { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl";
 
 export const SPIDERFY_SOURCE_NODES = "spiderfy-nodes";
 export const SPIDERFY_SOURCE_LEGS = "spiderfy-legs";

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -1,4 +1,4 @@
-import { toast } from "../../components/toast";
+import { toast } from "../../components/toastStore";
 
 export const LS_KEYS = {
   provider: "meshinfo.map.provider",

--- a/frontend/src/pages/map/useCoverageCompute.ts
+++ b/frontend/src/pages/map/useCoverageCompute.ts
@@ -4,7 +4,7 @@ import maplibregl, {
 } from "maplibre-gl";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import { toast } from "../../components/toast";
+import { toast } from "../../components/toastStore";
 import { env } from "../../env";
 import { buildBuildingRaster, type BuildingRaster, downsampleBuildingRaster } from "./buildingTiles";
 import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./canopyTiles";

--- a/frontend/src/pages/telemetry/MiniCharts.tsx
+++ b/frontend/src/pages/telemetry/MiniCharts.tsx
@@ -54,7 +54,7 @@ export function MiniLineChart({
 
   if (!hasData) {
     return (
-      <div className="h-[96px] flex items-center justify-center text-xs text-gray-500">
+      <div className="h-24 flex items-center justify-center text-xs text-gray-500">
         No data
       </div>
     );
@@ -64,7 +64,7 @@ export function MiniLineChart({
     <svg
       viewBox={`0 0 300 ${height}`}
       preserveAspectRatio="none"
-      className="w-full h-[96px]"
+      className="w-full h-24"
     >
       <path
         d={path}
@@ -94,7 +94,7 @@ export function MiniBarChart({
     <svg
       viewBox={`0 0 ${w} ${h}`}
       preserveAspectRatio="none"
-      className="w-full h-[96px]"
+      className="w-full h-24"
     >
       {values.map((b, i) => {
         const barH = clamp((b.v / maxV) * h, 0, h);

--- a/frontend/src/pages/telemetry/TelemetryDetailsPanel.tsx
+++ b/frontend/src/pages/telemetry/TelemetryDetailsPanel.tsx
@@ -378,7 +378,7 @@ function LineChart({
       <div className="mt-2 rounded-lg border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-950/20 overflow-hidden">
         <svg
           viewBox={`0 0 ${w} ${h}`}
-          className="w-full h-[220px] sm:h-[260px]"
+          className="w-full h-55 sm:h-65"
           onMouseLeave={() => setHover(null)}
           onMouseMove={(e) => {
             if (!points.length) return;


### PR DESCRIPTION
## Summary

Pure code-quality / lint cleanup — no behavior or visual changes. Clears the Tailwind language-server hints.

### Tailwind: arbitrary values → canonical scale
Converted 52 arbitrary-value utilities to their canonical spacing-scale
equivalents across 13 files (page containers, filter bars, charts, skeletons),
e.g. `max-w-[1600px]` → `max-w-400`, `min-w-[260px]` → `min-w-65`,
`h-[96px]` → `h-24`, `min-h-[30px]` → `min-h-7.5`.

These were verified pixel-identical: each new class compiles to
`calc(var(--spacing) * N)` matching the original pixels at the 16px root
(including the `.5` half-steps). Font sizes (`text-[10px]` etc.), `calc()`/`env()`,
`vh`/`vw`, and non-integer steps were intentionally left alone — they have no
canonical equivalent and aren't flagged.

### ESLint
- **`toast.tsx`** (`react-refresh/only-export-components`): split the non-component
  store (`toast()`, `ToastKind`, listener registry) into a new `toastStore.ts`, so
  `toast.tsx` exports only `<ToastHost>`. The three `toast` importers were repointed
  to `toastStore`. Restores reliable Fast Refresh for the component file.
- **`spiderfy.ts`** (`simple-import-sort/imports`): autofixed import order.
