### PR TITLE
feat(map): live lat/long pill + jump-to-coordinate (#498)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -21,9 +21,10 @@ import { ClusterDonutLayer } from "./map/clusterDonutLayer";
 import { type ClusterHover,ClusterHoverCard } from "./map/ClusterHoverCard";
 import { FiltersResetPill } from "./map/FiltersResetPill";
 import { circularMeanLng } from "./map/geo";
-import { bestSnr, computeMaxRange, geodesicCircleCoords, mbRoleColorExpr, queryTerrainElevationMSL, relativeTime, signalBarsHtml, TRANSPARENT_1PX_PNG } from "./map/helpers";
+import { bestSnr, computeMaxRange, formatLatLng, geodesicCircleCoords, mbRoleColorExpr, queryTerrainElevationMSL, relativeTime, signalBarsHtml, TRANSPARENT_1PX_PNG } from "./map/helpers";
 import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId } from "./map/linkFeatures";
 import { LosTubeLayer } from "./map/losTubeLayer";
+import { MapCoordinatePill } from "./map/MapCoordinatePill";
 import { MapCoveragePanel } from "./map/MapCoveragePanel";
 import { MapDetailsPanel } from "./map/MapDetailsPanel";
 import { MapHealthWidget } from "./map/MapHealthWidget";
@@ -208,6 +209,15 @@ export function Map() {
   const isDraggingMarkerRef = useRef(false);
   /** Terrain elevation (MSL m) under the cursor. */
   const [hoverElevationM, setHoverElevationM] = useState<number | null>(null);
+  /** Live cursor position [lng, lat]; null when the cursor isn't over the map. */
+  const [hoverCoord, setHoverCoord] = useState<[number, number] | null>(null);
+  /** Map-center [lng, lat] — the coordinate pill's fallback when not hovering. */
+  const [centerCoord, setCenterCoord] = useState<[number, number] | null>(null);
+  /** Whether the jump-to-coordinate pin is currently dropped. */
+  const [hasCoordPin, setHasCoordPin] = useState(false);
+  /** Draggable jump-to pin; independent of tool state. */
+  const coordPinMarkerRef = useRef<maplibregl.Marker | null>(null);
+  const coordPinPopupRef = useRef<maplibregl.Popup | null>(null);
 
   const [settingsPanelOpen, setSettingsPanelOpen] = useState<boolean>(() => {
     const stored = readJson<boolean | null>(LS_KEYS.settingsPanelOpen, null);
@@ -272,7 +282,11 @@ export function Map() {
     if (!settingsPanelOpen) return;
 
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSettingsPanelOpen(false);
+      if (e.key !== "Escape") return;
+      // Leave Escape for an editable field (e.g. the coordinate pill's input).
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      setSettingsPanelOpen(false);
     };
 
     document.addEventListener("keydown", onKeyDown);
@@ -748,6 +762,63 @@ export function Map() {
     setDetailsData(null);
   }
 
+  /** Center the map on a coordinate and drop (or move) the jump-to pin. Camera +
+   *  DOM marker only, so it doesn't touch tool state. */
+  const jumpToCoord = useCallback((lngLat: [number, number]) => {
+    const map = mbMapRef.current;
+    if (!map) return;
+    const [lng, lat] = lngLat;
+
+    // Center on the point; zoom in to a useful level but never zoom out.
+    map.easeTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), 14), duration: 800 });
+
+    const popupHtml = () => {
+      const ll = coordPinMarkerRef.current?.getLngLat() ?? { lng, lat };
+      return `<div style="font-size:11px;font-weight:600;white-space:nowrap">📍 ${formatLatLng(ll.lng, ll.lat)}</div>`;
+    };
+
+    if (coordPinMarkerRef.current) {
+      coordPinMarkerRef.current.setLngLat([lng, lat]);
+      coordPinPopupRef.current?.setHTML(popupHtml());
+      if (coordPinPopupRef.current && !coordPinPopupRef.current.isOpen()) {
+        coordPinMarkerRef.current.togglePopup();
+      }
+    } else {
+      const popup = new maplibregl.Popup({ offset: 28, closeButton: true, className: "map-coord-pin-popup" }).setHTML(popupHtml());
+      const marker = new maplibregl.Marker({ color: "#ec4899", draggable: true })
+        .setLngLat([lng, lat])
+        .setPopup(popup)
+        .addTo(map);
+      // Pause the cursor-elevation handler while dragging; refresh coords on drop.
+      marker.on("dragstart", () => { isDraggingMarkerRef.current = true; });
+      marker.on("dragend", () => {
+        isDraggingMarkerRef.current = false;
+        popup.setHTML(popupHtml());
+      });
+      coordPinMarkerRef.current = marker;
+      coordPinPopupRef.current = popup;
+      marker.togglePopup(); // open initially
+    }
+    setHasCoordPin(true);
+  }, []);
+
+  /** Remove the jump-to pin (and its popup). */
+  const clearCoordPin = useCallback(() => {
+    coordPinPopupRef.current?.remove();
+    coordPinPopupRef.current = null;
+    coordPinMarkerRef.current?.remove();
+    coordPinMarkerRef.current = null;
+    setHasCoordPin(false);
+  }, []);
+
+  // Tear down the jump-to pin when the map page unmounts.
+  useEffect(() => {
+    return () => {
+      coordPinPopupRef.current?.remove();
+      coordPinMarkerRef.current?.remove();
+    };
+  }, []);
+
   // ----------------------------
   // MapLibre: init + layers
   // ----------------------------
@@ -862,6 +933,8 @@ export function Map() {
     }
 
     mbMapRef.current = map;
+    // Seed the coordinate pill's fallback before the first moveend fires.
+    setCenterCoord(initialCenter);
 
     // Surface style/source/tile load failures instead of a silent blank map.
     map.on("error", (e) => {
@@ -933,6 +1006,8 @@ export function Map() {
       localStorage.setItem("savedZoom", map.getZoom().toString());
       localStorage.setItem("savedPitch", map.getPitch().toString());
       localStorage.setItem("savedBearing", map.getBearing().toString());
+      // Keep the coordinate pill's not-hovering fallback in sync with the view.
+      setCenterCoord([c.lng, c.lat]);
       // Mirror view into ?lat/lng/z (debounced); here so it follows recreation.
       pushViewToUrlRef.current();
     });
@@ -2113,6 +2188,10 @@ export function Map() {
       // Throttled via rAF so we don't call queryTerrainElevation on every pixel.
       let elevRafQueued = false;
       let pendingElevE: { lng: number; lat: number } | null = null;
+      // Gate setHoverCoord on a real 5dp change so a stationary cursor doesn't
+      // re-render the whole Map page each rAF frame.
+      let lastHoverLng = NaN;
+      let lastHoverLat = NaN;
       const onMapMouseMove = (e: maplibregl.MapMouseEvent) => {
         // Skip during marker drag — setHoverElevationM re-renders Map.tsx each
         // frame and stutters the marker behind the cursor.
@@ -2123,6 +2202,13 @@ export function Map() {
         requestAnimationFrame(() => {
           elevRafQueued = false;
           if (!pendingElevE || !mbMapRef.current) return;
+          const lng = Math.round(pendingElevE.lng * 1e5) / 1e5;
+          const lat = Math.round(pendingElevE.lat * 1e5) / 1e5;
+          if (lng !== lastHoverLng || lat !== lastHoverLat) {
+            lastHoverLng = lng;
+            lastHoverLat = lat;
+            setHoverCoord([lng, lat]);
+          }
           try {
             // Real MSL meters — users expect the elevation pill to match a topo map,
             // not the rendered terrain's exaggerated value. See queryTerrainElevationMSL.
@@ -2133,7 +2219,12 @@ export function Map() {
           }
         });
       };
-      const onMapMouseOut = () => setHoverElevationM(null);
+      const onMapMouseOut = () => {
+        setHoverElevationM(null);
+        setHoverCoord(null);
+        lastHoverLng = NaN;
+        lastHoverLat = NaN;
+      };
       map.on("mousemove", onMapMouseMove);
       map.on("mouseout", onMapMouseOut);
 
@@ -2680,17 +2771,14 @@ export function Map() {
         <span className="text-gray-200">Animations</span>
       </button>
 
-      {/* Live terrain elevation under the cursor — helps sanity-check coverage
-          paints. Only renders when 3D terrain is on and we got a valid sample. */}
-      {terrain3D && hoverElevationM != null && (
-        <div className="fixed top-3 left-[calc(var(--map-pad)+30rem)] sm:left-[calc(var(--map-pad)+33.75rem)] z-30 px-2.5 py-1 rounded-full text-[11px] font-medium border border-white/10 bg-gray-900/80 backdrop-blur-xl text-gray-300 shadow-2xl pointer-events-none select-none flex items-center gap-1.5">
-          <svg className="w-3 h-3 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 21l6-6 4 4 8-8" />
-          </svg>
-          <span className="tabular-nums">{Math.round(hoverElevationM)} m</span>
-          <span className="text-gray-600 text-[9px] uppercase tracking-wider">elev</span>
-        </div>
-      )}
+      <MapCoordinatePill
+        coord={hoverCoord}
+        centerCoord={centerCoord}
+        elevationM={terrain3D ? hoverElevationM : null}
+        hasPin={hasCoordPin}
+        onJump={jumpToCoord}
+        onClearPin={clearCoordPin}
+      />
 
       {/* Tools drawer — global, top-left next to search */}
       <MapToolsDrawer

--- a/frontend/src/pages/map/MapCoordinatePill.tsx
+++ b/frontend/src/pages/map/MapCoordinatePill.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useId, useRef, useState } from "react";
+
+import { toast } from "../../components/toastStore";
+import { copyTextToClipboard } from "../../utils/clipboard";
+import { formatLatLng, parseLatLng } from "./helpers";
+
+/**
+ * Live-coordinate pill: shows the lat/lng under the cursor (plus terrain
+ * elevation when 3D is on), or the map center when not hovering. Click to paste
+ * a "lat, lng" and jump-to-center with a pin, without disturbing the active tool.
+ */
+export function MapCoordinatePill({
+  coord,
+  centerCoord,
+  elevationM,
+  hasPin,
+  onJump,
+  onClearPin,
+}: {
+  /** Live cursor position [lng, lat], or null when not hovering the map. */
+  coord: [number, number] | null;
+  /** Map-center [lng, lat] fallback shown when not hovering. */
+  centerCoord: [number, number] | null;
+  /** Terrain elevation (MSL m) under the cursor, or null. */
+  elevationM: number | null;
+  /** Whether a jump-to pin is currently dropped. */
+  hasPin: boolean;
+  onJump: (lngLat: [number, number]) => void;
+  onClearPin: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const errorId = useId();
+
+  const isLive = coord != null;
+  const display = coord ?? centerCoord;
+
+  // Close the editor on outside pointerdown (pointer, so touch dismisses too).
+  useEffect(() => {
+    if (!editing) return;
+    const onDown = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setEditing(false);
+        setError(false);
+      }
+    };
+    document.addEventListener("pointerdown", onDown);
+    return () => document.removeEventListener("pointerdown", onDown);
+  }, [editing]);
+
+  const openEditor = () => {
+    setDraft(display ? formatLatLng(display[0], display[1]) : "");
+    setError(false);
+    setEditing(true);
+    // Focus + select after the input mounts.
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  };
+
+  const submit = () => {
+    const parsed = parseLatLng(draft);
+    if (!parsed) {
+      setError(true);
+      return;
+    }
+    onJump(parsed);
+    setEditing(false);
+    setError(false);
+  };
+
+  const copyCoords = async () => {
+    if (!display) return;
+    const text = formatLatLng(display[0], display[1]);
+    const ok = await copyTextToClipboard(text);
+    toast(ok ? `Copied ${text}` : "Couldn't copy coordinates", { kind: ok ? "success" : "error" });
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      // lg+ only: at ≥1024px --map-pad gains the nav-rail width, so this offset
+      // clears the tools drawer.
+      className="hidden lg:block fixed top-3 z-40 left-[calc(var(--map-pad)+33.75rem)]"
+    >
+      {editing ? (
+        <div className="flex flex-col gap-1 rounded-xl border border-cyan-500/40 bg-gray-900/90 backdrop-blur-xl shadow-2xl px-2.5 py-1.5 max-w-[calc(100vw-var(--map-pad)-35rem)]">
+          <div className="flex items-center gap-1.5">
+            <svg className="w-3.5 h-3.5 text-cyan-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            <input
+              ref={inputRef}
+              type="text"
+              value={draft}
+              placeholder="lat, lng"
+              aria-label="Jump to coordinates (lat, lng)"
+              aria-invalid={error}
+              aria-describedby={error ? errorId : undefined}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                if (error) setError(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submit();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setEditing(false);
+                  setError(false);
+                }
+              }}
+              className={`w-44 rounded-md bg-white/10 border px-1.5 py-0.5 text-[11px] font-mono text-gray-100 placeholder-gray-500
+                focus:outline-hidden focus:ring-1 ${
+                  error
+                    ? "border-red-500/60 focus:border-red-500/80 focus:ring-red-500/40"
+                    : "border-cyan-500/40 focus:border-cyan-500/70 focus:ring-cyan-500/40"
+                }`}
+            />
+            <button
+              type="button"
+              onClick={submit}
+              aria-label="Go to coordinates"
+              className="shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-cyan-300 hover:text-cyan-200 hover:bg-cyan-500/15 transition-colors"
+            >
+              Go
+            </button>
+          </div>
+          {error ? (
+            <span id={errorId} role="alert" className="text-[10px] text-red-400 pl-5">
+              Enter coordinates as <span className="font-mono">lat, lng</span>
+            </span>
+          ) : (
+            <span className="text-[10px] text-gray-500 pl-5">
+              Paste a <span className="font-mono">lat, lng</span> — centers the map &amp; drops a pin
+            </span>
+          )}
+        </div>
+      ) : (
+        <div className="flex items-center gap-0.5 rounded-full border border-white/10 bg-gray-900/80 backdrop-blur-xl text-gray-300 shadow-2xl">
+          <button
+            type="button"
+            onClick={openEditor}
+            title="Click to jump to coordinates"
+            aria-label="Live coordinates — click to jump to a location"
+            className="flex items-center gap-1.5 pl-2.5 pr-2 py-1 rounded-l-full hover:bg-white/5 transition-colors"
+          >
+            <svg className={`w-3 h-3 ${isLive ? "text-cyan-400" : "text-gray-500"}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            {display ? (
+              <span className="tabular-nums text-[11px] font-medium">{formatLatLng(display[0], display[1])}</span>
+            ) : (
+              <span className="text-[11px] text-gray-500">—</span>
+            )}
+            {isLive && elevationM != null && (
+              <>
+                <span className="text-gray-600">·</span>
+                <span className="tabular-nums text-[11px]">{Math.round(elevationM)} m</span>
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={copyCoords}
+            disabled={!display}
+            title="Copy coordinates"
+            aria-label="Copy coordinates"
+            className="shrink-0 p-1 text-gray-500 hover:text-gray-200 hover:bg-white/5 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+          </button>
+
+          {hasPin && (
+            <button
+              type="button"
+              onClick={onClearPin}
+              title="Clear dropped pin"
+              aria-label="Clear dropped pin"
+              className="shrink-0 p-1 pr-1.5 rounded-r-full text-fuchsia-400 hover:text-fuchsia-300 hover:bg-white/5 transition-colors"
+            >
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, type MergeOrigin, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import { COVERAGE_DETAIL_SIZE,type CoverageDetail } from "./coverageDetail";
+import { parseLatLng } from "./helpers";
 import { NumericDraftInput } from "./NumericDraftInput";
 import { Segmented } from "./Segmented";
 import type { DemSource } from "./terrainRgb";
@@ -12,37 +13,6 @@ interface MergeNodeOption {
   id: string;
   shortname?: string;
   longname?: string;
-}
-
-/** Parse "lat, lng" → [lng, lat]. Accepts a trailing ° and N/S/E/W hemisphere
- *  (e.g. "37.5° N, 122.3° W"). Returns null if invalid. */
-function parseLatLng(input: string): [number, number] | null {
-  const cleaned = input.trim().replace(/°/g, "");
-  let latStr: string;
-  let lngStr: string;
-  if (cleaned.includes(",")) {
-    const parts = cleaned.split(",");
-    if (parts.length !== 2) return null;
-    [latStr, lngStr] = parts;
-  } else {
-    const toks = cleaned.split(/\s+/).filter(Boolean);
-    if (toks.length === 2) [latStr, lngStr] = toks;
-    else if (toks.length === 4) { latStr = `${toks[0]} ${toks[1]}`; lngStr = `${toks[2]} ${toks[3]}`; }
-    else return null;
-  }
-  const parse = (t: string): number | null => {
-    const m = t.trim().match(/^(-?\d+(?:\.\d+)?)\s*([NSEW])?$/i);
-    if (!m) return null;
-    let v = Number(m[1]);
-    const h = m[2]?.toUpperCase();
-    if (h === "S" || h === "W") v = -Math.abs(v);
-    return Number.isFinite(v) ? v : null;
-  };
-  const lat = parse(latStr);
-  const lng = parse(lngStr);
-  if (lat == null || lng == null) return null;
-  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null;
-  return [lng, lat];
 }
 
 /** Info icon with hover/focus tooltip. `align` picks the edge it anchors to. */

--- a/frontend/src/pages/map/helpers.test.ts
+++ b/frontend/src/pages/map/helpers.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the shared lat/lng parse + format helpers.
+ *
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+
+import { formatLatLng, parseLatLng } from "./helpers";
+
+describe("parseLatLng", () => {
+  it("parses comma-separated lat,lng into [lng, lat]", () => {
+    expect(parseLatLng("37.5816, -121.4944")).toEqual([-121.4944, 37.5816]);
+  });
+
+  it("parses whitespace-separated coordinates", () => {
+    expect(parseLatLng("37.5816 -121.4944")).toEqual([-121.4944, 37.5816]);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseLatLng("  37.5816 ,  -121.4944  ")).toEqual([-121.4944, 37.5816]);
+  });
+
+  it("accepts a trailing degree sign and N/S/E/W hemisphere", () => {
+    expect(parseLatLng("37.5° N, 122.3° W")).toEqual([-122.3, 37.5]);
+  });
+
+  it("accepts four whitespace tokens with hemispheres", () => {
+    expect(parseLatLng("37.5 N 122.3 W")).toEqual([-122.3, 37.5]);
+  });
+
+  it("treats S/W as negative magnitudes regardless of sign", () => {
+    expect(parseLatLng("12.0 S, 8.0 E")).toEqual([8, -12]);
+  });
+
+  it("rejects out-of-range latitude", () => {
+    expect(parseLatLng("95, 10")).toBeNull();
+  });
+
+  it("rejects out-of-range longitude", () => {
+    expect(parseLatLng("10, 200")).toBeNull();
+  });
+
+  it("rejects the wrong number of components", () => {
+    expect(parseLatLng("1, 2, 3")).toBeNull();
+    expect(parseLatLng("5")).toBeNull();
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(parseLatLng("somewhere nice")).toBeNull();
+    expect(parseLatLng("")).toBeNull();
+  });
+});
+
+describe("formatLatLng", () => {
+  it("formats [lng, lat] as 'lat, lng' at 5 dp by default", () => {
+    expect(formatLatLng(-121.494445, 37.581622)).toBe("37.58162, -121.49444");
+  });
+
+  it("honors a custom precision", () => {
+    expect(formatLatLng(-121.4944, 37.5816, 2)).toBe("37.58, -121.49");
+  });
+});

--- a/frontend/src/pages/map/helpers.ts
+++ b/frontend/src/pages/map/helpers.ts
@@ -23,6 +23,44 @@ export function queryTerrainElevationMSL(map: MlMap, lnglat: [number, number]): 
   return e / exaggeration;
 }
 
+/** Parse "lat, lng" → [lng, lat]. Accepts a trailing ° and N/S/E/W hemisphere
+ *  (e.g. "37.5° N, 122.3° W"), comma- or whitespace-separated. Returns null if
+ *  invalid or out of range. */
+export function parseLatLng(input: string): [number, number] | null {
+  const cleaned = input.trim().replace(/°/g, "");
+  let latStr: string;
+  let lngStr: string;
+  if (cleaned.includes(",")) {
+    const parts = cleaned.split(",");
+    if (parts.length !== 2) return null;
+    [latStr, lngStr] = parts;
+  } else {
+    const toks = cleaned.split(/\s+/).filter(Boolean);
+    if (toks.length === 2) [latStr, lngStr] = toks;
+    else if (toks.length === 4) { latStr = `${toks[0]} ${toks[1]}`; lngStr = `${toks[2]} ${toks[3]}`; }
+    else return null;
+  }
+  const parse = (t: string): number | null => {
+    const m = t.trim().match(/^(-?\d+(?:\.\d+)?)\s*([NSEW])?$/i);
+    if (!m) return null;
+    let v = Number(m[1]);
+    const h = m[2]?.toUpperCase();
+    if (h === "S" || h === "W") v = -Math.abs(v);
+    return Number.isFinite(v) ? v : null;
+  };
+  const lat = parse(latStr);
+  const lng = parse(lngStr);
+  if (lat == null || lng == null) return null;
+  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null;
+  return [lng, lat];
+}
+
+/** Format a [lng, lat] pair as "lat, lng" (Google-Maps order) at the given
+ *  precision (default 5 dp ≈ 1 m). */
+export function formatLatLng(lng: number, lat: number, precision = 5): string {
+  return `${lat.toFixed(precision)}, ${lng.toFixed(precision)}`;
+}
+
 export function relativeTime(iso: string | null | undefined): string {
   if (!iso) return "Unknown";
   const ms = Date.now() - new Date(iso).getTime();

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,29 @@
+/**
+ * Copy text to the clipboard, returning whether it succeeded. Falls back to a
+ * hidden <textarea> + execCommand("copy") when navigator.clipboard is
+ * unavailable (e.g. plain-HTTP self-hosting).
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the textarea fallback
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #498.

Adds a persistent coordinate pill at the top of the map (replacing the old
elevation-only readout):

- **Live readout** — shows `lat, lng` under the cursor, with terrain elevation
  folded in when 3D terrain is on. Falls back to the map center when the cursor
  isn't over the map, so it's always populated.
- **Jump-to-coordinate** — click the pill to paste/type a `lat, lng`
  (also accepts `N/S/E/W` + `°`); the map eases-to-center on
  that point and drops a draggable pin. This is a camera-only move + DOM marker,
  so it never touches tool state — you can spot-check a location against a
  rendered coverage paint without closing the coverage panel.
- Copy-coordinates and clear-pin controls.

### Implementation
- New `MapCoordinatePill.tsx`.
- `parseLatLng` extracted from `MapCoveragePanel.tsx` into `helpers.ts` (now
  shared) alongside a new `formatLatLng`; unit-tested in `helpers.test.ts`.
- New `utils/clipboard.ts` with a secure-context-aware copy + `<textarea>`
  fallback (copy works over plain-HTTP self-hosting).
- `Map.tsx`: cursor/center coordinate tracking (gated to a real 5dp change so it
  doesn't re-render per frame), the pin marker lifecycle, and a guard so Escape
  in the pill input no longer also closes the Settings panel.

### Notes / scope
- Pill is shown on `lg+` (≥1024px), where `--map-pad` accounts for the nav rail
  and the live readout (mouse-hover) is meaningful.
- It centers + pins a spot for *visual* coverage inspection; it does not
  numerically sample the model at the point  — a possible follow-up.