### PR TITLE
Altitude assessment: fix "suspect" false positives + datum/source-aware normalization

### DIFF
--- a/frontend/src/pages/map/useCoverageMergeOrigins.ts
+++ b/frontend/src/pages/map/useCoverageMergeOrigins.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 
+import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
 import type { MergeOrigin } from "./coverageAnalysis";
 import type { IMapNode } from "./types";
 
@@ -39,7 +40,7 @@ export function useCoverageMergeOrigins(nodes: Record<string, IMapNode>, toolFro
             id: cleanId,
             label: n?.shortname || n?.longname || cleanId,
             position: [pos[0], pos[1]],
-            altitudeM: n?.position?.altitude ?? null,
+            altitudeM: effectiveAltitudeMslM(n?.position),
           }],
     );
   }, [nodes]);

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -5,6 +5,7 @@ import maplibregl, {
 import { useCallback, useEffect, useRef } from "react";
 
 import { env } from "../../env";
+import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
 import { normalizeLng, shortestLngDelta } from "./geo";
 import { computeP2PLoss } from "./itm";
 import { DEFAULT_ITM_ENV } from "./itmEnv";
@@ -108,7 +109,7 @@ export function useLosCompute(params: LosComputeParams) {
       const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
       if (!n?.map_position) { setLosResult(null); return; }
       fromPos = [n.map_position[0], n.map_position[1]];
-      fromAltitude = n.position?.altitude ?? null;
+      fromAltitude = effectiveAltitudeMslM(n.position);
     } else {
       fromPos = losVirtualFrom!;
     }
@@ -119,7 +120,7 @@ export function useLosCompute(params: LosComputeParams) {
       const n = nodes[toolToId] ?? nodes[`!${toolToId}`];
       if (!n?.map_position) { setLosResult(null); return; }
       toPos = [n.map_position[0], n.map_position[1]];
-      toAltitude = n.position?.altitude ?? null;
+      toAltitude = effectiveAltitudeMslM(n.position);
     } else {
       toPos = losVirtualTo!;
     }

--- a/frontend/src/pages/map/useScanCompute.ts
+++ b/frontend/src/pages/map/useScanCompute.ts
@@ -6,6 +6,7 @@ import { useEffect, useRef } from "react";
 
 import { env } from "../../env";
 import { ORIGIN_COLOR } from "../../palette";
+import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
 import { buildBuildingRaster, type BuildingRaster } from "./buildingTiles";
 import { buildCanopyRaster, type CanopyRaster } from "./canopyTiles";
 import { AGGRESSION_STOPS, type CoverageReliability, reliabilityPreset } from "./coverageAnalysis";
@@ -101,7 +102,7 @@ export function useScanCompute(params: ScanComputeParams) {
       const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
       if (n?.map_position) {
         origin = [n.map_position[0], n.map_position[1]];
-        originAltitude = n.position?.altitude ?? null;
+        originAltitude = effectiveAltitudeMslM(n.position);
         originShortname = n.shortname ?? undefined;
       }
     } else if (toolVirtualPos) {
@@ -169,7 +170,7 @@ export function useScanCompute(params: ScanComputeParams) {
             id: norm,
             shortname: node.shortname ?? undefined,
             position: [lng, lat],
-            altitudeM: node.position?.altitude ?? null,
+            altitudeM: effectiveAltitudeMslM(node.position),
           });
         }
 

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -14,7 +14,13 @@ import { getElsewhereLinks, resolveElsewhereUrl } from "../../utils/elsewhereLin
 import { formatTimestamp } from "../../utils/formatTimestamp";
 import { calculateDistanceBetweenNodes } from "../../utils/getDistanceBetweenTwoNodes";
 import { NodeMap } from "../NodeMap";
-import { classifyAltitude, getGroundElevation } from "./groundElevation";
+import {
+  classifyAltitude,
+  type GroundSample,
+  MAX_VALIDATABLE_UNCERTAINTY_M,
+  positionUncertaintyM,
+} from "./altitudeAssessment";
+import { getGroundElevation } from "./groundElevation";
 import {
   cleanNodeId,
   getLatLon,
@@ -266,18 +272,24 @@ export function NodeDetailsPanel({
   // ll is a fresh array each render; depend on its primitives instead.
   const lng = ll?.[0] ?? null;
   const lat = ll?.[1] ?? null;
-  const [groundM, setGroundM] = useState<number | null>(null);
+  const precisionBits = n?.position?.precision_bits ?? null;
+  const [ground, setGround] = useState<GroundSample | null>(null);
   useEffect(() => {
-    if (lng == null || lat == null || !id) { setGroundM(null); return; }
+    // Skip the fetch when the position is too imprecise to validate altitude against terrain.
+    if (lng == null || lat == null || !id ||
+        positionUncertaintyM(precisionBits) > MAX_VALIDATABLE_UNCERTAINTY_M) {
+      setGround(null);
+      return;
+    }
     let cancelled = false;
-    void getGroundElevation(id, lng, lat).then((elev) => {
-      if (!cancelled) setGroundM(elev);
+    void getGroundElevation(id, lng, lat).then((g) => {
+      if (!cancelled) setGround(g);
     });
     return () => { cancelled = true; };
-  }, [id, lng, lat]);
-  const altSanity = useMemo(
-    () => classifyAltitude(n?.position?.altitude, groundM),
-    [n?.position?.altitude, groundM],
+  }, [id, lng, lat, precisionBits]);
+  const altAssessment = useMemo(
+    () => classifyAltitude(n?.position?.altitude, ground, precisionBits),
+    [n?.position?.altitude, ground, precisionBits],
   );
 
   const distanceFromServer =
@@ -411,21 +423,31 @@ export function NodeDetailsPanel({
               <KV
                 k="Altitude"
                 v={
-                  altSanity.reportedM != null ? (
+                  altAssessment.reportedM != null ? (
                     <span className="inline-flex items-center gap-1.5">
-                      <span>{altSanity.reportedM} m</span>
-                      {altSanity.suspectReason && (
+                      <span>{altAssessment.reportedM} m</span>
+                      {altAssessment.suspectReason && (
                         <span
-                          className="group relative inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md
-                            bg-amber-500/15 text-amber-600 dark:text-amber-400 border border-amber-500/30
-                            text-[10px] font-medium cursor-help"
-                          title={altSanity.suspectReason}
+                          className={`group relative inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md
+                            text-[10px] font-medium cursor-help border ${
+                              altAssessment.severity === "info"
+                                ? "bg-slate-500/15 text-slate-600 dark:text-slate-300 border-slate-500/30"
+                                : "bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/30"
+                            }`}
+                          title={altAssessment.suspectReason}
                         >
-                          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                              d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
-                          </svg>
-                          suspect
+                          {altAssessment.severity === "info" ? (
+                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                          ) : (
+                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+                            </svg>
+                          )}
+                          {altAssessment.severity === "info" ? "note" : "check"}
                         </span>
                       )}
                     </span>

--- a/frontend/src/pages/nodes/NodeDetailsPanel.tsx
+++ b/frontend/src/pages/nodes/NodeDetailsPanel.tsx
@@ -288,8 +288,8 @@ export function NodeDetailsPanel({
     return () => { cancelled = true; };
   }, [id, lng, lat, precisionBits]);
   const altAssessment = useMemo(
-    () => classifyAltitude(n?.position?.altitude, ground, precisionBits),
-    [n?.position?.altitude, ground, precisionBits],
+    () => classifyAltitude(n?.position ?? null, ground),
+    [n?.position, ground],
   );
 
   const distanceFromServer =

--- a/frontend/src/pages/nodes/altitudeAssessment.test.ts
+++ b/frontend/src/pages/nodes/altitudeAssessment.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for altitude assessment classification + Meshtastic position-precision math.
+ *
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyAltitude,
+  type GroundSample,
+  MAX_VALIDATABLE_UNCERTAINTY_M,
+  positionUncertaintyM,
+} from "./altitudeAssessment";
+
+const ground = (min: number, max: number, center = (min + max) / 2): GroundSample => ({
+  min,
+  max,
+  center,
+});
+
+describe("positionUncertaintyM", () => {
+  it("treats undefined / full precision as zero uncertainty", () => {
+    expect(positionUncertaintyM(undefined)).toBe(0);
+    expect(positionUncertaintyM(null)).toBe(0);
+    expect(positionUncertaintyM(32)).toBe(0);
+    expect(positionUncertaintyM(0)).toBe(0);
+  });
+
+  it("matches Meshtastic precision presets (half-step error)", () => {
+    expect(positionUncertaintyM(13)).toBeCloseTo(2918, 0); // ~2.9 km
+    expect(positionUncertaintyM(16)).toBeCloseTo(365, 0); // ~365 m
+    expect(positionUncertaintyM(18)).toBeCloseTo(91, 0); // ~91 m
+  });
+});
+
+describe("classifyAltitude", () => {
+  it("passes a missing reading", () => {
+    expect(classifyAltitude(null, ground(2480, 2520)).severity).toBeNull();
+    expect(classifyAltitude(undefined, null).severity).toBeNull();
+  });
+
+  it("flags the 65535 firmware sentinel as bad", () => {
+    const s = classifyAltitude(65535, null);
+    expect(s.severity).toBe("bad");
+    expect(s.suspectReason).toMatch(/sentinel/);
+  });
+
+  it("flags absolutely implausible altitudes as bad", () => {
+    expect(classifyAltitude(-501, null).severity).toBe("bad");
+    expect(classifyAltitude(50_001, null).severity).toBe("bad");
+    expect(classifyAltitude(-500, null).severity).toBeNull(); // boundary is inclusive-OK
+  });
+
+  it("skips the terrain check when the position is too imprecise", () => {
+    // precision 13 (~2.9 km) > MAX_VALIDATABLE; the +353 m valley false-positive case.
+    expect(positionUncertaintyM(13)).toBeGreaterThan(MAX_VALIDATABLE_UNCERTAINTY_M);
+    const s = classifyAltitude(2508, ground(2150, 2160, 2155), 13);
+    expect(s.severity).toBeNull();
+    expect(s.suspectReason).toBeNull();
+  });
+
+  it("flags below-terrain readings on precise positions", () => {
+    const s = classifyAltitude(100, ground(2000, 2100, 2050), 32);
+    expect(s.severity).toBe("bad");
+    expect(s.suspectReason).toMatch(/below terrain/);
+  });
+
+  it("marks far-above-terrain readings as a neutral note, not bad", () => {
+    const s = classifyAltitude(2508, ground(2150, 2160, 2155), 32);
+    expect(s.severity).toBe("info");
+    expect(s.suspectReason).toMatch(/above terrain/);
+  });
+
+  it("passes a node sitting near its (bracketed) terrain", () => {
+    // Reported within ground spread + tolerances.
+    expect(classifyAltitude(2508, ground(2480, 2520, 2507), 32).severity).toBeNull();
+    expect(classifyAltitude(2508, ground(2480, 2520, 2507)).severity).toBeNull();
+  });
+
+  it("allows mast/rooftop height above terrain without flagging", () => {
+    expect(classifyAltitude(2200 + 100, ground(2200, 2200, 2200), 32).severity).toBeNull();
+  });
+});

--- a/frontend/src/pages/nodes/altitudeAssessment.test.ts
+++ b/frontend/src/pages/nodes/altitudeAssessment.test.ts
@@ -1,13 +1,17 @@
 /**
- * Unit tests for altitude assessment classification + Meshtastic position-precision math.
+ * Unit tests for altitude assessment: MSL/HAE normalization, position-precision math,
+ * and terrain classification.
  *
  * @vitest-environment node
  */
 import { describe, expect, it } from "vitest";
 
 import {
+  ALT_SOURCE,
   classifyAltitude,
+  effectiveAltitudeMslM,
   type GroundSample,
+  LOC_SOURCE,
   MAX_VALIDATABLE_UNCERTAINTY_M,
   positionUncertaintyM,
 } from "./altitudeAssessment";
@@ -33,51 +37,98 @@ describe("positionUncertaintyM", () => {
   });
 });
 
+describe("effectiveAltitudeMslM", () => {
+  it("prefers the MSL altitude field", () => {
+    expect(effectiveAltitudeMslM({ altitude: 2508, altitude_hae: 2478 })).toBe(2508);
+  });
+
+  it("falls back to HAE converted via geoidal separation when MSL is absent", () => {
+    // MSL = HAE - geoid_sep; geoid ~ -30 m in the western US → MSL ~ HAE + 30.
+    expect(effectiveAltitudeMslM({ altitude_hae: 2478, altitude_geoidal_separation: -30 })).toBe(2508);
+  });
+
+  it("uses raw HAE when geoidal separation is unknown", () => {
+    expect(effectiveAltitudeMslM({ altitude_hae: 2478 })).toBe(2478);
+  });
+
+  it("returns null with no usable altitude", () => {
+    expect(effectiveAltitudeMslM(null)).toBeNull();
+    expect(effectiveAltitudeMslM({})).toBeNull();
+  });
+});
+
 describe("classifyAltitude", () => {
   it("passes a missing reading", () => {
     expect(classifyAltitude(null, ground(2480, 2520)).severity).toBeNull();
-    expect(classifyAltitude(undefined, null).severity).toBeNull();
+    expect(classifyAltitude({}, null).severity).toBeNull();
   });
 
   it("flags the 65535 firmware sentinel as bad", () => {
-    const s = classifyAltitude(65535, null);
+    const s = classifyAltitude({ altitude: 65535 }, null);
     expect(s.severity).toBe("bad");
     expect(s.suspectReason).toMatch(/sentinel/);
   });
 
   it("flags absolutely implausible altitudes as bad", () => {
-    expect(classifyAltitude(-501, null).severity).toBe("bad");
-    expect(classifyAltitude(50_001, null).severity).toBe("bad");
-    expect(classifyAltitude(-500, null).severity).toBeNull(); // boundary is inclusive-OK
+    expect(classifyAltitude({ altitude: -501 }, null).severity).toBe("bad");
+    expect(classifyAltitude({ altitude: 50_001 }, null).severity).toBe("bad");
+    expect(classifyAltitude({ altitude: -500 }, null).severity).toBeNull(); // boundary inclusive-OK
   });
 
   it("skips the terrain check when the position is too imprecise", () => {
     // precision 13 (~2.9 km) > MAX_VALIDATABLE; the +353 m valley false-positive case.
     expect(positionUncertaintyM(13)).toBeGreaterThan(MAX_VALIDATABLE_UNCERTAINTY_M);
-    const s = classifyAltitude(2508, ground(2150, 2160, 2155), 13);
+    const s = classifyAltitude({ altitude: 2508, precision_bits: 13 }, ground(2150, 2160, 2155));
     expect(s.severity).toBeNull();
     expect(s.suspectReason).toBeNull();
   });
 
   it("flags below-terrain readings on precise positions", () => {
-    const s = classifyAltitude(100, ground(2000, 2100, 2050), 32);
+    const s = classifyAltitude({ altitude: 100, precision_bits: 32 }, ground(2000, 2100, 2050));
     expect(s.severity).toBe("bad");
     expect(s.suspectReason).toMatch(/below terrain/);
   });
 
   it("marks far-above-terrain readings as a neutral note, not bad", () => {
-    const s = classifyAltitude(2508, ground(2150, 2160, 2155), 32);
+    const s = classifyAltitude({ altitude: 2508, precision_bits: 32 }, ground(2150, 2160, 2155));
     expect(s.severity).toBe("info");
     expect(s.suspectReason).toMatch(/above terrain/);
   });
 
+  it("relabels manually-set readings but still flags them", () => {
+    const s = classifyAltitude(
+      { altitude: 100, precision_bits: 32, location_source: LOC_SOURCE.MANUAL },
+      ground(2000, 2100, 2050),
+    );
+    expect(s.severity).toBe("bad");
+    expect(s.suspectReason).toMatch(/Manually-set/);
+  });
+
+  it("widens tolerance for barometric altitude sources", () => {
+    // 130 m above terrain: would be 'info' for GPS (>120), but within barometric slack (120+60).
+    const g = ground(2000, 2000, 2000);
+    expect(classifyAltitude({ altitude: 2130, precision_bits: 32 }, g).severity).toBe("info");
+    expect(
+      classifyAltitude({ altitude: 2130, precision_bits: 32, altitude_source: ALT_SOURCE.BAROMETRIC }, g).severity,
+    ).toBeNull();
+  });
+
+  it("normalizes an HAE-only node before comparing to terrain", () => {
+    // HAE 2478 + geoid -30 → MSL 2508, sitting right on 2507 terrain → fine (no false flag).
+    const s = classifyAltitude(
+      { altitude_hae: 2478, altitude_geoidal_separation: -30, precision_bits: 32 },
+      ground(2490, 2520, 2507),
+    );
+    expect(s.reportedM).toBe(2508);
+    expect(s.severity).toBeNull();
+  });
+
   it("passes a node sitting near its (bracketed) terrain", () => {
-    // Reported within ground spread + tolerances.
-    expect(classifyAltitude(2508, ground(2480, 2520, 2507), 32).severity).toBeNull();
-    expect(classifyAltitude(2508, ground(2480, 2520, 2507)).severity).toBeNull();
+    expect(classifyAltitude({ altitude: 2508, precision_bits: 32 }, ground(2480, 2520, 2507)).severity).toBeNull();
+    expect(classifyAltitude({ altitude: 2508 }, ground(2480, 2520, 2507)).severity).toBeNull();
   });
 
   it("allows mast/rooftop height above terrain without flagging", () => {
-    expect(classifyAltitude(2200 + 100, ground(2200, 2200, 2200), 32).severity).toBeNull();
+    expect(classifyAltitude({ altitude: 2300, precision_bits: 32 }, ground(2200, 2200, 2200)).severity).toBeNull();
   });
 });

--- a/frontend/src/pages/nodes/altitudeAssessment.ts
+++ b/frontend/src/pages/nodes/altitudeAssessment.ts
@@ -8,7 +8,22 @@ export interface GroundSample {
   center: number;
 }
 
+/** Meshtastic Position.AltSource / LocSource enum values we act on. */
+export const ALT_SOURCE = { MANUAL: 1, BAROMETRIC: 4 } as const;
+export const LOC_SOURCE = { MANUAL: 1 } as const;
+
+/** Altitude-relevant subset of a node position (snake_case matches the API/protobuf). */
+export interface AltitudeInput {
+  altitude?: number | null;
+  altitude_hae?: number | null;
+  altitude_geoidal_separation?: number | null;
+  altitude_source?: number | null;
+  location_source?: number | null;
+  precision_bits?: number | null;
+}
+
 export interface AltitudeAssessment {
+  /** Effective MSL altitude (HAE-normalized) used for the assessment + display. */
   reportedM: number | null;
   groundM: number | null;
   /** "bad" = likely-wrong reading (amber), "info" = plausible but notable (neutral), null = looks fine. */
@@ -25,6 +40,8 @@ const HARD_MAX_M = 50_000;
 const BELOW_TERRAIN_M = 50;
 /** Reported this far above local terrain ⇒ notable (tall tower, aircraft, datum offset), not necessarily wrong. */
 const ABOVE_TERRAIN_M = 120;
+/** Barometric altimeters drift; widen both tolerances when the source is barometric. */
+const BAROMETRIC_EXTRA_M = 60;
 /** Above this horizontal uncertainty the terrain check is meaningless — the broadcast
  *  position can be kilometres from the node, so its terrain isn't the node's terrain. */
 export const MAX_VALIDATABLE_UNCERTAINTY_M = 150;
@@ -36,19 +53,31 @@ export function positionUncertaintyM(precisionBits?: number | null): number {
   return 2 ** (31 - precisionBits) * 0.011132;
 }
 
+/** Best-effort MSL altitude (m). Uses `altitude` (MSL per spec) when present; otherwise falls
+ *  back to a node that reports HAE, converting via MSL = HAE − geoidal_separation. */
+export function effectiveAltitudeMslM(pos: AltitudeInput | null | undefined): number | null {
+  if (!pos) return null;
+  const msl = pos.altitude;
+  if (typeof msl === "number" && Number.isFinite(msl)) return msl;
+  const hae = pos.altitude_hae;
+  if (typeof hae === "number" && Number.isFinite(hae)) {
+    const geoid = pos.altitude_geoidal_separation;
+    return typeof geoid === "number" && Number.isFinite(geoid) ? hae - geoid : hae;
+  }
+  return null;
+}
+
 export function classifyAltitude(
-  reported: number | null | undefined,
+  pos: AltitudeInput | null | undefined,
   ground: GroundSample | null,
-  precisionBits?: number | null,
 ): AltitudeAssessment {
-  const r =
-    typeof reported === "number" && Number.isFinite(reported) ? reported : null;
+  const r = effectiveAltitudeMslM(pos);
   const groundM = ground?.center ?? null;
   const fine: AltitudeAssessment = { reportedM: r, groundM, severity: null, suspectReason: null };
 
   if (r == null) return fine;
 
-  if (Math.round(r) === ALT_SENTINEL) {
+  if (pos?.altitude != null && Math.round(pos.altitude) === ALT_SENTINEL) {
     return {
       reportedM: r,
       groundM,
@@ -67,23 +96,28 @@ export function classifyAltitude(
   }
 
   // Privacy-truncated positions land up to kilometres off; terrain here isn't the node's terrain.
-  if (positionUncertaintyM(precisionBits) > MAX_VALIDATABLE_UNCERTAINTY_M) return fine;
+  if (positionUncertaintyM(pos?.precision_bits) > MAX_VALIDATABLE_UNCERTAINTY_M) return fine;
 
   if (ground != null) {
-    if (r < ground.min - BELOW_TERRAIN_M) {
+    const manual =
+      pos?.location_source === LOC_SOURCE.MANUAL || pos?.altitude_source === ALT_SOURCE.MANUAL;
+    const slack = pos?.altitude_source === ALT_SOURCE.BAROMETRIC ? BAROMETRIC_EXTRA_M : 0;
+    const subject = manual ? "Manually-set altitude" : "Reported altitude";
+
+    if (r < ground.min - (BELOW_TERRAIN_M + slack)) {
       return {
         reportedM: r,
         groundM,
         severity: "bad",
-        suspectReason: `Reports ${r.toFixed(0)} m — ${(ground.min - r).toFixed(0)} m below terrain (${ground.min.toFixed(0)} m).`,
+        suspectReason: `${subject}: ${r.toFixed(0)} m, ${(ground.min - r).toFixed(0)} m below terrain (${ground.min.toFixed(0)} m).`,
       };
     }
-    if (r > ground.max + ABOVE_TERRAIN_M) {
+    if (r > ground.max + (ABOVE_TERRAIN_M + slack)) {
       return {
         reportedM: r,
         groundM,
         severity: "info",
-        suspectReason: `Reports ${r.toFixed(0)} m — ${(r - ground.max).toFixed(0)} m above terrain (${ground.max.toFixed(0)} m). Tall tower, aircraft, or HAE-vs-MSL offset.`,
+        suspectReason: `${subject}: ${r.toFixed(0)} m, ${(r - ground.max).toFixed(0)} m above terrain (${ground.max.toFixed(0)} m). Tall tower, aircraft, or datum offset.`,
       };
     }
   }

--- a/frontend/src/pages/nodes/altitudeAssessment.ts
+++ b/frontend/src/pages/nodes/altitudeAssessment.ts
@@ -1,0 +1,92 @@
+/** Pure altitude-assessment logic (no network/DOM deps), unit-testable in isolation. */
+
+export interface GroundSample {
+  /** Min/max/center terrain elevation (m) around the node. The spread absorbs DEM
+   *  under-read on peaks/ridges and small position error before the altitude check. */
+  min: number;
+  max: number;
+  center: number;
+}
+
+export interface AltitudeAssessment {
+  reportedM: number | null;
+  groundM: number | null;
+  /** "bad" = likely-wrong reading (amber), "info" = plausible but notable (neutral), null = looks fine. */
+  severity: "bad" | "info" | null;
+  /** Human-readable explanation of the flag, or null when the reading looks fine. */
+  suspectReason: string | null;
+}
+
+const ALT_SENTINEL = 65535;
+/** Absolute plausibility bounds (m); lower bound matches the DEM decode's clamp. */
+const HARD_MIN_M = -500;
+const HARD_MAX_M = 50_000;
+/** Reported this far below local terrain ⇒ bad GPS/datum. */
+const BELOW_TERRAIN_M = 50;
+/** Reported this far above local terrain ⇒ notable (tall tower, aircraft, datum offset), not necessarily wrong. */
+const ABOVE_TERRAIN_M = 120;
+/** Above this horizontal uncertainty the terrain check is meaningless — the broadcast
+ *  position can be kilometres from the node, so its terrain isn't the node's terrain. */
+export const MAX_VALIDATABLE_UNCERTAINTY_M = 150;
+
+/** Meshtastic truncates lat/lng to the top `precisionBits` of the int32 (deg×1e7);
+ *  this returns the resulting half-step horizontal error in meters. 0 = full/unknown precision. */
+export function positionUncertaintyM(precisionBits?: number | null): number {
+  if (precisionBits == null || precisionBits <= 0 || precisionBits >= 32) return 0;
+  return 2 ** (31 - precisionBits) * 0.011132;
+}
+
+export function classifyAltitude(
+  reported: number | null | undefined,
+  ground: GroundSample | null,
+  precisionBits?: number | null,
+): AltitudeAssessment {
+  const r =
+    typeof reported === "number" && Number.isFinite(reported) ? reported : null;
+  const groundM = ground?.center ?? null;
+  const fine: AltitudeAssessment = { reportedM: r, groundM, severity: null, suspectReason: null };
+
+  if (r == null) return fine;
+
+  if (Math.round(r) === ALT_SENTINEL) {
+    return {
+      reportedM: r,
+      groundM,
+      severity: "bad",
+      suspectReason: "Reports 65535 m — firmware sentinel for missing altitude.",
+    };
+  }
+
+  if (r < HARD_MIN_M || r > HARD_MAX_M) {
+    return {
+      reportedM: r,
+      groundM,
+      severity: "bad",
+      suspectReason: `Reports ${r.toFixed(0)} m — outside any plausible altitude.`,
+    };
+  }
+
+  // Privacy-truncated positions land up to kilometres off; terrain here isn't the node's terrain.
+  if (positionUncertaintyM(precisionBits) > MAX_VALIDATABLE_UNCERTAINTY_M) return fine;
+
+  if (ground != null) {
+    if (r < ground.min - BELOW_TERRAIN_M) {
+      return {
+        reportedM: r,
+        groundM,
+        severity: "bad",
+        suspectReason: `Reports ${r.toFixed(0)} m — ${(ground.min - r).toFixed(0)} m below terrain (${ground.min.toFixed(0)} m).`,
+      };
+    }
+    if (r > ground.max + ABOVE_TERRAIN_M) {
+      return {
+        reportedM: r,
+        groundM,
+        severity: "info",
+        suspectReason: `Reports ${r.toFixed(0)} m — ${(r - ground.max).toFixed(0)} m above terrain (${ground.max.toFixed(0)} m). Tall tower, aircraft, or HAE-vs-MSL offset.`,
+      };
+    }
+  }
+
+  return fine;
+}

--- a/frontend/src/pages/nodes/groundElevation.ts
+++ b/frontend/src/pages/nodes/groundElevation.ts
@@ -1,26 +1,48 @@
 import { env } from "../../env";
 import { fetchElevationAt } from "../map/terrainRgb";
+import type { GroundSample } from "./altitudeAssessment";
 
-const cache = new Map<string, number | null>();
-const inflight = new Map<string, Promise<number | null>>();
+const cache = new Map<string, GroundSample | null>();
+const inflight = new Map<string, Promise<GroundSample | null>>();
 
-/** Cached Tilezen ground-elevation lookup keyed by node id. Reuses the LRU
- *  inside fetchElevationAt; same lat/lng tile across nodes is shared. */
+/** Box half-width (m) sampled around the node. */
+const NEIGHBORHOOD_M = 75;
+const RING = [
+  [0, 0], [1, 0], [-1, 0], [0, 1], [0, -1], [1, 1], [1, -1], [-1, 1], [-1, -1],
+] as const;
+
+async function sampleGround(
+  lng: number,
+  lat: number,
+  token: string,
+): Promise<GroundSample | null> {
+  const dLat = NEIGHBORHOOD_M / 111_320;
+  const dLng = NEIGHBORHOOD_M / (111_320 * Math.cos((lat * Math.PI) / 180));
+  const vals = await Promise.all(
+    RING.map(([ox, oy]) => fetchElevationAt(lng + ox * dLng, lat + oy * dLat, token)),
+  );
+  const finite = vals.filter((v): v is number => v != null);
+  if (finite.length === 0) return null;
+  return { min: Math.min(...finite), max: Math.max(...finite), center: vals[0] ?? finite[0] };
+}
+
+/** Cached neighborhood ground-elevation lookup keyed by node id. The inner
+ *  fetchElevationAt LRU shares tiles across the ring and across nodes. */
 export async function getGroundElevation(
   nodeId: string,
   lng: number,
   lat: number,
-): Promise<number | null> {
+): Promise<GroundSample | null> {
   if (cache.has(nodeId)) return cache.get(nodeId) ?? null;
   const existing = inflight.get(nodeId);
   if (existing) return existing;
 
   const token = env.MAPBOX_TOKEN ?? "";
-  const p = fetchElevationAt(lng, lat, token)
-    .then((elev) => {
-      cache.set(nodeId, elev);
+  const p = sampleGround(lng, lat, token)
+    .then((g) => {
+      cache.set(nodeId, g);
       inflight.delete(nodeId);
-      return elev;
+      return g;
     })
     .catch(() => {
       cache.set(nodeId, null);
@@ -29,48 +51,4 @@ export async function getGroundElevation(
     });
   inflight.set(nodeId, p);
   return p;
-}
-
-export interface AltitudeSanity {
-  reportedM: number | null;
-  groundM: number | null;
-  /** Human-readable explanation of the flag, or null when the reading looks fine. */
-  suspectReason: string | null;
-}
-
-/** Threshold (m) for flagging a reported altitude as inconsistent with terrain.
- *  Tall masts and rooftop installs sit comfortably below 50 m AGL. */
-const ALT_DELTA_M = 50;
-
-export function classifyAltitude(
-  reported: number | null | undefined,
-  ground: number | null,
-): AltitudeSanity {
-  const r =
-    typeof reported === "number" && Number.isFinite(reported) ? reported : null;
-  if (r == null) {
-    return { reportedM: null, groundM: ground, suspectReason: null };
-  }
-
-  // 65535 is the Meshtastic "no altitude" sentinel from a uint16 overflow.
-  if (Math.round(r) === 65535) {
-    return {
-      reportedM: r,
-      groundM: ground,
-      suspectReason: "Reports 65535 m — firmware sentinel for missing altitude.",
-    };
-  }
-
-  if (ground != null) {
-    const delta = r - ground;
-    if (Math.abs(delta) > ALT_DELTA_M) {
-      return {
-        reportedM: r,
-        groundM: ground,
-        suspectReason: `Reports ${r.toFixed(0)} m; terrain here is ${ground.toFixed(0)} m (${delta >= 0 ? "+" : ""}${delta.toFixed(0)} m).`,
-      };
-    }
-  }
-
-  return { reportedM: r, groundM: ground, suspectReason: null };
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -186,6 +186,14 @@ export interface INeighbor {
 
 export interface INodePosition {
   altitude?: number;
+  /** Height above WGS84 ellipsoid; alternative datum some devices report instead of MSL. */
+  altitude_hae?: number;
+  /** Geoid undulation N, where MSL = HAE − N. */
+  altitude_geoidal_separation?: number;
+  /** Meshtastic LocSource enum: 1=manual, 2=internal GPS, 3=external GPS. */
+  location_source?: number;
+  /** Meshtastic AltSource enum: 1=manual, 2=internal, 3=external, 4=barometric. */
+  altitude_source?: number;
   latitude_i: number;
   latitude: number;
   longitude_i: number;

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -292,6 +292,12 @@ ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS host_metrics JSONB;
 ALTER TABLE node_telemetry_current ADD COLUMN IF NOT EXISTS traffic_management_stats JSONB;
 ALTER TABLE nodes ADD COLUMN IF NOT EXISTS last_channel VARCHAR(10);
 
+-- Position datum/provenance: lets the frontend normalize HAE→MSL and flag manual/barometric readings.
+ALTER TABLE node_positions ADD COLUMN IF NOT EXISTS altitude_hae INTEGER;
+ALTER TABLE node_positions ADD COLUMN IF NOT EXISTS altitude_geoidal_separation INTEGER;
+ALTER TABLE node_positions ADD COLUMN IF NOT EXISTS location_source SMALLINT;
+ALTER TABLE node_positions ADD COLUMN IF NOT EXISTS altitude_source SMALLINT;
+
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Discord bridge tables
 -- ─────────────────────────────────────────────────────────────────────────────

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -674,9 +674,10 @@ class PostgresStorage:
         await conn.execute(
             """
             INSERT INTO node_positions (
-                node_id, latitude_i, longitude_i, altitude, time, precision_bits, geocoded, last_geocoding
+                node_id, latitude_i, longitude_i, altitude, time, precision_bits, geocoded, last_geocoding,
+                altitude_hae, altitude_geoidal_separation, location_source, altitude_source
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12)
             ON CONFLICT (node_id) DO UPDATE SET
                 latitude_i = EXCLUDED.latitude_i,
                 longitude_i = EXCLUDED.longitude_i,
@@ -684,7 +685,11 @@ class PostgresStorage:
                 time = EXCLUDED.time,
                 precision_bits = EXCLUDED.precision_bits,
                 geocoded = EXCLUDED.geocoded,
-                last_geocoding = EXCLUDED.last_geocoding
+                last_geocoding = EXCLUDED.last_geocoding,
+                altitude_hae = EXCLUDED.altitude_hae,
+                altitude_geoidal_separation = EXCLUDED.altitude_geoidal_separation,
+                location_source = EXCLUDED.location_source,
+                altitude_source = EXCLUDED.altitude_source
             WHERE
                 -- normal case: only accept newer-or-equal timestamps
                 (EXCLUDED.time IS NOT NULL AND (node_positions.time IS NULL OR EXCLUDED.time >= node_positions.time))
@@ -700,6 +705,10 @@ class PostgresStorage:
             position.get("precision_bits"),
             geocoded,
             last_geocoding,
+            position.get("altitude_hae"),
+            position.get("altitude_geoidal_separation"),
+            position.get("location_source"),
+            position.get("altitude_source"),
         )
 
     async def _write_node_neighborinfo(self, conn, node_id: str, neighborinfo: Dict[str, Any]):
@@ -1488,6 +1497,10 @@ class PostgresStorage:
                                 "altitude": row["altitude"],
                                 "time": row["time"],
                                 "precision_bits": row["precision_bits"],
+                                "altitude_hae": row["altitude_hae"],
+                                "altitude_geoidal_separation": row["altitude_geoidal_separation"],
+                                "location_source": row["location_source"],
+                                "altitude_source": row["altitude_source"],
                                 "geocoded": self._jsonb(row["geocoded"], None),
                                 "last_geocoding": row["last_geocoding"].isoformat() if row["last_geocoding"] else None,
                             }


### PR DESCRIPTION
## Summary 

Fixes false-positive altitude **"suspect"** flags on the node panel and makes altitude
handling datum- and provenance-aware across the app. Two layered commits:

1. **`fix(nodes): gate altitude suspect flag on position precision`**
2. **`feat(nodes): persist altitude datum/source, normalize HAE→MSL in panel + RF`**

Closes #508 

## Background

A correctly-reporting mountain node (ccbacc95, ~2508 m MSL) was flagged "suspect."
Investigation showed the old check compared the reported **MSL** altitude against the
DEM terrain at the node's **broadcast** coordinate and flagged deltas > 50 m. But
Meshtastic's location-privacy (`precision_bits`) truncates lat/lng **without** touching
altitude, so the coordinate lands up to kilometres away and the DEM is sampled in the
wrong place. For ccbacc95 the true terrain (5 independent sources incl. USGS 3DEP) is
~2507 m — the altitude was correct all along; the broadcast coord was ~1.8 km off in a
2155 m valley, producing a bogus +353 m. Also confirmed: Meshtastic never reports AGL —
`Position.altitude` is MSL (with `altitude_hae` as the alternate datum).

## Changes

**Assessment logic (frontend)**
- New pure, unit-tested module `altitudeAssessment.ts` (split from the DEM fetch in
  `groundElevation.ts`).
- **Precision gating:** skip the terrain check when horizontal uncertainty
  (`2^(31−precision_bits) × 0.011132 m`) exceeds ~150 m — you can't validate an altitude
  against terrain you can't locate.
- **Neighborhood DEM:** sample a 3×3 ~75 m box (`{min,max,center}`) to absorb DEM
  under-read on peaks/ridges.
- **Tiered severity:** sentinel (65535) / absurd range / below-terrain = `bad` (amber
  "check"); far-above-terrain = neutral `info` ("note"); softened, non-accusatory UX.

**Datum & provenance (backend + frontend)**
- Persist previously-discarded `altitude_hae`, `altitude_geoidal_separation`,
  `location_source`, `altitude_source` (idempotent `ALTER … ADD COLUMN IF NOT EXISTS`,
  auto-applied on startup; write + read paths + `INodePosition` type). No decode change —
  the fields already rode in the decoded payload.
- Shared helper `effectiveAltitudeMslM()`: uses MSL when present, else converts
  **HAE→MSL** (`MSL = HAE − geoidal_separation`). Applied at **every** reported-altitude
  read site, so **RF benefits too** — LoS, coverage-merge, and scan now use the correct
  datum, not just the node panel.
- Source-aware: **barometric** widens tolerance +60 m; **manual** entries are relabeled
  ("Manually-set altitude: …") but still flagged.

## Verification
- Frontend: 168 tests pass (incl. new precision, HAE-conversion, manual, barometric
  cases), `tsc` clean, ESLint clean.
- Backend: `py_compile` clean; migration verified (4 new columns present); `meshinfo`
  starts cleanly and processes MQTT.

## Limitations (by design)
- HAE *mislabeled into the `altitude` field* (a firmware bug) still can't be detected
  deterministically — precision-gating + the terrain check remain the backstop.
- Datum/source benefits only nodes that actually send those fields; many minimal packets
  omit them, and there's no historical backfill (accrues going forward).
