### PR TITLE
fix(map): stop spurious spiderfy collapse; fan click priority + geometry fixes (#514)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -38,17 +38,21 @@ import { type PacketArc, PacketCoalescer, type RawPacket } from "./map/packetCoa
 import { packetColor } from "./map/packetColors";
 import { findPathsBetween } from "./map/pathAnalysis";
 import {
+  anyIdsFanned,
   autoSpiderfyOverlappingPlainNodes,
   autoSpiderfyVisibleClusters,
+  dismissClusterSpiderfy,
   dismissPlainSpiderfy,
+  getActiveFanCenters,
   isSpiderfied,
   removeSpiderfyLayers,
   spiderfy,
   SPIDERFY_LAYER_LABELS,
+  SPIDERFY_LAYER_LEGS,
+  SPIDERFY_LAYER_LEGS_SHADOW,
   SPIDERFY_LAYER_NODES,
   SPIDERFY_SOURCE_NODES,
   spiderfyFeatures,
-  unspiderfy,
   updateSpiderfyPositions,
 } from "./map/spiderfy";
 import { LS_KEYS, readJson, writeJson } from "./map/storage";
@@ -1797,6 +1801,12 @@ export function Map() {
       bindFocusHover("unclustered-nodes");
       bindFocusHover("plain-nodes");
 
+      // True when the click point lands on a fanned spiderfy marker — those
+      // clicks must win over the layers still rendered underneath the fan.
+      const hitsSpiderfyNode = (point: maplibregl.Point): boolean =>
+        !!map.getLayer(SPIDERFY_LAYER_NODES) &&
+        map.queryRenderedFeatures(point, { layers: [SPIDERFY_LAYER_NODES] }).length > 0;
+
       // Cluster click — handler is on the invisible circle hit-test layer
       // ("clusters"), NOT the symbol donut layer. Circle hit-testing is reliable
       // geometry; symbol hit-testing is flaky with dynamic icon-size expressions.
@@ -1804,11 +1814,30 @@ export function Map() {
         const cluster = e.features?.[0];
         if (!cluster) return;
 
+        // Spiral fans put inner leaves inside the donut's hit circle — let the
+        // leaf click be handled by onNodeLayerClick instead of re-spiderfying.
+        if (hitsSpiderfyNode(e.point)) return;
+
         const clusterId = cluster.properties?.cluster_id;
         const source = map.getSource("nodes_clustered") as MlGeoJSONSource;
         if (!source || clusterId == null) return;
 
         const [lng, lat] = (cluster.geometry as any).coordinates as [number, number];
+
+        // Re-clicking the fanned cluster's own donut toggles the fan closed
+        // instead of wiping the selection and re-animating it.
+        if (isSpiderfied(map)) {
+          const b = map.project([lng, lat]);
+          const isActiveFan = getActiveFanCenters().some((c) => {
+            const a = map.project(c);
+            return Math.hypot(a.x - b.x, a.y - b.y) < 10;
+          });
+          if (isActiveFan) {
+            dismissClusterSpiderfy(map);
+            return;
+          }
+        }
+
         const currentZoom = map.getZoom();
         const maxZoom = map.getMaxZoom();
 
@@ -1819,7 +1848,8 @@ export function Map() {
           removeSpiderfyLayers(map);
           map.easeTo({ center: [lng, lat], zoom: Math.min(currentZoom + 2, maxZoom) });
         };
-        // getClusterExpansionZoom can be slow on first call; don't discard a slightly-late answer.
+        // getClusterExpansionZoom can be slow (or hang on a stale cluster_id
+        // after setData); fall back to a plain zoom-in if no answer in time.
         const timer = setTimeout(zoomFallback, 600);
 
         source.getClusterExpansionZoom(clusterId).then((zoom) => {
@@ -1837,7 +1867,7 @@ export function Map() {
             const pool = buildNodesGeoJSON(nodesRef.current, recentDaysRef.current, getFilters()).features
               .filter((f) => f.geometry?.type === "Point") as any;
             const count = (cluster.properties?.point_count as number) ?? 0;
-            void spiderfy(map, clusterId, [lng, lat], currentZoom, true, pool, count);
+            void spiderfy(map, clusterId, [lng, lat], true, pool, count);
           } else {
             // Ensure the zoom change is always perceptible. getClusterExpansionZoom
             // can return values only a tiny delta above current zoom, making the
@@ -1969,23 +1999,37 @@ export function Map() {
         // Clustering OFF: co-located nodes stack so only the top one is
         // clickable. If several overlap at the click, fan them out instead of
         // selecting whichever rendered on top. (#475)
-        if (!clusterEnabledRef.current && !isSpiderfied(map)) {
+        if (!clusterEnabledRef.current) {
           const overlap = findOverlappingPlainNodes(e.point);
           if (overlap.length >= 2) {
+            const ids = overlap.map((f) => (f.properties?.id ?? "") as string);
+            // Clicking the stacked originals under an open fan: keep the fan
+            // and let the user pick a leaf instead of re-fanning.
+            if (anyIdsFanned(ids)) return;
             const center: [number, number] = [
               circularMeanLng(overlap.map((f) => f.geometry.coordinates[0])),
               overlap.reduce((s, f) => s + f.geometry.coordinates[1], 0) / overlap.length,
             ];
-            void spiderfyFeatures(map, center, overlap as any, map.getZoom(), true);
+            void spiderfyFeatures(map, center, overlap as any, true);
             return;
           }
         }
 
         void handleNodeClick(id);
       };
-      map.on("click", "unclustered-nodes", onNodeLayerClick);
-      map.on("click", "plain-nodes", onNodeLayerClick);
+      // The base layers keep rendering under an open fan; when a click lands on
+      // a fanned marker, only the spiderfy binding may handle it (else one click
+      // selects two different nodes or double-consumes a tool pick).
+      map.on("click", "unclustered-nodes", (e) => {
+        if (!hitsSpiderfyNode(e.point)) onNodeLayerClick(e);
+      });
+      map.on("click", "plain-nodes", (e) => {
+        if (!hitsSpiderfyNode(e.point)) onNodeLayerClick(e);
+      });
       map.on("click", SPIDERFY_LAYER_NODES, onNodeLayerClick);
+      map.on("click", SPIDERFY_LAYER_LABELS, (e) => {
+        if (!hitsSpiderfyNode(e.point)) onNodeLayerClick(e);
+      });
 
       // Virtual-origin click (coverage, scan, LOS tools). Fires when the
       // user clicks empty map during pick mode — drops a synthetic pin at
@@ -2027,16 +2071,23 @@ export function Map() {
         const nodeLayers = ["unclustered-nodes", "plain-nodes", "unclustered-labels", "plain-labels"];
         if (map.getLayer(SPIDERFY_LAYER_NODES)) nodeLayers.push(SPIDERFY_LAYER_NODES);
         if (map.getLayer(SPIDERFY_LAYER_LABELS)) nodeLayers.push(SPIDERFY_LAYER_LABELS);
+        if (map.getLayer(SPIDERFY_LAYER_LEGS)) nodeLayers.push(SPIDERFY_LAYER_LEGS, SPIDERFY_LAYER_LEGS_SHADOW);
 
-        const hitNode = map.queryRenderedFeatures(e.point, { layers: nodeLayers }).length > 0;
+        // Small pad so a near-miss while aiming at a fan marker doesn't count
+        // as "empty space" and nuke the whole fan.
+        const PAD = 4;
+        const bbox: [maplibregl.PointLike, maplibregl.PointLike] = [
+          [e.point.x - PAD, e.point.y - PAD],
+          [e.point.x + PAD, e.point.y + PAD],
+        ];
+        const hitNode = map.queryRenderedFeatures(bbox, { layers: nodeLayers }).length > 0;
         const hitCluster =
-          map.queryRenderedFeatures(e.point, { layers: ["clusters"] }).length > 0;
+          map.queryRenderedFeatures(bbox, { layers: ["clusters"] }).length > 0;
         if (hitNode || hitCluster) return;
 
-        // Clustering off: fans are automatic, so dismiss-and-remember (the auto
-        // pass won't immediately re-open the same set). Clustering on: a cluster
-        // donut stays put, so a plain collapse is fine.
-        if (clusterEnabledRef.current) void unspiderfy(map);
+        // Dismiss-and-remember in both modes so the auto pass won't immediately
+        // re-open the set the user just closed.
+        if (clusterEnabledRef.current) dismissClusterSpiderfy(map);
         else dismissPlainSpiderfy(map);
         clearMapboxSelectionAndOverlays();
       });
@@ -2151,7 +2202,9 @@ export function Map() {
               resetTool();
               break;
             }
-            void unspiderfy(map);
+            // Same dismiss-and-remember as the empty-click path, per mode.
+            if (clusterEnabledRef.current) dismissClusterSpiderfy(map);
+            else dismissPlainSpiderfy(map);
             clearMapboxSelectionAndOverlays();
             break;
           case "ArrowLeft":
@@ -2352,6 +2405,9 @@ export function Map() {
         mbTouchCleanupRef.current = null;
       }
       if (mbMapRef.current) {
+        // Reset the spiderfy module state before the map dies — it's module-
+        // global and would otherwise leak a phantom fan into the next mount.
+        removeSpiderfyLayers(mbMapRef.current);
         mbMapRef.current.remove();
         mbMapRef.current = null;
         mbSelectedIdRef.current = null;
@@ -2390,6 +2446,9 @@ export function Map() {
       setDetailsData(null);
       const linksSource = map.getSource("links") as MlGeoJSONSource | undefined;
       linksSource?.setData(emptyLineFeatureCollection());
+      // setStyle wipes the fan layers; reset the module state with them or the
+      // auto passes stay blocked on a fan that no longer exists.
+      removeSpiderfyLayers(map);
 
       map.setStyle(buildMapStyle({ provider, osmBasemap, mapboxToken, mapboxStyle }));
     } catch {}

--- a/frontend/src/pages/map/spiderfy.ts
+++ b/frontend/src/pages/map/spiderfy.ts
@@ -35,14 +35,27 @@ interface SpiderfyGroup {
 interface SpiderfyState {
   groups: SpiderfyGroup[];
   lastZoom: number;
+  /** How the fan was opened. Auto fans obey the zoom floor and the reconcile
+   *  pass; click fans are pinned until the user dismisses them (#514). */
+  origin: "click" | "auto";
+  /** Zoom at open time — click fans collapse only when zooming out below it. */
+  openZoom: number;
 }
 
 let activeState: SpiderfyState | null = null;
 
-// Signature of a fan set the user explicitly dismissed (clustering-off). The
-// auto pass refuses to re-fan exactly this set until it changes, so dismissing
-// sticks instead of popping straight back open on the next pan.
+// Signature of a fan set the user explicitly dismissed. The auto passes refuse
+// to re-fan exactly this set until it changes, so dismissing sticks instead of
+// popping straight back open on the next pan/idle.
 let dismissedSignature: string | null = null;
+
+// True while unspiderfy's collapse animation runs — auto passes must not
+// re-fan (or tear down) mid-collapse.
+let collapsing = false;
+
+// Single-flight guard: the clustering-ON auto pass awaits per-cluster worker
+// round-trips and must not overlap itself.
+let clusterPassBusy = false;
 
 /** Stable signature of a set of fanned node ids (order-independent). */
 function groupsSignature(groups: SpiderfyGroup[]): string {
@@ -53,20 +66,28 @@ function groupsSignature(groups: SpiderfyGroup[]): string {
     .join(",");
 }
 
+// MapLibre GL's world is 512px at z0 (not 256 as in classic slippy-map math).
 function pixelsToDegrees(pixels: number, zoom: number): number {
-  return (pixels / (256 * Math.pow(2, zoom))) * 360;
+  return (pixels / (512 * Math.pow(2, zoom))) * 360;
+}
+
+/** Longitude degrees shrink by cos(lat) on screen; widen lng offsets so fans
+ *  stay round away from the equator. */
+function lngScaleAt(lat: number): number {
+  return 1 / Math.max(0.2, Math.cos((lat * Math.PI) / 180));
 }
 
 function circlePositions(
   center: [number, number],
   count: number,
   zoom: number,
-  radiusPx = 40,
+  radiusPx = 80,
 ): [number, number][] {
   const r = pixelsToDegrees(radiusPx, zoom);
+  const kx = lngScaleAt(center[1]);
   return Array.from({ length: count }, (_, i) => {
     const a = (2 * Math.PI * i) / count - Math.PI / 2;
-    return [center[0] + r * Math.cos(a), center[1] + r * Math.sin(a)] as [number, number];
+    return [center[0] + r * Math.cos(a) * kx, center[1] + r * Math.sin(a)] as [number, number];
   });
 }
 
@@ -74,12 +95,13 @@ function spiralPositions(
   center: [number, number],
   count: number,
   zoom: number,
-  basePx = 30,
+  basePx = 60,
 ): [number, number][] {
+  const kx = lngScaleAt(center[1]);
   return Array.from({ length: count }, (_, i) => {
     const a = i * GOLDEN_ANGLE;
     const r = pixelsToDegrees(basePx * Math.sqrt(i + 1), zoom);
-    return [center[0] + r * Math.cos(a), center[1] + r * Math.sin(a)] as [number, number];
+    return [center[0] + r * Math.cos(a) * kx, center[1] + r * Math.sin(a)] as [number, number];
   });
 }
 
@@ -183,6 +205,25 @@ function tryGetLeaves(
 
 /** Fallback: find N nearest nodes to `center` from a caller-supplied raw node pool
  *  (needed because querySourceFeatures hides features inside clusters). */
+// ~2km proximity cap (degrees², lng cos-corrected) for leaf plausibility.
+const LEAF_MAX_D2 = 0.02 * 0.02;
+
+function leafDist2(center: [number, number], f: GeoFeature<GeoPoint, GeoJsonProperties>): number {
+  const c = (f.geometry as GeoPoint).coordinates;
+  const dx = (c[0] - center[0]) * Math.cos((center[1] * Math.PI) / 180);
+  const dy = c[1] - center[1];
+  return dx * dx + dy * dy;
+}
+
+/** Drop leaves implausibly far from the cluster center — a stale cluster_id
+ *  after setData can silently resolve to a different cluster's members. */
+function leavesNear(
+  leaves: GeoFeature<GeoPoint, GeoJsonProperties>[],
+  center: [number, number],
+): GeoFeature<GeoPoint, GeoJsonProperties>[] {
+  return leaves.filter((f) => leafDist2(center, f) < LEAF_MAX_D2);
+}
+
 function findLeavesNearCenter(
   pool: GeoFeature<GeoPoint, GeoJsonProperties>[] | undefined,
   center: [number, number],
@@ -190,19 +231,12 @@ function findLeavesNearCenter(
 ): GeoFeature<GeoPoint, GeoJsonProperties>[] {
   if (!pool || pool.length === 0) return [];
   const withDist = pool
-    .map((f) => {
-      const c = (f.geometry as GeoPoint).coordinates;
-      const dx = c[0] - center[0];
-      const dy = c[1] - center[1];
-      return { f, d2: dx * dx + dy * dy };
-    })
+    .map((f) => ({ f, d2: leafDist2(center, f) }))
     .sort((a, b) => a.d2 - b.d2);
   const n = Math.max(1, Math.min(pointCount || withDist.length, withDist.length));
-  // Cap at ~2km (degrees² at equator) so we don't grab distant nodes on an invalid cluster
-  const maxD2 = 0.02 * 0.02;
   return withDist
     .slice(0, n)
-    .filter((x) => x.d2 < maxD2)
+    .filter((x) => x.d2 < LEAF_MAX_D2)
     .map((x) => x.f);
 }
 
@@ -304,9 +338,11 @@ function renderSpiderfy(
   groups: SpiderfyGroup[],
   zoom: number,
   animate: boolean,
+  origin: "click" | "auto",
 ): Promise<void> {
   const fresh = !isSpiderfied(map);
-  activeState = { groups, lastZoom: zoom };
+  const state: SpiderfyState = { groups, lastZoom: zoom, origin, openZoom: zoom };
+  activeState = state;
   if (fresh) addSpiderfyLayers(map);
 
   if (!animate || !fresh || prefersReducedMotion()) {
@@ -317,6 +353,11 @@ function renderSpiderfy(
   return new Promise<void>((resolve) => {
     const start = performance.now();
     function frame(now: number) {
+      // A newer render/teardown owns the sources now — stop writing stale frames.
+      if (activeState !== state) {
+        resolve();
+        return;
+      }
       const t = Math.min((now - start) / ANIMATE_MS, 1);
       if (!applyData(map, composeData(groups, zoom, t))) {
         removeSpiderfyLayers(map);
@@ -334,19 +375,19 @@ export async function spiderfy(
   map: MlMap,
   clusterId: number,
   center: [number, number],
-  zoom: number,
   animate = true,
   /** Raw node features used as fallback when the cluster API fails. */
   fallbackPool?: GeoFeature<GeoPoint, GeoJsonProperties>[],
   /** Expected member count — sizes the fallback result. */
   pointCount?: number,
+  origin: "click" | "auto" = "click",
 ): Promise<void> {
-  removeSpiderfyLayers(map);
-
   const source = map.getSource("nodes_clustered") as MlGeoJSONSource | undefined;
   if (!source) return;
 
-  let leaves = await tryGetLeaves(source, clusterId);
+  // Resolve leaves BEFORE touching the existing fan, so a failed or stale
+  // lookup never leaves the map fanless.
+  let leaves = leavesNear(await tryGetLeaves(source, clusterId), center);
 
   if (leaves.length === 0) {
     leaves = findLeavesNearCenter(fallbackPool, center, pointCount ?? 0);
@@ -354,7 +395,15 @@ export async function spiderfy(
 
   if (leaves.length === 0) return;
 
-  return renderSpiderfy(map, [{ center, leaves }], zoom, animate);
+  if (origin === "auto") {
+    // A fan opened (or a dismissal started) during the async lookup wins.
+    if (activeState || collapsing) return;
+    // Don't re-fan the set the user just dismissed.
+    if (groupsSignature([{ center, leaves }]) === dismissedSignature) return;
+  }
+
+  removeSpiderfyLayers(map);
+  return renderSpiderfy(map, [{ center, leaves }], map.getZoom(), animate, origin);
 }
 
 /** Spiderfy an explicit set of co-located features. Used when clustering is OFF
@@ -364,19 +413,23 @@ export async function spiderfyFeatures(
   map: MlMap,
   center: [number, number],
   leaves: GeoFeature<GeoPoint, GeoJsonProperties>[],
-  zoom: number,
   animate = true,
 ): Promise<void> {
-  removeSpiderfyLayers(map);
   if (leaves.length === 0) return;
-  return renderSpiderfy(map, [{ center, leaves }], zoom, animate);
+  removeSpiderfyLayers(map);
+  return renderSpiderfy(map, [{ center, leaves }], map.getZoom(), animate, "click");
 }
 
 export async function unspiderfy(map: MlMap): Promise<void> {
-  if (!isSpiderfied(map)) return;
+  if (!isSpiderfied(map)) {
+    // Layers can vanish without us (style swap, map teardown) — don't let the
+    // stale module state block every future auto pass.
+    activeState = null;
+    return;
+  }
 
   const state = activeState;
-  if (!state || !map.getSource(SPIDERFY_SOURCE_NODES)) {
+  if (!state) {
     removeSpiderfyLayers(map);
     return;
   }
@@ -386,18 +439,28 @@ export async function unspiderfy(map: MlMap): Promise<void> {
 
   if (prefersReducedMotion()) { removeSpiderfyLayers(map); return; }
 
+  collapsing = true;
   return new Promise<void>((resolve) => {
     const start = performance.now();
     const duration = ANIMATE_MS * 0.7;
+    const finish = (removeLayers: boolean) => {
+      collapsing = false;
+      if (removeLayers) removeSpiderfyLayers(map);
+      resolve();
+    };
     function frame(now: number) {
+      // A new fan took ownership mid-collapse — stop without destroying it.
+      if (activeState !== null) {
+        finish(false);
+        return;
+      }
       const t = Math.min((now - start) / duration, 1);
       if (!applyData(map, composeData(groups, zoom, 1 - t))) {
-        removeSpiderfyLayers(map);
-        resolve();
+        finish(true);
         return;
       }
       if (t < 1) requestAnimationFrame(frame);
-      else { removeSpiderfyLayers(map); resolve(); }
+      else finish(true);
     }
     requestAnimationFrame(frame);
   });
@@ -411,11 +474,28 @@ export function dismissPlainSpiderfy(map: MlMap): void {
   dismissedSignature = sig; // ...then record what was dismissed
 }
 
+/** Clustering-ON analogue: animated collapse that also remembers the dismissed
+ *  set, so the auto pass can't re-fan the cluster the user just closed. */
+export function dismissClusterSpiderfy(map: MlMap): void {
+  const sig = activeState ? groupsSignature(activeState.groups) : null;
+  void unspiderfy(map).then(() => {
+    // Only record if nothing new opened while the collapse animation ran.
+    if (sig && !activeState) dismissedSignature = sig;
+  });
+}
+
 export function updateSpiderfyPositions(map: MlMap): void {
   if (!activeState || !isSpiderfied(map)) return;
 
   const zoom = map.getZoom();
-  if (zoom < AUTO_SPIDERFY_MIN_ZOOM) {
+  // Auto fans obey the auto-pass zoom floor. Click fans survive until the user
+  // zooms out below where they opened (cluster membership changes down there);
+  // the 0.5 buffer absorbs pinch/trackpad jitter around the open zoom (#514).
+  const floor =
+    activeState.origin === "auto"
+      ? AUTO_SPIDERFY_MIN_ZOOM
+      : Math.min(activeState.openZoom - 0.5, AUTO_SPIDERFY_MIN_ZOOM);
+  if (zoom < floor) {
     removeSpiderfyLayers(map);
     return;
   }
@@ -430,12 +510,11 @@ export async function autoSpiderfyVisibleClusters(
   map: MlMap,
   fallbackPool?: GeoFeature<GeoPoint, GeoJsonProperties>[],
 ): Promise<void> {
-  if (activeState) return;
+  if (clusterPassBusy || collapsing || activeState) return;
   if (!map.getLayer("clusters")) return;
 
   const maxZoom = map.getMaxZoom();
-  const currentZoom = map.getZoom();
-  if (currentZoom < AUTO_SPIDERFY_MIN_ZOOM) return;
+  if (map.getZoom() < AUTO_SPIDERFY_MIN_ZOOM) return;
 
   const clusterFeatures = map.queryRenderedFeatures({ layers: ["clusters"] });
   if (clusterFeatures.length === 0) return;
@@ -443,37 +522,47 @@ export async function autoSpiderfyVisibleClusters(
   const source = map.getSource("nodes_clustered") as MlGeoJSONSource | undefined;
   if (!source) return;
 
-  for (const cluster of clusterFeatures) {
-    const clusterId = cluster.properties?.cluster_id;
-    if (clusterId == null) continue;
+  clusterPassBusy = true;
+  try {
+    for (const cluster of clusterFeatures) {
+      const clusterId = cluster.properties?.cluster_id;
+      if (clusterId == null) continue;
 
-    // Timeout guards against stale cluster_ids after setData
-    const expansionZoom = await new Promise<number | null>((resolve) => {
-      let done = false;
-      const timer = setTimeout(() => { if (!done) { done = true; resolve(null); } }, 500);
-      try {
-        source.getClusterExpansionZoom(clusterId).then((zoom) => {
-          if (done) return;
-          done = true;
-          clearTimeout(timer);
-          resolve(zoom ?? null);
-        }).catch(() => {
-          if (done) return;
-          done = true;
-          clearTimeout(timer);
-          resolve(null);
-        });
-      } catch { if (!done) { done = true; clearTimeout(timer); resolve(null); } }
-    });
+      // Timeout guards against stale cluster_ids after setData
+      const expansionZoom = await new Promise<number | null>((resolve) => {
+        let done = false;
+        const timer = setTimeout(() => { if (!done) { done = true; resolve(null); } }, 500);
+        try {
+          source.getClusterExpansionZoom(clusterId).then((zoom) => {
+            if (done) return;
+            done = true;
+            clearTimeout(timer);
+            resolve(zoom ?? null);
+          }).catch(() => {
+            if (done) return;
+            done = true;
+            clearTimeout(timer);
+            resolve(null);
+          });
+        } catch { if (!done) { done = true; clearTimeout(timer); resolve(null); } }
+      });
 
-    if (expansionZoom == null) continue;
+      // Revalidate after every await: a manual fan, a dismissal, or a zoom-out
+      // during the worker round-trip means this pass is stale — never stomp it.
+      if (activeState || collapsing) return;
+      if (map.getZoom() < AUTO_SPIDERFY_MIN_ZOOM) return;
 
-    if (expansionZoom >= maxZoom) {
-      const [lng, lat] = (cluster.geometry as any).coordinates as [number, number];
-      const count = (cluster.properties?.point_count as number) ?? 0;
-      await spiderfy(map, clusterId, [lng, lat], currentZoom, true, fallbackPool, count);
-      return;
+      if (expansionZoom == null) continue;
+
+      if (expansionZoom >= maxZoom) {
+        const [lng, lat] = (cluster.geometry as any).coordinates as [number, number];
+        const count = (cluster.properties?.point_count as number) ?? 0;
+        await spiderfy(map, clusterId, [lng, lat], true, fallbackPool, count, "auto");
+        return;
+      }
     }
+  } finally {
+    clusterPassBusy = false;
   }
 }
 
@@ -501,6 +590,11 @@ function groupFromIndices(
  *  Reconciles on each call — new stacks fan in, separated ones collapse — and
  *  skips re-rendering when the set is unchanged or was just dismissed. */
 export async function autoSpiderfyOverlappingPlainNodes(map: MlMap): Promise<void> {
+  if (collapsing) return;
+  // A click-opened fan is pinned: only the user (click-away, Escape, zoom-out)
+  // closes it — never a reconcile pass triggered by hover repaints or SSE data
+  // ticks (#514).
+  if (activeState?.origin === "click") return;
   if (!map.getLayer("plain-nodes")) return;
 
   const currentZoom = map.getZoom();
@@ -549,6 +643,10 @@ export async function autoSpiderfyOverlappingPlainNodes(map: MlMap): Promise<voi
   if (nextSig === currentSig) return; // already showing exactly this set
   if (nextSig === dismissedSignature) return; // user just dismissed this set
 
+  // A mid-load render (pan/setData retile) yields a partial snapshot; never
+  // reshape or collapse a fan on one — the next idle pass sees the full set.
+  if (!map.areTilesLoaded()) return;
+
   dismissedSignature = null; // the overlap set changed — old dismissal is stale
   if (groups.length === 0) {
     removeSpiderfyLayers(map);
@@ -556,5 +654,21 @@ export async function autoSpiderfyOverlappingPlainNodes(map: MlMap): Promise<voi
   }
   // Animate only the first fan; later reconciles swap data in place so existing
   // fans don't re-expand and the selection highlight survives.
-  await renderSpiderfy(map, groups, currentZoom, !activeState);
+  await renderSpiderfy(map, groups, currentZoom, !activeState, "auto");
+}
+
+/** True when any of the given node ids is currently fanned out. */
+export function anyIdsFanned(ids: string[]): boolean {
+  if (!activeState) return false;
+  const fanned = new Set(
+    activeState.groups.flatMap((g) =>
+      g.leaves.map((l) => l.properties?.id as string | undefined),
+    ),
+  );
+  return ids.some((id) => id && fanned.has(id));
+}
+
+/** Centers of the currently fanned groups (empty when nothing is fanned). */
+export function getActiveFanCenters(): [number, number][] {
+  return activeState ? activeState.groups.map((g) => g.center) : [];
 }


### PR DESCRIPTION
## Summary

Fixes #514 — spiderfied markers collapsed on cursor movement or after a short timeout,
making individual nodes hard to select. A deep review of the spiderfy system confirmed
the collapse was multi-causal: the auto-spiderfy pass runs on every `idle` event, and
this map idles constantly (hover repaints, SSE `last_seen` updates calling `setData`),
so several teardown paths fired with no click and no deliberate view change.

## Root causes fixed

- **Zoom-14 floor destroyed click-opened fans.** Fans open via click at any zoom, but two
  teardown sites removed any fan below z14. With clustering off below z14, a fan
  self-destructed ~0.5s after opening (its own animation settling fires `idle`).
- **Grouping mismatch (clustering off).** The click path could fan pairs the reconcile
  pass's stricter 16px rule couldn't reproduce, so the next idle collapsed/reshaped them.
- **Teardown-before-lookup.** `spiderfy()` removed the old fan before awaiting
  `getClusterLeaves`, which fails on cluster IDs invalidated by SSE `setData` — leaving
  nothing behind.
- **Races.** The cluster auto pass validated state only at entry, then awaited up to
  500ms/cluster and could stomp a fan the user just opened; stale collapse-animation
  frames could overwrite and destroy a newer fan.
- **Click priority.** Spiral fans put inner leaves inside the cluster's invisible hit
  circle, so clicking a leaf also fired the cluster handler — wiping selection, closing
  the panel, re-animating the fan (or zooming away via the 600ms fallback).

## Changes

- `SpiderfyState` tracks fan origin (`click` | `auto`): click fans are pinned — only
  click-away, Escape, selecting a node, or zooming out below the open zoom dismisses
  them; auto passes can no longer touch them. Zoom floor applies to auto fans only.
- Leaves resolve before the existing fan is torn down; results are proximity-validated
  against stale cluster IDs, with the nearest-nodes fallback now cos(lat)-corrected.
- Animation loops carry identity guards; auto passes are single-flight and revalidate
  after every await; `collapsing` flag prevents re-fan races mid-dismissal.
- Dismissal memory now works in cluster mode too (`dismissClusterSpiderfy`) — previously
  a dismissed cluster fan popped straight back open on the next idle pass. Escape now
  uses the same dismiss-and-remember as click-away in both modes.
- Fan-leaf clicks win over the donut/stacked originals underneath; re-clicking the
  fanned donut toggles the fan closed; fan labels are clickable; empty-click dismissal
  ignores fan legs and near-misses (±4px pad).
- Geometry: `pixelsToDegrees` used a 256px world tile — MapLibre 5 uses 512, so fans
  rendered 2× the requested radius; lng offsets now cos(lat)-corrected so fans stay
  round at all latitudes (constants doubled to preserve the shipped visual size).
- Style switches and unmount now reset spiderfy module state — a basemap swap previously
  left a phantom fan that silently disabled auto-spiderfy until reload.

## Testing

- `tsc --noEmit`, ESLint, and the full vitest suite (168 tests) pass.
- Manually exercised in the dev container: click-fan at low zoom survives hover/SSE
  churn; empty-click/Escape dismissal sticks in both clustering modes; leaf selection
  no longer wipes the panel.
