### PR TITLE
fix(map): overhaul of the coverage, LOS, and scan tools — determinism, worker-offloaded rasters, and RF/UX fixes

### DIFF
--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -16,7 +16,8 @@ declare global {
 }
 
 function get(key: keyof RuntimeEnv): string | undefined {
-  const runtime = window.__env__?.[key];
+  // globalThis, not window — this module is also imported by web workers
+  const runtime = (globalThis as { __env__?: RuntimeEnv }).__env__?.[key];
   if (runtime) return runtime;
   const buildTime = import.meta.env[key];
   return buildTime || undefined;

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -20,7 +20,7 @@ import { ActivityLayer } from "./map/activityLayer";
 import { ClusterDonutLayer } from "./map/clusterDonutLayer";
 import { type ClusterHover,ClusterHoverCard } from "./map/ClusterHoverCard";
 import { FiltersResetPill } from "./map/FiltersResetPill";
-import { circularMeanLng } from "./map/geo";
+import { circularMeanLng, normalizeLng } from "./map/geo";
 import { bestSnr, computeMaxRange, formatLatLng, geodesicCircleCoords, mbRoleColorExpr, queryTerrainElevationMSL, relativeTime, signalBarsHtml, TRANSPARENT_1PX_PNG } from "./map/helpers";
 import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId } from "./map/linkFeatures";
 import { LosTubeLayer } from "./map/losTubeLayer";
@@ -425,6 +425,7 @@ export function Map() {
     setLosDemSource: losState.setLosDemSource,
     setLosError: losState.setLosError,
     setIsComputingLos: losState.setIsComputingLos,
+    setLosTerrainWarning: losState.setLosTerrainWarning,
   });
 
   // Scan compute + per-class visibility + clear-on-tool-change + hover effects
@@ -2084,11 +2085,12 @@ export function Map() {
           map.getCanvas().style.cursor = "";
         } else if (t === "los" && step === "pickFrom") {
           setToolFromId(null);
-          losState.setLosVirtualFrom([e.lngLat.lng, e.lngLat.lat]);
+          // normalizeLng: clicks on a wrapped world copy give lngs outside ±180
+          losState.setLosVirtualFrom([normalizeLng(e.lngLat.lng), e.lngLat.lat]);
           setToolStep("pickTo");
         } else if (t === "los" && step === "pickTo") {
           setToolToId(null);
-          losState.setLosVirtualTo([e.lngLat.lng, e.lngLat.lat]);
+          losState.setLosVirtualTo([normalizeLng(e.lngLat.lng), e.lngLat.lat]);
           setToolStep("result");
           map.getCanvas().style.cursor = "";
         }
@@ -2967,6 +2969,7 @@ export function Map() {
           isComputing={terrain3D && !losState.losResult && !losState.losError}
           isRecomputing={losState.isComputingLos && !!losState.losResult}
           error={losState.losError}
+          terrainWarning={losState.losTerrainWarning}
           fromHwIdx={losState.losFromHwIdx} onFromHwIdxChange={losState.setLosFromHwIdx}
           fromAntIdx={losState.losFromAntIdx} onFromAntIdxChange={losState.setLosFromAntIdx}
           fromHeightM={losState.losFromHeightM} onFromHeightChange={losState.setLosFromHeightM}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -5,6 +5,7 @@ import maplibregl, {
   Map as MlMap,
 } from "maplibre-gl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 
 import { toast } from "../components/toastStore";
 import { env } from "../env";
@@ -413,6 +414,18 @@ export function Map() {
     }
   }, [isPickingNode]);
 
+  // Dragging an endpoint marker detaches any node anchor into a virtual pin
+  const { setLosVirtualFrom, setLosVirtualTo } = losState;
+  const onLosEndpointDragged = useCallback((which: "from" | "to", pos: [number, number]) => {
+    if (which === "from") {
+      setToolFromId(null);
+      setLosVirtualFrom(pos);
+    } else {
+      setToolToId(null);
+      setLosVirtualTo(pos);
+    }
+  }, [setToolFromId, setToolToId, setLosVirtualFrom, setLosVirtualTo]);
+
   // LOS compute + tube layer effects
   const losCompute = useLosCompute({
     activeTool, toolStep, toolFromId, toolToId,
@@ -424,6 +437,8 @@ export function Map() {
     terrain3D, styleEpoch, nodes,
     losResult: losState.losResult,
     mbMapRef, losTubeLayerRef,
+    isDraggingMarkerRef,
+    onEndpointDragged: onLosEndpointDragged,
     setLosResult: losState.setLosResult,
     setLosDemSource: losState.setLosDemSource,
     setLosError: losState.setLosError,
@@ -495,6 +510,10 @@ export function Map() {
     losCompute.losDemCacheRef.current = null;
     losCompute.losHoverMarkerRef.current?.remove();
     losCompute.losHoverMarkerRef.current = null;
+    losCompute.losFromMarkerRef.current?.remove();
+    losCompute.losFromMarkerRef.current = null;
+    losCompute.losToMarkerRef.current?.remove();
+    losCompute.losToMarkerRef.current = null;
     losState.setLosResult(null);
     losState.setLosError(null);
     losState.setLosTerrainWarning(null);
@@ -590,6 +609,72 @@ export function Map() {
     setToolToId(null);
     losState.setLosVirtualTo(pos);
   };
+
+  // Shareable LOS deep link: keep ?tool=los&from&to&fh&th&fq in sync with the analysis
+  const [, setSearchParamsLos] = useSearchParams();
+  const setSearchParamsLosRef = useRef(setSearchParamsLos);
+  setSearchParamsLosRef.current = setSearchParamsLos;
+  useEffect(() => {
+    const showing =
+      activeTool === "los" && toolStep === "result" &&
+      (toolFromId || losState.losVirtualFrom) && (toolToId || losState.losVirtualTo);
+    setSearchParamsLosRef.current((prev) => {
+      const sp = new URLSearchParams(prev);
+      const had = sp.get("tool") === "los";
+      if (showing) {
+        sp.set("tool", "los");
+        sp.set("from", toolFromId ?? `${losState.losVirtualFrom![1].toFixed(5)},${losState.losVirtualFrom![0].toFixed(5)}`);
+        sp.set("to", toolToId ?? `${losState.losVirtualTo![1].toFixed(5)},${losState.losVirtualTo![0].toFixed(5)}`);
+        sp.set("fh", String(losState.losFromHeightM));
+        sp.set("th", String(losState.losToHeightM));
+        sp.set("fq", String(losState.losFreqMhz));
+      } else if (had) {
+        for (const k of ["tool", "from", "to", "fh", "th", "fq"]) sp.delete(k);
+      } else {
+        return prev;
+      }
+      return sp;
+    }, { replace: true });
+  }, [activeTool, toolStep, toolFromId, toolToId, losState.losVirtualFrom, losState.losVirtualTo, losState.losFromHeightM, losState.losToHeightM, losState.losFreqMhz]);
+
+  // Restore a shared LOS analysis from the URL (once, on mount)
+  const losUrlRestoredRef = useRef(false);
+  useEffect(() => {
+    if (losUrlRestoredRef.current) return;
+    losUrlRestoredRef.current = true;
+    const sp = new URLSearchParams(window.location.search);
+    if (sp.get("tool") !== "los") return;
+    const parseEnd = (v: string | null): { id: string } | { pos: [number, number] } | null => {
+      if (!v) return null;
+      const m = v.match(/^(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)$/);
+      if (m) {
+        const lat = Number(m[1]);
+        const lng = Number(m[2]);
+        return Math.abs(lat) <= 90 && Math.abs(lng) <= 180 ? { pos: [lng, lat] } : null;
+      }
+      return /^!?[0-9a-zA-Z_-]{1,32}$/.test(v) ? { id: v.replace(/^!/, "") } : null;
+    };
+    const f = parseEnd(sp.get("from"));
+    const t = parseEnd(sp.get("to"));
+    if (!f || !t) return;
+    const num = (k: string, min: number, max: number): number | null => {
+      const raw = sp.get(k);
+      if (raw == null) return null;
+      const n = Number(raw);
+      return Number.isFinite(n) ? Math.max(min, Math.min(max, n)) : null;
+    };
+    const fh = num("fh", 0, 300);
+    const th = num("th", 0, 300);
+    const fq = num("fq", 100, 2500);
+    if (fh != null) losState.setLosFromHeightM(fh);
+    if (th != null) losState.setLosToHeightM(th);
+    if (fq != null) losState.setLosFreqMhz(fq);
+    if ("id" in f) setToolFromId(f.id); else losState.setLosVirtualFrom(f.pos);
+    if ("id" in t) setToolToId(t.id); else losState.setLosVirtualTo(t.pos);
+    setActiveTool("los");
+    setToolStep("result");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Draw shortest traceroute path on both providers
   useEffect(() => {

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -38,6 +38,7 @@ import { MapTraceroutePanel } from "./map/MapTraceroutePanel";
 import { type PacketArc, PacketCoalescer, type RawPacket } from "./map/packetCoalescer";
 import { packetColor } from "./map/packetColors";
 import { findPathsBetween } from "./map/pathAnalysis";
+import type { ScanClass } from "./map/scanAnalysis";
 import {
   anyIdsFanned,
   autoSpiderfyOverlappingPlainNodes,
@@ -450,10 +451,13 @@ export function Map() {
   // Scan compute + per-class visibility + clear-on-tool-change + hover effects
   const scanCompute = useScanCompute({
     activeTool, toolStep, toolFromId, toolVirtualPos,
-    provider, terrain3D, nodes,
+    terrain3D, styleEpoch, nodes,
+    nodesLoadFailed: nodesQueryFailed,
     scanTxDbm: scan.scanTxDbm,
     scanAntennaDbi: scan.scanAntennaDbi,
     scanRxAntennaDbi: scan.scanRxAntennaDbi,
+    scanRxHeightM: scan.scanRxHeightM,
+    scanFreqMhz: scan.scanFreqMhz,
     scanEffectiveSensitivityDbm: scan.scanEffectiveSensitivityDbm,
     scanAggressionIdx: scan.scanAggressionIdx,
     scanClutterEnabled: scan.scanClutterEnabled,
@@ -461,6 +465,7 @@ export function Map() {
     scanBuildingsEnabled: scan.scanBuildingsEnabled,
     scanAntennaHeightM: scan.scanAntennaHeightM,
     scanReliability: scan.scanReliability,
+    scanRetryNonce: scan.scanRetryNonce,
     hiddenScanClasses: scan.hiddenScanClasses,
     scanSummary: scan.scanSummary,
     scanHoverId: scan.scanHoverId,
@@ -468,6 +473,7 @@ export function Map() {
     setScanSummary: scan.setScanSummary,
     setIsScanning: scan.setIsScanning,
     setScanError: scan.setScanError,
+    setScanTerrainWarning: scan.setScanTerrainWarning,
     setScanDemSource: scan.setScanDemSource,
     setScanClutterStatus: scan.setScanClutterStatus,
     setScanCanopyStatus: scan.setScanCanopyStatus,
@@ -533,6 +539,8 @@ export function Map() {
     losState.setLosDemSource(null);
     scan.setScanDemSource(null);
     scan.setIsScanning(false);
+    scan.setScanError(null);
+    scan.setScanTerrainWarning(null);
 
     const mb = mbMapRef.current;
     if (mb) {
@@ -583,6 +591,56 @@ export function Map() {
       coverageCompute.coverageMarginRef.current = null;
     }
   };
+
+  // Stable ref to resetTool (recreated each render) so memoized panels can close
+  // without a fresh callback identity on every parent render.
+  const resetToolRef = useRef(resetTool);
+  resetToolRef.current = resetTool;
+
+  // Stable scan-panel callbacks. MapScanPanel is memoized and the map re-renders on
+  // every hover (elevation pill), so inline lambdas here would defeat the memo.
+  const handleScanClose = useCallback(() => {
+    // Overlay close returns to the coverage view; standalone close does a full reset.
+    if (keepCoveragePaintRef.current) {
+      coverageCompute.skipNextCoverageComputeRef.current = true;
+      coverage.setKeepCoveragePaint(false);
+      setActiveTool("coverage");
+    } else {
+      resetToolRef.current();
+    }
+    // Setters/refs are stable; deps intentionally empty so hover re-renders don't
+    // recreate the callback (would defeat MapScanPanel's memo).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const handleScanEnableTerrain = useCallback(() => setTerrain3D(true), []);
+  const handleScanSelectResult = useCallback((id: string) => {
+    // Fly to the target, then open its details panel.
+    const n = nodesRef.current[id] ?? nodesRef.current[`!${id}`];
+    const mb = mbMapRef.current;
+    if (n?.map_position && mb) {
+      mb.easeTo({ center: [n.map_position[0], n.map_position[1]], zoom: Math.max(mb.getZoom(), 13), duration: 800 });
+    }
+    handleNodeSelectRef.current(id);
+  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleScanHoverResult = useCallback((id: string | null) => scan.setScanHoverId(id), []);
+  const handleScanReturnToOrigin = useCallback(() => {
+    const mapNow = mbMapRef.current;
+    const view = scanCompute.scanInitialViewRef.current;
+    if (!mapNow || !view) return;
+    mapNow.easeTo({ center: view.center, zoom: view.zoom, pitch: view.pitch, bearing: view.bearing, duration: 800 });
+  }, [scanCompute.scanInitialViewRef]);
+  const handleScanToggleClassVisibility = useCallback((cls: ScanClass) => {
+    scan.setHiddenScanClasses((prev) => {
+      const next = new Set(prev);
+      if (next.has(cls)) next.delete(cls);
+      else next.add(cls);
+      return next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleScanRetry = useCallback(() => scan.setScanRetryNonce((n) => n + 1), []);
 
   // Swap LOS endpoints including their per-endpoint configs; the compute
   // effect picks the change up via its endpoint-scalar deps.
@@ -2223,12 +2281,13 @@ export function Map() {
         // Ignore if clicking on a node layer (handled by onNodeLayerClick) — the
         // label layers count too, or a label click drops a pin beside the node.
         const features = map.queryRenderedFeatures(e.point, {
-          layers: ["unclustered-nodes", "plain-nodes", "unclustered-labels", "plain-labels", "clusters", SPIDERFY_LAYER_NODES].filter((id) => map.getLayer(id)),
+          layers: ["unclustered-nodes", "plain-nodes", "unclustered-labels", "plain-labels", "clusters", SPIDERFY_LAYER_NODES, SPIDERFY_LAYER_LABELS].filter((id) => map.getLayer(id)),
         });
         if (features.length > 0) return;
 
         if ((t === "coverage" || t === "scan") && step === "pickFrom") {
-          setToolVirtualPos([e.lngLat.lng, e.lngLat.lat]);
+          // normalizeLng: clicks on a wrapped world copy give lngs outside ±180.
+          setToolVirtualPos([normalizeLng(e.lngLat.lng), e.lngLat.lat]);
           setToolStep("result");
           map.getCanvas().style.cursor = "";
         } else if (t === "los" && step === "pickFrom") {
@@ -2387,17 +2446,20 @@ export function Map() {
               // Merge-origin picking consumes Esc (the pick hook's own
               // listener cancels it) — don't also arm/close the tool.
               if (pickingMergeOriginRef.current) break;
-              // A coverage session carries state (paint, pins, settings) — one
-              // stray Esc shouldn't destroy it. Require a confirming Esc.
-              // keepCoveragePaint covers the Scan-from-here overlay too.
+              // Coverage, a standalone scan, and a Scan-from-here overlay each carry
+              // state (paint/pins/settings, and scan's ~800-tile DEM) — one stray Esc
+              // shouldn't destroy it. Require a confirming Esc, worded for the tool on screen.
               if (
-                (activeToolRef.current === "coverage" || keepCoveragePaintRef.current) &&
+                (activeToolRef.current === "coverage" ||
+                  activeToolRef.current === "scan" ||
+                  keepCoveragePaintRef.current) &&
                 toolStepRef.current === "result"
               ) {
                 const now = Date.now();
+                const toolName = activeToolRef.current === "scan" ? "Scan" : "Coverage";
                 if (now - coverageEscArmedAtRef.current > 3000) {
                   coverageEscArmedAtRef.current = now;
-                  toast("Press Esc again to close Coverage.");
+                  toast(`Press Esc again to close ${toolName}.`);
                   break;
                 }
                 coverageEscArmedAtRef.current = 0;
@@ -3247,22 +3309,26 @@ export function Map() {
             mbMapRef.current?.easeTo({ center: lngLat, duration: 600 });
           }}
           onScanFromHere={() => {
-            // Mirror coverage's RF settings so the scan results match the
-            // painted prediction. Origin (toolFromId / toolVirtualPos) is
-            // already shared between the tools.
-            scan.setScanHardwareIdx(coverage.coverageHardwareIdx);
-            scan.setScanAntennaIdx(coverage.coverageAntennaIdx);
-            scan.setScanAntennaHeightM(coverage.coverageAntennaHeightM);
-            scan.setScanCustomTxDbm(coverage.coverageCustomTxDbm);
-            scan.setScanRxHardwareIdx(coverage.coverageRxHardwareIdx);
-            scan.setScanRxAntennaIdx(coverage.coverageRxAntennaIdx);
-            scan.setScanPresetIdx(coverage.coveragePresetIdx);
-            scan.setScanCustomSensDbm(coverage.coverageCustomSensDbm);
-            scan.setScanAggressionIdx(coverage.coverageAggressionIdx);
-            scan.setScanClutterEnabled(coverage.coverageClutterEnabled);
-            scan.setScanCanopyEnabled(coverage.coverageCanopyEnabled);
-            scan.setScanBuildingsEnabled(coverage.coverageBuildingsEnabled);
-            scan.setScanReliability(coverage.coverageReliability);
+            // Mirror coverage's RF settings so the scan results match the painted
+            // prediction. applyMirror updates state WITHOUT persisting, so an overlay
+            // scan never overwrites the user's own saved scan defaults. Origin
+            // (toolFromId / toolVirtualPos) is already shared between the tools.
+            scan.applyMirror({
+              hardwareIdx: coverage.coverageHardwareIdx,
+              antennaIdx: coverage.coverageAntennaIdx,
+              antennaHeightM: coverage.coverageAntennaHeightM,
+              customTxDbm: coverage.coverageCustomTxDbm,
+              rxHardwareIdx: coverage.coverageRxHardwareIdx,
+              rxAntennaIdx: coverage.coverageRxAntennaIdx,
+              rxHeightM: coverage.coverageRxHeightM,
+              presetIdx: coverage.coveragePresetIdx,
+              customSensDbm: coverage.coverageCustomSensDbm,
+              aggressionIdx: coverage.coverageAggressionIdx,
+              clutterEnabled: coverage.coverageClutterEnabled,
+              canopyEnabled: coverage.coverageCanopyEnabled,
+              buildingsEnabled: coverage.coverageBuildingsEnabled,
+              reliability: coverage.coverageReliability,
+            });
             coverageCompute.skipNextCoverageComputeRef.current = true;
             coverage.setKeepCoveragePaint(true);
             setActiveTool("scan");
@@ -3294,66 +3360,34 @@ export function Map() {
           summary={scan.scanSummary}
           originLabel={
             toolFromId
-              ? ((nodes[toolFromId] ?? nodes[`!${toolFromId}`])?.shortname ?? toolFromId.slice(0, 8))
-              : "Virtual location"
+              ? ((nodes[toolFromId] ?? nodes[`!${toolFromId}`])?.shortname?.trim() || toolFromId.slice(0, 8))
+              : toolVirtualPos
+                ? `${toolVirtualPos[1].toFixed(5)}, ${toolVirtualPos[0].toFixed(5)}`
+                : "Virtual location"
           }
           isScanning={scan.isScanning}
           scanError={scan.scanError}
+          terrainWarning={scan.scanTerrainWarning}
+          onRetry={handleScanRetry}
           demSource={scan.scanDemSource}
           terrainNeeded={!terrain3D}
-          onEnableTerrain={() => setTerrain3D(true)}
-          onClose={() => {
-            // Overlay close returns to the coverage view; standalone close
-            // does a full reset.
-            if (coverage.keepCoveragePaint) {
-              coverageCompute.skipNextCoverageComputeRef.current = true;
-              coverage.setKeepCoveragePaint(false);
-              setActiveTool("coverage");
-            } else {
-              resetTool();
-            }
-          }}
-          onSelectResult={(id) => {
-            // Fly to the target, then open its details panel.
-            const n = nodes[id] ?? nodes[`!${id}`];
-            const mb = mbMapRef.current;
-            if (n?.map_position && mb) {
-              mb.easeTo({
-                center: [n.map_position[0], n.map_position[1]],
-                zoom: Math.max(mb.getZoom(), 13),
-                duration: 800,
-              });
-            }
-            handleNodeSelectRef.current(id);
-          }}
-          onHoverResult={(id) => scan.setScanHoverId(id)}
-          onReturnToOrigin={() => {
-            const mapNow = mbMapRef.current;
-            const view = scanCompute.scanInitialViewRef.current;
-            if (!mapNow || !view) return;
-            mapNow.easeTo({
-              center: view.center,
-              zoom: view.zoom,
-              pitch: view.pitch,
-              bearing: view.bearing,
-              duration: 800,
-            });
-          }}
+          onEnableTerrain={handleScanEnableTerrain}
+          onClose={handleScanClose}
+          onSelectResult={handleScanSelectResult}
+          onHoverResult={handleScanHoverResult}
+          onReturnToOrigin={handleScanReturnToOrigin}
           hiddenClasses={scan.hiddenScanClasses}
-          onToggleClassVisibility={(cls) =>
-            scan.setHiddenScanClasses((prev) => {
-              const next = new Set(prev);
-              if (next.has(cls)) next.delete(cls);
-              else next.add(cls);
-              return next;
-            })
-          }
+          onToggleClassVisibility={handleScanToggleClassVisibility}
           antennaIdx={scan.scanAntennaIdx}
           onAntennaIdxChange={scan.setScanAntennaIdx}
           hardwareIdx={scan.scanHardwareIdx}
           onHardwareIdxChange={scan.setScanHardwareIdx}
           antennaHeightM={scan.scanAntennaHeightM}
           onAntennaHeightChange={scan.setScanAntennaHeightM}
+          rxHeightM={scan.scanRxHeightM}
+          onRxHeightChange={scan.setScanRxHeightM}
+          freqMhz={scan.scanFreqMhz}
+          onFreqMhzChange={scan.setScanFreqMhz}
           rxHardwareIdx={scan.scanRxHardwareIdx}
           onRxHardwareIdxChange={scan.setScanRxHardwareIdx}
           rxAntennaIdx={scan.scanRxAntennaIdx}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -365,6 +365,13 @@ export function Map() {
   const activeToolRef = useRef(activeTool);
   const toolStepRef = useRef(toolStep);
   const toolFromIdRef = useRef(toolFromId);
+  // Merge-origin pick mode, read by the bind-once node/cluster click handlers
+  const pickingMergeOriginRef = useRef(mergeOrigins.pickingMergeOrigin);
+  const addMergeOriginByIdRef = useRef(mergeOrigins.addCoverageMergeOriginById);
+  // Coverage double-Esc guard: timestamp of the first (arming) Esc press
+  const coverageEscArmedAtRef = useRef(0);
+  // Scan-from-here overlay state, read by the bind-once Escape handler
+  const keepCoveragePaintRef = useRef(coverage.keepCoveragePaint);
 
   const isPickingNode = activeTool != null && toolStep !== "result";
   const terrain3DRef = useRef(terrain3D);
@@ -387,6 +394,9 @@ export function Map() {
   useEffect(() => { linkModeRef.current = linkMode; }, [linkMode]);
   useEffect(() => { roleFilterRef.current = roleFilter; }, [roleFilter]);
   useEffect(() => { activeToolRef.current = activeTool; }, [activeTool]);
+  useEffect(() => { pickingMergeOriginRef.current = mergeOrigins.pickingMergeOrigin; }, [mergeOrigins.pickingMergeOrigin]);
+  useEffect(() => { addMergeOriginByIdRef.current = mergeOrigins.addCoverageMergeOriginById; }, [mergeOrigins.addCoverageMergeOriginById]);
+  useEffect(() => { keepCoveragePaintRef.current = coverage.keepCoveragePaint; }, [coverage.keepCoveragePaint]);
   useEffect(() => { toolStepRef.current = toolStep; }, [toolStep]);
   useEffect(() => { toolFromIdRef.current = toolFromId; }, [toolFromId]);
   useEffect(() => { terrain3DRef.current = terrain3D; }, [terrain3D]);
@@ -468,6 +478,10 @@ export function Map() {
     setToolFromId(null);
     setToolToId(null);
     setToolVirtualPos(null);
+    // Merge origins are contextual to one analysis; closing the tool ends it
+    mergeOrigins.clearCoverageMergeOrigins();
+    // Stale arm must not let a later session close on a single Esc
+    coverageEscArmedAtRef.current = 0;
     losState.setLosVirtualFrom(null);
     losState.setLosVirtualTo(null);
     losCompute.losFitKeyRef.current = null;
@@ -1814,6 +1828,12 @@ export function Map() {
         const cluster = e.features?.[0];
         if (!cluster) return;
 
+        // A cluster click zooms; while picking a merge origin it must not
+        // also drop a coordinate pin underneath.
+        if (pickingMergeOriginRef.current) {
+          (e.originalEvent as MouseEvent & { _mergePickConsumed?: boolean })._mergePickConsumed = true;
+        }
+
         // Spiral fans put inner leaves inside the donut's hit circle — let the
         // leaf click be handled by onNodeLayerClick instead of re-spiderfying.
         if (hitsSpiderfyNode(e.point)) return;
@@ -1973,6 +1993,21 @@ export function Map() {
         if (!feature) return;
         const id = (feature.properties?.id ?? "") as string;
         if (!id) return;
+
+        // Merge-origin pick mode: a node click adds that node (with its GPS
+        // altitude) instead of dropping a coordinate pin or opening selection
+        if (pickingMergeOriginRef.current) {
+          (e.originalEvent as MouseEvent & { _mergePickConsumed?: boolean })._mergePickConsumed = true;
+          const cleanId = id.startsWith("!") ? id.slice(1) : id;
+          const primaryId = (toolFromIdRef.current ?? "").replace(/^!/, "");
+          if (cleanId === primaryId) {
+            toast("That node is already the primary origin.");
+          } else {
+            addMergeOriginByIdRef.current(id);
+          }
+          mergeOrigins.setPickingMergeOrigin(false);
+          return;
+        }
 
         // Tool pick modes intercept node clicks
         const activeToolCur = activeToolRef.current;
@@ -2199,6 +2234,24 @@ export function Map() {
         switch (e.key) {
           case "Escape":
             if (activeToolRef.current) {
+              // Merge-origin picking consumes Esc (the pick hook's own
+              // listener cancels it) — don't also arm/close the tool.
+              if (pickingMergeOriginRef.current) break;
+              // A coverage session carries state (paint, pins, settings) — one
+              // stray Esc shouldn't destroy it. Require a confirming Esc.
+              // keepCoveragePaint covers the Scan-from-here overlay too.
+              if (
+                (activeToolRef.current === "coverage" || keepCoveragePaintRef.current) &&
+                toolStepRef.current === "result"
+              ) {
+                const now = Date.now();
+                if (now - coverageEscArmedAtRef.current > 3000) {
+                  coverageEscArmedAtRef.current = now;
+                  toast("Press Esc again to close Coverage.");
+                  break;
+                }
+                coverageEscArmedAtRef.current = 0;
+              }
               resetTool();
               break;
             }

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -2959,10 +2959,16 @@ export function Map() {
             coverageCompute.coveragePoolRef.current?.terminate();
             coverageCompute.coveragePoolRef.current = null;
             coverageCompute.coverageRequestIdRef.current += 1;
+            // Flag the never-painted settings so re-selecting them offers Recalculate
+            coverageCompute.markComputeCancelled();
             coverage.setIsComputingCoverage(false);
             coverage.setIsFetchingCoverageTerrain(false);
             coverage.setCoverageProgress({ completed: 0, total: 0 });
           }}
+          autoRecalc={coverage.coverageAutoRecalc}
+          onAutoRecalcChange={coverage.setCoverageAutoRecalc}
+          paramsDirty={coverage.coverageParamsDirty}
+          onRecalculate={() => coverage.setCoverageRecalcNonce((n) => n + 1)}
           rxHardwareIdx={coverage.coverageRxHardwareIdx}
           onRxHardwareIdxChange={coverage.setCoverageRxHardwareIdx}
           rxAntennaIdx={coverage.coverageRxAntennaIdx}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -490,6 +490,8 @@ export function Map() {
     losCompute.losFitKeyRef.current = null;
     losCompute.losFromPosRef.current = null;
     losCompute.losToPosRef.current = null;
+    // Release the cached DEM (up to 16.8 MB) — it only helps within one session
+    losCompute.losDemCacheRef.current = null;
     losCompute.losHoverMarkerRef.current?.remove();
     losCompute.losHoverMarkerRef.current = null;
     losState.setLosResult(null);

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -111,6 +111,8 @@ export function Map() {
   const focusedNodeIdRef = useRef<string | null>(null);
   // Sticky after first style.load — `isStyleLoaded()` momentarily lies post-removeSource.
   const styleEverLoadedRef = useRef(false);
+  // Bumped per style.load so effects can re-push data into recreated sources/layers.
+  const [styleEpoch, setStyleEpoch] = useState(0);
   const mbSelectedIdRef = useRef<string | null>(null);
   // Last node-source signature; skips redundant setData. -1 = never set.
   const lastNodesSigRef = useRef<number>(-1);
@@ -418,7 +420,7 @@ export function Map() {
     losVirtualTo: losState.losVirtualTo,
     losFromHeightM: losState.losFromHeightM,
     losToHeightM: losState.losToHeightM,
-    provider, terrain3D, nodes,
+    terrain3D, styleEpoch, nodes,
     losResult: losState.losResult,
     mbMapRef, losTubeLayerRef,
     setLosResult: losState.setLosResult,
@@ -492,6 +494,8 @@ export function Map() {
     losCompute.losHoverMarkerRef.current = null;
     losState.setLosResult(null);
     losState.setLosError(null);
+    losState.setLosTerrainWarning(null);
+    losState.setIsComputingLos(false);
     coverage.setCoverageResult(null);
     coverage.setKeepCoveragePaint(false);
     scan.setScanSummary(null);
@@ -1587,6 +1591,10 @@ export function Map() {
         }
       }
 
+      // Tube altitudes are scaled by exaggeration at upload time; onAdd ran before
+      // terrain was re-applied above, so re-upload against the final exaggeration.
+      losTubeLayerRef.current?.refresh();
+
       // Ensure sources have current data (important after style changes)
       refreshMapboxNodeData();
 
@@ -2446,7 +2454,10 @@ export function Map() {
       }
     };
 
-    map.on("style.load", () => { styleEverLoadedRef.current = true; });
+    map.on("style.load", () => {
+      styleEverLoadedRef.current = true;
+      setStyleEpoch((e) => e + 1);
+    });
     map.on("style.load", ensureSourcesAndLayers);
 
     return () => {
@@ -2966,7 +2977,7 @@ export function Map() {
           terrainNeeded={!terrain3D}
           onEnableTerrain={() => setTerrain3D(true)}
           onClose={resetTool}
-          isComputing={terrain3D && !losState.losResult && !losState.losError}
+          isComputing={losState.isComputingLos}
           isRecomputing={losState.isComputingLos && !!losState.losResult}
           error={losState.losError}
           terrainWarning={losState.losTerrainWarning}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -134,7 +134,7 @@ export function Map() {
   const handleLinkHoverRef = useRef<(otherId: string | null) => void>(() => {});
   const selectedNodeIdRef = useRef<string | null>(null);
 
-  const { data: rawNodes = {} } = useGetNodesQuery();
+  const { data: rawNodes = {}, isError: nodesQueryFailed } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
   const { data: rawTraceroutes = [], isLoading: rawTraceroutesLoading } = useGetTraceroutesQuery();
 
@@ -435,6 +435,7 @@ export function Map() {
     losToHeightM: losState.losToHeightM,
     losFreqMhz: losState.losFreqMhz,
     terrain3D, styleEpoch, nodes,
+    nodesLoadFailed: nodesQueryFailed,
     losResult: losState.losResult,
     mbMapRef, losTubeLayerRef,
     isDraggingMarkerRef,
@@ -506,7 +507,8 @@ export function Map() {
     losCompute.losFitKeyRef.current = null;
     losCompute.losFromPosRef.current = null;
     losCompute.losToPosRef.current = null;
-    // Release the cached DEM (up to 16.8 MB) — it only helps within one session
+    // Release the cached rasters (DEM + canopy + buildings — tens of MB on long
+    // links) — they only help within one session
     losCompute.losDemCacheRef.current = null;
     losCompute.losHoverMarkerRef.current?.remove();
     losCompute.losHoverMarkerRef.current = null;
@@ -514,6 +516,8 @@ export function Map() {
     losCompute.losFromMarkerRef.current = null;
     losCompute.losToMarkerRef.current?.remove();
     losCompute.losToMarkerRef.current = null;
+    // Removing a marker mid-drag skips its dragend; unstick the shared flag
+    isDraggingMarkerRef.current = false;
     losState.setLosResult(null);
     losState.setLosError(null);
     losState.setLosTerrainWarning(null);
@@ -614,13 +618,26 @@ export function Map() {
   const [, setSearchParamsLos] = useSearchParams();
   const setSearchParamsLosRef = useRef(setSearchParamsLos);
   setSearchParamsLosRef.current = setSearchParamsLos;
+  // Snapshot the URL at first render: the write effect rewrites the real URL
+  // synchronously (loader-less router), so the restore effect must never read
+  // window.location at effect time — it would see its own params stripped.
+  const losUrlSnapshotRef = useRef<URLSearchParams | null>(null);
+  if (losUrlSnapshotRef.current === null) {
+    losUrlSnapshotRef.current = new URLSearchParams(window.location.search);
+  }
+  const losUrlRestoredRef = useRef(false);
   useEffect(() => {
+    // Hold all writes (including the strip branch) until the mount restore ran
+    if (!losUrlRestoredRef.current) return;
     const showing =
       activeTool === "los" && toolStep === "result" &&
       (toolFromId || losState.losVirtualFrom) && (toolToId || losState.losVirtualTo);
+    // No-op guard: react-router navigates even when the updater returns prev,
+    // so don't call setSearchParams at all when there is nothing to change.
+    const had = new URLSearchParams(window.location.search).get("tool") === "los";
+    if (!showing && !had) return;
     setSearchParamsLosRef.current((prev) => {
       const sp = new URLSearchParams(prev);
-      const had = sp.get("tool") === "los";
       if (showing) {
         sp.set("tool", "los");
         sp.set("from", toolFromId ?? `${losState.losVirtualFrom![1].toFixed(5)},${losState.losVirtualFrom![0].toFixed(5)}`);
@@ -628,21 +645,18 @@ export function Map() {
         sp.set("fh", String(losState.losFromHeightM));
         sp.set("th", String(losState.losToHeightM));
         sp.set("fq", String(losState.losFreqMhz));
-      } else if (had) {
-        for (const k of ["tool", "from", "to", "fh", "th", "fq"]) sp.delete(k);
       } else {
-        return prev;
+        for (const k of ["tool", "from", "to", "fh", "th", "fq"]) sp.delete(k);
       }
       return sp;
     }, { replace: true });
   }, [activeTool, toolStep, toolFromId, toolToId, losState.losVirtualFrom, losState.losVirtualTo, losState.losFromHeightM, losState.losToHeightM, losState.losFreqMhz]);
 
-  // Restore a shared LOS analysis from the URL (once, on mount)
-  const losUrlRestoredRef = useRef(false);
+  // Restore a shared LOS analysis from the URL snapshot (once, on mount)
   useEffect(() => {
     if (losUrlRestoredRef.current) return;
     losUrlRestoredRef.current = true;
-    const sp = new URLSearchParams(window.location.search);
+    const sp = losUrlSnapshotRef.current ?? new URLSearchParams();
     if (sp.get("tool") !== "los") return;
     const parseEnd = (v: string | null): { id: string } | { pos: [number, number] } | null => {
       if (!v) return null;
@@ -666,6 +680,13 @@ export function Map() {
     const fh = num("fh", 0, 300);
     const th = num("th", 0, 300);
     const fq = num("fq", 100, 2500);
+    // The sharer's values drive this session but must not overwrite the
+    // viewer's saved defaults in localStorage.
+    losState.markUrlAppliedSettings(
+      fh ?? losState.losFromHeightM,
+      th ?? losState.losToHeightM,
+      fq ?? losState.losFreqMhz,
+    );
     if (fh != null) losState.setLosFromHeightM(fh);
     if (th != null) losState.setLosToHeightM(th);
     if (fq != null) losState.setLosFreqMhz(fq);

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -420,6 +420,7 @@ export function Map() {
     losVirtualTo: losState.losVirtualTo,
     losFromHeightM: losState.losFromHeightM,
     losToHeightM: losState.losToHeightM,
+    losFreqMhz: losState.losFreqMhz,
     terrain3D, styleEpoch, nodes,
     losResult: losState.losResult,
     mbMapRef, losTubeLayerRef,
@@ -558,6 +559,36 @@ export function Map() {
       coverageCompute.coverageRaysRef.current = null;
       coverageCompute.coverageMarginRef.current = null;
     }
+  };
+
+  // Swap LOS endpoints including their per-endpoint configs; the compute
+  // effect picks the change up via its endpoint-scalar deps.
+  const swapLosEndpoints = () => {
+    const fid = toolFromId;
+    setToolFromId(toolToId);
+    setToolToId(fid);
+    const vf = losState.losVirtualFrom;
+    losState.setLosVirtualFrom(losState.losVirtualTo);
+    losState.setLosVirtualTo(vf);
+    const hw = losState.losFromHwIdx;
+    losState.setLosFromHwIdx(losState.losToHwIdx);
+    losState.setLosToHwIdx(hw);
+    const ant = losState.losFromAntIdx;
+    losState.setLosFromAntIdx(losState.losToAntIdx);
+    losState.setLosToAntIdx(ant);
+    const h = losState.losFromHeightM;
+    losState.setLosFromHeightM(losState.losToHeightM);
+    losState.setLosToHeightM(h);
+  };
+
+  // Typed "lat, lng" for a LOS endpoint becomes a virtual pin (detaches any node anchor)
+  const setLosFromPosition = (pos: [number, number]) => {
+    setToolFromId(null);
+    losState.setLosVirtualFrom(pos);
+  };
+  const setLosToPosition = (pos: [number, number]) => {
+    setToolToId(null);
+    losState.setLosVirtualTo(pos);
   };
 
   // Draw shortest traceroute path on both providers
@@ -2083,9 +2114,10 @@ export function Map() {
       map.on("click", (e) => {
         const t = activeToolRef.current;
         const step = toolStepRef.current;
-        // Ignore if clicking on a node layer (handled by onNodeLayerClick)
+        // Ignore if clicking on a node layer (handled by onNodeLayerClick) — the
+        // label layers count too, or a label click drops a pin beside the node.
         const features = map.queryRenderedFeatures(e.point, {
-          layers: ["unclustered-nodes", "plain-nodes", "clusters", SPIDERFY_LAYER_NODES].filter((id) => map.getLayer(id)),
+          layers: ["unclustered-nodes", "plain-nodes", "unclustered-labels", "plain-labels", "clusters", SPIDERFY_LAYER_NODES].filter((id) => map.getLayer(id)),
         });
         if (features.length > 0) return;
 
@@ -2937,7 +2969,7 @@ export function Map() {
               : activeTool === "scan"
                 ? "Scan: pick an origin (or click anywhere for a virtual location)"
                 : activeTool === "los"
-                  ? "LOS: pick the first node"
+                  ? "LOS: pick the first node (or click anywhere on the map)"
                   : "Traceroute: pick the first node"
           }
           hint="Press Esc to cancel"
@@ -2948,7 +2980,7 @@ export function Map() {
         <MapToolPrompt
           message={
             activeTool === "los"
-              ? "LOS: pick the second node"
+              ? "LOS: pick the second node (or click anywhere on the map)"
               : "Traceroute: pick the second node"
           }
           hint="Press Esc to cancel"
@@ -2962,14 +2994,15 @@ export function Map() {
           result={losState.losResult}
           fromLabel={
             toolFromId
-              ? ((nodes[toolFromId] ?? nodes[`!${toolFromId}`])?.shortname ?? toolFromId.slice(0, 8))
+              // `||` not `??` — some nodes report an empty shortname
+              ? ((nodes[toolFromId] ?? nodes[`!${toolFromId}`])?.shortname?.trim() || toolFromId.slice(0, 8))
               : losState.losVirtualFrom
                 ? `${losState.losVirtualFrom[1].toFixed(5)}, ${losState.losVirtualFrom[0].toFixed(5)}`
                 : ""
           }
           toLabel={
             toolToId
-              ? ((nodes[toolToId] ?? nodes[`!${toolToId}`])?.shortname ?? toolToId.slice(0, 8))
+              ? ((nodes[toolToId] ?? nodes[`!${toolToId}`])?.shortname?.trim() || toolToId.slice(0, 8))
               : losState.losVirtualTo
                 ? `${losState.losVirtualTo[1].toFixed(5)}, ${losState.losVirtualTo[0].toFixed(5)}`
                 : ""
@@ -2989,6 +3022,21 @@ export function Map() {
           toHwIdx={losState.losToHwIdx} onToHwIdxChange={losState.setLosToHwIdx}
           toAntIdx={losState.losToAntIdx} onToAntIdxChange={losState.setLosToAntIdx}
           toHeightM={losState.losToHeightM} onToHeightChange={losState.setLosToHeightM}
+          freqMhz={losState.losFreqMhz} onFreqMhzChange={losState.setLosFreqMhz}
+          presetIdx={losState.losPresetIdx} onPresetIdxChange={losState.setLosPresetIdx}
+          fromPosition={
+            toolFromId
+              ? (() => { const p = (nodes[toolFromId] ?? nodes[`!${toolFromId}`])?.map_position; return p ? [p[0], p[1]] as [number, number] : null; })()
+              : losState.losVirtualFrom
+          }
+          toPosition={
+            toolToId
+              ? (() => { const p = (nodes[toolToId] ?? nodes[`!${toolToId}`])?.map_position; return p ? [p[0], p[1]] as [number, number] : null; })()
+              : losState.losVirtualTo
+          }
+          onFromPositionChange={setLosFromPosition}
+          onToPositionChange={setLosToPosition}
+          onSwapEndpoints={swapLosEndpoints}
           demSource={losState.losDemSource}
           onProfileHover={losCompute.handleLosProfileHover}
         />

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -612,6 +612,9 @@ export function Map() {
     // recreate the callback (would defeat MapScanPanel's memo).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // Ref so the bind-once Escape handler can reuse the panel's exact close behavior.
+  const handleScanCloseRef = useRef(handleScanClose);
+  handleScanCloseRef.current = handleScanClose;
   const handleScanEnableTerrain = useCallback(() => setTerrain3D(true), []);
   const handleScanSelectResult = useCallback((id: string) => {
     // Fly to the target, then open its details panel.
@@ -2446,13 +2449,18 @@ export function Map() {
               // Merge-origin picking consumes Esc (the pick hook's own
               // listener cancels it) — don't also arm/close the tool.
               if (pickingMergeOriginRef.current) break;
-              // Coverage, a standalone scan, and a Scan-from-here overlay each carry
-              // state (paint/pins/settings, and scan's ~800-tile DEM) — one stray Esc
-              // shouldn't destroy it. Require a confirming Esc, worded for the tool on screen.
+              // Scan opened as a coverage overlay: Esc returns to coverage (paint
+              // preserved), matching the panel's close button — not a teardown of both.
+              // Coverage's own guard then governs the final close.
+              if (keepCoveragePaintRef.current && activeToolRef.current === "scan") {
+                handleScanCloseRef.current();
+                break;
+              }
+              // Coverage and a standalone scan each carry state (paint/pins/settings,
+              // and scan's ~800-tile DEM) — one stray Esc shouldn't destroy it. Require
+              // a confirming Esc, worded for the tool on screen.
               if (
-                (activeToolRef.current === "coverage" ||
-                  activeToolRef.current === "scan" ||
-                  keepCoveragePaintRef.current) &&
+                (activeToolRef.current === "coverage" || activeToolRef.current === "scan") &&
                 toolStepRef.current === "result"
               ) {
                 const now = Date.now();

--- a/frontend/src/pages/map/CoveragePresetsSection.tsx
+++ b/frontend/src/pages/map/CoveragePresetsSection.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useRef, useState } from "react";
+
+import { toast } from "../../components/toastStore";
+import {
+  type CoveragePanelSettings,
+  type CoveragePreset,
+  downloadPresets,
+  MAX_PRESET_NAME_LEN,
+  MAX_PRESETS,
+  parsePresetsFile,
+  readPresetLibrary,
+  resolvePreset,
+  snapshotPreset,
+  writePresetLibrary,
+} from "./coveragePresets";
+
+/** Presets row body: saved list (click = apply), save-as, export/import.
+ *  Applied-name state is parent-owned — this section unmounts on collapse. */
+export function CoveragePresetsSection({
+  current,
+  onApply,
+  appliedName,
+  onAppliedNameChange,
+  onCountChange,
+}: {
+  /** Live panel settings, used for Save. */
+  current: CoveragePanelSettings;
+  /** Applies a preset by fanning out to the panel's individual onChange props. */
+  onApply: (resolved: CoveragePanelSettings, name: string) => void;
+  /** Name of the last-applied preset (parent-owned). */
+  appliedName: string | null;
+  onAppliedNameChange: (name: string | null) => void;
+  /** Keeps the collapsed-row summary count in sync. */
+  onCountChange?: (count: number) => void;
+}) {
+  const [presets, setPresets] = useState<CoveragePreset[]>(() => readPresetLibrary());
+  const [draftName, setDraftName] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    onCountChange?.(presets.length);
+  }, [presets.length, onCountChange]);
+
+  const persist = (next: CoveragePreset[]) => {
+    setPresets(next);
+    writePresetLibrary(next);
+  };
+
+  const trimmedDraft = draftName.trim();
+  const nameExists = presets.some((p) => p.name === trimmedDraft);
+  const atCapacity = presets.length >= MAX_PRESETS && !nameExists;
+
+  const handleSave = () => {
+    if (!trimmedDraft || atCapacity) return;
+    const snap = snapshotPreset(trimmedDraft, current);
+    const next = nameExists
+      ? presets.map((p) => (p.name === snap.name ? snap : p))
+      : [...presets, snap];
+    persist(next);
+    setDraftName("");
+    onAppliedNameChange(snap.name);
+    toast(`Preset "${snap.name}" ${nameExists ? "updated" : "saved"}.`, { kind: "success" });
+  };
+
+  const handleApply = (p: CoveragePreset) => {
+    onApply(resolvePreset(p), p.name);
+    onAppliedNameChange(p.name);
+  };
+
+  const handleDelete = (name: string) => {
+    persist(presets.filter((p) => p.name !== name));
+    if (appliedName === name) onAppliedNameChange(null);
+    toast(`Preset "${name}" deleted.`);
+  };
+
+  const handleImportFile = async (file: File) => {
+    const text = await file.text();
+    const imported = parsePresetsFile(text);
+    if (!imported) {
+      toast("Couldn't read that file — not a coverage-presets JSON.", { kind: "error" });
+      return;
+    }
+    // Imports overwrite same-name entries; the rest append up to the cap
+    const byName = new Map(presets.map((p) => [p.name, p] as const));
+    let added = 0;
+    let updated = 0;
+    let skipped = 0;
+    for (const p of imported) {
+      if (byName.has(p.name)) {
+        byName.set(p.name, p);
+        updated += 1;
+      } else if (byName.size < MAX_PRESETS) {
+        byName.set(p.name, p);
+        added += 1;
+      } else {
+        skipped += 1;
+      }
+    }
+    persist([...byName.values()]);
+    const parts = [
+      added > 0 ? `${added} added` : null,
+      updated > 0 ? `${updated} updated` : null,
+      skipped > 0 ? `${skipped} skipped (library full)` : null,
+    ].filter(Boolean);
+    toast(`Presets imported: ${parts.length > 0 ? parts.join(", ") : "no changes"}.`, {
+      kind: skipped > 0 ? "error" : "success",
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {presets.length === 0 ? (
+        <div className="text-[10px] text-gray-500 leading-relaxed">
+          No saved presets yet. Configure the tool, then save the setup here to
+          recall it later — presets capture TX/RX hardware, environment,
+          accuracy, and overlay settings (not the pin location).
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1" role="list" aria-label="Saved coverage presets">
+          {presets.map((p) => (
+            <div
+              key={p.name}
+              role="listitem"
+              className={`flex items-center gap-1.5 pl-2 pr-1 py-1 rounded-md text-[11px] transition-colors ${
+                appliedName === p.name
+                  ? "bg-cyan-500/10 border border-cyan-500/30 text-cyan-200"
+                  : "bg-white/5 border border-transparent text-gray-300"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => handleApply(p)}
+                title={`Apply "${p.name}" (saved ${new Date(p.savedAt).toLocaleDateString()}) — recomputes coverage with these settings`}
+                className="flex-1 min-w-0 text-left truncate hover:text-cyan-300 transition-colors cursor-pointer"
+              >
+                {p.name}
+              </button>
+              {appliedName === p.name && (
+                <span className="shrink-0 text-[9px] uppercase tracking-wider text-cyan-400/80">active</span>
+              )}
+              <button
+                type="button"
+                onClick={() => handleDelete(p.name)}
+                aria-label={`Delete preset ${p.name}`}
+                className="shrink-0 inline-flex items-center justify-center w-5 h-5 rounded leading-none text-gray-500 hover:text-red-300 hover:bg-white/10 transition-colors"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          value={draftName}
+          maxLength={MAX_PRESET_NAME_LEN}
+          onChange={(e) => setDraftName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSave();
+            }
+          }}
+          placeholder="Preset name…"
+          aria-label="Name for the preset to save"
+          className="flex-1 min-w-0 px-2 py-1 rounded-md bg-white/5 border border-white/10 text-[10px] text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-cyan-500/50"
+        />
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!trimmedDraft || atCapacity}
+          title={
+            atCapacity
+              ? `Library is full (${MAX_PRESETS} presets) — delete one first`
+              : nameExists
+                ? `Overwrite "${trimmedDraft}" with the current settings`
+                : "Save the current settings as a new preset"
+          }
+          className="px-2 py-1 rounded-md border text-[10px] whitespace-nowrap shrink-0 transition-colors bg-cyan-500/10 border-cyan-500/30 text-cyan-300 hover:bg-cyan-500/20 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-cyan-500/10"
+        >
+          {nameExists ? "Overwrite" : "Save"}
+        </button>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 pt-1 border-t border-white/5">
+        <button
+          type="button"
+          onClick={() => downloadPresets(presets)}
+          disabled={presets.length === 0}
+          title="Download all presets as a JSON file to share or back up"
+          className="text-[10px] text-gray-400 hover:text-cyan-300 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-400"
+        >
+          Export all
+        </button>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          title="Import presets from a JSON file (same-name presets are overwritten)"
+          className="text-[10px] text-gray-400 hover:text-cyan-300 transition-colors"
+        >
+          Import…
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            // Reset so re-importing the same file re-fires onChange
+            e.target.value = "";
+            if (f) void handleImportFile(f);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/map/ElevationProfile.tsx
+++ b/frontend/src/pages/map/ElevationProfile.tsx
@@ -37,7 +37,7 @@ export function ElevationProfile({
 
   // Scales AND path strings memoized together — hover re-renders at pointer rate
   // and must not rebuild five path strings over every sample each move.
-  const { xScale, yScale, yTicks, terrainPath, fresnelPath, fresnel60Path, chordPath } = useMemo(() => {
+  const { xScale, yScale, yTicks, terrainPath, fresnelPath, fresnel60Path, chordPath, canopyPath, buildingPath } = useMemo(() => {
     const pts = result.points;
     if (pts.length === 0) {
       return {
@@ -48,15 +48,18 @@ export function ElevationProfile({
         fresnelPath: "",
         fresnel60Path: "",
         chordPath: "",
+        canopyPath: "",
+        buildingPath: "",
       };
     }
 
-    // Y: terrain min → max(chord + fresnel)
+    // Y: terrain min → max(chord + fresnel); clutter tops count toward the max
     let minY = Infinity;
     let maxY = -Infinity;
     for (const p of pts) {
       minY = Math.min(minY, p.effectiveGround);
-      maxY = Math.max(maxY, p.chord + p.fresnelRadius, p.effectiveGround);
+      const clutterTop = p.effectiveGround + Math.max(p.canopyM, p.buildingM);
+      maxY = Math.max(maxY, p.chord + p.fresnelRadius, clutterTop);
     }
     maxY = Math.max(maxY, result.fromHeightM, result.toHeightM);
     minY = Math.min(minY, result.fromHeightM, result.toHeightM);
@@ -96,6 +99,20 @@ export function ElevationProfile({
       .map((p) => `${xs(p.distanceKm)},${ys(p.chord - p.fresnelRadius * 0.6)}`)
       .join(" L ");
 
+    // Clutter bands: value drawn from the terrain surface upward. Zero-height
+    // stretches collapse into invisible slivers so one polygon per band works.
+    const clutterBand = (heightOf: (p: (typeof pts)[number]) => number): string => {
+      if (!pts.some((p) => heightOf(p) > 0.3)) return "";
+      const upper = pts
+        .map((p) => `${xs(p.distanceKm)},${ys(p.effectiveGround + heightOf(p))}`)
+        .join(" L ");
+      const lower = [...pts]
+        .reverse()
+        .map((p) => `${xs(p.distanceKm)},${ys(p.effectiveGround)}`)
+        .join(" L ");
+      return `M ${upper} L ${lower} Z`;
+    };
+
     return {
       xScale: xs,
       yScale: ys,
@@ -106,6 +123,8 @@ export function ElevationProfile({
       chordPath:
         `M ${xs(0)},${ys(result.fromHeightM)} ` +
         `L ${xs(result.totalDistanceKm)},${ys(result.toHeightM)}`,
+      canopyPath: clutterBand((p) => p.canopyM),
+      buildingPath: clutterBand((p) => p.buildingM),
     };
   }, [result, plotW, plotH]);
 
@@ -250,6 +269,18 @@ export function ElevationProfile({
           />
 
           <path d={terrainPath} fill="url(#terrainGradient)" />
+
+          {/* Clutter bands (display only — not part of the LOS verdict) */}
+          {buildingPath && (
+            <path d={buildingPath} fill="rgba(148,163,184,0.35)">
+              <title>Buildings along the path (height above ground)</title>
+            </path>
+          )}
+          {canopyPath && (
+            <path d={canopyPath} fill="rgba(34,197,94,0.28)">
+              <title>Tree canopy along the path (height above ground)</title>
+            </path>
+          )}
 
           <path
             d={chordPath}
@@ -397,6 +428,18 @@ export function ElevationProfile({
               <span className="text-gray-400 font-mono">
                 ±{Math.round(hoverPoint.fresnelRadius)}m
               </span>
+            </div>
+          )}
+          {hoverPoint.canopyM > 0.5 && (
+            <div className="flex justify-between gap-3">
+              <span className="text-gray-500">Canopy:</span>
+              <span className="text-emerald-400/90 font-mono">+{Math.round(hoverPoint.canopyM)}m</span>
+            </div>
+          )}
+          {hoverPoint.buildingM > 0.5 && (
+            <div className="flex justify-between gap-3">
+              <span className="text-gray-500">Building:</span>
+              <span className="text-slate-300 font-mono">+{Math.round(hoverPoint.buildingM)}m</span>
             </div>
           )}
         </div>

--- a/frontend/src/pages/map/ElevationProfile.tsx
+++ b/frontend/src/pages/map/ElevationProfile.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { LoSResult } from "./losAnalysis";
 
@@ -26,17 +26,28 @@ export function ElevationProfile({
   onHoverFraction?: (t: number | null) => void;
 }) {
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  // Keyboard-nav announcement for screen readers (pointer moves stay silent)
+  const [announce, setAnnounce] = useState("");
 
   const plotW = WIDTH - MARGIN.left - MARGIN.right;
   const plotH = HEIGHT - MARGIN.top - MARGIN.bottom;
 
-  const { xScale, yScale, yTicks } = useMemo(() => {
+  // The orange map marker must not outlive the chart (error/terrain-off swaps this tree out)
+  useEffect(() => () => { onHoverFraction?.(null); }, [onHoverFraction]);
+
+  // Scales AND path strings memoized together — hover re-renders at pointer rate
+  // and must not rebuild five path strings over every sample each move.
+  const { xScale, yScale, yTicks, terrainPath, fresnelPath, fresnel60Path, chordPath } = useMemo(() => {
     const pts = result.points;
     if (pts.length === 0) {
       return {
         xScale: (_x: number) => 0,
         yScale: (_y: number) => 0,
         yTicks: [] as number[],
+        terrainPath: "",
+        fresnelPath: "",
+        fresnel60Path: "",
+        chordPath: "",
       };
     }
 
@@ -62,7 +73,40 @@ export function ElevationProfile({
     const ticks: number[] = [];
     for (let i = 0; i <= tickCount; i++) ticks.push(paddedMin + step * i);
 
-    return { xScale: xs, yScale: ys, yTicks: ticks };
+    const terrain =
+      `M ${xs(0)},${plotH} ` +
+      pts.map((p) => `L ${xs(p.distanceKm)},${ys(p.effectiveGround)}`).join(" ") +
+      ` L ${xs(result.totalDistanceKm)},${plotH} Z`;
+
+    // Fresnel polygon around chord
+    const fresnelUpper = pts
+      .map((p) => `${xs(p.distanceKm)},${ys(p.chord + p.fresnelRadius)}`)
+      .join(" L ");
+    const fresnelLower = [...pts]
+      .reverse()
+      .map((p) => `${xs(p.distanceKm)},${ys(p.chord - p.fresnelRadius)}`)
+      .join(" L ");
+
+    // 60% Fresnel = usable threshold
+    const fresnel60Upper = pts
+      .map((p) => `${xs(p.distanceKm)},${ys(p.chord + p.fresnelRadius * 0.6)}`)
+      .join(" L ");
+    const fresnel60Lower = [...pts]
+      .reverse()
+      .map((p) => `${xs(p.distanceKm)},${ys(p.chord - p.fresnelRadius * 0.6)}`)
+      .join(" L ");
+
+    return {
+      xScale: xs,
+      yScale: ys,
+      yTicks: ticks,
+      terrainPath: terrain,
+      fresnelPath: `M ${fresnelUpper} L ${fresnelLower} Z`,
+      fresnel60Path: `M ${fresnel60Upper} L ${fresnel60Lower} Z`,
+      chordPath:
+        `M ${xs(0)},${ys(result.fromHeightM)} ` +
+        `L ${xs(result.totalDistanceKm)},${ys(result.toHeightM)}`,
+    };
   }, [result, plotW, plotH]);
 
   if (result.points.length === 0) {
@@ -72,37 +116,6 @@ export function ElevationProfile({
       </div>
     );
   }
-
-  const terrainPath =
-    `M ${xScale(0)},${plotH} ` +
-    result.points
-      .map((p) => `L ${xScale(p.distanceKm)},${yScale(p.effectiveGround)}`)
-      .join(" ") +
-    ` L ${xScale(result.totalDistanceKm)},${plotH} Z`;
-
-  // Fresnel polygon around chord
-  const fresnelUpper = result.points
-    .map((p) => `${xScale(p.distanceKm)},${yScale(p.chord + p.fresnelRadius)}`)
-    .join(" L ");
-  const fresnelLower = [...result.points]
-    .reverse()
-    .map((p) => `${xScale(p.distanceKm)},${yScale(p.chord - p.fresnelRadius)}`)
-    .join(" L ");
-  const fresnelPath = `M ${fresnelUpper} L ${fresnelLower} Z`;
-
-  // 60% Fresnel = usable threshold
-  const fresnel60Upper = result.points
-    .map((p) => `${xScale(p.distanceKm)},${yScale(p.chord + p.fresnelRadius * 0.6)}`)
-    .join(" L ");
-  const fresnel60Lower = [...result.points]
-    .reverse()
-    .map((p) => `${xScale(p.distanceKm)},${yScale(p.chord - p.fresnelRadius * 0.6)}`)
-    .join(" L ");
-  const fresnel60Path = `M ${fresnel60Upper} L ${fresnel60Lower} Z`;
-
-  const chordPath =
-    `M ${xScale(0)},${yScale(result.fromHeightM)} ` +
-    `L ${xScale(result.totalDistanceKm)},${yScale(result.toHeightM)}`;
 
   const losColor = result.losClear
     ? (result.fresnelClear ? "#06b6d4" : "#f97316")
@@ -116,6 +129,12 @@ export function ElevationProfile({
     onHoverFraction?.(
       result.totalDistanceKm > 0 ? result.points[clamped].distanceKm / result.totalDistanceKm : 0,
     );
+    const p = result.points[clamped];
+    setAnnounce(
+      `${p.distanceKm.toFixed(2)} kilometers: ground ${Math.round(p.ground)} meters, ` +
+      `path ${Math.round(p.chord)} meters, clearance ${Math.round(p.clearance) || 0} meters` +
+      (p.blocked ? ", blocked" : p.fresnelIntruded ? ", Fresnel intrusion" : ""),
+    );
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<SVGSVGElement>) => {
@@ -124,7 +143,13 @@ export function ElevationProfile({
     else if (e.key === "ArrowLeft") { e.preventDefault(); setHoverByIndex(cur - 1); }
     else if (e.key === "Home") { e.preventDefault(); setHoverByIndex(0); }
     else if (e.key === "End") { e.preventDefault(); setHoverByIndex(result.points.length - 1); }
-    else if (e.key === "Escape") { setHoverIdx(null); onHoverFraction?.(null); }
+    else if (e.key === "Escape") {
+      // Only clear the hover — without this, the same keypress reaches the
+      // document handler and closes the whole LOS tool.
+      e.stopPropagation();
+      setHoverIdx(null);
+      onHoverFraction?.(null);
+    }
   };
 
   const verdict = result.losClear
@@ -145,31 +170,27 @@ export function ElevationProfile({
       onHoverFraction?.(null);
       return;
     }
-    const distKm = (x / plotW) * result.totalDistanceKm;
-    let bestIdx = 0;
-    let bestDiff = Infinity;
-    for (let i = 0; i < result.points.length; i++) {
-      const diff = Math.abs(result.points[i].distanceKm - distKm);
-      if (diff < bestDiff) {
-        bestDiff = diff;
-        bestIdx = i;
-      }
-    }
+    // Samples are uniformly spaced (distanceKm = total·i/samples) — index math is exact
+    const frac = Math.min(1, Math.max(0, x / plotW));
+    const bestIdx = Math.round(frac * (result.points.length - 1));
     setHoverIdx(bestIdx);
     onHoverFraction?.(result.totalDistanceKm > 0 ? result.points[bestIdx].distanceKm / result.totalDistanceKm : 0);
   };
 
   return (
     <div className="relative">
+      {/* Announces keyboard-driven hover values; the visual tooltip is aria-hidden to SRs */}
+      <div className="sr-only" role="status" aria-live="polite">{announce}</div>
       <svg
         width="100%"
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        className="block cursor-crosshair focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400/60 rounded"
+        className="block cursor-crosshair touch-none focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400/60 rounded"
         role="img"
         aria-label={ariaLabel}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onBlur={() => { setHoverIdx(null); onHoverFraction?.(null); }}
+        onPointerDown={handlePointerMove}
         onPointerMove={handlePointerMove}
         onPointerLeave={() => { setHoverIdx(null); onHoverFraction?.(null); }}
       >
@@ -366,8 +387,8 @@ export function ElevationProfile({
                   : "text-emerald-400"
               }`}
             >
-              {hoverPoint.clearance >= 0 ? "+" : ""}
-              {Math.round(hoverPoint.clearance)}m
+              {(Math.round(hoverPoint.clearance) || 0) >= 0 ? "+" : ""}
+              {Math.round(hoverPoint.clearance) || 0}m
             </span>
           </div>
           {hoverPoint.fresnelRadius > 0 && (

--- a/frontend/src/pages/map/ElevationProfile.tsx
+++ b/frontend/src/pages/map/ElevationProfile.tsx
@@ -6,7 +6,9 @@ const WIDTH = 900;
 const HEIGHT = 130;
 const MARGIN = { top: 8, right: 12, bottom: 20, left: 36 };
 
-/** Cross-sectional elevation profile of a radio link: terrain, LoS chord, Fresnel zone, obstructions. */
+/** Cross-sectional elevation profile of a radio link: terrain, LoS chord, Fresnel zone, obstructions.
+ *  Terrain is drawn as effectiveGround (ground + k=4/3 earth bulge) — the standard curved-earth
+ *  profile — so what the chart shows matches the clearance/verdict math. */
 export function ElevationProfile({
   result,
   fromLabel,
@@ -42,8 +44,8 @@ export function ElevationProfile({
     let minY = Infinity;
     let maxY = -Infinity;
     for (const p of pts) {
-      minY = Math.min(minY, p.ground);
-      maxY = Math.max(maxY, p.chord + p.fresnelRadius, p.ground);
+      minY = Math.min(minY, p.effectiveGround);
+      maxY = Math.max(maxY, p.chord + p.fresnelRadius, p.effectiveGround);
     }
     maxY = Math.max(maxY, result.fromHeightM, result.toHeightM);
     minY = Math.min(minY, result.fromHeightM, result.toHeightM);
@@ -74,7 +76,7 @@ export function ElevationProfile({
   const terrainPath =
     `M ${xScale(0)},${plotH} ` +
     result.points
-      .map((p) => `L ${xScale(p.distanceKm)},${yScale(p.ground)}`)
+      .map((p) => `L ${xScale(p.distanceKm)},${yScale(p.effectiveGround)}`)
       .join(" ") +
     ` L ${xScale(result.totalDistanceKm)},${plotH} Z`;
 
@@ -296,7 +298,7 @@ export function ElevationProfile({
                 strokeWidth={1}
               />
               <circle
-                cy={yScale(hoverPoint.ground)}
+                cy={yScale(hoverPoint.effectiveGround)}
                 r={2.5}
                 fill="#f97316"
                 stroke="white"
@@ -343,6 +345,12 @@ export function ElevationProfile({
             <span className="text-gray-500">Ground:</span>
             <span className="text-amber-300 font-mono">{Math.round(hoverPoint.ground)}m</span>
           </div>
+          {hoverPoint.bulge >= 0.5 && (
+            <div className="flex justify-between gap-3">
+              <span className="text-gray-500">Curvature:</span>
+              <span className="text-amber-300/70 font-mono">+{Math.round(hoverPoint.bulge)}m</span>
+            </div>
+          )}
           <div className="flex justify-between gap-3">
             <span className="text-gray-500">LoS:</span>
             <span className="text-gray-200 font-mono">{Math.round(hoverPoint.chord)}m</span>

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, type MergeOrigin, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
@@ -19,11 +19,13 @@ interface MergeNodeOption {
 
 /** Info icon with hover/focus tooltip. `align` picks the edge it anchors to. */
 function InfoTip({ children, align = "right" }: { children: React.ReactNode; align?: "left" | "right" }) {
+  const tipId = useId();
   return (
     <span className="relative inline-flex items-center group">
       <button
         type="button"
         aria-label="More information"
+        aria-describedby={tipId}
         className="inline-flex items-center text-gray-600 group-hover:text-gray-400 transition-colors rounded focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400/60"
       >
         <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -31,6 +33,8 @@ function InfoTip({ children, align = "right" }: { children: React.ReactNode; ali
         </svg>
       </button>
       <span
+        id={tipId}
+        role="tooltip"
         className={`invisible group-hover:visible group-focus-within:visible absolute bottom-full mb-1 w-60 max-w-[calc(100vw-1rem)] p-2 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl text-[10px] text-gray-300 leading-relaxed z-50 normal-case tracking-normal font-normal ${
           align === "left" ? "left-0" : "right-0"
         }`}

--- a/frontend/src/pages/map/MapCoveragePanel.tsx
+++ b/frontend/src/pages/map/MapCoveragePanel.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, type MergeOrigin, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
 import { COVERAGE_DETAIL_SIZE,type CoverageDetail } from "./coverageDetail";
+import { type CoveragePanelSettings, readPresetLibrary } from "./coveragePresets";
+import { CoveragePresetsSection } from "./CoveragePresetsSection";
 import { parseLatLng } from "./helpers";
 import { NumericDraftInput } from "./NumericDraftInput";
 import { Segmented } from "./Segmented";
@@ -82,7 +84,7 @@ function Row({
   );
 }
 
-type RowKey = "tx" | "rx" | "env" | "acc" | "ov";
+type RowKey = "presets" | "tx" | "rx" | "env" | "acc" | "ov";
 
 export function MapCoveragePanel({
   result,
@@ -98,6 +100,10 @@ export function MapCoveragePanel({
   errorMessage,
   onRetry,
   onCancel,
+  autoRecalc,
+  onAutoRecalcChange,
+  paramsDirty,
+  onRecalculate,
   antennaIdx,
   onAntennaIdxChange,
   hardwareIdx,
@@ -165,6 +171,13 @@ export function MapCoveragePanel({
   errorMessage: string | null;
   onRetry: () => void;
   onCancel: () => void;
+  /** Auto-recompute on setting changes (persisted). */
+  autoRecalc: boolean;
+  onAutoRecalcChange: (v: boolean) => void;
+  /** True when settings changed but the recompute is deferred (manual mode). */
+  paramsDirty: boolean;
+  /** Runs a recompute with the current settings (reuses cached rasters). */
+  onRecalculate: () => void;
   /** Index into COMMON_ANTENNAS. */
   antennaIdx: number;
   onAntennaIdxChange: (idx: number) => void;
@@ -324,6 +337,42 @@ export function MapCoveragePanel({
   const [expandedRow, setExpandedRow] = useState<RowKey | null>(null);
   const toggleRow = (k: RowKey) => setExpandedRow((cur) => (cur === k ? null : k));
 
+  // Summary state lives here — the section unmounts when its row collapses
+  const [presetCount, setPresetCount] = useState(() => readPresetLibrary().length);
+  const [appliedPresetName, setAppliedPresetName] = useState<string | null>(null);
+  const onPresetCountChange = useCallback((count: number) => setPresetCount(count), []);
+  const currentPresetSettings: CoveragePanelSettings = {
+    hardwareIdx, customTxDbm,
+    antennaIdx, antennaHeightM,
+    rxHardwareIdx, rxAntennaIdx, rxHeightM,
+    presetIdx, customSensitivityDbm,
+    aggressionIdx, clutterEnabled, canopyEnabled, buildingsEnabled,
+    detail, reliability,
+    showContours, showRays,
+  };
+  // Fan out through the per-setting callbacks (React batches into one
+  // recompute); an explicit apply recomputes even in manual mode
+  const applyPresetSettings = (s: CoveragePanelSettings) => {
+    if (!autoRecalc) onRecalculate();
+    onHardwareIdxChange(s.hardwareIdx);
+    onCustomTxDbmChange(s.customTxDbm);
+    onAntennaIdxChange(s.antennaIdx);
+    onAntennaHeightChange(s.antennaHeightM);
+    onRxHardwareIdxChange(s.rxHardwareIdx);
+    onRxAntennaIdxChange(s.rxAntennaIdx);
+    onRxHeightChange(s.rxHeightM);
+    onPresetIdxChange(s.presetIdx);
+    onCustomSensitivityChange(s.customSensitivityDbm);
+    onAggressionIdxChange(s.aggressionIdx);
+    onClutterEnabledChange(s.clutterEnabled);
+    onCanopyEnabledChange(s.canopyEnabled);
+    onBuildingsEnabledChange(s.buildingsEnabled);
+    onDetailChange(s.detail);
+    onReliabilityChange(s.reliability);
+    onShowContoursChange(s.showContours);
+    onShowRaysChange(s.showRays);
+  };
+
   const [minimized, setMinimized] = useState(false);
 
   // Auto-minimize on the first result for each new origin so the painted
@@ -479,11 +528,13 @@ export function MapCoveragePanel({
     const progressPct = progressTotal > 0
       ? Math.round((progressCompleted / progressTotal) * 100)
       : 0;
-    const stageLabel = isFetchingTerrain
-      ? `Fetching terrain for ${originLabel}…`
-      : progressTotal > 0
-        ? `Computing coverage from ${originLabel} · ${progressCompleted}/${progressTotal} slices (${progressPct}%)`
-        : `Computing coverage from ${originLabel}…`;
+    const stageLabel = !isComputing
+      ? "Coverage paused."
+      : isFetchingTerrain
+        ? `Fetching terrain for ${originLabel}…`
+        : progressTotal > 0
+          ? `Computing coverage from ${originLabel} · ${progressCompleted}/${progressTotal} slices (${progressPct}%)`
+          : `Computing coverage from ${originLabel}…`;
     return (
       <div className="fixed z-1050 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl
         inset-x-0 bottom-0 rounded-t-2xl p-3 pb-5
@@ -491,11 +542,22 @@ export function MapCoveragePanel({
         sm:rounded-xl sm:pb-3">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-xs text-gray-400 min-w-0">
-            <div className="w-3 h-3 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin shrink-0" />
+            {isComputing && (
+              <div className="w-3 h-3 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin shrink-0" />
+            )}
             <span className="truncate">{stageLabel}</span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            {!isFetchingTerrain && (
+            {!isComputing && (
+              <button
+                type="button"
+                onClick={onRecalculate}
+                className="text-[10px] px-2 py-0.5 rounded-md bg-cyan-500/15 border border-cyan-500/40 text-cyan-200 hover:bg-cyan-500/25 transition-colors font-medium"
+              >
+                Compute
+              </button>
+            )}
+            {isComputing && (
               <button
                 type="button"
                 onClick={onCancel}
@@ -619,18 +681,31 @@ export function MapCoveragePanel({
             text-[10px] text-cyan-200 flex items-center gap-2 whitespace-nowrap">
             <div className="w-2.5 h-2.5 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin shrink-0" />
             <span className="truncate min-w-0">{label}</span>
-            {!isFetchingTerrain && (
-              <button
-                type="button"
-                onClick={onCancel}
-                className="px-1.5 py-0 rounded bg-red-500/15 hover:bg-red-500/25 border border-red-500/40 text-red-200 font-medium transition-colors"
-              >
-                Cancel
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-1.5 py-0 rounded bg-red-500/15 hover:bg-red-500/25 border border-red-500/40 text-red-200 font-medium transition-colors"
+            >
+              Cancel
+            </button>
           </div>
         );
       })()}
+      {/* Manual-mode pending chip: settings changed, recompute deferred. */}
+      {paramsDirty && !isComputing && !errorMessage && (
+        <div className="absolute -top-8 left-1/2 -translate-x-1/2 max-w-[calc(100vw-1rem)] px-3 py-1 rounded-full
+          bg-gray-900/95 backdrop-blur-xl border border-amber-500/40 shadow-2xl
+          text-[10px] text-amber-200 flex items-center gap-2 whitespace-nowrap">
+          <span className="truncate min-w-0">Settings changed</span>
+          <button
+            type="button"
+            onClick={onRecalculate}
+            className="px-1.5 py-0 rounded bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/40 text-amber-100 font-medium transition-colors"
+          >
+            Recalculate
+          </button>
+        </div>
+      )}
 
       <div
         className="flex items-center justify-between gap-3 px-3 py-2 border-b border-white/5 shrink-0 max-sm:touch-none"
@@ -995,6 +1070,32 @@ export function MapCoveragePanel({
       </div>
 
       <div className={`px-3 pb-5 space-y-2 overflow-y-auto overscroll-contain min-h-0 flex-1 sm:pb-3 ${minimized ? "hidden" : ""}`}>
+        <Row
+          icon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.7} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" />
+            </svg>
+          }
+          title="Presets"
+          summary={
+            appliedPresetName
+              ? <span className="text-cyan-300">{appliedPresetName}</span>
+              : presetCount > 0
+                ? `${presetCount} saved`
+                : "None saved"
+          }
+          expanded={expandedRow === "presets"}
+          onToggle={() => toggleRow("presets")}
+        >
+          <CoveragePresetsSection
+            current={currentPresetSettings}
+            onApply={applyPresetSettings}
+            appliedName={appliedPresetName}
+            onAppliedNameChange={setAppliedPresetName}
+            onCountChange={onPresetCountChange}
+          />
+        </Row>
+
         <Row
           icon={
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1528,6 +1629,34 @@ export function MapCoveragePanel({
                 { value: "survey",   label: "Survey", sub: "2048 px" },
               ]}
             />
+          </div>
+          <div className="flex items-center justify-between gap-2 pt-1 border-t border-white/5">
+            <label className="flex items-center gap-2 text-[11px] text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={autoRecalc}
+                onChange={(e) => onAutoRecalcChange(e.target.checked)}
+                className="w-3.5 h-3.5 accent-cyan-500 cursor-pointer"
+              />
+              <span className="inline-flex items-center gap-1 min-w-0">
+                Auto-recalculate
+                <InfoTip align="left">
+                  Recompute automatically when a setting changes (moving the
+                  pin always recomputes). Turn off to batch several changes
+                  and apply them with one Recalculate — handy at Ultra/Survey
+                  detail where each run takes a while.
+                </InfoTip>
+              </span>
+            </label>
+            {!autoRecalc && paramsDirty && (
+              <button
+                type="button"
+                onClick={onRecalculate}
+                className="px-2 py-0.5 rounded-md border text-[10px] whitespace-nowrap shrink-0 transition-colors bg-amber-500/15 border-amber-500/40 text-amber-200 hover:bg-amber-500/25 font-medium"
+              >
+                Recalculate
+              </button>
+            )}
           </div>
         </Row>
 

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { toast } from "../../components/toastStore";
+import { copyTextToClipboard } from "../../utils/clipboard";
 import {
   COMMON_ANTENNAS,
   COMMON_HARDWARE,
@@ -662,10 +663,11 @@ export function MapLosPanel({
           <button
             type="button"
             onClick={() => {
-              navigator.clipboard?.writeText(window.location.href).then(
-                () => toast("Link to this analysis copied."),
-                () => toast("Couldn't copy the link.", { kind: "error" }),
-              );
+              // copyTextToClipboard has an execCommand fallback for plain-HTTP installs
+              void copyTextToClipboard(window.location.href).then((ok) => {
+                if (ok) toast("Link to this analysis copied.");
+                else toast("Couldn't copy the link.", { kind: "error" });
+              });
             }}
             className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
             aria-label="Copy a shareable link to this analysis"

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -147,6 +147,7 @@ export function MapLosPanel({
   isComputing,
   isRecomputing = false,
   error,
+  terrainWarning,
   fromHwIdx, onFromHwIdxChange,
   fromAntIdx, onFromAntIdxChange,
   fromHeightM, onFromHeightChange,
@@ -169,6 +170,8 @@ export function MapLosPanel({
   isRecomputing?: boolean;
   /** Compute error; shows an error state instead of the spinner. */
   error?: string | null;
+  /** Non-fatal terrain-quality warning (failed tiles / missing samples). */
+  terrainWarning?: string | null;
   fromHwIdx: number; onFromHwIdxChange: (idx: number) => void;
   fromAntIdx: number; onFromAntIdxChange: (idx: number) => void;
   fromHeightM: number; onFromHeightChange: (m: number) => void;
@@ -549,6 +552,18 @@ export function MapLosPanel({
           </button>
         </div>
       </div>
+
+      {terrainWarning && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 px-3 py-1 text-[10px] text-amber-300 bg-amber-500/10 border-b border-amber-500/20 shrink-0"
+        >
+          <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          </svg>
+          {terrainWarning}
+        </div>
+      )}
 
       {/* Body: 3-column row on desktop (From | Profile | To); mobile stacks vertically
           with the profile on top, then the two endpoint configs. */}

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import { toast } from "../../components/toastStore";
 import {
   COMMON_ANTENNAS,
   COMMON_HARDWARE,
@@ -641,6 +642,22 @@ export function MapLosPanel({
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={minimized ? "M5 15l7-7 7 7" : "M5 9l7 7 7-7"} />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              navigator.clipboard?.writeText(window.location.href).then(
+                () => toast("Link to this analysis copied."),
+                () => toast("Couldn't copy the link.", { kind: "error" }),
+              );
+            }}
+            className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+            aria-label="Copy a shareable link to this analysis"
+            title="Copy a shareable link"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 11-5.656-5.656l1.5-1.5m3.5-2.344a4 4 0 010-5.656l3-3a4 4 0 115.656 5.656l-1.5 1.5" />
             </svg>
           </button>
           <details className="text-[10px] text-gray-500 relative">

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -5,36 +5,128 @@ import {
   COMMON_HARDWARE,
   effectiveSensitivityDbm,
   MESHTASTIC_PRESETS,
+  type ModemPreset,
 } from "./coverageAnalysis";
 import { ElevationProfile } from "./ElevationProfile";
+import { parseLatLng } from "./helpers";
+import { CABLE_LOSS_DB } from "./itmEnv";
 import type { LoSResult } from "./losAnalysis";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
 
-/** Modem preset assumed for link-budget readout in this panel.
- *  LongFast = Meshtastic default mesh setting; -130 dBm typical SX1262 sensitivity. */
-const LOS_PRESET = MESHTASTIC_PRESETS.find((p) => p.id === "LongFast") ?? MESHTASTIC_PRESETS[1];
+/** Fallback modem preset when the selected index is stale/out of range. */
+const DEFAULT_LOS_PRESET = MESHTASTIC_PRESETS.find((p) => p.id === "LongFast") ?? MESHTASTIC_PRESETS[1];
 
-/** One-direction link budget. Returns null if hw/ant lookups fail. */
+/** Common LoRa region frequencies (distinct MHz values; several regions share one). */
+const LORA_FREQS: { mhz: number; label: string }[] = [
+  { mhz: 915, label: "915 · US/ANZ" },
+  { mhz: 868, label: "868 · EU/RU" },
+  { mhz: 433, label: "433 · EU433" },
+  { mhz: 470, label: "470 · CN" },
+  { mhz: 865, label: "865 · IN" },
+  { mhz: 920, label: "920 · JP/KR/TH" },
+  { mhz: 923, label: "923 · TW/MY/SG" },
+];
+
+/** Normalize −0 → 0 after rounding so sub-half-dB negatives don't show a red unsigned "0". */
+function roundSigned(v: number): number {
+  return Math.round(v) || 0;
+}
+
+/** One-direction link budget vs the given modem preset. Returns null if hw/ant lookups fail. */
 function dirLinkBudget(
   txHwIdx: number,
   txAntIdx: number,
   rxHwIdx: number,
   rxAntIdx: number,
   itmLossDb: number,
+  preset: ModemPreset,
 ): { rssiDbm: number; marginDb: number; sensitivityDbm: number } | null {
   const txHw = COMMON_HARDWARE[txHwIdx];
   const txAnt = COMMON_ANTENNAS[txAntIdx];
   const rxHw = COMMON_HARDWARE[rxHwIdx];
   const rxAnt = COMMON_ANTENNAS[rxAntIdx];
   if (!txHw || !txAnt || !rxHw || !rxAnt) return null;
-  const rssiDbm = txHw.txDbm + txAnt.dbi + rxAnt.dbi - itmLossDb;
+  // CABLE_LOSS_DB keeps this consistent with coverage/scan (itmEnv shares it for that reason)
+  const rssiDbm = txHw.txDbm + txAnt.dbi + rxAnt.dbi - itmLossDb - CABLE_LOSS_DB;
   const sensitivityDbm = effectiveSensitivityDbm(
-    LOS_PRESET.sensitivityDbm,
+    preset.sensitivityDbm,
     rxHw.chipset,
     rxHw.sensitivityOffsetDb ?? 0,
   );
   return { rssiDbm, marginDb: rssiDbm - sensitivityDbm, sensitivityDbm };
+}
+
+/** Endpoint name that click-edits into a "lat, lng" input (mirrors the coverage origin editor). */
+function EndpointCoordLabel({
+  label,
+  color,
+  position,
+  onPositionChange,
+}: {
+  label: string;
+  color: string;
+  position: [number, number] | null;
+  onPositionChange?: (pos: [number, number]) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [bad, setBad] = useState(false);
+
+  if (!onPositionChange || !editing) {
+    return (
+      <button
+        type="button"
+        disabled={!onPositionChange}
+        onClick={() => {
+          setDraft(position ? `${position[1].toFixed(5)}, ${position[0].toFixed(5)}` : "");
+          setBad(false);
+          setEditing(true);
+        }}
+        title={onPositionChange ? "Click to enter coordinates (lat, lng)" : undefined}
+        className="font-medium truncate enabled:cursor-pointer enabled:hover:underline decoration-dotted underline-offset-2"
+        style={{ color }}
+      >
+        {label}
+      </button>
+    );
+  }
+  return (
+    <input
+      type="text"
+      autoFocus
+      value={draft}
+      placeholder="lat, lng"
+      aria-label={`${label} coordinates as lat, lng`}
+      aria-invalid={bad}
+      onChange={(e) => { setDraft(e.target.value); if (bad) setBad(false); }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          const parsed = parseLatLng(draft);
+          if (!parsed) { setBad(true); return; }
+          setEditing(false);
+          onPositionChange(parsed);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          setEditing(false);
+        }
+      }}
+      onBlur={() => {
+        // Bad value on blur = cancel, so a click-away can't move the endpoint to nonsense
+        const parsed = parseLatLng(draft);
+        setEditing(false);
+        setBad(false);
+        if (parsed) onPositionChange(parsed);
+      }}
+      className={`min-w-0 w-40 rounded-md bg-white/10 border px-1.5 py-0.5 text-[11px] font-mono text-gray-100
+        focus:outline-hidden focus:ring-1 ${
+          bad
+            ? "border-red-500/60 focus:border-red-500/80 focus:ring-red-500/40"
+            : "border-cyan-500/40 focus:border-cyan-500/70 focus:ring-cyan-500/40"
+        }`}
+    />
+  );
 }
 
 /** Endpoint config column: hardware/antenna/height for one end of the LOS link. */
@@ -60,7 +152,8 @@ function EndpointConfig({
   const [heightInput, setHeightInput] = useState(String(heightM));
   useEffect(() => { setHeightInput(String(heightM)); }, [heightM]);
   const commitHeight = () => {
-    const n = Number(heightInput.trim());
+    // Accept decimal comma — mobile keyboards emit "," in most non-US locales
+    const n = Number(heightInput.trim().replace(",", "."));
     if (!Number.isFinite(n) || heightInput.trim() === "") {
       onHeightChange(2);
       setHeightInput("2");
@@ -79,11 +172,13 @@ function EndpointConfig({
         <select
           value={hwIdx}
           onChange={(e) => onHwIdxChange(Number(e.target.value))}
+          aria-label={`${label} hardware`}
           className="w-full rounded border border-white/10 bg-white/5 px-1 py-0.5 text-[10px] text-gray-200
             focus:border-cyan-500/50 focus:outline-hidden [&>option]:bg-gray-800 [&>option]:text-gray-200"
         >
+          {/* Custom is a dead end here (no TX-power input like coverage has) — hide it */}
           {COMMON_HARDWARE.map((h, i) => (
-            <option key={i} value={i}>{h.label} ({h.txDbm} dBm)</option>
+            h.isCustom ? null : <option key={i} value={i}>{h.label} ({h.txDbm} dBm)</option>
           ))}
         </select>
       </div>
@@ -92,6 +187,7 @@ function EndpointConfig({
         <select
           value={antIdx}
           onChange={(e) => onAntIdxChange(Number(e.target.value))}
+          aria-label={`${label} antenna`}
           className="w-full rounded border border-white/10 bg-white/5 px-1 py-0.5 text-[10px] text-gray-200
             focus:border-cyan-500/50 focus:outline-hidden [&>option]:bg-gray-800 [&>option]:text-gray-200"
         >
@@ -154,6 +250,13 @@ export function MapLosPanel({
   toHwIdx, onToHwIdxChange,
   toAntIdx, onToAntIdxChange,
   toHeightM, onToHeightChange,
+  freqMhz, onFreqMhzChange,
+  presetIdx, onPresetIdxChange,
+  fromPosition = null,
+  toPosition = null,
+  onFromPositionChange,
+  onToPositionChange,
+  onSwapEndpoints,
   demSource,
   onProfileHover,
 }: {
@@ -178,6 +281,18 @@ export function MapLosPanel({
   toHwIdx: number; onToHwIdxChange: (idx: number) => void;
   toAntIdx: number; onToAntIdxChange: (idx: number) => void;
   toHeightM: number; onToHeightChange: (m: number) => void;
+  /** Link frequency (MHz). */
+  freqMhz: number; onFreqMhzChange: (mhz: number) => void;
+  /** Modem preset index into MESHTASTIC_PRESETS (drives the margin readout). */
+  presetIdx: number; onPresetIdxChange: (idx: number) => void;
+  /** Current endpoint coords (for the click-to-edit prefill). */
+  fromPosition?: [number, number] | null;
+  toPosition?: [number, number] | null;
+  /** Commit a typed "lat, lng" for an endpoint (detaches a node anchor). */
+  onFromPositionChange?: (pos: [number, number]) => void;
+  onToPositionChange?: (pos: [number, number]) => void;
+  /** Swap from/to endpoints including their hw/antenna/height configs. */
+  onSwapEndpoints?: () => void;
   /** DEM tile source (null before first compute). */
   demSource: DemSource | null;
   /** Fires with 0-1 distance fraction on chart hover. */
@@ -372,19 +487,23 @@ export function MapLosPanel({
     red: "bg-red-400",
   }[statusColor];
 
+  const losPreset = MESHTASTIC_PRESETS[presetIdx] ?? DEFAULT_LOS_PRESET;
   // Link budget per direction (TX→RX = from→to and to→from). Both must work for a usable link.
   const fwd = los.itmLossDb != null
-    ? dirLinkBudget(fromHwIdx, fromAntIdx, toHwIdx, toAntIdx, los.itmLossDb)
+    ? dirLinkBudget(fromHwIdx, fromAntIdx, toHwIdx, toAntIdx, los.itmLossDb, losPreset)
     : null;
   const rev = los.itmLossDb != null
-    ? dirLinkBudget(toHwIdx, toAntIdx, fromHwIdx, fromAntIdx, los.itmLossDb)
+    ? dirLinkBudget(toHwIdx, toAntIdx, fromHwIdx, fromAntIdx, los.itmLossDb, losPreset)
     : null;
   const worstMargin = fwd && rev ? Math.min(fwd.marginDb, rev.marginDb) : null;
-  const marginColor = worstMargin == null
+  // Color from the ROUNDED value so a red pill can't sit next to a "0 dB" reading
+  const worstMarginR = worstMargin == null ? null : roundSigned(worstMargin);
+  const marginColor = worstMarginR == null
     ? ""
-    : worstMargin >= 10 ? "text-emerald-300"
-    : worstMargin >= 0 ? "text-yellow-300"
+    : worstMarginR >= 10 ? "text-emerald-300"
+    : worstMarginR >= 0 ? "text-yellow-300"
     : "text-red-300";
+  const elevDiffR = roundSigned(los.elevationDiffM);
 
   return (
     <div
@@ -417,17 +536,41 @@ export function MapLosPanel({
             <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
             {statusLabel}
           </span>
-          <div className="text-[11px] text-gray-300 truncate">
-            <span style={{ color: fromColor }} className="font-medium">{fromLabel}</span>
-            <span className="text-gray-500 mx-1.5">→</span>
-            <span style={{ color: toColor }} className="font-medium">{toLabel}</span>
+          <div className="text-[11px] text-gray-300 truncate flex items-center">
+            <EndpointCoordLabel
+              label={fromLabel}
+              color={fromColor}
+              position={fromPosition}
+              onPositionChange={onFromPositionChange}
+            />
+            {onSwapEndpoints ? (
+              <button
+                type="button"
+                onClick={onSwapEndpoints}
+                title="Swap endpoints (incl. hardware/antenna/height)"
+                aria-label="Swap from and to endpoints"
+                className="mx-1 p-0.5 rounded text-gray-500 hover:text-cyan-300 hover:bg-white/10 transition-colors"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                </svg>
+              </button>
+            ) : (
+              <span className="text-gray-500 mx-1.5">→</span>
+            )}
+            <EndpointCoordLabel
+              label={toLabel}
+              color={toColor}
+              position={toPosition}
+              onPositionChange={onToPositionChange}
+            />
           </div>
           <span className="text-gray-500 text-[10px]">·</span>
           <span className="text-[11px] text-gray-300">
             <span className="text-gray-500">{los.totalDistanceKm.toFixed(2)}km</span>
             <span className="text-gray-600 mx-1">·</span>
             <span className="text-gray-500">
-              Δ{los.elevationDiffM >= 0 ? "+" : ""}{Math.round(los.elevationDiffM)}m
+              Δ{elevDiffR >= 0 ? "+" : ""}{elevDiffR}m
             </span>
             <span className="text-gray-600 mx-1">·</span>
             <span className="text-gray-500">
@@ -453,19 +596,19 @@ export function MapLosPanel({
                 </span>
               </>
             )}
-            {worstMargin != null && fwd && rev && (
+            {worstMarginR != null && fwd && rev && (
               <>
                 <span className="text-gray-600 mx-1">·</span>
                 <span
                   className={`font-medium ${marginColor}`}
                   title={
-                    `Link margin vs ${LOS_PRESET.label}.\n` +
-                    `${fromLabel} → ${toLabel}: RSSI ${Math.round(fwd.rssiDbm)} dBm, sens ${Math.round(fwd.sensitivityDbm)} dBm → ${fwd.marginDb >= 0 ? "+" : ""}${Math.round(fwd.marginDb)} dB\n` +
-                    `${toLabel} → ${fromLabel}: RSSI ${Math.round(rev.rssiDbm)} dBm, sens ${Math.round(rev.sensitivityDbm)} dBm → ${rev.marginDb >= 0 ? "+" : ""}${Math.round(rev.marginDb)} dB\n` +
+                    `Link margin vs ${losPreset.label} (incl. ${CABLE_LOSS_DB} dB cable loss).\n` +
+                    `${fromLabel} → ${toLabel}: RSSI ${Math.round(fwd.rssiDbm)} dBm, sens ${Math.round(fwd.sensitivityDbm)} dBm → ${roundSigned(fwd.marginDb) >= 0 ? "+" : ""}${roundSigned(fwd.marginDb)} dB\n` +
+                    `${toLabel} → ${fromLabel}: RSSI ${Math.round(rev.rssiDbm)} dBm, sens ${Math.round(rev.sensitivityDbm)} dBm → ${roundSigned(rev.marginDb) >= 0 ? "+" : ""}${roundSigned(rev.marginDb)} dB\n` +
                     `Worst direction shown — both must be positive for a usable link.`
                   }
                 >
-                  {worstMargin >= 0 ? "+" : ""}{Math.round(worstMargin)} dB
+                  {worstMarginR >= 0 ? "+" : ""}{worstMarginR} dB
                   <span className="text-gray-500 ml-1">margin</span>
                 </span>
               </>
@@ -521,8 +664,8 @@ export function MapLosPanel({
               )}
               {worstMargin != null && (
                 <div className="pt-1 border-t border-white/5">
-                  <strong>Link margin:</strong> RX − sensitivity vs <strong>{LOS_PRESET.label}</strong>{" "}
-                  ({LOS_PRESET.sensitivityDbm} dBm). Worst direction shown.
+                  <strong>Link margin:</strong> RX − sensitivity vs <strong>{losPreset.label}</strong>{" "}
+                  ({losPreset.sensitivityDbm} dBm), incl. {CABLE_LOSS_DB} dB cable loss. Worst direction shown.
                 </div>
               )}
               <div className="pt-1 border-t border-white/5">
@@ -551,6 +694,40 @@ export function MapLosPanel({
             </svg>
           </button>
         </div>
+      </div>
+
+      <div className={`flex items-center gap-3 px-3 py-1 border-b border-white/5 text-[10px] text-gray-500 shrink-0 ${minimized ? "max-sm:hidden" : ""}`}>
+        <label className="flex items-center gap-1.5">
+          <span className="uppercase tracking-wider">Freq</span>
+          <select
+            value={freqMhz}
+            onChange={(e) => onFreqMhzChange(Number(e.target.value))}
+            aria-label="Link frequency (LoRa region)"
+            className="rounded border border-white/10 bg-white/5 px-1 py-0.5 text-[10px] text-gray-200
+              focus:border-cyan-500/50 focus:outline-hidden [&>option]:bg-gray-800 [&>option]:text-gray-200"
+          >
+            {!LORA_FREQS.some((f) => f.mhz === freqMhz) && (
+              <option value={freqMhz}>{freqMhz} MHz</option>
+            )}
+            {LORA_FREQS.map((f) => (
+              <option key={f.mhz} value={f.mhz}>{f.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-1.5">
+          <span className="uppercase tracking-wider">Modem</span>
+          <select
+            value={presetIdx}
+            onChange={(e) => onPresetIdxChange(Number(e.target.value))}
+            aria-label="Modem preset for the link-margin readout"
+            className="rounded border border-white/10 bg-white/5 px-1 py-0.5 text-[10px] text-gray-200
+              focus:border-cyan-500/50 focus:outline-hidden [&>option]:bg-gray-800 [&>option]:text-gray-200"
+          >
+            {MESHTASTIC_PRESETS.map((p, i) => (
+              p.isCustom ? null : <option key={p.id} value={i}>{p.label}</option>
+            ))}
+          </select>
+        </label>
       </div>
 
       {terrainWarning && (

--- a/frontend/src/pages/map/MapLosPanel.tsx
+++ b/frontend/src/pages/map/MapLosPanel.tsx
@@ -64,11 +64,14 @@ function EndpointCoordLabel({
   color,
   position,
   onPositionChange,
+  fullWidth = false,
 }: {
   label: string;
   color: string;
   position: [number, number] | null;
   onPositionChange?: (pos: [number, number]) => void;
+  /** Fill the parent (endpoint config column) instead of the fixed header width. */
+  fullWidth?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -84,8 +87,8 @@ function EndpointCoordLabel({
           setBad(false);
           setEditing(true);
         }}
-        title={onPositionChange ? "Click to enter coordinates (lat, lng)" : undefined}
-        className="font-medium truncate enabled:cursor-pointer enabled:hover:underline decoration-dotted underline-offset-2"
+        title={onPositionChange ? "Click to edit or copy coordinates (lat, lng)" : undefined}
+        className="font-medium truncate max-w-full enabled:cursor-pointer enabled:hover:underline decoration-dotted underline-offset-2"
         style={{ color }}
       >
         {label}
@@ -96,6 +99,7 @@ function EndpointCoordLabel({
     <input
       type="text"
       autoFocus
+      onFocus={(e) => e.currentTarget.select()}
       value={draft}
       placeholder="lat, lng"
       aria-label={`${label} coordinates as lat, lng`}
@@ -120,7 +124,7 @@ function EndpointCoordLabel({
         setBad(false);
         if (parsed) onPositionChange(parsed);
       }}
-      className={`min-w-0 w-40 rounded-md bg-white/10 border px-1.5 py-0.5 text-[11px] font-mono text-gray-100
+      className={`min-w-0 ${fullWidth ? "w-full" : "w-40"} rounded-md bg-white/10 border px-1.5 py-0.5 text-[11px] font-mono text-gray-100
         focus:outline-hidden focus:ring-1 ${
           bad
             ? "border-red-500/60 focus:border-red-500/80 focus:ring-red-500/40"
@@ -138,6 +142,8 @@ function EndpointConfig({
   antIdx, onAntIdxChange,
   heightM, onHeightChange,
   usingGpsAltitude = false,
+  position = null,
+  onPositionChange,
 }: {
   label: string;
   color: string;
@@ -149,6 +155,9 @@ function EndpointConfig({
   onHeightChange: (m: number) => void;
   /** Node reported a GPS altitude, so the Height field doesn't affect the result. */
   usingGpsAltitude?: boolean;
+  /** Endpoint coords; makes the label click-to-edit like the header one. */
+  position?: [number, number] | null;
+  onPositionChange?: (pos: [number, number]) => void;
 }) {
   const [heightInput, setHeightInput] = useState(String(heightM));
   useEffect(() => { setHeightInput(String(heightM)); }, [heightM]);
@@ -167,7 +176,13 @@ function EndpointConfig({
 
   return (
     <div className="w-full sm:w-36 sm:shrink-0 p-2 space-y-1.5 text-[10px]">
-      <div className="font-medium truncate" style={{ color }}>{label}</div>
+      <EndpointCoordLabel
+        label={label}
+        color={color}
+        position={position}
+        onPositionChange={onPositionChange}
+        fullWidth
+      />
       <div>
         <div className="text-gray-500 uppercase tracking-wider mb-0.5">Hardware</div>
         <select
@@ -770,6 +785,8 @@ export function MapLosPanel({
             antIdx={fromAntIdx} onAntIdxChange={onFromAntIdxChange}
             heightM={fromHeightM} onHeightChange={onFromHeightChange}
             usingGpsAltitude={!los.fromIsFallback}
+            position={fromPosition}
+            onPositionChange={onFromPositionChange}
           />
         </div>
         <div className="order-1 sm:order-2 flex-1 min-w-0 px-2 py-1.5 sm:border-x border-white/5">
@@ -790,6 +807,8 @@ export function MapLosPanel({
             antIdx={toAntIdx} onAntIdxChange={onToAntIdxChange}
             heightM={toHeightM} onHeightChange={onToHeightChange}
             usingGpsAltitude={!los.toIsFallback}
+            position={toPosition}
+            onPositionChange={onToPositionChange}
           />
         </div>
       </div>

--- a/frontend/src/pages/map/MapScanPanel.tsx
+++ b/frontend/src/pages/map/MapScanPanel.tsx
@@ -1,13 +1,38 @@
-/** Scan-results panel: ranked LoS from origin to every node in view. */
-import { useEffect, useMemo, useRef, useState } from "react";
+/** Scan-results panel: ranked LoS from origin to every node within the scan radius. */
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import { AggressionSlider, BuildingStatusChip, CanopyStatusChip, ClassLegend, ClutterStatusChip } from "./ClutterUI";
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
+import { commitNumericDraft } from "./helpers";
 import { NumericDraftInput } from "./NumericDraftInput";
-import { type ScanClass, type ScanResult, scanSortKey, type ScanSummary } from "./scanAnalysis";
+import { type ScanClass, type ScanResult, type ScanSummary } from "./scanAnalysis";
 import { Segmented } from "./Segmented";
 import type { DemSource } from "./terrainRgb";
 import { useBottomSheetGesture } from "./useBottomSheet";
+
+/** Distance cutoff shown in copy; must track SCAN_RADIUS_KM in useScanCompute. */
+const SCAN_RADIUS_KM = 200;
+
+/** Common LoRa region frequencies (distinct MHz values; several regions share one). */
+const LORA_FREQS: { mhz: number; label: string }[] = [
+  { mhz: 915, label: "915 · US/ANZ" },
+  { mhz: 868, label: "868 · EU/RU" },
+  { mhz: 433, label: "433 · EU433" },
+  { mhz: 470, label: "470 · CN" },
+  { mhz: 865, label: "865 · IN" },
+  { mhz: 920, label: "920 · JP/KR/TH" },
+  { mhz: 923, label: "923 · TW/MY/SG" },
+];
+
+/** Normalize −0 → 0 after rounding so sub-half-dB negatives don't show a bare "0". */
+function roundSigned(v: number): number {
+  return Math.round(v) || 0;
+}
+
+// Resolve the stock-handheld defaults by label so a catalog reorder can't point
+// them at the wrong hardware (COMMON_HARDWARE is actively curated).
+const HANDHELD_HW_IDX = Math.max(0, COMMON_HARDWARE.findIndex((h) => h.label === "Heltec V3"));
+const HANDHELD_ANT_IDX = Math.max(0, COMMON_ANTENNAS.findIndex((a) => a.label.startsWith("Stock")));
 
 /** Collapsible settings row: header summarizes current state, body holds inline editors. */
 function SettingsRow({
@@ -58,7 +83,7 @@ const CLASS_STYLES: Record<ScanClass, { bg: string; text: string; border: string
   blocked:    { bg: "bg-red-500/15",     text: "text-red-300",     border: "border-red-500/30",     label: "Blocked" },
 };
 
-export function MapScanPanel({
+function MapScanPanelInner({
   summary,
   originLabel,
   isScanning,
@@ -81,6 +106,10 @@ export function MapScanPanel({
   onRxHardwareIdxChange,
   rxAntennaIdx,
   onRxAntennaIdxChange,
+  rxHeightM,
+  onRxHeightChange,
+  freqMhz,
+  onFreqMhzChange,
   customTxDbm,
   onCustomTxDbmChange,
   aggressionIdx,
@@ -101,12 +130,18 @@ export function MapScanPanel({
   reliability,
   onReliabilityChange,
   scanError,
+  terrainWarning,
+  onRetry,
 }: {
   summary: ScanSummary | null;
   originLabel: string;
   isScanning: boolean;
-  /** Last scan error; shows an error row instead of a blank panel. */
+  /** Last scan error; shown as a banner (results, if any, stay visible). */
   scanError?: string | null;
+  /** Non-fatal terrain-quality warning (failed tiles), or null. */
+  terrainWarning?: string | null;
+  /** Force a refetch + recompute after a failure. */
+  onRetry?: () => void;
   /** null = scan hasn't run yet; otherwise the bulk DEM source actually used. */
   demSource: DemSource | null;
   terrainNeeded?: boolean;
@@ -130,6 +165,12 @@ export function MapScanPanel({
   onRxHardwareIdxChange: (idx: number) => void;
   rxAntennaIdx: number;
   onRxAntennaIdxChange: (idx: number) => void;
+  /** RX antenna height AGL (m). */
+  rxHeightM: number;
+  onRxHeightChange: (m: number) => void;
+  /** Link frequency (MHz) — drives Fresnel geometry and ITM. */
+  freqMhz: number;
+  onFreqMhzChange: (mhz: number) => void;
   customTxDbm: number;
   onCustomTxDbmChange: (dbm: number) => void;
   /** Index into AGGRESSION_STOPS (0/1/2) for the per-pixel ITU clutter model. */
@@ -208,6 +249,10 @@ export function MapScanPanel({
     // handler closes the whole tool; refocus the summary on close.
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      // Let a field's own Escape (revert-and-blur) run first — don't slam the whole
+      // popover shut on the first Escape while the user is editing a value.
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
       const root = sheet.sheetRef.current;
       const open = root?.querySelectorAll<HTMLDetailsElement>("details[open]");
       if (!open || open.length === 0) return;
@@ -225,21 +270,25 @@ export function MapScanPanel({
     };
   }, [sheet.sheetRef]);
 
-  // Text-mode input; commit on blur/Enter, blank → 2 m default.
+  // Text-mode inputs; commit on blur/Enter, blank/garbage → revert to current value.
   const [heightInput, setHeightInput] = useState(String(antennaHeightM));
   useEffect(() => { setHeightInput(String(antennaHeightM)); }, [antennaHeightM]);
+  const [rxHeightInput, setRxHeightInput] = useState(String(rxHeightM));
+  useEffect(() => { setRxHeightInput(String(rxHeightM)); }, [rxHeightM]);
 
+  // summary.results is already ranked by scanSortKey (runScan sorts once); filter
+  // preserves order, so no re-sort here.
   const displayResults: ScanResult[] = useMemo(() => {
     if (!summary) return [];
-    const filtered = filter
-      ? summary.results.filter((r) => r.cls === filter)
-      : summary.results;
-    // Rank by scanSortKey (matches map order), not raw margin.
-    return [...filtered].sort((a, b) => scanSortKey(b) - scanSortKey(a));
+    return filter ? summary.results.filter((r) => r.cls === filter) : summary.results;
   }, [summary, filter]);
 
-  // Clear a stale map highlight if the row under the cursor re-sorts/filters away.
-  useEffect(() => { onHoverResult?.(null); }, [filter, displayResults, onHoverResult]);
+  // Clear a stale map highlight when the filter changes (a row may vanish under the
+  // cursor). onHoverResult is intentionally excluded — Map passes an inline lambda,
+  // so including it would refire on every parent render and cancel a live hover.
+  const onHoverResultRef = useRef(onHoverResult);
+  onHoverResultRef.current = onHoverResult;
+  useEffect(() => { onHoverResultRef.current?.(null); }, [filter]);
 
   if (terrainNeeded && onEnableTerrain) {
     return (
@@ -284,13 +333,16 @@ export function MapScanPanel({
   const isCustomPreset = MESHTASTIC_PRESETS[presetIdx]?.isCustom ?? false;
 
   const commitHeight = () => {
-    const trimmed = heightInput.trim();
-    if (trimmed === "") { onAntennaHeightChange(2); setHeightInput("2"); return; }
-    const n = Number(trimmed);
-    if (!Number.isFinite(n)) { onAntennaHeightChange(2); setHeightInput("2"); return; }
-    const clamped = Math.max(0, Math.min(300, n));
+    // Blank/garbage (incl. a decimal comma) reverts to the current height — never
+    // silently resets a rooftop analysis to the 2 m default (matches NumericDraftInput).
+    const clamped = commitNumericDraft(heightInput.replace(",", "."), 0, 300, antennaHeightM);
     onAntennaHeightChange(clamped);
     setHeightInput(String(clamped));
+  };
+  const commitRxHeight = () => {
+    const clamped = commitNumericDraft(rxHeightInput.replace(",", "."), 0, 300, rxHeightM);
+    onRxHeightChange(clamped);
+    setRxHeightInput(String(clamped));
   };
 
   const total = summary ? summary.results.length : 0;
@@ -306,8 +358,8 @@ export function MapScanPanel({
   const rxHardware = COMMON_HARDWARE[rxHardwareIdx]?.label ?? "Custom";
   const rxAntDbi = COMMON_ANTENNAS[rxAntennaIdx]?.dbi ?? 0;
 
-  const txSummaryStr = `${txHardware} · ${txAntDbi} dBi · ${antennaHeightM}m · ${txPreset}`;
-  const rxSummaryStr = rxMatchesTx ? "Same as TX" : `${rxHardware} · ${rxAntDbi} dBi`;
+  const txSummaryStr = `${txHardware} · ${txAntDbi} dBi · ${antennaHeightM}m · ${txPreset} · ${freqMhz} MHz`;
+  const rxSummaryStr = rxMatchesTx ? `Same as TX · ${rxHeightM}m` : `${rxHardware} · ${rxAntDbi} dBi · ${rxHeightM}m`;
   const envParts: string[] = [];
   if (clutterEnabled) envParts.push("clutter");
   if (canopyEnabled) envParts.push("canopy");
@@ -363,6 +415,13 @@ export function MapScanPanel({
             </svg>
             Scan
           </span>
+          {/* Minimized: the body is hidden, so surface scan/error state in the header. */}
+          {minimized && isScanning && (
+            <span className="w-1.5 h-1.5 rounded-full bg-cyan-400 animate-pulse shrink-0" title="Scanning…" />
+          )}
+          {minimized && !isScanning && scanError && (
+            <span className="w-1.5 h-1.5 rounded-full bg-red-400 shrink-0" title={scanError} />
+          )}
           <div
             className="text-[11px] text-gray-300 truncate"
             title={summary ? `From ${originLabel} · ${reachable} reachable / ${total}` : `From ${originLabel}`}
@@ -409,7 +468,7 @@ export function MapScanPanel({
             {/* Fixed so it escapes the side-panel's overflow. */}
             <div className="fixed z-1060 overflow-y-auto p-2 rounded-lg bg-gray-900/95 border border-white/10 shadow-2xl space-y-2
               inset-x-3 top-4 bottom-4 w-auto max-w-none
-              sm:inset-auto sm:top-16 sm:left-[calc(var(--map-pad)+22.5rem)] sm:w-90 sm:max-h-[calc(100vh-8rem)]">
+              sm:inset-auto sm:top-16 sm:left-[calc(var(--map-pad)+22.5rem)] sm:w-90 sm:max-w-[calc(100vw-var(--map-pad)-23.5rem)] sm:max-h-[calc(100vh-8rem)]">
               <div className="flex items-center justify-between px-0.5 pb-0.5">
                 <span className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
                   Scan settings
@@ -550,6 +609,27 @@ export function MapScanPanel({
                     </div>
                   </div>
                 </div>
+                <div>
+                  <label htmlFor="scan-freq" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                    Frequency (region)
+                  </label>
+                  <select
+                    id="scan-freq"
+                    value={freqMhz}
+                    onChange={(e) => onFreqMhzChange(Number(e.target.value))}
+                    aria-label="Link frequency (LoRa region)"
+                    className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-gray-200
+                      focus:border-cyan-500/50 focus:outline-hidden focus:ring-1 focus:ring-cyan-500/50
+                      [&>option]:bg-gray-800 [&>option]:text-gray-200"
+                  >
+                    {!LORA_FREQS.some((f) => f.mhz === freqMhz) && (
+                      <option value={freqMhz}>{freqMhz} MHz</option>
+                    )}
+                    {LORA_FREQS.map((f) => (
+                      <option key={f.mhz} value={f.mhz}>{f.label}</option>
+                    ))}
+                  </select>
+                </div>
               </SettingsRow>
 
               <SettingsRow
@@ -576,8 +656,8 @@ export function MapScanPanel({
                             onRxHardwareIdxChange(snap.hw);
                             onRxAntennaIdxChange(snap.ant);
                           } else {
-                            onRxHardwareIdxChange(4); // Heltec V3
-                            onRxAntennaIdxChange(0);  // rubber duck
+                            onRxHardwareIdxChange(HANDHELD_HW_IDX);
+                            onRxAntennaIdxChange(HANDHELD_ANT_IDX);
                           }
                         }
                       }}
@@ -588,14 +668,42 @@ export function MapScanPanel({
                   <button
                     type="button"
                     onClick={() => {
-                      onRxHardwareIdxChange(4); // Heltec V3
-                      onRxAntennaIdxChange(0);  // rubber duck
+                      onRxHardwareIdxChange(HANDHELD_HW_IDX);
+                      onRxAntennaIdxChange(HANDHELD_ANT_IDX);
                     }}
                     className="text-[10px] text-cyan-400/70 hover:text-cyan-300 transition-colors"
                     title="Set RX to a stock handheld (Heltec V3, rubber duck) — typical 'who can hear me?' setup"
                   >
                     Use handheld
                   </button>
+                </div>
+                <div>
+                  <label htmlFor="scan-rx-height" className="text-[10px] font-medium uppercase tracking-wider text-gray-500 mb-1 block">
+                    Antenna Height
+                  </label>
+                  <div className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2 py-1 w-20">
+                    <input
+                      id="scan-rx-height"
+                      type="text"
+                      inputMode="decimal"
+                      value={rxHeightInput}
+                      onChange={(e) => setRxHeightInput(e.target.value)}
+                      onBlur={commitRxHeight}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLInputElement).blur();
+                        } else if (e.key === "Escape") {
+                          setRxHeightInput(String(rxHeightM));
+                          (e.currentTarget as HTMLInputElement).blur();
+                        }
+                      }}
+                      aria-label="RX antenna height above ground at each target (meters)"
+                      title="RX antenna height AGL at each target node (m). Blank = current value."
+                      className="min-w-0 flex-1 bg-transparent text-xs text-gray-200 text-center focus:outline-hidden"
+                    />
+                    <span className="text-[10px] text-gray-500 shrink-0">m</span>
+                  </div>
                 </div>
                 {!rxMatchesTx && (
                   <div className="grid grid-cols-2 gap-2">
@@ -749,28 +857,54 @@ export function MapScanPanel({
       </div>
 
       <div className={`overflow-y-auto overscroll-contain flex-1 ${minimized ? "hidden" : ""}`}>
-        {isScanning && (
+        {/* Recompute indicator — results stay visible underneath so a config tweak
+            keeps the ranked list and scroll position instead of blanking to a spinner. */}
+        {isScanning && summary && (
+          <div role="status" className="px-3 py-1.5 flex items-center justify-center gap-2 text-[10px] text-cyan-300/80 border-b border-white/5 bg-cyan-500/5">
+            <span className="w-1.5 h-1.5 rounded-full bg-cyan-400 animate-pulse" />
+            Recomputing…
+          </div>
+        )}
+
+        {scanError && (
+          <div role="alert" className="px-3 py-2 flex items-center gap-2 text-[11px] text-red-300 border-b border-red-500/20 bg-red-500/5">
+            <span className="flex-1 min-w-0">
+              {scanError}{summary && summary.results.length > 0 ? " Showing previous results." : ""}
+            </span>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="shrink-0 px-2 py-0.5 rounded border border-red-400/40 text-red-200 hover:bg-red-500/15 transition-colors"
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+
+        {terrainWarning && !scanError && (
+          <div role="status" className="px-3 py-2 text-[10px] text-amber-300/90 border-b border-amber-500/20 bg-amber-500/5">
+            {terrainWarning}
+          </div>
+        )}
+
+        {isScanning && !summary && (
           <div role="status" className="px-3 py-6 text-center text-[11px] text-gray-400">
             <div className="inline-flex items-center gap-2">
               <span className="w-2 h-2 rounded-full bg-cyan-400 animate-pulse" />
-              Scanning targets in view…
+              Scanning nodes within {SCAN_RADIUS_KM} km…
             </div>
           </div>
         )}
 
-        {!isScanning && !summary && scanError && (
-          <div role="alert" className="px-3 py-6 text-center text-[11px] text-red-300">
-            {scanError}
-          </div>
-        )}
-
-        {!isScanning && summary && summary.results.length === 0 && (
+        {!isScanning && summary && summary.results.length === 0 && !scanError && (
           <div className="px-3 py-6 text-center text-[11px] text-gray-400">
-            No target nodes within 200 km of the origin. Try a different location.
+            No nodes within {SCAN_RADIUS_KM} km of the origin. Try a different location.
           </div>
         )}
 
-        {!isScanning && summary && summary.results.length > 0 && (
+        {summary && summary.results.length > 0 && (
           <>
             {/* Left-click filters list; right-click hides class on map. */}
             <div className="grid grid-cols-4 gap-1.5 px-3 py-2 text-[10px] text-gray-400 border-b border-white/5">
@@ -814,46 +948,53 @@ export function MapScanPanel({
             <ul className="divide-y divide-white/5">
               {displayResults.map((r) => {
                 const s = CLASS_STYLES[r.cls];
+                const label = r.shortname ?? r.id.slice(0, 8);
+                // roundSigned kills the −0 that Math.round yields for (−0.5,0); show one
+                // decimal for a blocked node whose shortfall would otherwise read "0 dB".
+                const m = roundSigned(r.marginDb);
+                const marginStr = r.cls === "blocked"
+                  ? (m === 0 ? `${r.marginDb.toFixed(1)} dB` : `${m} dB`)
+                  : `+${m} dB`;
                 return (
-                  <li
-                    key={r.id}
-                    role="button"
-                    tabIndex={0}
-                    className="px-3 py-1.5 hover:bg-white/5 focus:bg-white/10 focus:outline-none cursor-pointer transition-colors"
-                    onClick={() => onSelectResult(r.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelectResult(r.id); }
-                    }}
-                    onMouseEnter={() => onHoverResult?.(r.id)}
-                    onMouseLeave={() => onHoverResult?.(null)}
-                    onFocus={() => onHoverResult?.(r.id)}
-                    onBlur={() => onHoverResult?.(null)}
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium border ${s.bg} ${s.text} ${s.border}`}>
-                        {s.label}
-                      </span>
-                      <span className="text-[11px] text-gray-100 font-medium truncate flex-1">
-                        {r.shortname ?? r.id.slice(0, 8)}
-                      </span>
-                      <span className="shrink-0 text-[10px] text-gray-400 tabular-nums">
-                        {r.distanceKm.toFixed(1)} km
-                      </span>
-                      <span className={`shrink-0 text-[10px] tabular-nums ${r.cls === "blocked" ? "text-red-400" : "text-emerald-400"}`}>
-                        {r.cls === "blocked"
-                          ? `${Math.round(r.marginDb)} dB`
-                          : `+${Math.round(r.marginDb)} dB`}
-                      </span>
-                    </div>
-                    {r.cls !== "clear" && (
-                      <div className="pl-[3.1rem] text-[9px] text-gray-500 mt-0.5">
-                        {r.losBlocked && `LoS blocked · `}
-                        {r.fresnelIntruded && !r.losBlocked && `Fresnel intrusion · `}
-                        {r.diffractionLossDb > 0.5 &&
-                          `diffraction ${r.diffractionLossDb.toFixed(1)} dB · `}
-                        RSSI {Math.round(r.rssiDbm)} dBm
+                  <li key={r.id}>
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`${label}, ${s.label}, ${r.distanceKm.toFixed(1)} km, margin ${marginStr}`}
+                      className="px-3 py-1.5 hover:bg-white/5 focus:bg-white/10 focus:outline-none cursor-pointer transition-colors"
+                      onClick={() => onSelectResult(r.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelectResult(r.id); }
+                      }}
+                      onMouseEnter={() => onHoverResult?.(r.id)}
+                      onMouseLeave={() => onHoverResult?.(null)}
+                      onFocus={() => onHoverResult?.(r.id)}
+                      onBlur={() => onHoverResult?.(null)}
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium border ${s.bg} ${s.text} ${s.border}`}>
+                          {s.label}
+                        </span>
+                        <span className="text-[11px] text-gray-100 font-medium truncate flex-1">
+                          {label}
+                        </span>
+                        <span className="shrink-0 text-[10px] text-gray-400 tabular-nums">
+                          {r.distanceKm.toFixed(1)} km
+                        </span>
+                        <span className={`shrink-0 text-[10px] tabular-nums ${r.cls === "blocked" ? "text-red-400" : "text-emerald-400"}`}>
+                          {marginStr}
+                        </span>
                       </div>
-                    )}
+                      {r.cls !== "clear" && (
+                        <div className="pl-[3.1rem] text-[9px] text-gray-500 mt-0.5">
+                          {r.losBlocked && `LoS blocked · `}
+                          {r.fresnelIntruded && !r.losBlocked && `Fresnel intrusion · `}
+                          {r.diffractionLossDb > 0.5 &&
+                            `diffraction ${r.diffractionLossDb.toFixed(1)} dB · `}
+                          RSSI {Math.round(r.rssiDbm)} dBm
+                        </div>
+                      )}
+                    </div>
                   </li>
                 );
               })}
@@ -864,6 +1005,8 @@ export function MapScanPanel({
     </div>
   );
 }
+
+export const MapScanPanel = memo(MapScanPanelInner);
 
 function StatPill({
   label,
@@ -887,10 +1030,13 @@ function StatPill({
   // hide-on-map action so it isn't pointer-and-desktop-only.
   const lpTimer = useRef<number | null>(null);
   const didLongPress = useRef(false);
-  const startLongPress = () => {
+  const startLongPress = (e: React.PointerEvent) => {
+    // Only touch long-press arms the timer — a held LEFT mouse button must not hide
+    // the class (that's the right-click / contextmenu path).
+    if (e.pointerType !== "touch") return;
     didLongPress.current = false;
     lpTimer.current = window.setTimeout(() => {
-      didLongPress.current = true;
+      didLongPress.current = true; // swallow the synthetic click that follows a touch
       onContextMenu?.();
     }, 500);
   };
@@ -901,17 +1047,24 @@ function StatPill({
     <button
       type="button"
       aria-pressed={active}
+      aria-label={hidden ? `${label} — hidden on map` : label}
       onClick={() => {
         if (didLongPress.current) { didLongPress.current = false; return; }
         onClick?.();
       }}
       onContextMenu={(e) => {
         e.preventDefault();
+        // Android also fires contextmenu on long-press; if our touch timer already
+        // toggled, ignore this duplicate. Otherwise (desktop right-click, or an early
+        // Android contextmenu) cancel the timer and toggle exactly once.
+        if (didLongPress.current) return;
+        cancelLongPress();
         onContextMenu?.();
       }}
       onPointerDown={startLongPress}
       onPointerUp={cancelLongPress}
       onPointerLeave={cancelLongPress}
+      onPointerCancel={cancelLongPress}
       onKeyDown={(e) => {
         if (e.key === "h" || e.key === "H") { e.preventDefault(); onContextMenu?.(); }
       }}

--- a/frontend/src/pages/map/MapToolsDrawer.tsx
+++ b/frontend/src/pages/map/MapToolsDrawer.tsx
@@ -159,12 +159,10 @@ export function MapToolsDrawer({
                 aria-disabled={hardDisabled}
                 onClick={() => {
                   if (hardDisabled) return;
-                  if (terrainGated) {
-                    onRequestTerrainSetup?.();
-                    setOpen(false);
-                    return;
-                  }
+                  // Terrain-gated tools still arm: their panels prompt to
+                  // enable 3D terrain, so the user's intent isn't dropped.
                   onSelect(tool.id);
+                  if (terrainGated) onRequestTerrainSetup?.();
                   setOpen(false);
                 }}
                 className={`w-full px-3 py-2 text-left transition-colors flex items-start gap-2.5 ${
@@ -197,7 +195,7 @@ export function MapToolsDrawer({
                     {hardDisabled
                       ? "Temporarily disabled — being polished."
                       : terrainGated
-                        ? "Click to enable 3D terrain."
+                        ? "Needs 3D terrain — click to set up."
                         : tool.description}
                   </div>
                 </div>

--- a/frontend/src/pages/map/buildingTiles.ts
+++ b/frontend/src/pages/map/buildingTiles.ts
@@ -23,7 +23,8 @@ const MAX_ZOOM = 10;
 const DEFAULT_MAX_TILES_PER_REQUEST = 256;
 
 function tileBaseUrl(): string {
-  const apiBase = env.API_BASE_URL ?? window.location.origin;
+  // globalThis, not window — also runs inside the raster-build worker
+  const apiBase = env.API_BASE_URL ?? globalThis.location.origin;
   return `${apiBase}/tiles/buildings`;
 }
 
@@ -321,7 +322,9 @@ export function sampleBuildingAt(
   lat: number,
 ): BuildingSample | null {
   const { width, height, bounds, heightM, mask } = raster;
-  const fx = ((lng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
+  // Seam unwrap, matching sampleDEMAt: a [179,181] bbox must accept lng -179
+  const sLng = lng < bounds.west ? lng + 360 : lng > bounds.east ? lng - 360 : lng;
+  const fx = ((sLng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
   const fy = ((bounds.north - lat) / (bounds.north - bounds.south)) * (height - 1);
   if (!Number.isFinite(fx) || !Number.isFinite(fy) || fx < 0 || fx > width - 1 || fy < 0 || fy > height - 1) return null;
 

--- a/frontend/src/pages/map/canopyTiles.ts
+++ b/frontend/src/pages/map/canopyTiles.ts
@@ -23,7 +23,8 @@ const MAX_ZOOM = 12;
 const DEFAULT_MAX_TILES_PER_REQUEST = 256;
 
 function tileBaseUrl(): string {
-  const apiBase = env.API_BASE_URL ?? window.location.origin;
+  // globalThis, not window — also runs inside the raster-build worker
+  const apiBase = env.API_BASE_URL ?? globalThis.location.origin;
   return `${apiBase}/tiles/canopy`;
 }
 
@@ -336,7 +337,9 @@ export function sampleCanopyAt(
   lat: number,
 ): CanopySample | null {
   const { width, height, bounds, heightM, stdM, mask } = raster;
-  const fx = ((lng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
+  // Seam unwrap, matching sampleDEMAt: a [179,181] bbox must accept lng -179
+  const sLng = lng < bounds.west ? lng + 360 : lng > bounds.east ? lng - 360 : lng;
+  const fx = ((sLng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
   const fy = ((bounds.north - lat) / (bounds.north - bounds.south)) * (height - 1);
   if (!Number.isFinite(fx) || !Number.isFinite(fy) || fx < 0 || fx > width - 1 || fy < 0 || fy > height - 1) return null;
 

--- a/frontend/src/pages/map/coverageContours.ts
+++ b/frontend/src/pages/map/coverageContours.ts
@@ -172,14 +172,15 @@ function stitchSegments(
   return lines;
 }
 
-/** Grid (x,y) → lng/lat. Row 0 = north, row height-1 = south. */
+/** Grid (x,y) → lng/lat. Row 0 = north. Cell-center convention ((x+0.5)/w),
+ *  matching where renderCoverageRaster computes and the ImageSource paints. */
 function gridToLngLat(
   x: number, y: number,
   width: number, height: number,
   bounds: DEMBounds,
 ): [number, number] {
-  const lng = bounds.west + (x / (width - 1)) * (bounds.east - bounds.west);
-  const lat = bounds.north - (y / (height - 1)) * (bounds.north - bounds.south);
+  const lng = bounds.west + ((x + 0.5) / width) * (bounds.east - bounds.west);
+  const lat = bounds.north - ((y + 0.5) / height) * (bounds.north - bounds.south);
   return [lng, lat];
 }
 

--- a/frontend/src/pages/map/coverageExport.ts
+++ b/frontend/src/pages/map/coverageExport.ts
@@ -46,8 +46,6 @@ export function exportCoverage(
     ext = "geojson";
   } else {
     // KML color format: aabbggrr (byte-reversed from CSS hex)
-    const esc = (s: string) =>
-      s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     const styleFor = (threshold: number) => {
       if (threshold <= 0) return "contour0";
       if (threshold <= 10) return "contour10";
@@ -67,6 +65,7 @@ export function exportCoverage(
       </LineString>
     </Placemark>`).join("");
 
+    // Lands inside CDATA — escaping would double-encode
     const description = [
       `Model: Longley-Rice v1.4 (ITS) via WASM`,
       `Origin height: ${Math.round(result.originHeightM)} m${result.originIsFallback ? " (fallback)" : ""}`,
@@ -74,7 +73,7 @@ export function exportCoverage(
       `TX: ${result.txDbm} dBm, antenna ${result.txAntennaDbi} dBi`,
       `RX: antenna ${result.rxAntennaDbi} dBi @ ${Math.round(result.rxAntennaHeightAboveGroundM)} m AGL, sensitivity ${result.rxSensitivityDbm} dBm`,
       `Generated: ${stamp}`,
-    ].map(esc).join("\n");
+    ].join("\n");
 
     payload = `<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -99,7 +98,7 @@ export function exportCoverage(
     </Style>
     <Placemark>
       <name>Coverage origin</name>
-      <description><![CDATA[${esc(`${Math.round(result.originHeightM)} m MSL · TX ${result.txDbm} dBm · ${result.txAntennaDbi} dBi`)}]]></description>
+      <description><![CDATA[${`${Math.round(result.originHeightM)} m MSL · TX ${result.txDbm} dBm · ${result.txAntennaDbi} dBi`}]]></description>
       <styleUrl>#origin</styleUrl>
       <Point>
         <coordinates>${result.origin[0]},${result.origin[1]},${Math.round(result.originHeightM)}</coordinates>

--- a/frontend/src/pages/map/coveragePresets.ts
+++ b/frontend/src/pages/map/coveragePresets.ts
@@ -89,7 +89,7 @@ export function snapshotPreset(name: string, s: CoveragePanelSettings): Coverage
 }
 
 /** Hardware label → index; unknown labels land on the Custom slot so txDbm is honored. */
-function resolveHardware(label: string): { idx: number; isCustom: boolean } {
+export function resolveHardware(label: string): { idx: number; isCustom: boolean } {
   const i = COMMON_HARDWARE.findIndex((h) => h.label === label);
   if (i >= 0) return { idx: i, isCustom: COMMON_HARDWARE[i].isCustom ?? false };
   const custom = COMMON_HARDWARE.findIndex((h) => h.isCustom);
@@ -97,7 +97,7 @@ function resolveHardware(label: string): { idx: number; isCustom: boolean } {
 }
 
 /** Antenna label → index; unknown labels resolve to the closest gain. */
-function resolveAntenna(label: string, dbi: number): number {
+export function resolveAntenna(label: string, dbi: number): number {
   const i = COMMON_ANTENNAS.findIndex((a) => a.label === label);
   if (i >= 0) return i;
   let best = 0;

--- a/frontend/src/pages/map/coveragePresets.ts
+++ b/frontend/src/pages/map/coveragePresets.ts
@@ -1,0 +1,224 @@
+/**
+ * Named coverage-settings presets: snapshot/apply, localStorage library,
+ * JSON export/import. Serialization is semantic (labels/ids + numeric values)
+ * so presets survive catalog reordering; unresolvable entries fall back to
+ * the Custom slot or closest-gain antenna.
+ */
+import { AGGRESSION_STOPS, COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, DEFAULT_AGGRESSION_IDX, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
+import { COVERAGE_DETAIL_SIZE, type CoverageDetail } from "./coverageDetail";
+import { LS_KEYS, readJson, writeJson } from "./storage";
+
+/** Panel-native settings bag (catalog indices + numbers). */
+export interface CoveragePanelSettings {
+  hardwareIdx: number;
+  customTxDbm: number;
+  antennaIdx: number;
+  antennaHeightM: number;
+  rxHardwareIdx: number;
+  rxAntennaIdx: number;
+  rxHeightM: number;
+  presetIdx: number;
+  customSensitivityDbm: number;
+  aggressionIdx: number;
+  clutterEnabled: boolean;
+  canopyEnabled: boolean;
+  buildingsEnabled: boolean;
+  detail: CoverageDetail;
+  reliability: CoverageReliability;
+  showContours: boolean;
+  showRays: boolean;
+}
+
+/** Version-stable preset payload. */
+export interface CoveragePreset {
+  v: 1;
+  name: string;
+  savedAt: string;
+  tx: { hardware: string; txDbm: number; antenna: string; antennaDbi: number; antennaHeightM: number };
+  rx: { hardware: string; antenna: string; antennaDbi: number; heightM: number };
+  modem: { id: string; sensitivityDbm: number };
+  env: { clutterEnabled: boolean; aggression: string; canopyEnabled: boolean; buildingsEnabled: boolean };
+  accuracy: { reliability: string; detail: string };
+  overlays: { contours: boolean; rays: boolean };
+}
+
+export const MAX_PRESETS = 30;
+export const MAX_PRESET_NAME_LEN = 60;
+
+const clampNum = (v: unknown, min: number, max: number, fallback: number): number => {
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+};
+
+export function snapshotPreset(name: string, s: CoveragePanelSettings): CoveragePreset {
+  const hw = COMMON_HARDWARE[s.hardwareIdx] ?? COMMON_HARDWARE[0];
+  const rxHw = COMMON_HARDWARE[s.rxHardwareIdx] ?? COMMON_HARDWARE[0];
+  const ant = COMMON_ANTENNAS[s.antennaIdx] ?? COMMON_ANTENNAS[0];
+  const rxAnt = COMMON_ANTENNAS[s.rxAntennaIdx] ?? COMMON_ANTENNAS[0];
+  const modem = MESHTASTIC_PRESETS[s.presetIdx] ?? MESHTASTIC_PRESETS[0];
+  return {
+    v: 1,
+    name: name.trim().slice(0, MAX_PRESET_NAME_LEN),
+    savedAt: new Date().toISOString(),
+    tx: {
+      hardware: hw.label,
+      txDbm: hw.isCustom ? s.customTxDbm : hw.txDbm,
+      antenna: ant.label,
+      antennaDbi: ant.dbi,
+      antennaHeightM: s.antennaHeightM,
+    },
+    rx: { hardware: rxHw.label, antenna: rxAnt.label, antennaDbi: rxAnt.dbi, heightM: s.rxHeightM },
+    modem: { id: modem.id, sensitivityDbm: modem.isCustom ? s.customSensitivityDbm : modem.sensitivityDbm },
+    env: {
+      clutterEnabled: s.clutterEnabled,
+      aggression: AGGRESSION_STOPS[s.aggressionIdx]?.id ?? AGGRESSION_STOPS[DEFAULT_AGGRESSION_IDX].id,
+      canopyEnabled: s.canopyEnabled,
+      buildingsEnabled: s.buildingsEnabled,
+    },
+    accuracy: { reliability: s.reliability, detail: s.detail },
+    overlays: { contours: s.showContours, rays: s.showRays },
+  };
+}
+
+/** Hardware label → index; unknown labels land on the Custom slot so txDbm is honored. */
+function resolveHardware(label: string): { idx: number; isCustom: boolean } {
+  const i = COMMON_HARDWARE.findIndex((h) => h.label === label);
+  if (i >= 0) return { idx: i, isCustom: COMMON_HARDWARE[i].isCustom ?? false };
+  const custom = COMMON_HARDWARE.findIndex((h) => h.isCustom);
+  return { idx: custom >= 0 ? custom : 0, isCustom: true };
+}
+
+/** Antenna label → index; unknown labels resolve to the closest gain. */
+function resolveAntenna(label: string, dbi: number): number {
+  const i = COMMON_ANTENNAS.findIndex((a) => a.label === label);
+  if (i >= 0) return i;
+  let best = 0;
+  let bestDelta = Number.POSITIVE_INFINITY;
+  COMMON_ANTENNAS.forEach((a, idx) => {
+    const d = Math.abs(a.dbi - dbi);
+    if (d < bestDelta) { bestDelta = d; best = idx; }
+  });
+  return best;
+}
+
+export function resolvePreset(p: CoveragePreset): CoveragePanelSettings {
+  const hw = resolveHardware(p.tx.hardware);
+  const rxHw = resolveHardware(p.rx.hardware);
+  const modemIdx = MESHTASTIC_PRESETS.findIndex((m) => m.id === p.modem.id);
+  const customModemIdx = MESHTASTIC_PRESETS.findIndex((m) => m.isCustom);
+  const aggressionIdx = AGGRESSION_STOPS.findIndex((a) => a.id === p.env.aggression);
+  const detail = (Object.keys(COVERAGE_DETAIL_SIZE) as CoverageDetail[]).includes(p.accuracy.detail as CoverageDetail)
+    ? (p.accuracy.detail as CoverageDetail)
+    : "standard";
+  const reliability = RELIABILITY_PRESETS.some((r) => r.id === p.accuracy.reliability)
+    ? (p.accuracy.reliability as CoverageReliability)
+    : "typical";
+  return {
+    hardwareIdx: hw.idx,
+    customTxDbm: clampNum(p.tx.txDbm, 10, 35, 22),
+    antennaIdx: resolveAntenna(p.tx.antenna, p.tx.antennaDbi),
+    antennaHeightM: clampNum(p.tx.antennaHeightM, 0, 300, 2),
+    rxHardwareIdx: rxHw.idx,
+    rxAntennaIdx: resolveAntenna(p.rx.antenna, p.rx.antennaDbi),
+    rxHeightM: clampNum(p.rx.heightM, 0, 300, 2),
+    presetIdx: modemIdx >= 0 ? modemIdx : (customModemIdx >= 0 ? customModemIdx : 0),
+    customSensitivityDbm: clampNum(p.modem.sensitivityDbm, -150, -100, -130),
+    aggressionIdx: aggressionIdx >= 0 ? aggressionIdx : DEFAULT_AGGRESSION_IDX,
+    clutterEnabled: !!p.env.clutterEnabled,
+    canopyEnabled: !!p.env.canopyEnabled,
+    buildingsEnabled: !!p.env.buildingsEnabled,
+    detail,
+    reliability,
+    showContours: !!p.overlays.contours,
+    showRays: !!p.overlays.rays,
+  };
+}
+
+/** Shape-check one candidate (import or LS read); returns a sanitized copy or null. */
+function sanitizePreset(raw: unknown): CoveragePreset | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const p = raw as Record<string, unknown>;
+  if (p.v !== 1 || typeof p.name !== "string" || p.name.trim() === "") return null;
+  const tx = p.tx as Record<string, unknown> | undefined;
+  const rx = p.rx as Record<string, unknown> | undefined;
+  const modem = p.modem as Record<string, unknown> | undefined;
+  const env = p.env as Record<string, unknown> | undefined;
+  const accuracy = p.accuracy as Record<string, unknown> | undefined;
+  const overlays = p.overlays as Record<string, unknown> | undefined;
+  if (!tx || !rx || !modem || !env || !accuracy || !overlays) return null;
+  const str = (v: unknown, fallback: string) => (typeof v === "string" ? v : fallback);
+  return {
+    v: 1,
+    name: p.name.trim().slice(0, MAX_PRESET_NAME_LEN),
+    savedAt: str(p.savedAt, new Date().toISOString()),
+    tx: {
+      hardware: str(tx.hardware, ""),
+      txDbm: clampNum(tx.txDbm, 10, 35, 22),
+      antenna: str(tx.antenna, ""),
+      antennaDbi: clampNum(tx.antennaDbi, -5, 20, 3),
+      antennaHeightM: clampNum(tx.antennaHeightM, 0, 300, 2),
+    },
+    rx: {
+      hardware: str(rx.hardware, ""),
+      antenna: str(rx.antenna, ""),
+      antennaDbi: clampNum(rx.antennaDbi, -5, 20, 3),
+      heightM: clampNum(rx.heightM, 0, 300, 2),
+    },
+    modem: { id: str(modem.id, "LongFast"), sensitivityDbm: clampNum(modem.sensitivityDbm, -150, -100, -130) },
+    env: {
+      clutterEnabled: !!env.clutterEnabled,
+      aggression: str(env.aggression, AGGRESSION_STOPS[DEFAULT_AGGRESSION_IDX].id),
+      canopyEnabled: !!env.canopyEnabled,
+      buildingsEnabled: !!env.buildingsEnabled,
+    },
+    accuracy: { reliability: str(accuracy.reliability, "typical"), detail: str(accuracy.detail, "standard") },
+    overlays: { contours: !!overlays.contours, rays: !!overlays.rays },
+  };
+}
+
+export function readPresetLibrary(): CoveragePreset[] {
+  const raw = readJson<unknown>(LS_KEYS.coveragePresets, []);
+  if (!Array.isArray(raw)) return [];
+  return raw.map(sanitizePreset).filter((p): p is CoveragePreset => p !== null).slice(0, MAX_PRESETS);
+}
+
+export function writePresetLibrary(presets: CoveragePreset[]): void {
+  writeJson(LS_KEYS.coveragePresets, presets.slice(0, MAX_PRESETS));
+}
+
+/** Serialize the library for file export. */
+export function presetsToFile(presets: CoveragePreset[]): string {
+  return JSON.stringify({ v: 1, kind: "meshinfo-coverage-presets", presets }, null, 2);
+}
+
+/** Parse an imported file: accepts a library file or a bare single preset. */
+export function parsePresetsFile(text: string): CoveragePreset[] | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  const candidates: unknown[] = Array.isArray(obj.presets) ? obj.presets : [obj];
+  const parsed = candidates.map(sanitizePreset).filter((p): p is CoveragePreset => p !== null);
+  return parsed.length > 0 ? parsed : null;
+}
+
+/** Trigger a JSON download of the library. */
+export function downloadPresets(presets: CoveragePreset[]): void {
+  const now = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  const stamp = `${now.getUTCFullYear()}${p(now.getUTCMonth() + 1)}${p(now.getUTCDate())}-${p(now.getUTCHours())}${p(now.getUTCMinutes())}${p(now.getUTCSeconds())}`;
+  const blob = new Blob([presetsToFile(presets)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `meshinfo-coverage-presets-${stamp}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}

--- a/frontend/src/pages/map/coveragePresets.ts
+++ b/frontend/src/pages/map/coveragePresets.ts
@@ -29,14 +29,16 @@ export interface CoveragePanelSettings {
   showRays: boolean;
 }
 
-/** Version-stable preset payload. */
+/** Version-stable preset payload. `customTxDbm`/`customSensitivityDbm` carry
+ *  the Custom-slot scratch values even when a catalog entry is selected, so a
+ *  restore doesn't clobber them with the selection's effective value. */
 export interface CoveragePreset {
   v: 1;
   name: string;
   savedAt: string;
-  tx: { hardware: string; txDbm: number; antenna: string; antennaDbi: number; antennaHeightM: number };
+  tx: { hardware: string; txDbm: number; antenna: string; antennaDbi: number; antennaHeightM: number; customTxDbm?: number };
   rx: { hardware: string; antenna: string; antennaDbi: number; heightM: number };
-  modem: { id: string; sensitivityDbm: number };
+  modem: { id: string; sensitivityDbm: number; customSensitivityDbm?: number };
   env: { clutterEnabled: boolean; aggression: string; canopyEnabled: boolean; buildingsEnabled: boolean };
   accuracy: { reliability: string; detail: string };
   overlays: { contours: boolean; rays: boolean };
@@ -67,9 +69,14 @@ export function snapshotPreset(name: string, s: CoveragePanelSettings): Coverage
       antenna: ant.label,
       antennaDbi: ant.dbi,
       antennaHeightM: s.antennaHeightM,
+      customTxDbm: s.customTxDbm,
     },
     rx: { hardware: rxHw.label, antenna: rxAnt.label, antennaDbi: rxAnt.dbi, heightM: s.rxHeightM },
-    modem: { id: modem.id, sensitivityDbm: modem.isCustom ? s.customSensitivityDbm : modem.sensitivityDbm },
+    modem: {
+      id: modem.id,
+      sensitivityDbm: modem.isCustom ? s.customSensitivityDbm : modem.sensitivityDbm,
+      customSensitivityDbm: s.customSensitivityDbm,
+    },
     env: {
       clutterEnabled: s.clutterEnabled,
       aggression: AGGRESSION_STOPS[s.aggressionIdx]?.id ?? AGGRESSION_STOPS[DEFAULT_AGGRESSION_IDX].id,
@@ -107,6 +114,7 @@ export function resolvePreset(p: CoveragePreset): CoveragePanelSettings {
   const rxHw = resolveHardware(p.rx.hardware);
   const modemIdx = MESHTASTIC_PRESETS.findIndex((m) => m.id === p.modem.id);
   const customModemIdx = MESHTASTIC_PRESETS.findIndex((m) => m.isCustom);
+  const modemIsCustom = modemIdx < 0 || (MESHTASTIC_PRESETS[modemIdx]?.isCustom ?? false);
   const aggressionIdx = AGGRESSION_STOPS.findIndex((a) => a.id === p.env.aggression);
   const detail = (Object.keys(COVERAGE_DETAIL_SIZE) as CoverageDetail[]).includes(p.accuracy.detail as CoverageDetail)
     ? (p.accuracy.detail as CoverageDetail)
@@ -114,16 +122,20 @@ export function resolvePreset(p: CoveragePreset): CoveragePanelSettings {
   const reliability = RELIABILITY_PRESETS.some((r) => r.id === p.accuracy.reliability)
     ? (p.accuracy.reliability as CoverageReliability)
     : "typical";
+  // Scratch values: prefer the explicit fields; older payloads fall back to
+  // the effective value only when the selection actually IS the Custom slot.
+  const scratchTxDbm = p.tx.customTxDbm ?? (hw.isCustom ? p.tx.txDbm : 22);
+  const scratchSensDbm = p.modem.customSensitivityDbm ?? (modemIsCustom ? p.modem.sensitivityDbm : -133);
   return {
     hardwareIdx: hw.idx,
-    customTxDbm: clampNum(p.tx.txDbm, 10, 35, 22),
+    customTxDbm: clampNum(scratchTxDbm, 10, 35, 22),
     antennaIdx: resolveAntenna(p.tx.antenna, p.tx.antennaDbi),
     antennaHeightM: clampNum(p.tx.antennaHeightM, 0, 300, 2),
     rxHardwareIdx: rxHw.idx,
     rxAntennaIdx: resolveAntenna(p.rx.antenna, p.rx.antennaDbi),
     rxHeightM: clampNum(p.rx.heightM, 0, 300, 2),
     presetIdx: modemIdx >= 0 ? modemIdx : (customModemIdx >= 0 ? customModemIdx : 0),
-    customSensitivityDbm: clampNum(p.modem.sensitivityDbm, -150, -100, -130),
+    customSensitivityDbm: clampNum(scratchSensDbm, -150, -100, -133),
     aggressionIdx: aggressionIdx >= 0 ? aggressionIdx : DEFAULT_AGGRESSION_IDX,
     clutterEnabled: !!p.env.clutterEnabled,
     canopyEnabled: !!p.env.canopyEnabled,
@@ -136,7 +148,7 @@ export function resolvePreset(p: CoveragePreset): CoveragePanelSettings {
 }
 
 /** Shape-check one candidate (import or LS read); returns a sanitized copy or null. */
-function sanitizePreset(raw: unknown): CoveragePreset | null {
+export function sanitizePreset(raw: unknown): CoveragePreset | null {
   if (typeof raw !== "object" || raw === null) return null;
   const p = raw as Record<string, unknown>;
   if (p.v !== 1 || typeof p.name !== "string" || p.name.trim() === "") return null;
@@ -158,6 +170,7 @@ function sanitizePreset(raw: unknown): CoveragePreset | null {
       antenna: str(tx.antenna, ""),
       antennaDbi: clampNum(tx.antennaDbi, -5, 20, 3),
       antennaHeightM: clampNum(tx.antennaHeightM, 0, 300, 2),
+      customTxDbm: typeof tx.customTxDbm === "number" ? clampNum(tx.customTxDbm, 10, 35, 22) : undefined,
     },
     rx: {
       hardware: str(rx.hardware, ""),
@@ -165,7 +178,11 @@ function sanitizePreset(raw: unknown): CoveragePreset | null {
       antennaDbi: clampNum(rx.antennaDbi, -5, 20, 3),
       heightM: clampNum(rx.heightM, 0, 300, 2),
     },
-    modem: { id: str(modem.id, "LongFast"), sensitivityDbm: clampNum(modem.sensitivityDbm, -150, -100, -130) },
+    modem: {
+      id: str(modem.id, "LongFast"),
+      sensitivityDbm: clampNum(modem.sensitivityDbm, -150, -100, -130),
+      customSensitivityDbm: typeof modem.customSensitivityDbm === "number" ? clampNum(modem.customSensitivityDbm, -150, -100, -133) : undefined,
+    },
     env: {
       clutterEnabled: !!env.clutterEnabled,
       aggression: str(env.aggression, AGGRESSION_STOPS[DEFAULT_AGGRESSION_IDX].id),

--- a/frontend/src/pages/map/coverageRaster.ts
+++ b/frontend/src/pages/map/coverageRaster.ts
@@ -194,9 +194,11 @@ export function renderCoverageRaster(
     txHeights[k] = Math.max(0.5, Math.min(3000, origins[k].antennaHeightAboveGroundM));
   }
 
-  // Step over OUTPUT grid; terrain via bilinear sampleDEMAt is (lng,lat)-continuous
-  const lonStep = (bounds.east - bounds.west) / (outputWidth - 1);
-  const latStep = (bounds.north - bounds.south) / (outputHeight - 1);
+  // Step over OUTPUT grid at pixel CENTERS ((i+0.5)/w) so each computed value
+  // sits exactly where the ImageSource paints it (texture spans bounds
+  // edge-to-edge). Terrain via bilinear sampleDEMAt is (lng,lat)-continuous.
+  const lonStep = (bounds.east - bounds.west) / outputWidth;
+  const latStep = (bounds.north - bounds.south) / outputHeight;
 
   // Reusable input object (65k+ computes per frame → don't allocate). ITM wants AGL, clamped [0.5, 3000].
   const itmInput = {
@@ -229,11 +231,11 @@ export function renderCoverageRaster(
     : null;
 
   for (let j = rowStart; j < rowEnd; j++) {
-    const lat = bounds.north - j * latStep;
+    const lat = bounds.north - (j + 0.5) * latStep;
     const outRowOffset = (j - rowStart) * outputWidth;
     for (let i = 0; i < outputWidth; i++) {
       const outPxIdx = outRowOffset + i;
-      const lng = bounds.west + i * lonStep;
+      const lng = bounds.west + (i + 0.5) * lonStep;
       const demElev = sampleDEMAt(dem, lng, lat);
       if (Number.isNaN(demElev)) {
         rgba[outPxIdx * 4 + 3] = 0;

--- a/frontend/src/pages/map/coverageRays.ts
+++ b/frontend/src/pages/map/coverageRays.ts
@@ -67,18 +67,20 @@ export function extractCoverageRays(opts: ExtractRaysOptions): VisibilityRayFeat
   const demToLat = (gy: number) =>
     bounds.north - (gy / (demH - 1)) * (bounds.north - bounds.south);
 
-  const margScaleX = marginW / demW;
-  const margScaleY = marginH / demH;
-
-  // DEM-pixel metres at bbox mid-lat, for viewshed angles and earth-bulge
+  // Per-axis DEM-pixel metres: union bboxes (merge origins) aren't square in
+  // metres, so a single scale would skew azimuths and distances N-S vs E-W.
   const midLat = (bounds.north + bounds.south) / 2;
   const bboxWidthM =
     (bounds.east - bounds.west) * 111_320 * Math.cos((midLat * Math.PI) / 180);
-  const metersPerDemPixel = bboxWidthM / (demW - 1);
+  const bboxHeightM = (bounds.north - bounds.south) * 111_320;
+  const mPerPxX = bboxWidthM / (demW - 1);
+  const mPerPxY = bboxHeightM / (demH - 1);
+  /** Step length in true metres (finest pixel), so distM = t × stepM exactly. */
+  const stepM = Math.min(mPerPxX, mPerPxY);
 
   const features: Feature<LineString, { azimuth: number; marginDb: number }>[] = [];
 
-  const maxSteps = Math.ceil(Math.hypot(demW, demH));
+  const maxSteps = Math.ceil(Math.hypot(demW * mPerPxX, demH * mPerPxY) / stepM);
 
   const pushSegment = (
     az: number,
@@ -103,9 +105,10 @@ export function extractCoverageRays(opts: ExtractRaysOptions): VisibilityRayFeat
 
   for (let az = 0; az < 360; az += azimuthStepDeg) {
     const azRad = (az * Math.PI) / 180;
-    // Azimuth: 0° = N, clockwise; grid y+ = south
-    const dx = Math.sin(azRad);
-    const dy = -Math.cos(azRad);
+    // Azimuth: 0° = N, clockwise; grid y+ = south. Direction is a true-metre
+    // unit vector converted to (anisotropic) grid units per step.
+    const dx = (Math.sin(azRad) * stepM) / mPerPxX;
+    const dy = (-Math.cos(azRad) * stepM) / mPerPxY;
 
     // R2 viewshed: running max terrain-to-observer angle. Visible iff pixel top exceeds it.
     let maxAngle = -Infinity;
@@ -146,7 +149,7 @@ export function extractCoverageRays(opts: ExtractRaysOptions): VisibilityRayFeat
         continue;
       }
 
-      const distM = t * metersPerDemPixel;
+      const distM = t * stepM;
       // 4/3-earth bulge: d²/(2·R_eff). Keeps long rays from faking over-the-horizon.
       const earthDrop = (distM * distM) / (2 * EFFECTIVE_EARTH_RADIUS_M);
       const effTerrainElev = terrainElev - earthDrop;
@@ -159,8 +162,10 @@ export function extractCoverageRays(opts: ExtractRaysOptions): VisibilityRayFeat
       const visible = pixelAngle > maxAngle;
       if (terrainAngle > maxAngle) maxAngle = terrainAngle;
 
-      const margPx = Math.min(marginW - 1, Math.floor(gx * margScaleX));
-      const margPy = Math.min(marginH - 1, Math.floor(gy * margScaleY));
+      // DEM edge-convention coord → normalized position → margin CELL (the
+      // margin grid uses cell-center convention)
+      const margPx = Math.min(marginW - 1, Math.max(0, Math.floor((gx / (demW - 1)) * marginW)));
+      const margPy = Math.min(marginH - 1, Math.max(0, Math.floor((gy / (demH - 1)) * marginH)));
       const m = margin[margPy * marginW + margPx];
       const marginOk = !Number.isNaN(m) && m >= 0;
 

--- a/frontend/src/pages/map/coverageSliceWorker.ts
+++ b/frontend/src/pages/map/coverageSliceWorker.ts
@@ -1,6 +1,7 @@
 /**
  * Coverage slice worker: runs ITM per pixel over a row range of a shared DEM.
- * Each worker keeps its own ITM WASM context warm across requests.
+ * Keeps its ITM WASM context warm across requests and caches the raster set
+ * by generation id, so same-generation slices carry no buffers.
  */
 import type { BuildingRaster } from "./buildingTiles";
 import type { CanopyRaster } from "./canopyTiles";
@@ -27,21 +28,13 @@ export interface SliceOrigin {
   antennaHeightAboveGroundM: number;
 }
 
-export interface CoverageSliceRequest {
-  requestId: number;
-  /** Transferable DEM buffer (main thread ships a copy per worker). */
+/** Raster buffers shipped once per generation (pool attaches them lazily,
+ *  only for workers that haven't seen the generation yet). */
+export interface CoverageRasterPayload {
   demBuffer: ArrayBuffer;
   demWidth: number;
   demHeight: number;
   bounds: DEMBounds;
-  /** Primary + optional merge origins. */
-  origins: SliceOrigin[];
-  params: RasterParams;
-  /** rowStart/rowEnd are OUTPUT-grid indices (decoupled from DEM). */
-  outputWidth: number;
-  outputHeight: number;
-  rowStart: number;
-  rowEnd: number;
   /** Optional class-ID raster aligned to DEM bounds. Absent → default class everywhere. */
   clutterBuffer?: ArrayBuffer;
   clutterWidth?: number;
@@ -59,6 +52,30 @@ export interface CoverageSliceRequest {
   buildingHeight?: number;
 }
 
+export interface CoverageSliceRequest {
+  requestId: number;
+  /** Raster generation this slice targets; the worker's cache must match. */
+  rasterGen: number;
+  /** Present only when the pool decides this worker needs the buffers. */
+  rasters?: CoverageRasterPayload;
+  /** Primary + optional merge origins. */
+  origins: SliceOrigin[];
+  params: RasterParams;
+  /** rowStart/rowEnd are OUTPUT-grid indices (decoupled from DEM). */
+  outputWidth: number;
+  outputHeight: number;
+  rowStart: number;
+  rowEnd: number;
+}
+
+/** Control messages: free cached rasters (tool exit — they hold ~100 MB at
+ *  full tiers) or pre-compile the ITM WASM ahead of the first compute. */
+export interface ControlMessage {
+  kind: "clearRasters" | "warmup";
+}
+
+export type CoverageWorkerMessage = CoverageSliceRequest | ControlMessage;
+
 export interface CoverageSliceResponse {
   requestId: number;
   rgba: Uint8ClampedArray;
@@ -71,6 +88,8 @@ export interface CoverageSliceResponse {
   blockedCount: number;
   maxMarginDb: number;
   itmUnavailable?: boolean;
+  /** Worker lacks rasters for `rasterGen` — the pool re-sends the slice with buffers attached. */
+  cacheMiss?: boolean;
 }
 
 // One ITM WASM context per worker, kept warm across requests.
@@ -85,92 +104,130 @@ function getItmContext(): Promise<ItmContext> {
   return itmContextPromise;
 }
 
+// Raster cache, valid while cachedGen matches incoming requests.
+let cachedGen = -1;
+let cachedDem: DEM | null = null;
+let cachedClutter: ClutterRaster | null = null;
+let cachedCanopy: CanopyRaster | null = null;
+let cachedBuildings: BuildingRaster | null = null;
+
+function clearRasterCache(): void {
+  cachedGen = -1;
+  cachedDem = null;
+  cachedClutter = null;
+  cachedCanopy = null;
+  cachedBuildings = null;
+}
+
+function adoptRasters(gen: number, r: CoverageRasterPayload): void {
+  cachedDem = {
+    data: new Float32Array(r.demBuffer),
+    width: r.demWidth,
+    height: r.demHeight,
+    bounds: r.bounds,
+  };
+  cachedClutter =
+    r.clutterBuffer && r.clutterWidth && r.clutterHeight
+      ? {
+          data: new Uint8Array(r.clutterBuffer),
+          width: r.clutterWidth,
+          height: r.clutterHeight,
+          bounds: r.bounds,
+          tilesPresent: 0,
+          tilesTotal: 0,
+        }
+      : null;
+  cachedCanopy =
+    r.canopyHeightBuffer && r.canopyStdBuffer && r.canopyMaskBuffer && r.canopyWidth && r.canopyHeight
+      ? {
+          heightM: new Float32Array(r.canopyHeightBuffer),
+          stdM: new Float32Array(r.canopyStdBuffer),
+          mask: new Float32Array(r.canopyMaskBuffer),
+          width: r.canopyWidth,
+          height: r.canopyHeight,
+          bounds: r.bounds,
+          tilesPresent: 0,
+          tilesTotal: 0,
+        }
+      : null;
+  cachedBuildings =
+    r.buildingHeightBuffer && r.buildingMaskBuffer && r.buildingWidth && r.buildingHeight
+      ? {
+          heightM: new Float32Array(r.buildingHeightBuffer),
+          mask: new Float32Array(r.buildingMaskBuffer),
+          width: r.buildingWidth,
+          height: r.buildingHeight,
+          bounds: r.bounds,
+          tilesPresent: 0,
+          tilesTotal: 0,
+        }
+      : null;
+  cachedGen = gen;
+}
+
 const post = (msg: CoverageSliceResponse, transfer: Transferable[] = []) => {
   (self as unknown as {
     postMessage: (m: CoverageSliceResponse, t: Transferable[]) => void;
   }).postMessage(msg, transfer);
 };
 
-self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
+/** Empty slice payload for error/miss responses. */
+function emptySlice(
+  msg: CoverageSliceRequest,
+  extra: Partial<CoverageSliceResponse>,
+): void {
+  const sliceN = msg.outputWidth * (msg.rowEnd - msg.rowStart);
+  const empty = new Uint8ClampedArray(sliceN * 4);
+  const emptyMargin = new Float32Array(sliceN);
+  emptyMargin.fill(Number.NaN);
+  post({
+    requestId: msg.requestId,
+    rgba: empty,
+    marginDb: emptyMargin,
+    rowStart: msg.rowStart,
+    rowEnd: msg.rowEnd,
+    clearCount: 0,
+    fresnelCount: 0,
+    blockedCount: 0,
+    maxMarginDb: 0,
+    ...extra,
+  }, [empty.buffer, emptyMargin.buffer]);
+}
+
+self.onmessage = async (evt: MessageEvent<CoverageWorkerMessage>) => {
   const msg = evt.data;
+  if ("kind" in msg) {
+    if (msg.kind === "clearRasters") clearRasterCache();
+    else if (msg.kind === "warmup") void getItmContext().catch(() => {});
+    return;
+  }
 
   let itm: ItmContext;
   try {
     itm = await getItmContext();
   } catch (err) {
     console.warn("[coverageSliceWorker] ITM WASM not available:", err);
-    const sliceN = msg.outputWidth * (msg.rowEnd - msg.rowStart);
-    const empty = new Uint8ClampedArray(sliceN * 4);
-    const emptyMargin = new Float32Array(sliceN);
-    emptyMargin.fill(Number.NaN);
-    post({
-      requestId: msg.requestId,
-      rgba: empty,
-      marginDb: emptyMargin,
-      rowStart: msg.rowStart,
-      rowEnd: msg.rowEnd,
-      clearCount: 0,
-      fresnelCount: 0,
-      blockedCount: 0,
-      maxMarginDb: 0,
-      itmUnavailable: true,
-    }, [empty.buffer, emptyMargin.buffer]);
+    emptySlice(msg, { itmUnavailable: true });
     return;
   }
 
   try {
-    const dem: DEM = {
-      data: new Float32Array(msg.demBuffer),
-      width: msg.demWidth,
-      height: msg.demHeight,
-      bounds: msg.bounds,
-    };
-    const clutter: ClutterRaster | null =
-      msg.clutterBuffer && msg.clutterWidth && msg.clutterHeight
-        ? {
-            data: new Uint8Array(msg.clutterBuffer),
-            width: msg.clutterWidth,
-            height: msg.clutterHeight,
-            bounds: msg.bounds,
-            tilesPresent: 0,
-            tilesTotal: 0,
-          }
-        : null;
-    const canopy: CanopyRaster | null =
-      msg.canopyHeightBuffer && msg.canopyStdBuffer && msg.canopyMaskBuffer && msg.canopyWidth && msg.canopyHeight
-        ? {
-            heightM: new Float32Array(msg.canopyHeightBuffer),
-            stdM: new Float32Array(msg.canopyStdBuffer),
-            mask: new Float32Array(msg.canopyMaskBuffer),
-            width: msg.canopyWidth,
-            height: msg.canopyHeight,
-            bounds: msg.bounds,
-            tilesPresent: 0,
-            tilesTotal: 0,
-          }
-        : null;
-    const buildings: BuildingRaster | null =
-      msg.buildingHeightBuffer && msg.buildingMaskBuffer && msg.buildingWidth && msg.buildingHeight
-        ? {
-            heightM: new Float32Array(msg.buildingHeightBuffer),
-            mask: new Float32Array(msg.buildingMaskBuffer),
-            width: msg.buildingWidth,
-            height: msg.buildingHeight,
-            bounds: msg.bounds,
-            tilesPresent: 0,
-            tilesTotal: 0,
-          }
-        : null;
+    if (msg.rasters) adoptRasters(msg.rasterGen, msg.rasters);
+    if (cachedGen !== msg.rasterGen || !cachedDem) {
+      // Worker-recreation race; the pool re-sends with buffers attached
+      emptySlice(msg, { cacheMiss: true });
+      return;
+    }
     const rendered = renderCoverageRaster(
-      dem,
+      cachedDem,
       msg.params,
       itm,
       msg.origins,
       { rowStart: msg.rowStart, rowEnd: msg.rowEnd },
       { width: msg.outputWidth, height: msg.outputHeight },
-      clutter,
-      canopy,
-      buildings,
+      cachedClutter,
+      cachedCanopy,
+      cachedBuildings,
     );
     post({
       requestId: msg.requestId,
@@ -185,21 +242,7 @@ self.onmessage = async (evt: MessageEvent<CoverageSliceRequest>) => {
     }, [rendered.rgba.buffer, rendered.marginDb.buffer]);
   } catch (err) {
     console.warn("[coverageSliceWorker] compute failed:", err);
-    const sliceN = msg.outputWidth * (msg.rowEnd - msg.rowStart);
-    const empty = new Uint8ClampedArray(sliceN * 4);
-    const emptyMargin = new Float32Array(sliceN);
-    emptyMargin.fill(Number.NaN);
-    post({
-      requestId: msg.requestId,
-      rgba: empty,
-      marginDb: emptyMargin,
-      rowStart: msg.rowStart,
-      rowEnd: msg.rowEnd,
-      clearCount: 0,
-      fresnelCount: 0,
-      blockedCount: 0,
-      maxMarginDb: 0,
-    }, [empty.buffer, emptyMargin.buffer]);
+    emptySlice(msg, {});
   }
 };
 

--- a/frontend/src/pages/map/coverageWorkerPool.ts
+++ b/frontend/src/pages/map/coverageWorkerPool.ts
@@ -2,17 +2,33 @@
  * Promise-based worker pool for coverage slice workers. Sized to
  * navigator.hardwareConcurrency, capped at MAX_POOL_SIZE. FCFS dispatch;
  * workers keep ITM WASM warm across tasks.
+ *
+ * Rasters are registered once per generation via setRasters(); the pool
+ * clones + transfers them lazily per worker on first use of a generation,
+ * so same-generation recomputes ship no buffers.
  */
+import type { BuildingRaster } from "./buildingTiles";
+import type { CanopyRaster } from "./canopyTiles";
 import type {
+  CoverageRasterPayload,
   CoverageSliceRequest,
   CoverageSliceResponse,
 } from "./coverageSliceWorker";
+import type { ClutterRaster } from "./landcoverTiles";
+import type { DEM } from "./terrainDEM";
 
 const MAX_POOL_SIZE = 8;
 
+/** Authoritative raster set the pool clones per worker on demand. */
+export interface PoolRasterSet {
+  dem: DEM;
+  clutter: ClutterRaster | null;
+  canopy: CanopyRaster | null;
+  buildings: BuildingRaster | null;
+}
+
 interface PendingTask {
   req: CoverageSliceRequest;
-  transfer: Transferable[];
   resolve: (r: CoverageSliceResponse) => void;
   reject: (err: unknown) => void;
 }
@@ -23,6 +39,13 @@ export class CoverageWorkerPool {
   private readonly queue: PendingTask[] = [];
   /** Tracked so terminate() can reject them (worker death = no response). */
   private readonly inFlight: Set<PendingTask> = new Set();
+  /** Monotonic raster generation; slices reference it instead of carrying buffers. */
+  private rasterGen = 0;
+  private rasters: PoolRasterSet | null = null;
+  /** Which generation each worker has cached. */
+  private readonly workerGen = new WeakMap<Worker, number>();
+  /** Set by terminate(); dispatches after that reject immediately. */
+  private terminated = false;
 
   constructor(size?: number) {
     const concurrency = navigator.hardwareConcurrency || 4;
@@ -38,13 +61,61 @@ export class CoverageWorkerPool {
     return this.workers.length;
   }
 
+  /** Register the raster set for subsequent slices. No copies happen here —
+   *  each worker receives its clone on the first slice of the new generation. */
+  setRasters(rasters: PoolRasterSet): number {
+    this.rasterGen += 1;
+    this.rasters = rasters;
+    return this.rasterGen;
+  }
+
+  /** The generation the pool currently serves; callers must re-register
+   *  (setRasters) before dispatching if their handle is older. */
+  get currentGen(): number {
+    return this.rasterGen;
+  }
+
+  /** Pre-compile ITM WASM in every worker ahead of the first compute. */
+  warmup(): void {
+    for (const w of this.workers) {
+      try {
+        w.postMessage({ kind: "warmup" });
+      } catch {}
+    }
+  }
+
+  /** Drop the raster refs and tell workers to free their caches (~100 MB each
+   *  at full tiers). Safe to call anytime; the next compute re-registers. */
+  releaseRasters(): void {
+    this.rasters = null;
+    for (const w of this.workers) {
+      this.workerGen.delete(w);
+      try {
+        w.postMessage({ kind: "clearRasters" });
+      } catch {}
+    }
+  }
+
+  /** Reject all queued (not yet running) tasks. Called when a newer request
+   *  supersedes them so heavy stale slices don't delay fresh work. In-flight
+   *  slices can't be aborted (synchronous WASM) and run to completion. */
+  dropQueued(): void {
+    if (this.queue.length === 0) return;
+    const err = new Error("pool superseded");
+    for (const t of this.queue) t.reject(err);
+    this.queue.length = 0;
+  }
+
   /** Dispatch to first free worker; queues if all busy. */
-  dispatch(
-    req: CoverageSliceRequest,
-    transfer: Transferable[],
-  ): Promise<CoverageSliceResponse> {
+  dispatch(req: CoverageSliceRequest): Promise<CoverageSliceResponse> {
     return new Promise((resolve, reject) => {
-      const task: PendingTask = { req, transfer, resolve, reject };
+      if (this.terminated) {
+        // Tasks queued on a dead pool never settle; message must match the
+        // benign-cancel regex in useCoverageCompute
+        reject(new Error("pool terminated"));
+        return;
+      }
+      const task: PendingTask = { req, resolve, reject };
       const free = this.workers.find((w) => !this.busy.has(w));
       if (free) {
         this.run(free, task);
@@ -54,36 +125,129 @@ export class CoverageWorkerPool {
     });
   }
 
+  /** Clone the registered rasters into transferable buffers for one worker. */
+  private buildPayload(): { payload: CoverageRasterPayload; transfer: Transferable[] } | null {
+    const r = this.rasters;
+    if (!r) return null;
+    const demCopy = new Float32Array(r.dem.data);
+    const clutterCopy = r.clutter ? new Uint8Array(r.clutter.data) : null;
+    const canopyHeightCopy = r.canopy ? new Float32Array(r.canopy.heightM) : null;
+    const canopyStdCopy = r.canopy ? new Float32Array(r.canopy.stdM) : null;
+    const canopyMaskCopy = r.canopy ? new Float32Array(r.canopy.mask) : null;
+    const buildingHeightCopy = r.buildings ? new Float32Array(r.buildings.heightM) : null;
+    const buildingMaskCopy = r.buildings ? new Float32Array(r.buildings.mask) : null;
+    const payload: CoverageRasterPayload = {
+      demBuffer: demCopy.buffer,
+      demWidth: r.dem.width,
+      demHeight: r.dem.height,
+      bounds: r.dem.bounds,
+      clutterBuffer: clutterCopy?.buffer,
+      clutterWidth: r.clutter?.width,
+      clutterHeight: r.clutter?.height,
+      canopyHeightBuffer: canopyHeightCopy?.buffer,
+      canopyStdBuffer: canopyStdCopy?.buffer,
+      canopyMaskBuffer: canopyMaskCopy?.buffer,
+      canopyWidth: r.canopy?.width,
+      canopyHeight: r.canopy?.height,
+      buildingHeightBuffer: buildingHeightCopy?.buffer,
+      buildingMaskBuffer: buildingMaskCopy?.buffer,
+      buildingWidth: r.buildings?.width,
+      buildingHeight: r.buildings?.height,
+    };
+    const transfer: Transferable[] = [demCopy.buffer];
+    if (clutterCopy) transfer.push(clutterCopy.buffer);
+    if (canopyHeightCopy) transfer.push(canopyHeightCopy.buffer);
+    if (canopyStdCopy) transfer.push(canopyStdCopy.buffer);
+    if (canopyMaskCopy) transfer.push(canopyMaskCopy.buffer);
+    if (buildingHeightCopy) transfer.push(buildingHeightCopy.buffer);
+    if (buildingMaskCopy) transfer.push(buildingMaskCopy.buffer);
+    return { payload, transfer };
+  }
+
+  private postTask(worker: Worker, task: PendingTask): boolean {
+    const needRasters =
+      task.req.rasterGen === this.rasterGen &&
+      this.workerGen.get(worker) !== task.req.rasterGen;
+    if (needRasters) {
+      const built = this.buildPayload();
+      if (!built) return false;
+      this.workerGen.set(worker, task.req.rasterGen);
+      worker.postMessage({ ...task.req, rasters: built.payload }, built.transfer);
+      return true;
+    }
+    worker.postMessage(task.req);
+    return true;
+  }
+
   private run(worker: Worker, task: PendingTask): void {
     this.busy.add(worker);
     this.inFlight.add(task);
+    let retriedMiss = false;
     const onMessage = (evt: MessageEvent<CoverageSliceResponse>) => {
       if (evt.data.requestId !== task.req.requestId) return;
+      if (evt.data.cacheMiss) {
+        // Worker lost/never had this generation; re-send once with buffers
+        if (!retriedMiss && task.req.rasterGen === this.rasterGen && this.rasters) {
+          retriedMiss = true;
+          const built = this.buildPayload();
+          if (built) {
+            this.workerGen.set(worker, task.req.rasterGen);
+            worker.postMessage({ ...task.req, rasters: built.payload }, built.transfer);
+            return;
+          }
+        }
+        cleanup();
+        task.reject(new Error("pool superseded"));
+        return;
+      }
       cleanup();
       task.resolve(evt.data);
     };
     const onError = (err: ErrorEvent) => {
+      // An errored worker may be dead — replace it or the next task hangs
+      workerBroken = true;
       cleanup();
       task.reject(err.error ?? new Error(err.message));
     };
+    let workerBroken = false;
     const cleanup = () => {
       worker.removeEventListener("message", onMessage);
       worker.removeEventListener("error", onError);
       this.busy.delete(worker);
       this.inFlight.delete(task);
+      const successor = workerBroken ? this.replaceWorker(worker) : worker;
       const next = this.queue.shift();
-      if (next) this.run(worker, next);
+      if (next && successor) this.run(successor, next);
     };
     worker.addEventListener("message", onMessage);
     worker.addEventListener("error", onError);
-    worker.postMessage(task.req, task.transfer);
+    if (!this.postTask(worker, task)) {
+      cleanup();
+      task.reject(new Error("pool superseded"));
+    }
+  }
+
+  /** Swap a broken worker for a fresh one in place. Returns null if the pool
+   *  was terminated in the meantime. */
+  private replaceWorker(dead: Worker): Worker | null {
+    dead.terminate();
+    this.workerGen.delete(dead);
+    const idx = this.workers.indexOf(dead);
+    if (idx < 0) return null; // pool terminated
+    const fresh = new Worker(new URL("./coverageSliceWorker.ts", import.meta.url), {
+      type: "module",
+    });
+    this.workers[idx] = fresh;
+    return fresh;
   }
 
   /** Terminate all workers; reject queued + in-flight tasks (promises would otherwise hang). */
   terminate(): void {
+    this.terminated = true;
     for (const w of this.workers) w.terminate();
     this.workers.length = 0;
     this.busy.clear();
+    this.rasters = null;
     const err = new Error("pool terminated");
     for (const t of this.inFlight) t.reject(err);
     this.inFlight.clear();

--- a/frontend/src/pages/map/landcoverTiles.ts
+++ b/frontend/src/pages/map/landcoverTiles.ts
@@ -16,7 +16,8 @@ const MAX_ZOOM = 12;
 const DEFAULT_MAX_TILES_PER_REQUEST = 256;
 
 function tileBaseUrl(): string {
-  const apiBase = env.API_BASE_URL ?? window.location.origin;
+  // globalThis, not window — also runs inside the raster-build worker
+  const apiBase = env.API_BASE_URL ?? globalThis.location.origin;
   return `${apiBase}/tiles/landcover`;
 }
 
@@ -266,7 +267,9 @@ export function sampleClutterClassAt(
   lat: number,
 ): number {
   const { width, height, bounds, data } = raster;
-  const fx = ((lng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
+  // Seam unwrap, matching sampleDEMAt: a [179,181] bbox must accept lng -179
+  const sLng = lng < bounds.west ? lng + 360 : lng > bounds.east ? lng - 360 : lng;
+  const fx = ((sLng - bounds.west) / (bounds.east - bounds.west)) * (width - 1);
   const fy = ((bounds.north - lat) / (bounds.north - bounds.south)) * (height - 1);
   if (!Number.isFinite(fx) || !Number.isFinite(fy) || fx < 0 || fx > width - 1 || fy < 0 || fy > height - 1) return NLCD_DEFAULT_CLASS_ID;
   const x = Math.round(fx);

--- a/frontend/src/pages/map/losAnalysis.ts
+++ b/frontend/src/pages/map/losAnalysis.ts
@@ -3,6 +3,8 @@
  * Earth bulge at k=4/3; First Fresnel F₁ = 17.32·√(d₁·d₂/(f·d)) m; 60% clearance threshold.
  */
 
+import { interpLngLatUnwrapped } from "./geo";
+
 const R_EARTH_KM = 6371;
 const K_REFRACTION = 4 / 3;
 const FRESNEL_CLEARANCE_THRESHOLD = 0.6;
@@ -100,14 +102,6 @@ export function haversineKm(a: [number, number], b: [number, number]): number {
   return 2 * R_EARTH_KM * Math.asin(Math.sqrt(s));
 }
 
-function lerpLngLat(
-  from: [number, number],
-  to: [number, number],
-  t: number,
-): [number, number] {
-  return [from[0] + (to[0] - from[0]) * t, from[1] + (to[1] - from[1]) * t];
-}
-
 /** Earth bulge (m) at d1 from A toward B (d2 = D - d1). */
 function earthBulgeM(d1Km: number, d2Km: number): number {
   return (d1Km * d2Km * 1000) / (2 * K_REFRACTION * R_EARTH_KM);
@@ -183,7 +177,9 @@ export function analyzeLineOfSight(input: LoSInput): LoSResult {
     const distanceKm = totalDistanceKm * t;
     const d2 = totalDistanceKm - distanceKm;
 
-    const [lng, lat] = lerpLngLat(from, to, t);
+    // Seam-aware interp: keeps antimeridian-crossing paths on the short way,
+    // matching the tube layer / hover marker / DEM bbox.
+    const [lng, lat] = interpLngLatUnwrapped(from, to, t);
     const ground = queryTerrainM(lng, lat) ?? 0;
 
     const chord = fromHeightM + (toHeightM - fromHeightM) * t;

--- a/frontend/src/pages/map/losAnalysis.ts
+++ b/frontend/src/pages/map/losAnalysis.ts
@@ -44,6 +44,11 @@ export interface LoSInput {
   /** Path samples; default 100. */
   samples?: number;
   queryTerrainM: TerrainSampler;
+  /** Optional clutter samplers (canopy/building height above ground, m). Display
+   *  only — clutter is drawn on the profile, not part of the LOS/Fresnel verdict
+   *  (coverage/ITM model it as loss, not hard blockage). */
+  queryCanopyM?: TerrainSampler;
+  queryBuildingM?: TerrainSampler;
 }
 
 export interface LoSPoint {
@@ -64,6 +69,10 @@ export interface LoSPoint {
   clearanceRatio: number;
   blocked: boolean;
   fresnelIntruded: boolean;
+  /** Canopy height above ground (m); 0 = none/unknown. Chart display only. */
+  canopyM: number;
+  /** Building height above ground (m); 0 = none/unknown. Chart display only. */
+  buildingM: number;
 }
 
 export interface LoSResult {
@@ -125,6 +134,8 @@ export function analyzeLineOfSight(input: LoSInput): LoSResult {
     freqGHz = 0.915,
     samples = 100,
     queryTerrainM,
+    queryCanopyM,
+    queryBuildingM,
   } = input;
   const fromAntH = input.fromAntennaHeightM ?? antennaHeightM;
   const toAntH = input.toAntennaHeightM ?? antennaHeightM;
@@ -230,6 +241,8 @@ export function analyzeLineOfSight(input: LoSInput): LoSResult {
       clearanceRatio,
       blocked,
       fresnelIntruded,
+      canopyM: Math.max(0, queryCanopyM?.(lng, lat) ?? 0),
+      buildingM: Math.max(0, queryBuildingM?.(lng, lat) ?? 0),
     });
   }
 

--- a/frontend/src/pages/map/losTubeLayer.ts
+++ b/frontend/src/pages/map/losTubeLayer.ts
@@ -97,6 +97,10 @@ export class LosTubeLayer implements maplibregl.CustomLayerInterface {
     this.uMatrix = gl.getUniformLocation(program, "u_matrix");
 
     this.buffer = gl.createBuffer();
+
+    // Re-adding after setStyle: restore the cached geometry, otherwise the tube
+    // silently vanishes until the next result push (onRemove keeps lastData).
+    this.upload();
   }
 
   onRemove(_map: maplibregl.Map, gl: WebGLRenderingContext): void {

--- a/frontend/src/pages/map/rasterBuildClient.ts
+++ b/frontend/src/pages/map/rasterBuildClient.ts
@@ -1,0 +1,128 @@
+/**
+ * Promise API over the raster-build worker. Falls back to main-thread builds
+ * if the worker can't start (very old browsers, blocked workers).
+ */
+import { env } from "../../env";
+import { buildBuildingRaster } from "./buildingTiles";
+import { buildCanopyRaster } from "./canopyTiles";
+import { buildClutterRaster } from "./landcoverTiles";
+import type {
+  RasterBuildRequest,
+  RasterBuildResponse,
+  RasterBuildResult,
+} from "./rasterBuildWorker";
+import type { DEMBounds } from "./terrainDEM";
+import { buildDem } from "./terrainRgb";
+
+export interface BuildRastersOptions {
+  bounds: DEMBounds;
+  size: number;
+  maxTiles: number;
+  token: string;
+  wantClutter: boolean;
+  wantCanopy: boolean;
+  wantBuildings: boolean;
+}
+
+let worker: Worker | null = null;
+let workerBroken = false;
+/** True once the worker has delivered any response — distinguishes a script
+ *  that never loaded (404 after redeploy, CSP block: permanent, fall back)
+ *  from a runtime death (OOM: recreate lazily). */
+let workerDelivered = false;
+let nextId = 1;
+const pending = new Map<number, {
+  opts: BuildRastersOptions;
+  resolve: (r: RasterBuildResult) => void;
+  reject: (e: Error) => void;
+}>();
+
+function ensureWorker(): Worker | null {
+  if (workerBroken) return null;
+  if (worker) return worker;
+  try {
+    worker = new Worker(new URL("./rasterBuildWorker.ts", import.meta.url), {
+      type: "module",
+    });
+  } catch (err) {
+    console.warn("[rasterBuild] worker unavailable, building on main thread:", err);
+    workerBroken = true;
+    return null;
+  }
+  worker.onmessage = (evt: MessageEvent<RasterBuildResponse>) => {
+    workerDelivered = true;
+    const resp = evt.data;
+    const p = pending.get(resp.id);
+    if (!p) return;
+    pending.delete(resp.id);
+    if (resp.error !== undefined) p.reject(new Error(resp.error));
+    else p.resolve(resp);
+  };
+  worker.onerror = (err) => {
+    console.warn("[rasterBuild] worker error:", err.message);
+    worker?.terminate();
+    worker = null;
+    const drained = [...pending.values()];
+    pending.clear();
+    if (!workerDelivered) {
+      // Script never loaded — permanent for this session. Serve the live
+      // requests on the main thread instead of failing them.
+      workerBroken = true;
+      for (const p of drained) {
+        buildOnMainThread(p.opts).then(p.resolve, p.reject);
+      }
+    } else {
+      // Runtime death after prior successes: fail live builds, recreate lazily.
+      for (const p of drained) {
+        p.reject(new Error(err.message || "raster build worker error"));
+      }
+    }
+  };
+  return worker;
+}
+
+async function buildOnMainThread(opts: BuildRastersOptions): Promise<RasterBuildResult> {
+  const common = {
+    bounds: opts.bounds,
+    targetWidth: opts.size,
+    targetHeight: opts.size,
+    maxTiles: opts.maxTiles,
+  };
+  const [built, clutter, canopy, buildings] = await Promise.all([
+    buildDem({ ...common, token: opts.token }),
+    opts.wantClutter ? buildClutterRaster(common) : Promise.resolve(null),
+    opts.wantCanopy ? buildCanopyRaster(common) : Promise.resolve(null),
+    opts.wantBuildings ? buildBuildingRaster(common) : Promise.resolve(null),
+  ]);
+  return {
+    dem: built.dem,
+    demSource: built.source,
+    demTilesFailed: built.tilesFailed,
+    demTilesTotal: built.tilesTotal,
+    clutter,
+    canopy,
+    buildings,
+  };
+}
+
+/** Build the coverage raster set, preferring the worker. */
+export function buildCoverageRasters(opts: BuildRastersOptions): Promise<RasterBuildResult> {
+  const w = ensureWorker();
+  if (!w) return buildOnMainThread(opts);
+  return new Promise<RasterBuildResult>((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, { opts, resolve, reject });
+    const req: RasterBuildRequest = {
+      id,
+      bounds: opts.bounds,
+      size: opts.size,
+      maxTiles: opts.maxTiles,
+      token: opts.token,
+      wantClutter: opts.wantClutter,
+      wantCanopy: opts.wantCanopy,
+      wantBuildings: opts.wantBuildings,
+      runtimeEnv: { VITE_API_BASE_URL: env.API_BASE_URL },
+    };
+    w.postMessage(req);
+  });
+}

--- a/frontend/src/pages/map/rasterBuildWorker.ts
+++ b/frontend/src/pages/map/rasterBuildWorker.ts
@@ -1,0 +1,83 @@
+/**
+ * Raster-build worker: fetches + decodes + resamples the coverage raster set
+ * (DEM, clutter, canopy, buildings) off the main thread. The 2048² bilinear
+ * resamples used to stall the UI for hundreds of ms per cache-miss compute.
+ * Tile LRU caches live in this worker for the coverage tool.
+ */
+import { buildBuildingRaster, type BuildingRaster } from "./buildingTiles";
+import { buildCanopyRaster, type CanopyRaster } from "./canopyTiles";
+import { buildClutterRaster, type ClutterRaster } from "./landcoverTiles";
+import type { DEM, DEMBounds } from "./terrainDEM";
+import { buildDem, type DemSource } from "./terrainRgb";
+
+export interface RasterBuildRequest {
+  id: number;
+  bounds: DEMBounds;
+  size: number;
+  maxTiles: number;
+  token: string;
+  wantClutter: boolean;
+  wantCanopy: boolean;
+  wantBuildings: boolean;
+  /** Runtime env the worker can't read from window.__env__ (self-hosted tile base). */
+  runtimeEnv?: { VITE_API_BASE_URL?: string };
+}
+
+export interface RasterBuildResult {
+  dem: DEM;
+  demSource: DemSource;
+  demTilesFailed: number;
+  demTilesTotal: number;
+  clutter: ClutterRaster | null;
+  canopy: CanopyRaster | null;
+  buildings: BuildingRaster | null;
+}
+
+export type RasterBuildResponse =
+  | ({ id: number; error?: undefined } & RasterBuildResult)
+  | { id: number; error: string };
+
+self.onmessage = async (evt: MessageEvent<RasterBuildRequest>) => {
+  const req = evt.data;
+  if (req.runtimeEnv) {
+    const g = globalThis as { __env__?: Record<string, string | undefined> };
+    g.__env__ = { ...g.__env__, ...req.runtimeEnv };
+  }
+  try {
+    const common = {
+      bounds: req.bounds,
+      targetWidth: req.size,
+      targetHeight: req.size,
+      maxTiles: req.maxTiles,
+    };
+    const [built, clutter, canopy, buildings] = await Promise.all([
+      buildDem({ ...common, token: req.token }),
+      req.wantClutter ? buildClutterRaster(common) : Promise.resolve(null),
+      req.wantCanopy ? buildCanopyRaster(common) : Promise.resolve(null),
+      req.wantBuildings ? buildBuildingRaster(common) : Promise.resolve(null),
+    ]);
+    const response: RasterBuildResponse = {
+      id: req.id,
+      dem: built.dem,
+      demSource: built.source,
+      demTilesFailed: built.tilesFailed,
+      demTilesTotal: built.tilesTotal,
+      clutter,
+      canopy,
+      buildings,
+    };
+    const transfer: Transferable[] = [built.dem.data.buffer];
+    if (clutter) transfer.push(clutter.data.buffer);
+    if (canopy) transfer.push(canopy.heightM.buffer, canopy.stdM.buffer, canopy.mask.buffer);
+    if (buildings) transfer.push(buildings.heightM.buffer, buildings.mask.buffer);
+    (self as unknown as {
+      postMessage: (m: RasterBuildResponse, t: Transferable[]) => void;
+    }).postMessage(response, transfer);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    (self as unknown as { postMessage: (m: RasterBuildResponse) => void }).postMessage({
+      id: req.id,
+      error: msg,
+    });
+  }
+};

--- a/frontend/src/pages/map/scanAnalysis.test.ts
+++ b/frontend/src/pages/map/scanAnalysis.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { runScan, type ScanResult, scanSortKey, type ScanSummary,scanToGeoJSON } from "./scanAnalysis";
+
+function mkResult(over: Partial<ScanResult>): ScanResult {
+  return {
+    id: "x", position: [0, 0], distanceKm: 1, cls: "clear",
+    rssiDbm: -100, marginDb: 10, diffractionLossDb: 0, losBlocked: false, fresnelIntruded: false,
+    ...over,
+  };
+}
+
+describe("scanSortKey", () => {
+  it("ranks reachable above blocked", () => {
+    const reachable = mkResult({ cls: "clear", marginDb: -5, distanceKm: 199 });
+    const blocked = mkResult({ cls: "blocked", marginDb: -1, distanceKm: 1 });
+    expect(scanSortKey(reachable)).toBeGreaterThan(scanSortKey(blocked));
+  });
+
+  it("orders blocked targets nearest-first (documented intent)", () => {
+    const near = mkResult({ cls: "blocked", distanceKm: 1 });
+    const far = mkResult({ cls: "blocked", distanceKm: 150 });
+    // Descending sort by key → nearest must produce the LARGER key.
+    expect(scanSortKey(near)).toBeGreaterThan(scanSortKey(far));
+  });
+
+  it("orders reachable by margin descending", () => {
+    const strong = mkResult({ marginDb: 30, distanceKm: 10 });
+    const weak = mkResult({ marginDb: 3, distanceKm: 10 });
+    expect(scanSortKey(strong)).toBeGreaterThan(scanSortKey(weak));
+  });
+});
+
+describe("scanToGeoJSON", () => {
+  it("unwraps a seam-crossing link the short way (not around the globe)", () => {
+    const summary: ScanSummary = {
+      origin: [179.9, 1],
+      results: [mkResult({ id: "b", position: [-179.9, 1] })],
+      clearCount: 1, fresnelCount: 0, diffractedCount: 0, blockedCount: 0,
+    };
+    const fc = scanToGeoJSON(summary);
+    const coords = fc.features[0].geometry.coordinates as [number, number][];
+    expect(coords[0][0]).toBe(179.9);
+    // Target unwrapped to ~180.1 (short hop across the seam), not -179.9.
+    expect(coords[1][0]).toBeCloseTo(180.1, 6);
+  });
+
+  it("assigns stable feature ids matching result order", () => {
+    const summary: ScanSummary = {
+      origin: [0, 0],
+      results: [mkResult({ id: "a" }), mkResult({ id: "b" })],
+      clearCount: 2, fresnelCount: 0, diffractedCount: 0, blockedCount: 0,
+    };
+    const fc = scanToGeoJSON(summary);
+    expect(fc.features.map((f) => f.id)).toEqual([0, 1]);
+  });
+});
+
+describe("runScan", () => {
+  const flatTerrain = () => 0;
+
+  it("includes a co-located target instead of silently dropping it", () => {
+    const summary = runScan({
+      origin: [10, 10],
+      originAltitudeM: 30,
+      targets: [
+        { id: "same", position: [10, 10], altitudeM: 30 },
+        { id: "near", position: [10.05, 10], altitudeM: 30 },
+      ],
+      queryTerrainM: flatTerrain,
+    });
+    const ids = summary.results.map((r) => r.id);
+    expect(ids).toContain("same");
+    expect(ids).toContain("near");
+    expect(summary.results.length).toBe(2);
+  });
+
+  it("applies the maxDistanceKm cutoff", () => {
+    const summary = runScan({
+      origin: [10, 10],
+      originAltitudeM: 30,
+      targets: [
+        { id: "inside", position: [10.1, 10], altitudeM: 30 },
+        { id: "outside", position: [20, 10], altitudeM: 30 },
+      ],
+      queryTerrainM: flatTerrain,
+      maxDistanceKm: 50,
+    });
+    const ids = summary.results.map((r) => r.id);
+    expect(ids).toContain("inside");
+    expect(ids).not.toContain("outside");
+  });
+
+  it("does not sweep the globe for a seam-crossing pair (antimeridian-safe)", () => {
+    // A ~22 km neighbour across the seam. A raw linear lerp would sample terrain
+    // ~360° the wrong way; the seam-safe interp keeps the run finite and sane.
+    const summary = runScan({
+      origin: [179.9, 1],
+      originAltitudeM: 30,
+      targets: [{ id: "b", position: [-179.9, 1], altitudeM: 30 }],
+      queryTerrainM: flatTerrain,
+    });
+    expect(summary.results.length).toBe(1);
+    expect(summary.results[0].distanceKm).toBeLessThan(30);
+    expect(Number.isFinite(summary.results[0].rssiDbm)).toBe(true);
+  });
+});

--- a/frontend/src/pages/map/scanAnalysis.ts
+++ b/frontend/src/pages/map/scanAnalysis.ts
@@ -1,15 +1,25 @@
 /**
  * Best-neighbors scan: LoS + link budget from origin to each target, classified and ranked.
- * Stays on the main thread with 60 samples/ray.
+ * Runs on the main thread; runScanAsync chunks + yields so a dense mesh doesn't freeze the UI.
  */
 import { type BuildingRaster, sampleBuildingAt } from "./buildingTiles";
 import type { CanopyRaster } from "./canopyTiles";
 import { NLCD_DEFAULT_CLASS_ID } from "./clutterClasses";
 import { type BuildingPathContext, type CanopyPathContext, computePathClutterLoss, makeClutterScratch } from "./clutterPath";
 import { pathLossDb } from "./coverageAnalysis";
+import { interpLngLatUnwrapped, unwrapLngTo } from "./geo";
 import { computeP2PLossFast, type ItmContext,ModeOfVariability } from "./itm";
+import { CABLE_LOSS_DB, FADE_MARGIN_DB, FREQ_MHZ } from "./itmEnv";
 import { type ClutterRaster, sampleClutterClassAt } from "./landcoverTiles";
 import { analyzeLineOfSight, haversineKm, type TerrainSampler } from "./losAnalysis";
+
+/** Fallback fixed sample count when no DEM resolution is supplied. */
+export const DEFAULT_RAY_SAMPLES = 60;
+/** Adaptive-sampling bounds. Max caps per-target ITM cost; the ITM context must
+ *  hold MAX_SCAN_PATH_POINTS (= max samples + 1 point + slack) or computeP2PLossFast throws. */
+export const MIN_RAY_SAMPLES = 48;
+export const MAX_RAY_SAMPLES = 512;
+export const MAX_SCAN_PATH_POINTS = MAX_RAY_SAMPLES + 8;
 
 /** Optional ITM config; when provided, ITM replaces FSPL+knife-edge for path loss. */
 export interface ScanItmConfig {
@@ -55,14 +65,19 @@ export interface ScanInput {
   originShortname?: string;
   targets: ScanTarget[];
   queryTerrainM: TerrainSampler;
-  /** LoS samples per ray; default 60. */
+  /** Fixed LoS samples per ray when demMppM is absent; default 60. */
   raySamples?: number;
+  /** DEM metres/pixel; when set, samples scale per-target to ~native resolution
+   *  (clamped MIN_RAY_SAMPLES..MAX_RAY_SAMPLES) so long rays don't alias out ridges. */
+  demMppM?: number;
   freqGHz?: number;
   txDbm?: number;
   /** TX-side antenna gain (dBi). */
   txAntennaDbi?: number;
   /** RX-side antenna gain (dBi); defaults to txAntennaDbi for symmetric links. */
   rxAntennaDbi?: number;
+  /** RX antenna height AGL (m) at each target; default 2. */
+  rxAntennaHeightM?: number;
   rxSensitivityDbm?: number;
   fadeMarginDb?: number;
   cableLossDb?: number;
@@ -90,192 +105,264 @@ export interface ScanSummary {
   blockedCount: number;
 }
 
-/** Sort key: reachable by margin desc, blocked last by nearest-first. */
+/** Sort key: reachable by margin desc; blocked last, nearest-first (nearest blocked
+ *  are the actionable ones). Both bands stay disjoint (blocked keys are ≤ -1000). */
 export function scanSortKey(r: ScanResult): number {
-  if (r.cls === "blocked") return -1000 - 1 / Math.max(0.1, r.distanceKm);
+  if (r.cls === "blocked") return -1000 - r.distanceKm;
   return r.marginDb - r.distanceKm * 0.01;
 }
 
-/** Synchronous scan. Caller must chunk if jank becomes an issue. */
-export function runScan(input: ScanInput): ScanSummary {
-  const {
-    origin,
-    originAltitudeM,
-    originShortname,
-    targets,
-    queryTerrainM,
-    raySamples = 60,
-    freqGHz = 0.915,
-    txDbm = 22,
-    txAntennaDbi = 3,
-    rxAntennaDbi = txAntennaDbi,
-    rxSensitivityDbm = -130,
-    fadeMarginDb = 15,
-    cableLossDb = 0.5,
-    clutterRaster = null,
-    canopyRaster = null,
-    buildingRaster = null,
-    clutterAggression = 1.0,
-    maxDistanceKm = Infinity,
-  } = input;
+/** Resolved link-budget scalars shared across every target in a run. */
+interface ScanBudget {
+  freqGHz: number;
+  freqMhz: number;
+  raySamples: number;
+  demMppM?: number;
+  txDbm: number;
+  txAntennaDbi: number;
+  rxAntennaDbi: number;
+  rxAntennaHeightM: number;
+  rxSensitivityDbm: number;
+  fadeMarginDb: number;
+  cableLossDb: number;
+  clutterAggression: number;
+  maxDistanceKm: number;
+}
 
-  const freqMhz = freqGHz * 1000;
-  const results: ScanResult[] = [];
-  let clearCount = 0;
-  let fresnelCount = 0;
-  let diffractedCount = 0;
-  let blockedCount = 0;
+/** Per-target sample count: ~DEM-native resolution, clamped, when demMppM is known. */
+function samplesForDistance(distanceKm: number, budget: ScanBudget): number {
+  if (!budget.demMppM || !Number.isFinite(budget.demMppM) || budget.demMppM <= 0) {
+    return budget.raySamples;
+  }
+  const n = Math.ceil((distanceKm * 1000) / budget.demMppM);
+  return Math.max(MIN_RAY_SAMPLES, Math.min(MAX_RAY_SAMPLES, n));
+}
 
-  const clutterScratch = makeClutterScratch();
-  const canopyCtx: CanopyPathContext | null = canopyRaster
-    ? { raster: canopyRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
-    : null;
-  const buildingCtx: BuildingPathContext | null = buildingRaster
-    ? { raster: buildingRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
-    : null;
+/** Evaluate one target. Returns null for co-located-or-farther-than-cutoff targets. */
+function scanOneTarget(
+  t: ScanTarget,
+  input: ScanInput,
+  budget: ScanBudget,
+  clutterScratch: ReturnType<typeof makeClutterScratch>,
+  canopyCtx: CanopyPathContext | null,
+  buildingCtx: BuildingPathContext | null,
+): ScanResult | null {
+  const { origin, originAltitudeM, queryTerrainM, clutterRaster, buildingRaster } = input;
+  const d = haversineKm(origin, t.position);
+  if (d > budget.maxDistanceKm) return null;
 
-  for (const t of targets) {
-    const d = haversineKm(origin, t.position);
-    if (d > maxDistanceKm) continue;
-    if (d < 0.01) continue;
-
-    const los = analyzeLineOfSight({
-      from: origin,
-      to: t.position,
-      fromAltitudeM: originAltitudeM ?? null,
-      toAltitudeM: t.altitudeM ?? null,
-      antennaHeightM: 2,
-      freqGHz,
-      samples: raySamples,
-      queryTerrainM,
-    });
-
-    // LoS points only carry distanceKm; lerp lng/lat ourselves to sample
-    // raster lookups. DSM endpoint-skip rationale: see coverageRaster.ts.
-    const profileM = new Float64Array(los.points.map((p) => p.ground));
-    const profileClasses = new Uint8Array(profileM.length);
-    const lastPathIdx = profileM.length - 1;
-    for (let s = 0; s < profileM.length; s++) {
-      const tFrac = profileM.length > 1 ? s / lastPathIdx : 0;
-      const sLng = origin[0] + (t.position[0] - origin[0]) * tFrac;
-      const sLat = origin[1] + (t.position[1] - origin[1]) * tFrac;
-      if (clutterRaster) {
-        profileClasses[s] = sampleClutterClassAt(clutterRaster, sLng, sLat);
-      } else {
-        profileClasses[s] = NLCD_DEFAULT_CLASS_ID;
-      }
-      if (buildingRaster && s !== 0 && s !== lastPathIdx) {
-        const sample = sampleBuildingAt(buildingRaster, sLng, sLat);
-        if (sample && sample.heightM > 0) profileM[s] += sample.heightM;
-      }
-    }
-
-    const spacingM = profileM.length > 1 ? (d * 1000) / (profileM.length - 1) : 0;
-    const txAGLm = los.points.length > 0
-      ? Math.max(0.5, los.fromHeightM - los.points[0].ground)
-      : 2;
-    const rxAGLm = los.points.length > 0
-      ? Math.max(0.5, los.toHeightM - los.points[los.points.length - 1].ground)
-      : 2;
-    if (canopyCtx) {
-      canopyCtx.origLng = origin[0];
-      canopyCtx.origLat = origin[1];
-      canopyCtx.destLng = t.position[0];
-      canopyCtx.destLat = t.position[1];
-    }
-    if (buildingCtx) {
-      buildingCtx.origLng = origin[0];
-      buildingCtx.origLat = origin[1];
-      buildingCtx.destLng = t.position[0];
-      buildingCtx.destLat = t.position[1];
-    }
-    const clutterLossDb = computePathClutterLoss(
-      profileM,
-      profileClasses,
-      profileM.length,
-      spacingM,
-      txAGLm,
-      rxAGLm,
-      freqMhz,
-      clutterAggression,
-      clutterScratch,
-      canopyCtx,
-      buildingCtx,
-    );
-
-    // Path loss: ITM (terrain-aware) when available, else FSPL + knife-edge
-    let totalLossDb: number;
-    if (input.itm && los.points.length >= 2) {
-      const itmLoss = computeP2PLossFast(input.itm.context, {
-        txHeightM: txAGLm,
-        rxHeightM: rxAGLm,
-        profileM,
-        pointSpacingM: spacingM,
-        climate: input.itm.climate,
-        surfaceRefractivityN: input.itm.surfaceRefractivityN,
-        freqMhz: freqGHz * 1000,
-        polarization: input.itm.polarization,
-        groundDielectric: input.itm.groundDielectric,
-        groundConductivity: input.itm.groundConductivity,
-        mdvar: ModeOfVariability.SingleMessage,
-        time: input.itm.timePct ?? 50,
-        location: input.itm.locationPct ?? 50,
-        situation: input.itm.situationPct ?? 50,
-      });
-      // Fallback to FSPL if ITM returns garbage
-      totalLossDb =
-        Number.isFinite(itmLoss) && itmLoss > 0
-          ? itmLoss + clutterLossDb + cableLossDb
-          : pathLossDb(d, freqMhz) + los.diffractionLossDb + clutterLossDb + cableLossDb;
-    } else {
-      totalLossDb = pathLossDb(d, freqMhz) + los.diffractionLossDb + clutterLossDb + cableLossDb;
-    }
-    const rssiDbm = txDbm + txAntennaDbi + rxAntennaDbi - totalLossDb;
-    const marginDb = rssiDbm - rxSensitivityDbm - fadeMarginDb;
-
-    let cls: ScanClass;
-    if (marginDb < 0) {
-      cls = "blocked";
-      blockedCount++;
-    } else if (!los.losClear) {
-      cls = "diffracted";
-      diffractedCount++;
-    } else if (!los.fresnelClear) {
-      cls = "fresnel";
-      fresnelCount++;
-    } else {
-      cls = "clear";
-      clearCount++;
-    }
-
-    results.push({
+  // Co-located node (same rooftop/mast): geometry is degenerate, so synthesize a
+  // trivially-clear budget rather than dropping it silently from the results.
+  if (d < 0.01) {
+    const totalLossDb = pathLossDb(d, budget.freqMhz) + budget.cableLossDb;
+    const rssiDbm = budget.txDbm + budget.txAntennaDbi + budget.rxAntennaDbi - totalLossDb;
+    const marginDb = rssiDbm - budget.rxSensitivityDbm - budget.fadeMarginDb;
+    return {
       id: t.id,
       shortname: t.shortname,
       position: t.position,
       distanceKm: d,
-      cls,
+      cls: marginDb < 0 ? "blocked" : "clear",
       rssiDbm,
       marginDb,
-      diffractionLossDb: los.diffractionLossDb,
-      losBlocked: !los.losClear,
-      fresnelIntruded: !los.fresnelClear,
-    });
+      diffractionLossDb: 0,
+      losBlocked: false,
+      fresnelIntruded: false,
+    };
   }
 
-  results.sort((a, b) => scanSortKey(b) - scanSortKey(a));
+  const samples = samplesForDistance(d, budget);
+  const los = analyzeLineOfSight({
+    from: origin,
+    to: t.position,
+    fromAltitudeM: originAltitudeM ?? null,
+    toAltitudeM: t.altitudeM ?? null,
+    antennaHeightM: budget.rxAntennaHeightM,
+    freqGHz: budget.freqGHz,
+    samples,
+    queryTerrainM,
+  });
+
+  // LoS points only carry distanceKm; unwrap lng/lat ourselves (seam-safe, matching
+  // the terrain profile) to sample raster lookups. DSM endpoint-skip: see coverageRaster.ts.
+  const profileM = new Float64Array(los.points.map((p) => p.ground));
+  const profileClasses = new Uint8Array(profileM.length);
+  const lastPathIdx = profileM.length - 1;
+  for (let s = 0; s < profileM.length; s++) {
+    const tFrac = profileM.length > 1 ? s / lastPathIdx : 0;
+    const [sLng, sLat] = interpLngLatUnwrapped(origin, t.position, tFrac);
+    if (clutterRaster) {
+      profileClasses[s] = sampleClutterClassAt(clutterRaster, sLng, sLat);
+    } else {
+      profileClasses[s] = NLCD_DEFAULT_CLASS_ID;
+    }
+    if (buildingRaster && s !== 0 && s !== lastPathIdx) {
+      const sample = sampleBuildingAt(buildingRaster, sLng, sLat);
+      if (sample && sample.heightM > 0) profileM[s] += sample.heightM;
+    }
+  }
+
+  const spacingM = profileM.length > 1 ? (d * 1000) / (profileM.length - 1) : 0;
+  const txAGLm = los.points.length > 0
+    ? Math.max(0.5, los.fromHeightM - los.points[0].ground)
+    : budget.rxAntennaHeightM;
+  const rxAGLm = los.points.length > 0
+    ? Math.max(0.5, los.toHeightM - los.points[los.points.length - 1].ground)
+    : budget.rxAntennaHeightM;
+  if (canopyCtx) {
+    canopyCtx.origLng = origin[0];
+    canopyCtx.origLat = origin[1];
+    canopyCtx.destLng = t.position[0];
+    canopyCtx.destLat = t.position[1];
+  }
+  if (buildingCtx) {
+    buildingCtx.origLng = origin[0];
+    buildingCtx.origLat = origin[1];
+    buildingCtx.destLng = t.position[0];
+    buildingCtx.destLat = t.position[1];
+  }
+  const clutterLossDb = computePathClutterLoss(
+    profileM,
+    profileClasses,
+    profileM.length,
+    spacingM,
+    txAGLm,
+    rxAGLm,
+    budget.freqMhz,
+    budget.clutterAggression,
+    clutterScratch,
+    canopyCtx,
+    buildingCtx,
+  );
+
+  // Path loss: ITM (terrain-aware) when available, else FSPL + knife-edge
+  let totalLossDb: number;
+  if (input.itm && los.points.length >= 2) {
+    const itmLoss = computeP2PLossFast(input.itm.context, {
+      txHeightM: txAGLm,
+      rxHeightM: rxAGLm,
+      profileM,
+      pointSpacingM: spacingM,
+      climate: input.itm.climate,
+      surfaceRefractivityN: input.itm.surfaceRefractivityN,
+      freqMhz: budget.freqMhz,
+      polarization: input.itm.polarization,
+      groundDielectric: input.itm.groundDielectric,
+      groundConductivity: input.itm.groundConductivity,
+      mdvar: ModeOfVariability.SingleMessage,
+      time: input.itm.timePct ?? 50,
+      location: input.itm.locationPct ?? 50,
+      situation: input.itm.situationPct ?? 50,
+    });
+    // Fallback to FSPL if ITM returns garbage
+    totalLossDb =
+      Number.isFinite(itmLoss) && itmLoss > 0
+        ? itmLoss + clutterLossDb + budget.cableLossDb
+        : pathLossDb(d, budget.freqMhz) + los.diffractionLossDb + clutterLossDb + budget.cableLossDb;
+  } else {
+    totalLossDb = pathLossDb(d, budget.freqMhz) + los.diffractionLossDb + clutterLossDb + budget.cableLossDb;
+  }
+  const rssiDbm = budget.txDbm + budget.txAntennaDbi + budget.rxAntennaDbi - totalLossDb;
+  const marginDb = rssiDbm - budget.rxSensitivityDbm - budget.fadeMarginDb;
+
+  let cls: ScanClass;
+  if (marginDb < 0) cls = "blocked";
+  else if (!los.losClear) cls = "diffracted";
+  else if (!los.fresnelClear) cls = "fresnel";
+  else cls = "clear";
 
   return {
-    origin,
-    originShortname,
-    results,
-    clearCount,
-    fresnelCount,
-    diffractedCount,
-    blockedCount,
+    id: t.id,
+    shortname: t.shortname,
+    position: t.position,
+    distanceKm: d,
+    cls,
+    rssiDbm,
+    marginDb,
+    diffractionLossDb: los.diffractionLossDb,
+    losBlocked: !los.losClear,
+    fresnelIntruded: !los.fresnelClear,
   };
 }
 
-/** FeatureCollection of lines from origin → each target. */
+function resolveBudget(input: ScanInput): ScanBudget {
+  const freqGHz = input.freqGHz ?? FREQ_MHZ / 1000;
+  return {
+    freqGHz,
+    freqMhz: freqGHz * 1000,
+    raySamples: input.raySamples ?? DEFAULT_RAY_SAMPLES,
+    demMppM: input.demMppM,
+    txDbm: input.txDbm ?? 22,
+    txAntennaDbi: input.txAntennaDbi ?? 3,
+    rxAntennaDbi: input.rxAntennaDbi ?? input.txAntennaDbi ?? 3,
+    rxAntennaHeightM: input.rxAntennaHeightM ?? 2,
+    rxSensitivityDbm: input.rxSensitivityDbm ?? -130,
+    fadeMarginDb: input.fadeMarginDb ?? FADE_MARGIN_DB,
+    cableLossDb: input.cableLossDb ?? CABLE_LOSS_DB,
+    clutterAggression: input.clutterAggression ?? 1.0,
+    maxDistanceKm: input.maxDistanceKm ?? Infinity,
+  };
+}
+
+function summarize(origin: [number, number], originShortname: string | undefined, results: ScanResult[]): ScanSummary {
+  let clearCount = 0, fresnelCount = 0, diffractedCount = 0, blockedCount = 0;
+  for (const r of results) {
+    if (r.cls === "clear") clearCount++;
+    else if (r.cls === "fresnel") fresnelCount++;
+    else if (r.cls === "diffracted") diffractedCount++;
+    else blockedCount++;
+  }
+  results.sort((a, b) => scanSortKey(b) - scanSortKey(a));
+  return { origin, originShortname, results, clearCount, fresnelCount, diffractedCount, blockedCount };
+}
+
+/** Synchronous scan (used by tests / small meshes). Prefer runScanAsync in the UI. */
+export function runScan(input: ScanInput): ScanSummary {
+  const budget = resolveBudget(input);
+  const clutterScratch = makeClutterScratch();
+  const canopyCtx: CanopyPathContext | null = input.canopyRaster
+    ? { raster: input.canopyRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
+  const buildingCtx: BuildingPathContext | null = input.buildingRaster
+    ? { raster: input.buildingRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
+  const results: ScanResult[] = [];
+  for (const t of input.targets) {
+    const r = scanOneTarget(t, input, budget, clutterScratch, canopyCtx, buildingCtx);
+    if (r) results.push(r);
+  }
+  return summarize(input.origin, input.originShortname, results);
+}
+
+/** Chunked scan that yields to the event loop between batches so the map stays
+ *  interactive on dense meshes. `shouldCancel` aborts mid-run (returns null). */
+export async function runScanAsync(
+  input: ScanInput,
+  opts: { chunkSize?: number; shouldCancel?: () => boolean } = {},
+): Promise<ScanSummary | null> {
+  const { chunkSize = 40, shouldCancel } = opts;
+  const budget = resolveBudget(input);
+  const clutterScratch = makeClutterScratch();
+  const canopyCtx: CanopyPathContext | null = input.canopyRaster
+    ? { raster: input.canopyRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
+  const buildingCtx: BuildingPathContext | null = input.buildingRaster
+    ? { raster: input.buildingRaster, origLng: 0, origLat: 0, destLng: 0, destLat: 0 }
+    : null;
+  const results: ScanResult[] = [];
+  const targets = input.targets;
+  for (let i = 0; i < targets.length; i++) {
+    if (shouldCancel?.()) return null;
+    const r = scanOneTarget(targets[i], input, budget, clutterScratch, canopyCtx, buildingCtx);
+    if (r) results.push(r);
+    // Yield on a macrotask boundary so paint/input aren't starved.
+    if ((i + 1) % chunkSize === 0) await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  if (shouldCancel?.()) return null;
+  return summarize(input.origin, input.originShortname, results);
+}
+
+/** FeatureCollection of lines from origin → each target (seam-unwrapped for display). */
 export function scanToGeoJSON(
   summary: ScanSummary,
 ): GeoJSON.FeatureCollection<GeoJSON.LineString, {
@@ -289,7 +376,9 @@ export function scanToGeoJSON(
     id: i, // stable id for setFeatureState
     geometry: {
       type: "LineString" as const,
-      coordinates: [summary.origin, r.position],
+      // Unwrap the target into the origin's longitude frame so a seam-crossing
+      // link draws the short hop, not a 359° sweep across the whole map.
+      coordinates: [summary.origin, [unwrapLngTo(summary.origin[0], r.position[0]), r.position[1]]],
     },
     properties: {
       cls: r.cls,

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -32,6 +32,8 @@ export const LS_KEYS = {
   coverageAutoRecalc: "meshinfo.map.coverageAutoRecalc",
   /** Last-used coverage settings (semantic CoveragePreset payload). */
   coverageLastSettings: "meshinfo.map.coverageLastSettings",
+  /** Last-used LOS settings (frequency, modem preset, per-endpoint hw/antenna/height). */
+  losSettings: "meshinfo.map.losSettings",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -26,6 +26,10 @@ export const LS_KEYS = {
   /** Building-height tier on/off. Off → bare-earth DEM + class-nominal endpoint h_a. */
   coverageBuildingsEnabled: "meshinfo.map.coverageBuildingsEnabled",
   scanBuildingsEnabled: "meshinfo.map.scanBuildingsEnabled",
+  /** Named coverage-settings presets (CoveragePreset[]). */
+  coveragePresets: "meshinfo.map.coveragePresets",
+  /** Coverage auto-recompute on setting changes (default true). */
+  coverageAutoRecalc: "meshinfo.map.coverageAutoRecalc",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -30,6 +30,8 @@ export const LS_KEYS = {
   coveragePresets: "meshinfo.map.coveragePresets",
   /** Coverage auto-recompute on setting changes (default true). */
   coverageAutoRecalc: "meshinfo.map.coverageAutoRecalc",
+  /** Last-used coverage settings (semantic CoveragePreset payload). */
+  coverageLastSettings: "meshinfo.map.coverageLastSettings",
 } as const;
 
 export function readJson<T>(key: string, fallback: T): T {

--- a/frontend/src/pages/map/storage.ts
+++ b/frontend/src/pages/map/storage.ts
@@ -16,16 +16,14 @@ export const LS_KEYS = {
   buildings3D: "meshinfo.map.buildings3D",
   /** AGGRESSION_STOPS index (0/1/2). Default 1 = calibrated baseline. */
   coverageAggressionIdx: "meshinfo.map.coverageAggressionIdx",
-  scanAggressionIdx: "meshinfo.map.scanAggressionIdx",
   /** Clutter model on/off. Off → aggression = 0, ITM-only path loss. */
   coverageClutterEnabled: "meshinfo.map.coverageClutterEnabled",
-  scanClutterEnabled: "meshinfo.map.scanClutterEnabled",
   /** Canopy-height tier on/off. Off → fall back to class-nominal heights. */
   coverageCanopyEnabled: "meshinfo.map.coverageCanopyEnabled",
-  scanCanopyEnabled: "meshinfo.map.scanCanopyEnabled",
   /** Building-height tier on/off. Off → bare-earth DEM + class-nominal endpoint h_a. */
   coverageBuildingsEnabled: "meshinfo.map.coverageBuildingsEnabled",
-  scanBuildingsEnabled: "meshinfo.map.scanBuildingsEnabled",
+  /** Last-used scan settings (frequency, modem preset, TX/RX hw/antenna/height, env, reliability). */
+  scanSettings: "meshinfo.map.scanSettings",
   /** Named coverage-settings presets (CoveragePreset[]). */
   coveragePresets: "meshinfo.map.coveragePresets",
   /** Coverage auto-recompute on setting changes (default true). */

--- a/frontend/src/pages/map/terrainDEM.ts
+++ b/frontend/src/pages/map/terrainDEM.ts
@@ -117,6 +117,19 @@ export function unionDemBoundsAround(
   return out;
 }
 
+/** True if `inner` fits inside `outer`, tolerating a ±360° longitude-frame
+ *  difference (both bboxes may be unwrapped around different antimeridian sides). */
+export function demBoundsContain(outer: DEMBounds, inner: DEMBounds): boolean {
+  const dMid = (inner.west + inner.east) / 2 - (outer.west + outer.east) / 2;
+  const shift = dMid > 180 ? -360 : dMid < -180 ? 360 : 0;
+  return (
+    inner.west + shift >= outer.west &&
+    inner.east + shift <= outer.east &&
+    inner.south >= outer.south &&
+    inner.north <= outer.north
+  );
+}
+
 /** Lng/lat for DEM pixel (x, y). */
 export function demPixelToLngLat(dem: DEM, x: number, y: number): [number, number] {
   const { bounds, width, height } = dem;

--- a/frontend/src/pages/map/terrainRgb.ts
+++ b/frontend/src/pages/map/terrainRgb.ts
@@ -289,11 +289,18 @@ export interface BuildDemOptions {
 /** Tile source for DEM attribution. */
 export type DemSource = "tilezen" | "mapbox-terrain-rgb";
 
+export interface BuiltDem {
+  dem: DEM;
+  /** Tiles that errored (network/decode); their pixels are NaN holes. */
+  tilesFailed: number;
+  tilesTotal: number;
+}
+
 /** Try Tilezen; fall back to Mapbox terrain-rgb when a token is configured. Returns source tag for attribution. */
-export async function buildDem(opts: BuildDemOptions): Promise<{ dem: DEM; source: DemSource }> {
+export async function buildDem(opts: BuildDemOptions): Promise<BuiltDem & { source: DemSource }> {
   try {
-    const dem = await buildDemFromTilezen(opts);
-    return { dem, source: "tilezen" };
+    const built = await buildDemFromTilezen(opts);
+    return { ...built, source: "tilezen" };
   } catch (err) {
     if (!opts.token) {
       console.warn("[terrainRgb] Bulk DEM from Tilezen failed (no Mapbox fallback — token not configured):", err);
@@ -303,13 +310,13 @@ export async function buildDem(opts: BuildDemOptions): Promise<{ dem: DEM; sourc
       "[terrainRgb] Bulk DEM from Tilezen failed, falling back to Mapbox terrain-rgb:",
       err,
     );
-    const dem = await buildDemFromTerrainRgb(opts);
-    return { dem, source: "mapbox-terrain-rgb" };
+    const built = await buildDemFromTerrainRgb(opts);
+    return { ...built, source: "mapbox-terrain-rgb" };
   }
 }
 
 /** Stitch terrain tiles for bounds, bilinear-resample to target grid. Per-tile failures → NaN pixels. */
-export async function buildDemFromTerrainRgb(opts: BuildDemOptions): Promise<DEM> {
+export async function buildDemFromTerrainRgb(opts: BuildDemOptions): Promise<BuiltDem> {
   const { bounds, targetWidth, targetHeight, token } = opts;
   const maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES_PER_REQUEST;
 
@@ -412,11 +419,15 @@ export async function buildDemFromTerrainRgb(opts: BuildDemOptions): Promise<DEM
     }
   }
 
-  return { data, width: targetWidth, height: targetHeight, bounds };
+  return {
+    dem: { data, width: targetWidth, height: targetHeight, bounds },
+    tilesFailed: failureCount,
+    tilesTotal: totalTiles,
+  };
 }
 
 /** Tilezen twin of buildDemFromTerrainRgb. 256 px tiles, max z=15. */
-export async function buildDemFromTilezen(opts: BuildDemOptions): Promise<DEM> {
+export async function buildDemFromTilezen(opts: BuildDemOptions): Promise<BuiltDem> {
   const { bounds, targetWidth, targetHeight } = opts;
   const maxTiles = opts.maxTiles ?? DEFAULT_MAX_TILES_PER_REQUEST;
 
@@ -516,5 +527,9 @@ export async function buildDemFromTilezen(opts: BuildDemOptions): Promise<DEM> {
     }
   }
 
-  return { data, width: targetWidth, height: targetHeight, bounds };
+  return {
+    dem: { data, width: targetWidth, height: targetHeight, bounds },
+    tilesFailed: failureCount,
+    tilesTotal: totalTiles,
+  };
 }

--- a/frontend/src/pages/map/terrainRgb.ts
+++ b/frontend/src/pages/map/terrainRgb.ts
@@ -113,9 +113,10 @@ class TileLRU {
 // ~64 × 512² × 4B ≈ 64 MB worst case
 const tileCache = new TileLRU(64);
 
-// Sized to fit a standard-detail compute (256 max tiles) so back-to-back computes at the
-// same origin hit 100% cache. 256 × 256² × 4B ≈ 64 MB worst case.
-const tilezenCache = new TileLRU(256);
+// Fits a High-detail compute (512 tiles); Ultra/Survey still partially thrash,
+// accepted since the coverage fetch-cache avoids same-origin refetches.
+// 512 × 256² × 4B ≈ 128 MB worst case.
+const tilezenCache = new TileLRU(512);
 
 async function fetchTile(
   z: number,

--- a/frontend/src/pages/map/useCoverageCompute.ts
+++ b/frontend/src/pages/map/useCoverageCompute.ts
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { toast } from "../../components/toastStore";
 import { env } from "../../env";
+import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
 import { buildBuildingRaster, type BuildingRaster, downsampleBuildingRaster } from "./buildingTiles";
 import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./canopyTiles";
 import { AGGRESSION_STOPS, type MergeOrigin, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./coverageAnalysis";
@@ -14,13 +15,13 @@ import { COVERAGE_DETAIL_MAX_TILES, COVERAGE_DETAIL_SIZE } from "./coverageDetai
 import { exportCoverage } from "./coverageExport";
 import type { RasterParams } from "./coverageRaster";
 import { extractCoverageRays, type VisibilityRayFeatureCollection } from "./coverageRays";
-import type { CoverageSliceRequest, SliceOrigin } from "./coverageSliceWorker";
+import type { SliceOrigin } from "./coverageSliceWorker";
 import { CoverageWorkerPool } from "./coverageWorkerPool";
 import { queryTerrainElevationMSL } from "./helpers";
 import { CABLE_LOSS_DB, clampRxHeightM, DEFAULT_ITM_ENV, FADE_MARGIN_DB, FREQ_MHZ } from "./itmEnv";
 import { buildClutterRaster, type ClutterRaster, downsampleClutterRaster } from "./landcoverTiles";
 import { type DEM, type DEMBounds, downsampleDEM, sampleDEMAt, unionDemBoundsAround } from "./terrainDEM";
-import { buildDem, fetchElevationAt } from "./terrainRgb";
+import { buildDem, type DemSource, fetchElevationAt } from "./terrainRgb";
 import type { IMapNode } from "./types";
 import type { CoverageState } from "./useCoverageState";
 
@@ -47,6 +48,30 @@ type CoverageComputeParams = {
   setPickingMergeOrigin: (v: boolean) => void;
   moveCoverageMergeOrigin: (id: string, position: [number, number]) => void;
 };
+
+/** Debounce for parameter-only recomputes; origin moves and explicit
+ *  recalculates run immediately. */
+const PARAM_RECOMPUTE_DEBOUNCE_MS = 350;
+
+/** Fetched rasters + telemetry, reused while bounds/detail/layer toggles are
+ *  unchanged. */
+type FetchedRasters = {
+  key: string;
+  dem: DEM;
+  clutter: ClutterRaster | null;
+  canopy: CanopyRaster | null;
+  buildings: BuildingRaster | null;
+  demSource: DemSource;
+  clutterStatus: { tilesPresent: number; tilesTotal: number } | null;
+  canopyStatus: { tilesPresent: number; tilesTotal: number } | null;
+  buildingsStatus: { tilesPresent: number; tilesTotal: number } | null;
+};
+
+/** Pool raster registration handle; pool identity matters because Cancel
+ *  terminates + recreates the pool, which resets its generation counter. */
+type RasterGenHandle = { pool: CoverageWorkerPool; gen: number; key: string };
+
+const yieldToMain = () => new Promise<void>((r) => setTimeout(r, 0));
 
 export function useCoverageCompute(params: CoverageComputeParams) {
   const {
@@ -91,7 +116,8 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     if (toolFromId) {
       const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
       if (!n?.map_position) return null;
-      return { lng: n.map_position[0], lat: n.map_position[1], alt: n.position?.altitude ?? null };
+      // HAE-aware MSL altitude, matching merge-origin resolution
+      return { lng: n.map_position[0], lat: n.map_position[1], alt: effectiveAltitudeMslM(n.position) };
     }
     if (toolVirtualPos) return { lng: toolVirtualPos[0], lat: toolVirtualPos[1], alt: null };
     return null;
@@ -122,29 +148,54 @@ export function useCoverageCompute(params: CoverageComputeParams) {
   }, []);
   useEffect(() => {
     return () => {
+      // Invalidate first so terminate's rejections read as superseded
+      coverageRequestIdRef.current += 1;
       coveragePoolRef.current?.terminate();
       coveragePoolRef.current = null;
     };
   }, []);
 
-  /** Cached authoritative DEM; drag-preview reuses it without re-fetching tiles. */
-  const coverageDemRef = useRef<DEM | null>(null);
-  /** 256² downsample of the above; lets drag preview run LR at ~8-12 fps. */
+  /** Fetched rasters keyed by bounds/detail/layer toggles; parameter-only
+   *  recomputes reuse them (no refetch, no 2048² main-thread resample). */
+  const coverageFetchCacheRef = useRef<FetchedRasters | null>(null);
+  /** Pool registration of the authoritative rasters (worker-side cache). */
+  const coverageRasterGenRef = useRef<RasterGenHandle | null>(null);
+  /** Pool registration of the downsampled drag-preview rasters. */
+  const coverageDragGenRef = useRef<RasterGenHandle | null>(null);
+  /** 256² downsample of the authoritative DEM; drag preview runs LR at ~8-12 fps. */
   const coverageDragDemRef = useRef<DEM | null>(null);
-  /** Authoritative + 256² downsampled class-ID rasters; drag preview reuses these. */
-  const coverageClutterRef = useRef<ClutterRaster | null>(null);
   const coverageDragClutterRef = useRef<ClutterRaster | null>(null);
-  /** Authoritative + 256² downsampled canopy-height rasters; drag preview reuses these. */
-  const coverageCanopyRef = useRef<CanopyRaster | null>(null);
   const coverageDragCanopyRef = useRef<CanopyRaster | null>(null);
-  /** Authoritative + 256² downsampled building-height rasters; drag preview reuses these. */
-  const coverageBuildingsRef = useRef<BuildingRaster | null>(null);
   const coverageDragBuildingsRef = useRef<BuildingRaster | null>(null);
   /** Latest raster params snapshot (drag preview reuses untouched). */
   const coverageLastRasterParamsRef = useRef<RasterParams | null>(null);
   /** Single-flight drag preview; latest pending position fires when current completes. */
   const dragPreviewBusyRef = useRef(false);
   const dragPreviewPendingRef = useRef<[number, number] | null>(null);
+
+  /** Origin ground per rounded lng/lat, so recomputes at the same pin reuse
+   *  the exact same height. Viewport-sourced fallbacks are retried against
+   *  the deterministic z15 fetch on later computes. */
+  const originGroundCacheRef = useRef<Map<string, { value: number; source: "fetch" | "viewport" }>>(new globalThis.Map());
+
+  /** Change-detection for the compute effect: skip refires that don't alter
+   *  the render (poll identity churn, overlay flips, zero-move drags). */
+  const lastComputedKeyRef = useRef<string | null>(null);
+  const lastOriginKeyRef = useRef<string | null>(null);
+  const lastNoncesRef = useRef<{ retry: number; recalc: number }>({ retry: 0, recalc: 0 });
+  /** Retry-nonce value at the last fetch; a bump busts the raster fetch cache. */
+  const lastRetryNonceRef = useRef(0);
+  /** Live full computes; the no-op early-return only tidies UI state when 0. */
+  const activeComputeCountRef = useRef(0);
+  /** computeKey whose run was cancelled — the paint doesn't reflect it, so
+   *  matching settings must offer Recalculate. */
+  const cancelledComputeKeyRef = useRef<string | null>(null);
+  /** Origin metadata of the last painted compute, for lazy ray extraction. */
+  const lastRenderMetaRef = useRef<{
+    origin: [number, number];
+    originHeightM: number;
+    rxHeightM: number;
+  } | null>(null);
 
   /** Cached contour GeoJSON for Export without recomputing. */
   const coverageContoursRef = useRef<ContourFeatureCollection | null>(null);
@@ -166,8 +217,19 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     coverageResultRef.current = c.coverageResult;
   }, [c.coverageResult]);
 
-  /** Export coverage as GeoJSON or KML (iso-margin 0/10/20 dB contours + metadata). */
+  /** Export coverage as GeoJSON or KML (iso-margin 0/10/20 dB contours + metadata).
+   *  Contours are built lazily from the cached margin grid. */
   const handleCoverageExport = useCallback((format: "geojson" | "kml") => {
+    if (!coverageContoursRef.current && coverageMarginRef.current) {
+      const m = coverageMarginRef.current;
+      coverageContoursRef.current = extractCoverageContours({
+        margin: m.data,
+        width: m.width,
+        height: m.height,
+        bounds: m.bounds,
+        thresholdsDb: [0, 10, 20],
+      });
+    }
     if (!coverageResultRef.current || !coverageContoursRef.current) {
       toast("Nothing to export yet — run a coverage prediction first.");
       return;
@@ -176,16 +238,15 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     toast(`Coverage exported as ${format.toUpperCase()}.`, { kind: "success" });
   }, []);
 
-  /** Run pool over a DEM, stitch slices, paint RGBA to `coverage-raster`.
-   *  Shared by main compute + drag preview. Null = superseded or WASM missing. */
+  /** Run pool over the registered raster generation, stitch slices, paint RGBA
+   *  to `coverage-raster`. Shared by main compute + drag preview. The raster
+   *  buffers live in the pool (see setRasters); slices carry only params.
+   *  Null = superseded or WASM missing. */
   const renderCoverageToImageSource = useCallback(async (opts: {
+    /** Authoritative DEM for bounds/dims; buffers already registered on the pool. */
     dem: DEM;
-    /** Optional class-ID raster aligned to DEM bounds. Null = workers fall back to default class. */
-    clutter?: ClutterRaster | null;
-    /** Optional canopy-height raster aligned to DEM bounds. Null = workers fall back to class-nominal. */
-    canopy?: CanopyRaster | null;
-    /** Optional building-height raster aligned to DEM bounds. Null = bare-earth + class-nominal endpoint h_a. */
-    buildings?: BuildingRaster | null;
+    /** Pool raster generation to compute against. */
+    rasterGen: number;
     /** Primary + (optional) merge origins. Single-element array preserves the
      *  pre-merge single-origin compute byte-identically. */
     origins: SliceOrigin[];
@@ -209,14 +270,17 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     outputHeight: number;
     itmUnavailable?: boolean;
   } | null> => {
-    const { dem, clutter, canopy, buildings, origins, params: rp, requestId, onSliceProgress } = opts;
+    const { dem, rasterGen, origins, params: rp, requestId, onSliceProgress } = opts;
     const outputWidth = opts.outputWidth ?? dem.width;
     const outputHeight = opts.outputHeight ?? dem.height;
     const mb = mbMapRef.current;
     if (!mb) return null;
     const pool = ensureCoveragePool();
-    const poolSize = pool.size;
-    const rowsPerTask = Math.ceil(outputHeight / poolSize);
+    // Queued tasks belong to superseded requests; drop them
+    pool.dropQueued();
+    // 2 slices per worker: finer progress + less straggler tail than 1:1
+    const totalSlices = Math.min(pool.size * 2, outputHeight);
+    const rowsPerTask = Math.ceil(outputHeight / totalSlices);
 
     const sliceResponses: Array<{
       rgba: Uint8ClampedArray;
@@ -229,59 +293,22 @@ export function useCoverageCompute(params: CoverageComputeParams) {
       itmUnavailable?: boolean;
     }> = [];
     const tasks: Promise<unknown>[] = [];
-    const totalSlices = Math.min(
-      poolSize,
-      Math.ceil(outputHeight / rowsPerTask),
-    );
     let completedSlices = 0;
     onSliceProgress?.(0, totalSlices);
 
-    for (let i = 0; i < poolSize; i++) {
-      const rowStart = i * rowsPerTask;
-      if (rowStart >= outputHeight) break;
+    for (let rowStart = 0; rowStart < outputHeight; rowStart += rowsPerTask) {
       const rowEnd = Math.min(rowStart + rowsPerTask, outputHeight);
-      const demCopy = new Float32Array(dem.data);
-      // Transferable buffers can't be shared across workers; copy per slice.
-      const clutterCopy = clutter ? new Uint8Array(clutter.data) : null;
-      const canopyHeightCopy = canopy ? new Float32Array(canopy.heightM) : null;
-      const canopyStdCopy = canopy ? new Float32Array(canopy.stdM) : null;
-      const canopyMaskCopy = canopy ? new Float32Array(canopy.mask) : null;
-      const buildingHeightCopy = buildings ? new Float32Array(buildings.heightM) : null;
-      const buildingMaskCopy = buildings ? new Float32Array(buildings.mask) : null;
-      const req: CoverageSliceRequest = {
-        requestId,
-        demBuffer: demCopy.buffer,
-        demWidth: dem.width,
-        demHeight: dem.height,
-        bounds: dem.bounds,
-        origins,
-        params: rp,
-        outputWidth,
-        outputHeight,
-        rowStart,
-        rowEnd,
-        clutterBuffer: clutterCopy?.buffer,
-        clutterWidth: clutter?.width,
-        clutterHeight: clutter?.height,
-        canopyHeightBuffer: canopyHeightCopy?.buffer,
-        canopyStdBuffer: canopyStdCopy?.buffer,
-        canopyMaskBuffer: canopyMaskCopy?.buffer,
-        canopyWidth: canopy?.width,
-        canopyHeight: canopy?.height,
-        buildingHeightBuffer: buildingHeightCopy?.buffer,
-        buildingMaskBuffer: buildingMaskCopy?.buffer,
-        buildingWidth: buildings?.width,
-        buildingHeight: buildings?.height,
-      };
-      const transfer: Transferable[] = [demCopy.buffer];
-      if (clutterCopy) transfer.push(clutterCopy.buffer);
-      if (canopyHeightCopy) transfer.push(canopyHeightCopy.buffer);
-      if (canopyStdCopy) transfer.push(canopyStdCopy.buffer);
-      if (canopyMaskCopy) transfer.push(canopyMaskCopy.buffer);
-      if (buildingHeightCopy) transfer.push(buildingHeightCopy.buffer);
-      if (buildingMaskCopy) transfer.push(buildingMaskCopy.buffer);
       tasks.push(
-        pool.dispatch(req, transfer).then((resp) => {
+        pool.dispatch({
+          requestId,
+          rasterGen,
+          origins,
+          params: rp,
+          outputWidth,
+          outputHeight,
+          rowStart,
+          rowEnd,
+        }).then((resp) => {
           sliceResponses.push(resp);
           completedSlices += 1;
           if (requestId === coverageRequestIdRef.current) {
@@ -289,6 +316,8 @@ export function useCoverageCompute(params: CoverageComputeParams) {
           }
         }),
       );
+      // Yield between dispatches; per-worker buffer clones on gen change are heavy
+      if (rowStart + rowsPerTask < outputHeight) await yieldToMain();
     }
     await Promise.all(tasks);
 
@@ -340,6 +369,11 @@ export function useCoverageCompute(params: CoverageComputeParams) {
         resolve(URL.createObjectURL(blob));
       }, "image/png");
     });
+    // A newer request may have painted while toBlob ran
+    if (requestId !== coverageRequestIdRef.current) {
+      URL.revokeObjectURL(url);
+      return null;
+    }
 
     const src = mb.getSource("coverage-raster") as maplibregl.ImageSource | undefined;
     const coords: [[number, number], [number, number], [number, number], [number, number]] = [
@@ -385,8 +419,13 @@ export function useCoverageCompute(params: CoverageComputeParams) {
       c.setIsComputingCoverage(false);
       c.setIsFetchingCoverageTerrain(false);
       c.setCoverageError(null);
+      c.setCoverageParamsDirty(false);
       c.setCoverageProgress({ completed: 0, total: 0 });
       lastRecenteredOriginRef.current = null;
+      lastComputedKeyRef.current = null;
+      lastOriginKeyRef.current = null;
+      // Invalidate in-flight computes — no ghost paint after close
+      coverageRequestIdRef.current += 1;
       return;
     }
     // Suppress the redundant recompute on overlay enter/exit (params unchanged).
@@ -399,6 +438,8 @@ export function useCoverageCompute(params: CoverageComputeParams) {
       c.setIsComputingCoverage(false);
       c.setIsFetchingCoverageTerrain(false);
       c.setCoverageProgress({ completed: 0, total: 0 });
+      lastComputedKeyRef.current = null;
+      coverageRequestIdRef.current += 1;
       return;
     }
     const mb = mbMapRef.current;
@@ -414,7 +455,7 @@ export function useCoverageCompute(params: CoverageComputeParams) {
       const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
       if (n?.map_position) {
         origin = [n.map_position[0], n.map_position[1]];
-        altitude = n.position?.altitude ?? null;
+        altitude = effectiveAltitudeMslM(n.position);
       }
     } else if (toolVirtualPos) {
       origin = toolVirtualPos;
@@ -422,43 +463,30 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     }
     if (!origin) {
       c.setCoverageResult(null);
+      lastComputedKeyRef.current = null;
+      coverageRequestIdRef.current += 1;
       return;
     }
 
-    // Mark as computing but keep the previous result visible so controls stay up
-    c.setIsComputingCoverage(true);
-    c.setCoverageError(null);
-    c.setCoverageProgress({ completed: 0, total: 0 });
+    // Tokenless OK — all sources are Tilezen/self-hosted; the token only
+    // enables the Mapbox terrain-rgb fallback.
+    const mapboxToken = env.MAPBOX_TOKEN ?? "";
 
     const radKm = coverageRadiusKm;
     // Union bbox over primary + merge origins (all share radiusKm since TX
     // params are global); seam-aware so straddling origins don't span the globe.
+    // Positions quantized to the change-detection precision (4/5 dp) so GPS
+    // jitter can't change fetchKey.
     const demBounds = unionDemBoundsAround(
-      [origin, ...coverageMergeOrigins.map((m) => m.position)],
+      [
+        [Number(origin[0].toFixed(4)), Number(origin[1].toFixed(4))] as [number, number],
+        ...coverageMergeOrigins.map(
+          (m) => [Number(m.position[0].toFixed(5)), Number(m.position[1].toFixed(5))] as [number, number],
+        ),
+      ],
       radKm,
       1.05,
     );
-    // Recenter only when the origin actually moved; pure parameter recomputes
-    // (TX power, antenna, clutter on/off, etc.) shouldn't yank the user's view.
-    const prev = lastRecenteredOriginRef.current;
-    const movedSignificantly =
-      !prev ||
-      Math.abs(prev[0] - origin[0]) > 1e-6 ||
-      Math.abs(prev[1] - origin[1]) > 1e-6;
-    if (movedSignificantly) {
-      mb.easeTo({ center: origin, duration: 300 });
-      lastRecenteredOriginRef.current = [origin[0], origin[1]];
-    }
-
-    const mapboxToken = env.MAPBOX_TOKEN;
-    if (!mapboxToken) {
-      console.warn("[Map] Coverage compute aborted — Mapbox token missing.");
-      c.setIsComputingCoverage(false);
-      return;
-    }
-
-    const requestId = ++coverageRequestIdRef.current;
-    let cancelled = false;
 
     // Pool-based compute: fetch DEM once, slice to workers, stitch RGBA.
     // DEM is fixed 2048²; "Detail" only changes OUTPUT_SIZE (paint pixelation, not RF accuracy).
@@ -483,297 +511,424 @@ export function useCoverageCompute(params: CoverageComputeParams) {
       situationPct: rel.situation,
     };
 
-    (async () => {
-      const t0 = performance.now();
-      const timings: Record<string, number> = {};
-      const mark = (name: string, fromMs: number) => {
-        timings[name] = performance.now() - fromMs;
-      };
-      try {
-        // 1. Fetch terrain + (when enabled) land-cover + canopy + buildings in
-        //    parallel; all at DEM_SIZE so the worker samples them at the same
-        //    lng/lat indexing. Skip individual fetches when their respective
-        //    models are toggled off — saves the network + decode cost.
-        const tFetch = performance.now();
-        c.setIsFetchingCoverageTerrain(true);
-        const [{ dem, source: demSourceUsed }, clutter, canopy, buildings] = await Promise.all([
-          buildDem({
-            bounds: demBounds,
-            targetWidth: DEM_SIZE,
-            targetHeight: DEM_SIZE,
-            token: mapboxToken,
-            maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-          }),
-          c.coverageClutterEnabled
-            ? buildClutterRaster({
-                bounds: demBounds,
-                targetWidth: DEM_SIZE,
-                targetHeight: DEM_SIZE,
-                maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-              })
-            : Promise.resolve(null),
-          c.coverageCanopyEnabled
-            ? buildCanopyRaster({
-                bounds: demBounds,
-                targetWidth: DEM_SIZE,
-                targetHeight: DEM_SIZE,
-                maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-              })
-            : Promise.resolve(null),
-          c.coverageBuildingsEnabled
-            ? buildBuildingRaster({
-                bounds: demBounds,
-                targetWidth: DEM_SIZE,
-                targetHeight: DEM_SIZE,
-                maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-              })
-            : Promise.resolve(null),
-        ]);
-        c.setCoverageDemSource(demSourceUsed);
-        c.setCoverageClutterStatus(
-          clutter ? { tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal } : null,
-        );
-        c.setCoverageCanopyStatus(
-          canopy ? { tilesPresent: canopy.tilesPresent, tilesTotal: canopy.tilesTotal } : null,
-        );
-        c.setCoverageBuildingsStatus(
-          buildings ? { tilesPresent: buildings.tilesPresent, tilesTotal: buildings.tilesTotal } : null,
-        );
-        mark("demFetchMs", tFetch);
-        if (cancelled || requestId !== coverageRequestIdRef.current) {
-          c.setIsFetchingCoverageTerrain(false);
-          return;
-        }
+    // ---- Change detection & scheduling -------------------------------------
+    // Rounding gives GPS-jitter hysteresis: ~11 m position, 10 m altitude
+    const mergeKey = coverageMergeOrigins
+      .map((m) => `${m.id}@${m.position[0].toFixed(5)},${m.position[1].toFixed(5)},${m.altitudeM == null ? "x" : Math.round(m.altitudeM / 10)}`)
+      .join(";");
+    const originKey = `${origin[0].toFixed(4)},${origin[1].toFixed(4)}|${mergeKey}`;
+    const altKey = altitude == null || !Number.isFinite(altitude) ? "x" : String(Math.round(altitude / 10) * 10);
+    const computeKey = JSON.stringify({
+      o: originKey,
+      alt: altKey,
+      r: radKm,
+      p: rasterParams,
+      d: c.coverageDetail,
+      ah: c.coverageAntennaHeightM,
+      layers: [c.coverageClutterEnabled, c.coverageCanopyEnabled, c.coverageBuildingsEnabled],
+      nr: c.coverageRetryNonce,
+      nc: c.coverageRecalcNonce,
+    });
+    if (computeKey === cancelledComputeKeyRef.current) {
+      // Cancelled settings: the paint doesn't reflect them despite
+      // lastComputedKeyRef — keep the dirty chip up
+      c.setCoverageParamsDirty(true);
+      return;
+    }
+    if (computeKey === lastComputedKeyRef.current) {
+      // Settings match the painted result (e.g. changed and changed back,
+      // poll-identity refire, zero-move drag) — nothing to recompute.
+      c.setCoverageParamsDirty(false);
+      if (activeComputeCountRef.current === 0) {
+        // Tidy leftover busy state (e.g. after a drag-preview stomp) — never
+        // while a live compute owns the indicators
+        c.setIsComputingCoverage(false);
         c.setIsFetchingCoverageTerrain(false);
+        c.setCoverageProgress({ completed: 0, total: 0 });
+      }
+      return;
+    }
+    const noncesChanged =
+      lastNoncesRef.current.retry !== c.coverageRetryNonce ||
+      lastNoncesRef.current.recalc !== c.coverageRecalcNonce;
+    const originChanged = lastOriginKeyRef.current !== originKey;
+    const isFirst = lastComputedKeyRef.current === null;
 
-        // Resolve origin ground via two independent sources; we take the MAX because
-        // a low-zoom-averaged reading can only under-report a peak, never over-report:
-        //   1. `queryTerrainElevation` reads the loaded raster-dem tiles. Accurate when
-        //      zoomed in (~5-30 m px at z=13-14); at low zoom can under-read a peak by ~180 m.
-        //   2. `fetchElevationAt` does a dedicated z=15 fetch — viewport-independent,
-        //      LRU-cached. Source: Tilezen (USGS 3DEP / SRTM), Mapbox terrain-RGB fallback.
-        // queryTerrainElevationMSL undoes MapLibre's built-in exaggeration multiply.
-        const mbElev = queryTerrainElevationMSL(mb, origin!);
-        const mbElevOk = typeof mbElev === "number" && Number.isFinite(mbElev);
-        const fetchElev = await fetchElevationAt(origin![0], origin![1], mapboxToken);
-        const fetchOk = fetchElev != null && Number.isFinite(fetchElev);
-        let originGroundHighZoom: number | null = null;
-        if (mbElevOk && fetchOk) {
-          originGroundHighZoom = Math.max(mbElev, fetchElev);
-        } else if (mbElevOk) {
-          originGroundHighZoom = mbElev;
-        } else if (fetchOk) {
-          originGroundHighZoom = fetchElev;
-        }
-        const originGroundFromDem = sampleDEMAt(dem, origin![0], origin![1]);
-        const groundOkDem = !Number.isNaN(originGroundFromDem);
-        const groundOkHz = originGroundHighZoom != null;
-        const groundOk = groundOkHz || groundOkDem;
-        // Narrowed to number with a 0 fallback; downstream usage is guarded by groundOk.
-        const originGround: number = groundOkHz
-          ? (originGroundHighZoom as number)
-          : groundOkDem
-            ? originGroundFromDem
-            : 0;
-        // Guards against junk altitudes (GPS glitch, unit-scaled values); matches losAnalysis.ts
-        const MAX_HEIGHT_ABOVE_TERRAIN_M = 1000;
-        const altValid =
-          altitude != null &&
-          Number.isFinite(altitude) &&
-          (!groundOk ||
-            (altitude >= originGround &&
-              altitude <= originGround + MAX_HEIGHT_ABOVE_TERRAIN_M));
-        const baseM = altValid
-          ? (altitude as number)
-          : (groundOk ? originGround : 0);
-        const originHeightM = baseM + c.coverageAntennaHeightM;
-        const originIsFallback = !groundOk && !altValid;
-        // ITM wants TX height above profile[0] (bbox DEM value). Compensate so TX MSL matches
-        // originHeightM after profile[0]+txHeight. Collapses to antennaHeight on flat terrain.
-        const txAboveGroundM = groundOkDem
-          ? originHeightM - originGroundFromDem
-          : c.coverageAntennaHeightM;
+    if (!c.coverageAutoRecalc && !originChanged && !noncesChanged && !isFirst) {
+      // Manual mode: parameter tweaks wait for the Recalculate button
+      c.setCoverageParamsDirty(true);
+      return;
+    }
+    const delayMs = originChanged || noncesChanged || isFirst ? 0 : PARAM_RECOMPUTE_DEBOUNCE_MS;
 
-        // Sample terrain off the same DEM the workers see so txHeightM (AGL
-        // relative to profile[0]) collapses cleanly to coverageAntennaHeightM
-        // on flat terrain.
-        const mergeOriginsResolved: SliceOrigin[] = [];
-        for (const m of coverageMergeOrigins) {
-          const terrain = sampleDEMAt(dem, m.position[0], m.position[1]);
-          const terrainOk = !Number.isNaN(terrain);
-          const altOk =
-            m.altitudeM != null &&
-            Number.isFinite(m.altitudeM) &&
-            (!terrainOk ||
-              (m.altitudeM >= terrain && m.altitudeM <= terrain + 1000));
-          const baseM = altOk ? (m.altitudeM as number) : (terrainOk ? terrain : 0);
-          const heightM = baseM + c.coverageAntennaHeightM;
-          mergeOriginsResolved.push({
-            position: m.position,
-            heightM,
-            antennaHeightAboveGroundM: terrainOk ? heightM - terrain : c.coverageAntennaHeightM,
-          });
-        }
+    let cancelled = false;
+    const commitAndLaunch = () => {
+      lastComputedKeyRef.current = computeKey;
+      lastOriginKeyRef.current = originKey;
+      cancelledComputeKeyRef.current = null;
+      const retryNonceChanged = lastRetryNonceRef.current !== c.coverageRetryNonce;
+      lastRetryNonceRef.current = c.coverageRetryNonce;
+      // Retry implies the cached ground may be bad too
+      if (retryNonceChanged) originGroundCacheRef.current.clear();
+      lastNoncesRef.current = { retry: c.coverageRetryNonce, recalc: c.coverageRecalcNonce };
+      c.setCoverageParamsDirty(false);
 
-        // 3. Dispatch pool; OUTPUT_SIZE decoupled from DEM_SIZE so Detail only changes paint sharpness
-        const tDispatch = performance.now();
-        const rendered = await renderCoverageToImageSource({
-          dem,
-          clutter,
-          canopy,
-          buildings,
-          origins: [
-            {
-              position: origin!,
-              heightM: originHeightM,
-              antennaHeightAboveGroundM: txAboveGroundM,
+      // Mark as computing but keep the previous result visible so controls stay up
+      c.setIsComputingCoverage(true);
+      c.setCoverageError(null);
+      c.setCoverageProgress({ completed: 0, total: 0 });
+
+      // Recenter only when the origin actually moved; pure parameter recomputes
+      // (TX power, antenna, clutter on/off, etc.) shouldn't yank the user's view.
+      const prev = lastRecenteredOriginRef.current;
+      const movedSignificantly =
+        !prev ||
+        Math.abs(prev[0] - origin![0]) > 1e-6 ||
+        Math.abs(prev[1] - origin![1]) > 1e-6;
+      if (movedSignificantly) {
+        mb.easeTo({ center: origin!, duration: 300 });
+        lastRecenteredOriginRef.current = [origin![0], origin![1]];
+      }
+
+      const requestId = ++coverageRequestIdRef.current;
+
+      activeComputeCountRef.current += 1;
+      (async () => {
+        const t0 = performance.now();
+        const timings: Record<string, number> = {};
+        const mark = (name: string, fromMs: number) => {
+          timings[name] = performance.now() - fromMs;
+        };
+        try {
+          // 1. Rasters: reuse the fetched set when bounds/detail/layer toggles
+          //    are unchanged; otherwise fetch terrain + enabled clutter tiers in
+          //    parallel, all at DEM_SIZE for uniform lng/lat indexing.
+          const fetchKey = [
+            demBounds.west.toFixed(6), demBounds.south.toFixed(6),
+            demBounds.east.toFixed(6), demBounds.north.toFixed(6),
+            c.coverageDetail,
+            c.coverageClutterEnabled, c.coverageCanopyEnabled, c.coverageBuildingsEnabled,
+          ].join("|");
+          let fetched = coverageFetchCacheRef.current;
+          const cacheHit = fetched != null && fetched.key === fetchKey && !retryNonceChanged;
+          if (!cacheHit) {
+            const tFetch = performance.now();
+            c.setIsFetchingCoverageTerrain(true);
+            const [{ dem, source: demSourceUsed }, clutter, canopy, buildings] = await Promise.all([
+              buildDem({
+                bounds: demBounds,
+                targetWidth: DEM_SIZE,
+                targetHeight: DEM_SIZE,
+                token: mapboxToken,
+                maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
+              }),
+              c.coverageClutterEnabled
+                ? buildClutterRaster({
+                    bounds: demBounds,
+                    targetWidth: DEM_SIZE,
+                    targetHeight: DEM_SIZE,
+                    maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
+                  })
+                : Promise.resolve(null),
+              c.coverageCanopyEnabled
+                ? buildCanopyRaster({
+                    bounds: demBounds,
+                    targetWidth: DEM_SIZE,
+                    targetHeight: DEM_SIZE,
+                    maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
+                  })
+                : Promise.resolve(null),
+              c.coverageBuildingsEnabled
+                ? buildBuildingRaster({
+                    bounds: demBounds,
+                    targetWidth: DEM_SIZE,
+                    targetHeight: DEM_SIZE,
+                    maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
+                  })
+                : Promise.resolve(null),
+            ]);
+            mark("demFetchMs", tFetch);
+            if (requestId !== coverageRequestIdRef.current) {
+              c.setIsFetchingCoverageTerrain(false);
+              return;
+            }
+            c.setIsFetchingCoverageTerrain(false);
+            fetched = {
+              key: fetchKey,
+              dem, clutter, canopy, buildings,
+              demSource: demSourceUsed,
+              clutterStatus: clutter ? { tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal } : null,
+              canopyStatus: canopy ? { tilesPresent: canopy.tilesPresent, tilesTotal: canopy.tilesTotal } : null,
+              buildingsStatus: buildings ? { tilesPresent: buildings.tilesPresent, tilesTotal: buildings.tilesTotal } : null,
+            };
+            coverageFetchCacheRef.current = fetched;
+          }
+          const { dem, clutter, canopy, buildings } = fetched!;
+          // After the supersession check, so stale computes can't clobber chips
+          c.setCoverageDemSource(fetched!.demSource);
+          c.setCoverageClutterStatus(fetched!.clutterStatus);
+          c.setCoverageCanopyStatus(fetched!.canopyStatus);
+          c.setCoverageBuildingsStatus(fetched!.buildingsStatus);
+
+          // 2. Origin ground: the z=15 fetch (viewport-independent, LRU-cached;
+          //    Tilezen 3DEP/SRTM, Mapbox fallback) is authoritative. The map
+          //    query depends on loaded viewport tiles — fallback only, never
+          //    max()ed in — and results are pinned per position for the session
+          //    so identical settings paint identically.
+          const groundKey = `${origin![0].toFixed(5)},${origin![1].toFixed(5)}`;
+          const groundCached = originGroundCacheRef.current.get(groundKey) ?? null;
+          let originGroundHighZoom: number | null = groundCached?.value ?? null;
+          if (groundCached == null || groundCached.source === "viewport") {
+            const fetchElev = await fetchElevationAt(origin![0], origin![1], mapboxToken);
+            if (fetchElev != null && Number.isFinite(fetchElev)) {
+              originGroundHighZoom = fetchElev;
+              if (originGroundCacheRef.current.size > 64) originGroundCacheRef.current.clear();
+              originGroundCacheRef.current.set(groundKey, { value: fetchElev, source: "fetch" });
+            } else if (groundCached == null) {
+              const mbElev = queryTerrainElevationMSL(mb, origin!);
+              if (typeof mbElev === "number" && Number.isFinite(mbElev)) {
+                originGroundHighZoom = mbElev;
+                if (originGroundCacheRef.current.size > 64) originGroundCacheRef.current.clear();
+                originGroundCacheRef.current.set(groundKey, { value: mbElev, source: "viewport" });
+              }
+            }
+          }
+          if (requestId !== coverageRequestIdRef.current) return;
+          const originGroundFromDem = sampleDEMAt(dem, origin![0], origin![1]);
+          const groundOkDem = !Number.isNaN(originGroundFromDem);
+          const groundOkHz = originGroundHighZoom != null;
+          const groundOk = groundOkHz || groundOkDem;
+          // Narrowed to number with a 0 fallback; downstream usage is guarded by groundOk.
+          const originGround: number = groundOkHz
+            ? (originGroundHighZoom as number)
+            : groundOkDem
+              ? originGroundFromDem
+              : 0;
+          // Guards against junk altitudes (GPS glitch, unit-scaled values); matches losAnalysis.ts
+          const MAX_HEIGHT_ABOVE_TERRAIN_M = 1000;
+          const altValid =
+            altitude != null &&
+            Number.isFinite(altitude) &&
+            (!groundOk ||
+              (altitude >= originGround &&
+                altitude <= originGround + MAX_HEIGHT_ABOVE_TERRAIN_M));
+          const baseM = altValid
+            ? (altitude as number)
+            : (groundOk ? originGround : 0);
+          const originHeightM = baseM + c.coverageAntennaHeightM;
+          const originIsFallback = !groundOk && !altValid;
+          // ITM wants TX height above profile[0] (bbox DEM value). Compensate so TX MSL matches
+          // originHeightM after profile[0]+txHeight. Collapses to antennaHeight on flat terrain.
+          const txAboveGroundM = groundOkDem
+            ? originHeightM - originGroundFromDem
+            : c.coverageAntennaHeightM;
+
+          // Sample terrain off the same DEM the workers see so txHeightM (AGL
+          // relative to profile[0]) collapses cleanly to coverageAntennaHeightM
+          // on flat terrain.
+          const mergeOriginsResolved: SliceOrigin[] = [];
+          for (const m of coverageMergeOrigins) {
+            const terrain = sampleDEMAt(dem, m.position[0], m.position[1]);
+            const terrainOk = !Number.isNaN(terrain);
+            const altOk =
+              m.altitudeM != null &&
+              Number.isFinite(m.altitudeM) &&
+              (!terrainOk ||
+                (m.altitudeM >= terrain && m.altitudeM <= terrain + 1000));
+            const baseM = altOk ? (m.altitudeM as number) : (terrainOk ? terrain : 0);
+            const heightM = baseM + c.coverageAntennaHeightM;
+            mergeOriginsResolved.push({
+              position: m.position,
+              heightM,
+              antennaHeightAboveGroundM: terrainOk ? heightM - terrain : c.coverageAntennaHeightM,
+            });
+          }
+
+          // 3. Register rasters on the pool (buffers ship per worker per
+          //    generation). Reuse only on a true cache hit AND while the handle
+          //    is the pool's live gen — a refetch means new buffers, and drag
+          //    previews advance the gen.
+          const pool = ensureCoveragePool();
+          const genHandle = coverageRasterGenRef.current;
+          let rasterGen: number;
+          if (
+            cacheHit &&
+            genHandle &&
+            genHandle.pool === pool &&
+            genHandle.key === fetchKey &&
+            genHandle.gen === pool.currentGen
+          ) {
+            rasterGen = genHandle.gen;
+          } else {
+            rasterGen = pool.setRasters({ dem, clutter, canopy, buildings });
+            coverageRasterGenRef.current = { pool, gen: rasterGen, key: fetchKey };
+            // A new authoritative generation obsoletes any drag registration
+            coverageDragGenRef.current = null;
+          }
+          const tDispatch = performance.now();
+          const rendered = await renderCoverageToImageSource({
+            dem,
+            rasterGen,
+            origins: [
+              {
+                position: origin!,
+                heightM: originHeightM,
+                antennaHeightAboveGroundM: txAboveGroundM,
+              },
+              ...mergeOriginsResolved,
+            ],
+            params: rasterParams,
+            requestId,
+            outputWidth: OUTPUT_SIZE,
+            outputHeight: OUTPUT_SIZE,
+            onSliceProgress: (completed, total) => {
+              c.setCoverageProgress({ completed, total });
             },
-            ...mergeOriginsResolved,
-          ],
-          params: rasterParams,
-          requestId,
-          outputWidth: OUTPUT_SIZE,
-          outputHeight: OUTPUT_SIZE,
-          onSliceProgress: (completed, total) => {
-            c.setCoverageProgress({ completed, total });
-          },
-        });
-        mark("poolComputeMs", tDispatch);
-        if (cancelled || requestId !== coverageRequestIdRef.current) return;
-        if (!rendered) {
-          // Current request (supersession returned above) → hard failure; a
-          // vanished map is a benign teardown, so only surface a real failure.
+          });
+          mark("poolComputeMs", tDispatch);
+          if (requestId !== coverageRequestIdRef.current) return;
+          if (!rendered) {
+            // Current request (supersession returned above) → hard failure; a
+            // vanished map is a benign teardown, so only surface a real failure.
+            c.setIsComputingCoverage(false);
+            c.setCoverageProgress({ completed: 0, total: 0 });
+            if (mbMapRef.current) {
+              c.setCoverageResult(null);
+              c.setCoverageError("Coverage compute failed. See the developer console and try again.");
+            }
+            return;
+          }
+          if (rendered.itmUnavailable) {
+            console.warn(
+              "[Map] Coverage compute: ITM WASM not built. Run `yarn build:wasm`.",
+            );
+            c.setCoverageResult(null);
+            c.setIsComputingCoverage(false);
+            c.setCoverageProgress({ completed: 0, total: 0 });
+            c.setCoverageError(
+              "Coverage model unavailable — the ITM WebAssembly module failed to load. " +
+                "Try refreshing the page; if the problem persists, check the developer console.",
+            );
+            return;
+          }
+
+          // Don't cache a hollow DEM (transient tile failure) — Retry must refetch
+          if (rendered.demCoveredPixels / rendered.totalPx < 0.05 && coverageFetchCacheRef.current?.key === fetchKey) {
+            coverageFetchCacheRef.current = null;
+          }
+
+          // 4. Publish margin + metadata; contours/rays are built lazily by
+          //    the overlay effects (saves ~50-150 ms when toggled off)
+          coverageMarginRef.current = {
+            data: rendered.marginDb,
+            width: rendered.outputWidth,
+            height: rendered.outputHeight,
+            bounds: dem.bounds,
+          };
+          lastRenderMetaRef.current = {
+            origin: origin!,
+            originHeightM,
+            rxHeightM: clampRxHeightM(c.coverageRxHeightM),
+          };
+          coverageContoursRef.current = null;
+          coverageRaysRef.current = null;
+
+          const computeMs = performance.now() - t0;
+          if (import.meta.env.DEV) {
+            console.info(
+              `[Map] Coverage compute: ${computeMs.toFixed(0)} ms ` +
+                `for ${OUTPUT_SIZE}² output / ${DEM_SIZE}² dem across ${ensureCoveragePool().size} workers ` +
+                `(${Math.round((rendered.demCoveredPixels / rendered.totalPx) * 100)}% terrain-covered, ` +
+                `rasters ${cacheHit ? "cached" : "fetched"})`,
+              timings,
+            );
+          }
+
+          c.setCoverageResult({
+            origin: origin!,
+            originHeightM,
+            originIsFallback,
+            radiusKm: radKm,
+            clearCount: rendered.clearCount,
+            fresnelCount: rendered.fresnelCount,
+            blockedCount: rendered.blockedCount,
+            scannedPixels: rendered.totalPx,
+            frequencyGHz: 0.915,
+            txAntennaDbi: c.coverageAntennaDbi,
+            rxAntennaDbi: c.coverageRxAntennaDbi,
+            rxAntennaHeightAboveGroundM: c.coverageRxHeightM,
+            txDbm: c.coverageTxDbm,
+            rxSensitivityDbm: c.coverageEffectiveSensitivityDbm,
+          });
           c.setIsComputingCoverage(false);
           c.setCoverageProgress({ completed: 0, total: 0 });
-          if (mbMapRef.current) {
-            c.setCoverageResult(null);
-            c.setCoverageError("Coverage compute failed. See the developer console and try again.");
+
+          // 5. Refresh drag-preview downsamples off the critical path
+          setTimeout(() => {
+            if (requestId !== coverageRequestIdRef.current) return;
+            coverageDragDemRef.current = downsampleDEM(dem, 256, 256);
+            coverageDragClutterRef.current = clutter ? downsampleClutterRaster(clutter, 256, 256) : null;
+            coverageDragCanopyRef.current = canopy ? downsampleCanopyRaster(canopy, 256, 256) : null;
+            coverageDragBuildingsRef.current = buildings ? downsampleBuildingRaster(buildings, 256, 256) : null;
+            coverageDragGenRef.current = null; // re-register on next drag
+            coverageLastRasterParamsRef.current = rasterParams;
+          }, 0);
+        } catch (err) {
+          // Superseded computes must not touch the successor's state. Effect
+          // `cancelled` is deliberately not consulted — a re-run may not
+          // relaunch; only supersession means someone else owns the indicators.
+          if (requestId !== coverageRequestIdRef.current) return;
+          const msg = err instanceof Error ? err.message : String(err);
+          // User cancel / supersession rejects pool tasks — expected, not an error
+          if (/pool (terminated|superseded)/i.test(msg)) {
+            c.setIsComputingCoverage(false);
+            c.setIsFetchingCoverageTerrain(false);
+            c.setCoverageProgress({ completed: 0, total: 0 });
+            // Still current here = the pool moved on underneath us; drop the
+            // registration so the next compute self-heals
+            coverageRasterGenRef.current = null;
+            return;
           }
-          return;
-        }
-        if (rendered.itmUnavailable) {
-          console.warn(
-            "[Map] Coverage compute: ITM WASM not built. Run `yarn build:wasm`.",
-          );
+          console.warn("[Map] Coverage computation failed:", err);
           c.setCoverageResult(null);
           c.setIsComputingCoverage(false);
-          c.setCoverageProgress({ completed: 0, total: 0 });
-          c.setCoverageError(
-            "Coverage model unavailable — the ITM WebAssembly module failed to load. " +
-              "Try refreshing the page; if the problem persists, check the developer console.",
-          );
-          return;
-        }
-
-        // 4. Cache full + downsampled rasters for the drag-preview pass.
-        coverageDemRef.current = dem;
-        coverageDragDemRef.current = downsampleDEM(dem, 256, 256);
-        coverageClutterRef.current = clutter;
-        coverageDragClutterRef.current = clutter ? downsampleClutterRaster(clutter, 256, 256) : null;
-        coverageCanopyRef.current = canopy;
-        coverageDragCanopyRef.current = canopy ? downsampleCanopyRaster(canopy, 256, 256) : null;
-        coverageBuildingsRef.current = buildings;
-        coverageDragBuildingsRef.current = buildings ? downsampleBuildingRaster(buildings, 256, 256) : null;
-        coverageLastRasterParamsRef.current = rasterParams;
-
-        // 5. Iso-contours (0 dB = edge, +10 reliable, +20 strong) from output-sized margin grid
-        coverageMarginRef.current = {
-          data: rendered.marginDb,
-          width: rendered.outputWidth,
-          height: rendered.outputHeight,
-          bounds: dem.bounds,
-        };
-        const contours = extractCoverageContours({
-          margin: rendered.marginDb,
-          width: rendered.outputWidth,
-          height: rendered.outputHeight,
-          bounds: dem.bounds,
-          thresholdsDb: [0, 10, 20],
-        });
-        coverageContoursRef.current = contours;
-        try {
-          const src = mb.getSource("coverage-contours") as MlGeoJSONSource | undefined;
-          src?.setData(contours);
-        } catch (err) { if (import.meta.env.DEV) console.warn("[Map] coverage-contours setData:", err); }
-
-        // 6. Visibility rays: R2 viewshed AND margin grid; costs ~50-100 ms
-        const rays = extractCoverageRays({
-          dem,
-          margin: rendered.marginDb,
-          width: rendered.outputWidth,
-          height: rendered.outputHeight,
-          bounds: dem.bounds,
-          origin: origin!,
-          originHeightM,
-          rxHeightM: clampRxHeightM(c.coverageRxHeightM),
-          azimuthStepDeg: 1,
-        });
-        coverageRaysRef.current = rays;
-        try {
-          const src = mb.getSource("coverage-rays") as MlGeoJSONSource | undefined;
-          src?.setData(rays);
-        } catch (err) { if (import.meta.env.DEV) console.warn("[Map] coverage-rays setData:", err); }
-
-        const computeMs = performance.now() - t0;
-        if (import.meta.env.DEV) {
-          console.info(
-            `[Map] Coverage compute: ${computeMs.toFixed(0)} ms ` +
-              `for ${OUTPUT_SIZE}² output / ${DEM_SIZE}² dem across ${ensureCoveragePool().size} workers ` +
-              `(${Math.round((rendered.demCoveredPixels / rendered.totalPx) * 100)}% terrain-covered)`,
-            timings,
-          );
-        }
-
-        c.setCoverageResult({
-          origin: origin!,
-          originHeightM,
-          originIsFallback,
-          radiusKm: radKm,
-          clearCount: rendered.clearCount,
-          fresnelCount: rendered.fresnelCount,
-          blockedCount: rendered.blockedCount,
-          scannedPixels: rendered.totalPx,
-          frequencyGHz: 0.915,
-          txAntennaDbi: c.coverageAntennaDbi,
-          rxAntennaDbi: c.coverageRxAntennaDbi,
-          rxAntennaHeightAboveGroundM: c.coverageRxHeightM,
-          txDbm: c.coverageTxDbm,
-          rxSensitivityDbm: c.coverageEffectiveSensitivityDbm,
-        });
-        c.setIsComputingCoverage(false);
-        c.setCoverageProgress({ completed: 0, total: 0 });
-      } catch (err) {
-        if (cancelled) return;
-        const msg = err instanceof Error ? err.message : String(err);
-        // User cancel rejects pool tasks with "pool terminated" — expected, not an error
-        if (/pool terminated/i.test(msg)) {
-          c.setIsComputingCoverage(false);
           c.setIsFetchingCoverageTerrain(false);
           c.setCoverageProgress({ completed: 0, total: 0 });
-          return;
+          const isTerrain = /terrain|tile|fetch|network|cors|http/i.test(msg);
+          c.setCoverageError(
+            isTerrain
+              ? "Couldn't fetch terrain tiles. Check your connection and try again."
+              : "Coverage compute failed. See the developer console and try again.",
+          );
         }
-        console.warn("[Map] Coverage computation failed:", err);
-        c.setCoverageResult(null);
-        c.setIsComputingCoverage(false);
-        c.setIsFetchingCoverageTerrain(false);
-        c.setCoverageProgress({ completed: 0, total: 0 });
-        const isTerrain = /terrain|tile|fetch|network|cors|http/i.test(msg);
-        c.setCoverageError(
-          isTerrain
-            ? "Couldn't fetch terrain tiles. Check your connection and try again."
-            : "Coverage compute failed. See the developer console and try again.",
-        );
-      }
-    })();
+      })().finally(() => {
+        activeComputeCountRef.current = Math.max(0, activeComputeCountRef.current - 1);
+      });
+    };
+
+    // Immediate for origin/nonce/first (a deferred launch would flash the
+    // paused state); debounced for parameter tweaks. `cancelled` guards only
+    // the deferred launch — in-flight computes are cancelled solely via
+    // requestId supersession (an effect re-run may not relaunch).
+    let timer: number | null = null;
+    if (delayMs === 0) {
+      commitAndLaunch();
+    } else {
+      timer = window.setTimeout(() => {
+        if (!cancelled) commitAndLaunch();
+      }, delayMs);
+    }
 
     return () => {
       cancelled = true;
+      if (timer != null) window.clearTimeout(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, c.coverageAntennaDbi, c.coverageRxAntennaDbi, c.coverageRxHeightM, c.coverageTxDbm, c.coverageAggressionIdx, c.coverageClutterEnabled, c.coverageCanopyEnabled, c.coverageBuildingsEnabled, coverageMergeOrigins, c.coverageEffectiveSensitivityDbm, c.coverageDetail, c.coverageAntennaHeightM, c.coverageReliability, terrain3D, originLng, originLat, originAlt, c.coverageRetryNonce, c.keepCoveragePaint]);
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, coverageRadiusKm, c.coverageAntennaDbi, c.coverageRxAntennaDbi, c.coverageRxHeightM, c.coverageTxDbm, c.coverageAggressionIdx, c.coverageClutterEnabled, c.coverageCanopyEnabled, c.coverageBuildingsEnabled, coverageMergeOrigins, c.coverageEffectiveSensitivityDbm, c.coverageDetail, c.coverageAntennaHeightM, c.coverageReliability, terrain3D, originLng, originLat, originAlt, c.coverageRetryNonce, c.coverageRecalcNonce, c.coverageAutoRecalc, c.keepCoveragePaint]);
 
   // Hide coverage layers when leaving tool; sources/layers stay for fast
-  // re-entry. keepCoveragePaint exempts the Scan-from-here overlay.
+  // re-entry. keepCoveragePaint exempts the Scan-from-here overlay. Cached
+  // rasters (~100 MB/worker at full tiers) are released; re-entry refetches.
   useEffect(() => {
     const mb = mbMapRef.current;
     if (!mb) return;
@@ -789,31 +944,78 @@ export function useCoverageCompute(params: CoverageComputeParams) {
           mb.setLayoutProperty("coverage-rays-line", "visibility", "none");
         }
       } catch {}
+      coveragePoolRef.current?.releaseRasters();
+      coverageFetchCacheRef.current = null;
+      coverageRasterGenRef.current = null;
+      coverageDragGenRef.current = null;
+      coverageDragDemRef.current = null;
+      coverageDragClutterRef.current = null;
+      coverageDragCanopyRef.current = null;
+      coverageDragBuildingsRef.current = null;
+      coverageLastRasterParamsRef.current = null;
     }
   }, [activeTool, c.keepCoveragePaint, mbMapRef]);
 
+  // Contours are extracted lazily on first show after each compute
   useEffect(() => {
     const mb = mbMapRef.current;
     if (!mb) return;
+    const show = (activeTool === "coverage" || c.keepCoveragePaint) && c.showCoverageContours;
+    if (show && !coverageContoursRef.current && coverageMarginRef.current) {
+      const m = coverageMarginRef.current;
+      coverageContoursRef.current = extractCoverageContours({
+        margin: m.data,
+        width: m.width,
+        height: m.height,
+        bounds: m.bounds,
+        thresholdsDb: [0, 10, 20],
+      });
+      try {
+        const src = mb.getSource("coverage-contours") as MlGeoJSONSource | undefined;
+        src?.setData(coverageContoursRef.current);
+      } catch (err) { if (import.meta.env.DEV) console.warn("[Map] coverage-contours setData:", err); }
+    }
     if (!mb.getLayer("coverage-contours-line")) return;
     try {
       mb.setLayoutProperty(
         "coverage-contours-line",
         "visibility",
-        (activeTool === "coverage" || c.keepCoveragePaint) && c.showCoverageContours ? "visible" : "none",
+        show ? "visible" : "none",
       );
     } catch {}
   }, [activeTool, c.showCoverageContours, c.coverageResult, c.keepCoveragePaint, mbMapRef]);
 
+  // Rays likewise; needs the full-res DEM from the fetch cache
   useEffect(() => {
     const mb = mbMapRef.current;
     if (!mb) return;
+    const show = (activeTool === "coverage" || c.keepCoveragePaint) && c.showCoverageRays;
+    const meta = lastRenderMetaRef.current;
+    const dem = coverageFetchCacheRef.current?.dem;
+    if (show && !coverageRaysRef.current && coverageMarginRef.current && meta && dem) {
+      const m = coverageMarginRef.current;
+      coverageRaysRef.current = extractCoverageRays({
+        dem,
+        margin: m.data,
+        width: m.width,
+        height: m.height,
+        bounds: m.bounds,
+        origin: meta.origin,
+        originHeightM: meta.originHeightM,
+        rxHeightM: meta.rxHeightM,
+        azimuthStepDeg: 1,
+      });
+      try {
+        const src = mb.getSource("coverage-rays") as MlGeoJSONSource | undefined;
+        src?.setData(coverageRaysRef.current);
+      } catch (err) { if (import.meta.env.DEV) console.warn("[Map] coverage-rays setData:", err); }
+    }
     if (!mb.getLayer("coverage-rays-line")) return;
     try {
       mb.setLayoutProperty(
         "coverage-rays-line",
         "visibility",
-        (activeTool === "coverage" || c.keepCoveragePaint) && c.showCoverageRays ? "visible" : "none",
+        show ? "visible" : "none",
       );
     } catch {}
   }, [activeTool, c.showCoverageRays, c.coverageResult, c.keepCoveragePaint, mbMapRef]);
@@ -854,6 +1056,18 @@ export function useCoverageCompute(params: CoverageComputeParams) {
         .setLngLat(origin)
         .addTo(mb);
 
+      /** Meters between two lng/lat points (equirectangular, fine at pin scale). */
+      const metersBetween = (a: { lng: number; lat: number }, b: { lng: number; lat: number }) => {
+        const dLat = (b.lat - a.lat) * 111_320;
+        const dLng = (b.lng - a.lng) * 111_320 * Math.cos((b.lat * Math.PI) / 180);
+        return Math.hypot(dLat, dLng);
+      };
+      /** Wiggle threshold: below this, no preview and snap back on release
+       *  (keeps node anchor + GPS altitude). */
+      const MICRO_DRAG_M = 8;
+      let dragStartPos: maplibregl.LngLat | null = null;
+      let previewRanThisDrag = false;
+
       // Drag preview: 256² compute off cached downsampled DEM, single-flight, newest-wins
       const runDragPreview = async (lngLat: [number, number]) => {
         if (dragPreviewBusyRef.current) {
@@ -875,7 +1089,7 @@ export function useCoverageCompute(params: CoverageComputeParams) {
           // Real MSL — see queryTerrainElevationMSL helper for the exaggeration math.
           const mbGround = queryTerrainElevationMSL(mb, lngLat);
           const mbGroundOk = typeof mbGround === "number" && Number.isFinite(mbGround);
-          // Never under-report: take the higher of the two sources when both are valid.
+          // Preview-only; dragend runs the full deterministic resolution
           const accurateGround = mbGroundOk && demGroundOk
             ? Math.max(mbGround, demGround)
             : mbGroundOk ? mbGround : demGroundOk ? demGround : 0;
@@ -884,12 +1098,25 @@ export function useCoverageCompute(params: CoverageComputeParams) {
           const txAboveGroundM = demGroundOk
             ? originH - demGround
             : antennaH;
+          // Register the downsampled rasters once per drag session (a full
+          // compute may have advanced the pool generation since)
+          const pool = ensureCoveragePool();
+          let dragGen = coverageDragGenRef.current;
+          if (!dragGen || dragGen.pool !== pool || dragGen.gen !== pool.currentGen) {
+            dragGen = { pool, gen: pool.setRasters({ dem, clutter, canopy, buildings }), key: "drag" };
+            coverageDragGenRef.current = dragGen;
+            // Drag rasters own the pool gen now; full computes must re-register
+            coverageRasterGenRef.current = null;
+          }
+          previewRanThisDrag = true;
           coverageRequestIdRef.current = previewId;
+          // Stomping the id discards any in-flight compute; clear its indicators
+          c.setIsComputingCoverage(false);
+          c.setIsFetchingCoverageTerrain(false);
+          c.setCoverageProgress({ completed: 0, total: 0 });
           await renderCoverageToImageSource({
             dem,
-            clutter,
-            canopy,
-            buildings,
+            rasterGen: dragGen.gen,
             origins: [{
               position: lngLat,
               heightM: originH,
@@ -898,6 +1125,12 @@ export function useCoverageCompute(params: CoverageComputeParams) {
             params: dragParams,
             requestId: previewId,
           });
+        } catch (err) {
+          // Supersession rejections are expected mid-drag
+          const msg = err instanceof Error ? err.message : String(err);
+          if (!/pool (terminated|superseded)/i.test(msg)) {
+            console.warn("[Map] Coverage drag preview failed:", err);
+          }
         } finally {
           dragPreviewBusyRef.current = false;
           const pending = dragPreviewPendingRef.current;
@@ -910,9 +1143,13 @@ export function useCoverageCompute(params: CoverageComputeParams) {
 
       marker.on("dragstart", () => {
         isDraggingMarkerRef.current = true;
+        dragStartPos = marker.getLngLat();
+        previewRanThisDrag = false;
       });
       marker.on("drag", () => {
         const ll = marker.getLngLat();
+        // No preview inside the micro-drag radius — nothing to restore on snapback
+        if (dragStartPos && metersBetween(dragStartPos, ll) < MICRO_DRAG_M) return;
         runDragPreview([ll.lng, ll.lat]);
       });
 
@@ -921,12 +1158,27 @@ export function useCoverageCompute(params: CoverageComputeParams) {
         isDraggingMarkerRef.current = false;
         const ll = marker.getLngLat();
         dragPreviewPendingRef.current = null;
+        if (dragStartPos && metersBetween(dragStartPos, ll) < MICRO_DRAG_M) {
+          // Wiggle: snap back instead of detaching a node-anchored origin
+          marker.setLngLat(dragStartPos);
+          if (previewRanThisDrag) {
+            // Wander-and-return painted low-res previews; force a full repaint
+            c.setCoverageRecalcNonce((n) => n + 1);
+          }
+          return;
+        }
+        // An 8-14 m move can round into the same originKey cell; bump the
+        // nonce so the low-res preview is always replaced
+        if (previewRanThisDrag) c.setCoverageRecalcNonce((n) => n + 1);
         setToolFromId(null);
         setToolVirtualPos([ll.lng, ll.lat]);
       });
       coverageOriginMarkerRef.current = marker;
     }
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, nodes, mbMapRef, isDraggingMarkerRef, c.coverageAntennaHeightMRef, renderCoverageToImageSource, setToolFromId, setToolVirtualPos]);
+    // c.* used in drag closures are stable setters/refs; depending on the whole
+    // `c` object (new identity per render) would re-run this every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTool, toolStep, toolFromId, toolVirtualPos, nodes, mbMapRef, isDraggingMarkerRef, c.coverageAntennaHeightMRef, ensureCoveragePool, renderCoverageToImageSource, setToolFromId, setToolVirtualPos]);
 
   useEffect(() => {
     return () => {
@@ -936,6 +1188,11 @@ export function useCoverageCompute(params: CoverageComputeParams) {
       }
     };
   }, []);
+
+  // Pre-warm workers + ITM WASM while the user is still picking an origin
+  useEffect(() => {
+    if (activeTool === "coverage") ensureCoveragePool().warmup();
+  }, [activeTool, ensureCoveragePool]);
 
   // While picking, the next map click adds a virtual merge origin and exits.
   // Auto-cancels if the user navigates away from the coverage tool.
@@ -1036,10 +1293,19 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     };
   }, []);
 
+  /** Panel Cancel: the committed computeKey was never painted, so matching
+   *  settings must offer Recalculate. */
+  const setCoverageParamsDirtyStable = c.setCoverageParamsDirty;
+  const markComputeCancelled = useCallback(() => {
+    cancelledComputeKeyRef.current = lastComputedKeyRef.current;
+    setCoverageParamsDirtyStable(true);
+  }, [setCoverageParamsDirtyStable]);
+
   return {
     coverageRadiusKm,
     coverageRequestIdRef,
     skipNextCoverageComputeRef,
+    markComputeCancelled,
     coveragePoolRef,
     coverageContoursRef,
     coverageRaysRef,

--- a/frontend/src/pages/map/useCoverageCompute.ts
+++ b/frontend/src/pages/map/useCoverageCompute.ts
@@ -7,8 +7,8 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { toast } from "../../components/toastStore";
 import { env } from "../../env";
 import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
-import { buildBuildingRaster, type BuildingRaster, downsampleBuildingRaster } from "./buildingTiles";
-import { buildCanopyRaster, type CanopyRaster, downsampleCanopyRaster } from "./canopyTiles";
+import { type BuildingRaster, downsampleBuildingRaster } from "./buildingTiles";
+import { type CanopyRaster, downsampleCanopyRaster } from "./canopyTiles";
 import { AGGRESSION_STOPS, type MergeOrigin, reliabilityPreset, REPRESENTATIVE_CLUTTER_DB } from "./coverageAnalysis";
 import { type ContourFeatureCollection, extractCoverageContours } from "./coverageContours";
 import { COVERAGE_DETAIL_MAX_TILES, COVERAGE_DETAIL_SIZE } from "./coverageDetail";
@@ -19,10 +19,12 @@ import type { SliceOrigin } from "./coverageSliceWorker";
 import { CoverageWorkerPool } from "./coverageWorkerPool";
 import { queryTerrainElevationMSL } from "./helpers";
 import { CABLE_LOSS_DB, clampRxHeightM, DEFAULT_ITM_ENV, FADE_MARGIN_DB, FREQ_MHZ } from "./itmEnv";
-import { buildClutterRaster, type ClutterRaster, downsampleClutterRaster } from "./landcoverTiles";
+import { type ClutterRaster, downsampleClutterRaster } from "./landcoverTiles";
+import { buildCoverageRasters } from "./rasterBuildClient";
 import { type DEM, type DEMBounds, downsampleDEM, sampleDEMAt, unionDemBoundsAround } from "./terrainDEM";
-import { buildDem, type DemSource, fetchElevationAt } from "./terrainRgb";
+import { type DemSource, fetchElevationAt } from "./terrainRgb";
 import type { IMapNode } from "./types";
+import { MAX_MERGE_ORIGINS } from "./useCoverageMergeOrigins";
 import type { CoverageState } from "./useCoverageState";
 
 type CoverageComputeParams = {
@@ -96,7 +98,10 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     const aggression = c.coverageClutterEnabled
       ? (AGGRESSION_STOPS[c.coverageAggressionIdx]?.value ?? 1.0)
       : 0;
-    const clutter = REPRESENTATIVE_CLUTTER_DB * aggression;
+    // Half-weighted: the bbox must CONTAIN the real footprint, and open
+    // terrain sees far less per-pixel clutter than the representative value —
+    // full weight clipped flat-desert coverage at the DEM edge.
+    const clutter = REPRESENTATIVE_CLUTTER_DB * aggression * 0.5;
     const budget =
       c.coverageTxDbm +
       c.coverageAntennaDbi +
@@ -185,6 +190,14 @@ export function useCoverageCompute(params: CoverageComputeParams) {
   const lastNoncesRef = useRef<{ retry: number; recalc: number }>({ retry: 0, recalc: 0 });
   /** Retry-nonce value at the last fetch; a bump busts the raster fetch cache. */
   const lastRetryNonceRef = useRef(0);
+  /** DEM source of the previous fetch; a silent provider swap changes the
+   *  whole terrain model, so surface it. */
+  const lastDemSourceRef = useRef<DemSource | null>(null);
+  /** fetchKeys already warned about edge-clipped coverage, plus a rate limit —
+   *  cap-bound networks clip on every recompute and each merge-origin add
+   *  mints a new key. */
+  const edgeClipWarnedKeysRef = useRef<Set<string>>(new Set());
+  const lastEdgeClipToastAtRef = useRef(0);
   /** Live full computes; the no-op early-return only tidies UI state when 0. */
   const activeComputeCountRef = useRef(0);
   /** computeKey whose run was cancelled — the paint doesn't reflect it, so
@@ -614,49 +627,41 @@ export function useCoverageCompute(params: CoverageComputeParams) {
           if (!cacheHit) {
             const tFetch = performance.now();
             c.setIsFetchingCoverageTerrain(true);
-            const [{ dem, source: demSourceUsed }, clutter, canopy, buildings] = await Promise.all([
-              buildDem({
-                bounds: demBounds,
-                targetWidth: DEM_SIZE,
-                targetHeight: DEM_SIZE,
-                token: mapboxToken,
-                maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-              }),
-              c.coverageClutterEnabled
-                ? buildClutterRaster({
-                    bounds: demBounds,
-                    targetWidth: DEM_SIZE,
-                    targetHeight: DEM_SIZE,
-                    maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-                  })
-                : Promise.resolve(null),
-              c.coverageCanopyEnabled
-                ? buildCanopyRaster({
-                    bounds: demBounds,
-                    targetWidth: DEM_SIZE,
-                    targetHeight: DEM_SIZE,
-                    maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-                  })
-                : Promise.resolve(null),
-              c.coverageBuildingsEnabled
-                ? buildBuildingRaster({
-                    bounds: demBounds,
-                    targetWidth: DEM_SIZE,
-                    targetHeight: DEM_SIZE,
-                    maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
-                  })
-                : Promise.resolve(null),
-            ]);
+            // Fetch + decode + 2048² resample run in the raster-build worker
+            const built = await buildCoverageRasters({
+              bounds: demBounds,
+              size: DEM_SIZE,
+              maxTiles: COVERAGE_DETAIL_MAX_TILES[c.coverageDetail],
+              token: mapboxToken,
+              wantClutter: c.coverageClutterEnabled,
+              wantCanopy: c.coverageCanopyEnabled,
+              wantBuildings: c.coverageBuildingsEnabled,
+            });
             mark("demFetchMs", tFetch);
             if (requestId !== coverageRequestIdRef.current) {
               c.setIsFetchingCoverageTerrain(false);
               return;
             }
             c.setIsFetchingCoverageTerrain(false);
+            const { dem, clutter, canopy, buildings } = built;
+            if (built.demTilesFailed > 0) {
+              toast(
+                `${built.demTilesFailed}/${built.demTilesTotal} terrain tiles failed to load — coverage may have gaps. Retry refetches them.`,
+                { kind: "error" },
+              );
+            }
+            if (lastDemSourceRef.current && lastDemSourceRef.current !== built.demSource) {
+              toast(
+                built.demSource === "mapbox-terrain-rgb"
+                  ? "Terrain source fell back to Mapbox terrain-rgb — the paint may shift versus previous runs."
+                  : "Terrain source restored to Tilezen (USGS 3DEP/SRTM).",
+              );
+            }
+            lastDemSourceRef.current = built.demSource;
             fetched = {
               key: fetchKey,
               dem, clutter, canopy, buildings,
-              demSource: demSourceUsed,
+              demSource: built.demSource,
               clutterStatus: clutter ? { tilesPresent: clutter.tilesPresent, tilesTotal: clutter.tilesTotal } : null,
               canopyStatus: canopy ? { tilesPresent: canopy.tilesPresent, tilesTotal: canopy.tilesTotal } : null,
               buildingsStatus: buildings ? { tilesPresent: buildings.tilesPresent, tilesTotal: buildings.tilesTotal } : null,
@@ -815,6 +820,34 @@ export function useCoverageCompute(params: CoverageComputeParams) {
           // Don't cache a hollow DEM (transient tile failure) — Retry must refetch
           if (rendered.demCoveredPixels / rendered.totalPx < 0.05 && coverageFetchCacheRef.current?.key === fetchKey) {
             coverageFetchCacheRef.current = null;
+          }
+
+          // Reachable pixels on the bbox border mean the true footprint likely
+          // extends past the analysis area (bbox sizing is a heuristic)
+          if (!edgeClipWarnedKeysRef.current.has(fetchKey)) {
+            const m = rendered.marginDb;
+            const w = rendered.outputWidth;
+            const h = rendered.outputHeight;
+            let clipped = false;
+            for (let i = 0; i < w && !clipped; i++) {
+              if (m[i] >= 0 || m[(h - 1) * w + i] >= 0) clipped = true;
+            }
+            for (let j = 1; j < h - 1 && !clipped; j++) {
+              if (m[j * w] >= 0 || m[j * w + w - 1] >= 0) clipped = true;
+            }
+            if (clipped) {
+              if (edgeClipWarnedKeysRef.current.size > 32) edgeClipWarnedKeysRef.current.clear();
+              edgeClipWarnedKeysRef.current.add(fetchKey);
+              // Rate-limit the toast; the key is recorded regardless so an
+              // unchanged analysis area never re-warns
+              const now = Date.now();
+              if (now - lastEdgeClipToastAtRef.current > 60_000) {
+                lastEdgeClipToastAtRef.current = now;
+                toast(
+                  "Coverage reaches the edge of the analysis area — the real footprint may extend farther than painted.",
+                );
+              }
+            }
           }
 
           // 4. Publish margin + metadata; contours/rays are built lazily by
@@ -1208,20 +1241,28 @@ export function useCoverageCompute(params: CoverageComputeParams) {
     const prevCursor = canvas.style.cursor;
     canvas.style.cursor = "crosshair";
     const onClick = (e: maplibregl.MapMouseEvent) => {
+      // Node/cluster handlers (Map.tsx) claim their clicks first — a node
+      // click adds the node itself as a merge origin, not a coordinate pin.
+      if ((e.originalEvent as MouseEvent & { _mergePickConsumed?: boolean })._mergePickConsumed) {
+        return;
+      }
       const lng = e.lngLat.lng;
       const lat = e.lngLat.lat;
       // 6-dp coords give ~0.1 m precision and a stable id key.
       const id = `virtual:${lng.toFixed(6)},${lat.toFixed(6)}`;
-      setCoverageMergeOrigins((prev) =>
-        prev.some((o) => o.id === id)
-          ? prev
-          : [...prev, {
-              id,
-              label: `Pin ${lat.toFixed(4)}, ${lng.toFixed(4)}`,
-              position: [lng, lat],
-              altitudeM: null,
-            }],
-      );
+      setCoverageMergeOrigins((prev) => {
+        if (prev.some((o) => o.id === id)) return prev;
+        if (prev.length >= MAX_MERGE_ORIGINS) {
+          toast(`Merge-origin limit reached (${MAX_MERGE_ORIGINS}) — remove one first.`);
+          return prev;
+        }
+        return [...prev, {
+          id,
+          label: `Pin ${lat.toFixed(4)}, ${lng.toFixed(4)}`,
+          position: [lng, lat],
+          altitudeM: null,
+        }];
+      });
       setPickingMergeOrigin(false);
     };
     const onKey = (e: KeyboardEvent) => {

--- a/frontend/src/pages/map/useCoverageMergeOrigins.ts
+++ b/frontend/src/pages/map/useCoverageMergeOrigins.ts
@@ -1,8 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
 
+import { toast } from "../../components/toastStore";
 import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
 import type { MergeOrigin } from "./coverageAnalysis";
 import type { IMapNode } from "./types";
+
+/** Each merge origin multiplies per-pixel ITM cost; 8 keeps Survey tractable. */
+export const MAX_MERGE_ORIGINS = 8;
 
 /** Coverage-merge origins are session-only by design — contextual to one analysis. */
 export function useCoverageMergeOrigins(nodes: Record<string, IMapNode>, toolFromId: string | null) {
@@ -33,16 +37,19 @@ export function useCoverageMergeOrigins(nodes: Record<string, IMapNode>, toolFro
     const pos = n?.map_position;
     if (!pos) return;
     const cleanId = nodeId.startsWith("!") ? nodeId.slice(1) : nodeId;
-    setCoverageMergeOrigins((prev) =>
-      prev.some((o) => o.id === cleanId)
-        ? prev
-        : [...prev, {
-            id: cleanId,
-            label: n?.shortname || n?.longname || cleanId,
-            position: [pos[0], pos[1]],
-            altitudeM: effectiveAltitudeMslM(n?.position),
-          }],
-    );
+    setCoverageMergeOrigins((prev) => {
+      if (prev.some((o) => o.id === cleanId)) return prev;
+      if (prev.length >= MAX_MERGE_ORIGINS) {
+        toast(`Merge-origin limit reached (${MAX_MERGE_ORIGINS}) — remove one first.`);
+        return prev;
+      }
+      return [...prev, {
+        id: cleanId,
+        label: n?.shortname || n?.longname || cleanId,
+        position: [pos[0], pos[1]],
+        altitudeM: effectiveAltitudeMslM(n?.position),
+      }];
+    });
   }, [nodes]);
 
   const mergeNodeOptions = useMemo(() => {

--- a/frontend/src/pages/map/useCoverageState.ts
+++ b/frontend/src/pages/map/useCoverageState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, type CoverageResult, DEFAULT_AGGRESSION_IDX, effectiveSensitivityDbm, MESHTASTIC_PRESETS } from "./coverageAnalysis";
 import type { CoverageDetail } from "./coverageDetail";
+import { type CoveragePanelSettings, resolvePreset, sanitizePreset, snapshotPreset } from "./coveragePresets";
 import { clampAggressionIdx } from "./helpers";
 import { LS_KEYS, readJson, writeJson } from "./storage";
 import type { DemSource } from "./terrainRgb";
@@ -42,16 +43,27 @@ export function useCoverageState() {
   // Drives the building-height status chip; null until first compute.
   const [coverageBuildingsStatus, setCoverageBuildingsStatus] = useState<ClutterStatus>(null);
 
+  // Last-used settings, restored via the semantic preset payload so indices
+  // survive catalog reordering across versions. Env toggles keep their own
+  // (authoritative) keys below; Detail stays session-scoped — the heavy tiers
+  // are deliberately opt-in per session.
+  const [restored] = useState<CoveragePanelSettings | null>(() => {
+    const raw = readJson<unknown>(LS_KEYS.coverageLastSettings, null);
+    if (!raw) return null;
+    const clean = sanitizePreset(raw);
+    return clean ? resolvePreset(clean) : null;
+  });
+
   // Index into COMMON_ANTENNAS (value-based <select> can't distinguish same-dBi models)
-  const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(3);
+  const [coverageAntennaIdx, setCoverageAntennaIdx] = useState(restored?.antennaIdx ?? 3);
   const coverageAntennaDbi = COMMON_ANTENNAS[coverageAntennaIdx]?.dbi ?? 3;
-  const [coverageHardwareIdx, setCoverageHardwareIdx] = useState(0);
+  const [coverageHardwareIdx, setCoverageHardwareIdx] = useState(restored?.hardwareIdx ?? 0);
   // Asymmetric RX defaults: Heltec V3 + rubber duck @ 2 m (stock portable)
-  const [coverageRxHardwareIdx, setCoverageRxHardwareIdx] = useState(4);
-  const [coverageRxAntennaIdx, setCoverageRxAntennaIdx] = useState(0);
+  const [coverageRxHardwareIdx, setCoverageRxHardwareIdx] = useState(restored?.rxHardwareIdx ?? 4);
+  const [coverageRxAntennaIdx, setCoverageRxAntennaIdx] = useState(restored?.rxAntennaIdx ?? 0);
   const coverageRxAntennaDbi = COMMON_ANTENNAS[coverageRxAntennaIdx]?.dbi ?? 3;
-  const [coverageRxHeightM, setCoverageRxHeightM] = useState(2);
-  const [coverageCustomTxDbm, setCoverageCustomTxDbm] = useState(22);
+  const [coverageRxHeightM, setCoverageRxHeightM] = useState(restored?.rxHeightM ?? 2);
+  const [coverageCustomTxDbm, setCoverageCustomTxDbm] = useState(restored?.customTxDbm ?? 22);
   const coverageTxDbm = COMMON_HARDWARE[coverageHardwareIdx]?.isCustom
     ? coverageCustomTxDbm
     : (COMMON_HARDWARE[coverageHardwareIdx]?.txDbm ?? 22);
@@ -87,18 +99,18 @@ export function useCoverageState() {
     setCoverageBuildingsEnabledRaw(v);
     writeJson(LS_KEYS.coverageBuildingsEnabled, v);
   }, []);
-  const [coveragePresetIdx, setCoveragePresetIdx] = useState(0); // MediumFast
-  const [coverageCustomSensDbm, setCoverageCustomSensDbm] = useState(-133);
+  const [coveragePresetIdx, setCoveragePresetIdx] = useState(restored?.presetIdx ?? 0); // MediumFast
+  const [coverageCustomSensDbm, setCoverageCustomSensDbm] = useState(restored?.customSensitivityDbm ?? -133);
   const coverageSensitivityDbm = MESHTASTIC_PRESETS[coveragePresetIdx]?.isCustom
     ? coverageCustomSensDbm
     : (MESHTASTIC_PRESETS[coveragePresetIdx]?.sensitivityDbm ?? -130);
   // Session-scoped (not persisted)
   const [coverageDetail, setCoverageDetail] = useState<CoverageDetail>("standard");
   // Antenna AGL (m); overrides GPS altitude on node-anchored origins
-  const [coverageAntennaHeightM, setCoverageAntennaHeightM] = useState(2);
-  const [coverageReliability, setCoverageReliability] = useState<CoverageReliability>("typical");
+  const [coverageAntennaHeightM, setCoverageAntennaHeightM] = useState(restored?.antennaHeightM ?? 2);
+  const [coverageReliability, setCoverageReliability] = useState<CoverageReliability>(restored?.reliability ?? "typical");
   // Ref mirror so the drag-preview closure sees latest without re-binding
-  const coverageAntennaHeightMRef = useRef(2);
+  const coverageAntennaHeightMRef = useRef(restored?.antennaHeightM ?? 2);
   useEffect(() => {
     coverageAntennaHeightMRef.current = coverageAntennaHeightM;
   }, [coverageAntennaHeightM]);
@@ -108,8 +120,37 @@ export function useCoverageState() {
     return effectiveSensitivityDbm(coverageSensitivityDbm, hw.chipset, hw.sensitivityOffsetDb ?? 0);
   }, [coverageSensitivityDbm, coverageRxHardwareIdx]);
 
-  const [showCoverageContours, setShowCoverageContours] = useState(false);
-  const [showCoverageRays, setShowCoverageRays] = useState(false);
+  const [showCoverageContours, setShowCoverageContours] = useState(restored?.showContours ?? false);
+  const [showCoverageRays, setShowCoverageRays] = useState(restored?.showRays ?? false);
+
+  // Write-through of the full settings bag (debounced; slider drags coalesce).
+  // A ref keeps the latest bag so unmount can flush a still-pending write.
+  const lastSettingsBagRef = useRef<CoveragePanelSettings | null>(null);
+  useEffect(() => {
+    const bag: CoveragePanelSettings = {
+      hardwareIdx: coverageHardwareIdx, customTxDbm: coverageCustomTxDbm,
+      antennaIdx: coverageAntennaIdx, antennaHeightM: coverageAntennaHeightM,
+      rxHardwareIdx: coverageRxHardwareIdx, rxAntennaIdx: coverageRxAntennaIdx, rxHeightM: coverageRxHeightM,
+      presetIdx: coveragePresetIdx, customSensitivityDbm: coverageCustomSensDbm,
+      aggressionIdx: coverageAggressionIdx, clutterEnabled: coverageClutterEnabled,
+      canopyEnabled: coverageCanopyEnabled, buildingsEnabled: coverageBuildingsEnabled,
+      detail: coverageDetail, reliability: coverageReliability,
+      showContours: showCoverageContours, showRays: showCoverageRays,
+    };
+    lastSettingsBagRef.current = bag;
+    const t = window.setTimeout(() => {
+      writeJson(LS_KEYS.coverageLastSettings, snapshotPreset("__last", bag));
+    }, 500);
+    return () => window.clearTimeout(t);
+  }, [coverageHardwareIdx, coverageCustomTxDbm, coverageAntennaIdx, coverageAntennaHeightM, coverageRxHardwareIdx, coverageRxAntennaIdx, coverageRxHeightM, coveragePresetIdx, coverageCustomSensDbm, coverageAggressionIdx, coverageClutterEnabled, coverageCanopyEnabled, coverageBuildingsEnabled, coverageDetail, coverageReliability, showCoverageContours, showCoverageRays]);
+  useEffect(() => {
+    return () => {
+      // Unmount flush — changes made within the debounce window still persist
+      if (lastSettingsBagRef.current) {
+        writeJson(LS_KEYS.coverageLastSettings, snapshotPreset("__last", lastSettingsBagRef.current));
+      }
+    };
+  }, []);
 
   return {
     // Results

--- a/frontend/src/pages/map/useCoverageState.ts
+++ b/frontend/src/pages/map/useCoverageState.ts
@@ -15,8 +15,20 @@ export function useCoverageState() {
   const [isComputingCoverage, setIsComputingCoverage] = useState(false);
   const [isFetchingCoverageTerrain, setIsFetchingCoverageTerrain] = useState(false);
   const [coverageError, setCoverageError] = useState<string | null>(null);
-  // Bumped by the panel's Retry button to force a recompute
+  // Retry button: forces a recompute and busts the raster fetch cache
   const [coverageRetryNonce, setCoverageRetryNonce] = useState(0);
+  // Recalculate button (manual mode): forces a recompute, reuses cached rasters
+  const [coverageRecalcNonce, setCoverageRecalcNonce] = useState(0);
+  // Auto-recompute on setting changes (persisted); off = dirty flag + Recalculate
+  const [coverageAutoRecalc, setCoverageAutoRecalcRaw] = useState(() =>
+    readJson<boolean>(LS_KEYS.coverageAutoRecalc, true),
+  );
+  const setCoverageAutoRecalc = useCallback((v: boolean) => {
+    setCoverageAutoRecalcRaw(v);
+    writeJson(LS_KEYS.coverageAutoRecalc, v);
+  }, []);
+  // Settings changed but the recompute is deferred (manual mode)
+  const [coverageParamsDirty, setCoverageParamsDirty] = useState(false);
   // total === 0 means idle / drag preview / terrain fetch
   const [coverageProgress, setCoverageProgress] = useState<{ completed: number; total: number }>({ completed: 0, total: 0 });
   const [coverageDemSource, setCoverageDemSource] = useState<DemSource | null>(null);
@@ -106,6 +118,9 @@ export function useCoverageState() {
     isFetchingCoverageTerrain, setIsFetchingCoverageTerrain,
     coverageError, setCoverageError,
     coverageRetryNonce, setCoverageRetryNonce,
+    coverageRecalcNonce, setCoverageRecalcNonce,
+    coverageAutoRecalc, setCoverageAutoRecalc,
+    coverageParamsDirty, setCoverageParamsDirty,
     coverageProgress, setCoverageProgress,
     coverageDemSource, setCoverageDemSource,
     keepCoveragePaint, setKeepCoveragePaint,

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -24,8 +24,9 @@ type LosComputeParams = {
   losVirtualTo: [number, number] | null;
   losFromHeightM: number;
   losToHeightM: number;
-  provider: string;
   terrain3D: boolean;
+  /** Bumped on style.load — re-pushes tube/obstructions after setStyle wipes them. */
+  styleEpoch: number;
   nodes: Record<string, IMapNode>;
   losResult: LoSResult | null;
   mbMapRef: React.RefObject<MlMap | null>;
@@ -41,11 +42,28 @@ export function useLosCompute(params: LosComputeParams) {
   const {
     activeTool, toolStep, toolFromId, toolToId,
     losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM,
-    provider, terrain3D, nodes, losResult,
+    terrain3D, styleEpoch, nodes, losResult,
     mbMapRef, losTubeLayerRef,
     setLosResult, setLosDemSource, setLosError, setIsComputingLos,
     setLosTerrainWarning,
   } = params;
+
+  // Endpoint scalars (not the whole `nodes` object) drive the effects below, so
+  // live SSE node churn can't retrigger a compute unless an endpoint actually moved.
+  const resolveEndpoint = (
+    id: string | null,
+    virtual: [number, number] | null,
+  ): { lng: number | null; lat: number | null; alt: number | null } => {
+    if (id) {
+      const n = nodes[id] ?? nodes[`!${id}`];
+      if (!n?.map_position) return { lng: null, lat: null, alt: null };
+      return { lng: n.map_position[0], lat: n.map_position[1], alt: effectiveAltitudeMslM(n.position) };
+    }
+    if (virtual) return { lng: virtual[0], lat: virtual[1], alt: null };
+    return { lng: null, lat: null, alt: null };
+  };
+  const { lng: fromLng, lat: fromLat, alt: fromAlt } = resolveEndpoint(toolFromId, losVirtualFrom);
+  const { lng: toLng, lat: toLat, alt: toAlt } = resolveEndpoint(toolToId, losVirtualTo);
 
   // LOS endpoints from the compute effect; refs so the hover-marker callback reads them without deps churn
   const losFromPosRef = useRef<[number, number] | null>(null);
@@ -97,36 +115,25 @@ export function useLosCompute(params: LosComputeParams) {
       setLosResult(null);
       setLosError(null);
       setLosTerrainWarning(null);
+      setIsComputingLos(false);
       return;
     }
-    const hasFrom = toolFromId || losVirtualFrom;
-    const hasTo = toolToId || losVirtualTo;
-    if (!hasFrom || !hasTo) { setLosResult(null); return; }
+    if (fromLng == null || fromLat == null || toLng == null || toLat == null) {
+      // A picked endpoint lost its position (e.g. a live update dropped it) —
+      // land on the error state, not an eternal spinner.
+      setLosResult(null);
+      setLosError("An endpoint no longer has a map position.");
+      setIsComputingLos(false);
+      return;
+    }
     if (!terrain3D) { setLosResult(null); return; }
     const mb = mbMapRef.current;
     if (!mb) { setLosResult(null); return; }
 
-    let fromPos: [number, number];
-    let fromAltitude: number | null = null;
-    if (toolFromId) {
-      const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
-      if (!n?.map_position) { setLosResult(null); return; }
-      fromPos = [n.map_position[0], n.map_position[1]];
-      fromAltitude = effectiveAltitudeMslM(n.position);
-    } else {
-      fromPos = losVirtualFrom!;
-    }
-
-    let toPos: [number, number];
-    let toAltitude: number | null = null;
-    if (toolToId) {
-      const n = nodes[toolToId] ?? nodes[`!${toolToId}`];
-      if (!n?.map_position) { setLosResult(null); return; }
-      toPos = [n.map_position[0], n.map_position[1]];
-      toAltitude = effectiveAltitudeMslM(n.position);
-    } else {
-      toPos = losVirtualTo!;
-    }
+    const fromPos: [number, number] = [fromLng, fromLat];
+    const fromAltitude = fromAlt;
+    const toPos: [number, number] = [toLng, toLat];
+    const toAltitude = toAlt;
 
     // Stashed for the hover-marker callback (refs avoid deps churn)
     losFromPosRef.current = fromPos;
@@ -194,6 +201,8 @@ export function useLosCompute(params: LosComputeParams) {
           }
           setLosDemSource(demSourceUsedForLos);
         } catch (err) {
+          // A stale run's late rejection must not clobber the newer run's state
+          if (cancelled) return;
           console.warn("[Map] LoS DEM fetch failed:", err);
           setLosError("Couldn't load terrain elevation data. Check your connection and try again.");
           setLosResult(null);
@@ -294,7 +303,7 @@ export function useLosCompute(params: LosComputeParams) {
       if (!cancelled) console.warn("[Map] LoS run failed:", err);
     });
     return () => { cancelled = true; };
-  }, [activeTool, toolStep, toolFromId, toolToId, losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM, provider, terrain3D, nodes, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
+  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, terrain3D, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
 
   // Push LoS result → 3D tube layer + obstruction source.
   // Altitudes are scaled by terrain exaggeration to stay pinned to the visual surface.
@@ -302,46 +311,31 @@ export function useLosCompute(params: LosComputeParams) {
     const mb = mbMapRef.current;
     if (!mb) return;
 
-    const hasFrom = toolFromId || losVirtualFrom;
-    const hasTo = toolToId || losVirtualTo;
-    const showing =
-      activeTool === "los" && toolStep === "result" && losResult && hasFrom && hasTo;
     const obsSrc = mb.getSource("los-obstructions") as MlGeoJSONSource | undefined;
     const tube = losTubeLayerRef.current;
 
-    if (!showing) {
+    if (
+      activeTool !== "los" || toolStep !== "result" || !losResult ||
+      fromLng == null || fromLat == null || toLng == null || toLat == null
+    ) {
       tube?.setData(null);
       obsSrc?.setData({ type: "FeatureCollection", features: [] });
       return;
     }
 
-    let fromPos: [number, number];
-    let toPos: [number, number];
-    if (toolFromId) {
-      const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
-      if (!n?.map_position) return;
-      fromPos = [n.map_position[0], n.map_position[1]];
-    } else {
-      fromPos = losVirtualFrom!;
-    }
-    if (toolToId) {
-      const n = nodes[toolToId] ?? nodes[`!${toolToId}`];
-      if (!n?.map_position) return;
-      toPos = [n.map_position[0], n.map_position[1]];
-    } else {
-      toPos = losVirtualTo!;
-    }
+    const fromPos: [number, number] = [fromLng, fromLat];
+    const toPos: [number, number] = [toLng, toLat];
 
     // Tube layer scales altitudes internally
-    const tubeData = losPointsToTubeData(fromPos, toPos, losResult!.points, losResult!.totalDistanceKm);
+    const tubeData = losPointsToTubeData(fromPos, toPos, losResult.points, losResult.totalDistanceKm);
     tube?.setData(tubeData);
 
     // fill-extrusion doesn't auto-scale base/top — scale manually
     const obstructions = pickObstructions(
       fromPos,
       toPos,
-      losResult!.points,
-      losResult!.totalDistanceKm,
+      losResult.points,
+      losResult.totalDistanceKm,
       3,
     );
     const exagRaw = mb.getTerrain()?.exaggeration;
@@ -352,7 +346,9 @@ export function useLosCompute(params: LosComputeParams) {
       f.properties.topM *= exag;
     });
     obsSrc?.setData(obsGeo);
-  }, [activeTool, toolStep, losResult, toolFromId, toolToId, losVirtualFrom, losVirtualTo, nodes, mbMapRef, losTubeLayerRef]);
+    // styleEpoch dep: setStyle recreates the obstruction source empty and strips the
+    // tube layer's GL objects — this effect re-pushes both after style.load.
+  }, [activeTool, toolStep, losResult, fromLng, fromLat, toLng, toLat, styleEpoch, mbMapRef, losTubeLayerRef]);
 
   return {
     losFromPosRef,

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { env } from "../../env";
 import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
 import { normalizeLng, shortestLngDelta } from "./geo";
-import { computeP2PLoss } from "./itm";
+import { computeP2PLoss, isItmAvailable } from "./itm";
 import { DEFAULT_ITM_ENV } from "./itmEnv";
 import { analyzeLineOfSight, haversineKm, type LoSResult } from "./losAnalysis";
 import { losPointsToTubeData, LosTubeLayer, obstructionsToGeoJSON, pickObstructions } from "./losTubeLayer";
@@ -25,6 +25,8 @@ type LosComputeParams = {
   losVirtualTo: [number, number] | null;
   losFromHeightM: number;
   losToHeightM: number;
+  /** Link frequency (MHz) — drives Fresnel geometry and ITM. */
+  losFreqMhz: number;
   terrain3D: boolean;
   /** Bumped on style.load — re-pushes tube/obstructions after setStyle wipes them. */
   styleEpoch: number;
@@ -43,7 +45,7 @@ export function useLosCompute(params: LosComputeParams) {
   const {
     activeTool, toolStep, toolFromId, toolToId,
     losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM,
-    terrain3D, styleEpoch, nodes, losResult,
+    losFreqMhz, terrain3D, styleEpoch, nodes, losResult,
     mbMapRef, losTubeLayerRef,
     setLosResult, setLosDemSource, setLosError, setIsComputingLos,
     setLosTerrainWarning,
@@ -81,6 +83,12 @@ export function useLosCompute(params: LosComputeParams) {
     losHoverMarkerRef.current?.remove();
     losHoverMarkerRef.current = null;
   }, []);
+
+  // Warm the ITM WASM while the user is still picking endpoints so the first
+  // result doesn't pay tile fetch + module load sequentially.
+  useEffect(() => {
+    if (activeTool === "los") void isItmAvailable();
+  }, [activeTool]);
 
   const handleLosProfileHover = useCallback((fraction: number | null) => {
     const mb = mbMapRef.current;
@@ -233,7 +241,7 @@ export function useLosCompute(params: LosComputeParams) {
           toAltitudeM: toAltitude,
           fromAntennaHeightM: losFromHeightM,
           toAntennaHeightM: losToHeightM,
-          freqGHz: 0.915,
+          freqGHz: losFreqMhz / 1000,
           samples,
           queryTerrainM: (lng, lat) => {
             const elev = sampleDEMAt(dem, lng, lat);
@@ -311,7 +319,7 @@ export function useLosCompute(params: LosComputeParams) {
       if (!cancelled) console.warn("[Map] LoS run failed:", err);
     });
     return () => { cancelled = true; };
-  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, terrain3D, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
+  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, losFreqMhz, terrain3D, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
 
   // Push LoS result → 3D tube layer + obstruction source.
   // Altitudes are scaled by terrain exaggeration to stay pinned to the visual surface.

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -32,6 +32,8 @@ type LosComputeParams = {
   terrain3D: boolean;
   /** Bumped on style.load — re-pushes tube/obstructions after setStyle wipes them. */
   styleEpoch: number;
+  /** Nodes query errored — an empty `nodes` map is final, not still-loading. */
+  nodesLoadFailed: boolean;
   nodes: Record<string, IMapNode>;
   losResult: LoSResult | null;
   mbMapRef: React.RefObject<MlMap | null>;
@@ -51,7 +53,7 @@ export function useLosCompute(params: LosComputeParams) {
   const {
     activeTool, toolStep, toolFromId, toolToId,
     losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM,
-    losFreqMhz, terrain3D, styleEpoch, nodes, losResult,
+    losFreqMhz, terrain3D, styleEpoch, nodes, nodesLoadFailed, losResult,
     mbMapRef, losTubeLayerRef,
     isDraggingMarkerRef, onEndpointDragged,
     setLosResult, setLosDemSource, setLosError, setIsComputingLos,
@@ -103,10 +105,15 @@ export function useLosCompute(params: LosComputeParams) {
   useEffect(() => () => {
     losHoverMarkerRef.current?.remove();
     losHoverMarkerRef.current = null;
-    losFromMarkerRef.current?.remove();
-    losFromMarkerRef.current = null;
-    losToMarkerRef.current?.remove();
-    losToMarkerRef.current = null;
+    if (losFromMarkerRef.current || losToMarkerRef.current) {
+      losFromMarkerRef.current?.remove();
+      losFromMarkerRef.current = null;
+      losToMarkerRef.current?.remove();
+      losToMarkerRef.current = null;
+      // A removal mid-drag skips dragend; don't leave the shared flag stuck
+      isDraggingMarkerRef.current = false;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Warm the ITM WASM while the user is still picking endpoints so the first
@@ -156,7 +163,8 @@ export function useLosCompute(params: LosComputeParams) {
       setLosResult(null);
       // Nodes not loaded yet (URL-restored link): stay in the loading state and
       // let the nodes arrival retrigger via the endpoint-scalar/nodesEmpty deps.
-      if (nodesEmpty) return;
+      // A failed nodes query is final — fall through to the error instead.
+      if (nodesEmpty && !nodesLoadFailed) return;
       // A picked endpoint lost its position (e.g. a live update dropped it) —
       // land on the error state, not an eternal spinner.
       setLosError("An endpoint no longer has a map position.");
@@ -251,7 +259,9 @@ export function useLosCompute(params: LosComputeParams) {
           demSourceUsedForLos = built.demSource;
           demTilesFailed = built.demTilesFailed;
           demTilesTotal = built.demTilesTotal;
-          canopy = built.canopy;
+          // stdM is unread on the LOS path (only heightM feeds the profile bands);
+          // dropping it saves 16.8 MB at the 2048² cap while the cache is held.
+          canopy = built.canopy ? { ...built.canopy, stdM: new Float32Array(0) } : null;
           buildings = built.buildings;
           // A holed DEM would pin bad terrain under this bbox forever — let failed tiles retry.
           if (built.demTilesFailed === 0) {
@@ -370,7 +380,7 @@ export function useLosCompute(params: LosComputeParams) {
     return () => { cancelled = true; };
     // styleEpoch: map-readiness signal — a URL-restored analysis mounts before the
     // map exists and needs style.load to retrigger (DEM cache keeps re-runs cheap).
-  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, losFreqMhz, terrain3D, styleEpoch, nodesEmpty, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
+  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, losFreqMhz, terrain3D, styleEpoch, nodesEmpty, nodesLoadFailed, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
 
   // Push LoS result → 3D tube layer + obstruction source.
   // Altitudes are scaled by terrain exaggeration to stay pinned to the visual surface.
@@ -435,8 +445,13 @@ export function useLosCompute(params: LosComputeParams) {
     ];
     for (const end of ends) {
       if (!showing || end.lng == null || end.lat == null) {
-        end.ref.current?.remove();
-        end.ref.current = null;
+        if (end.ref.current) {
+          // Marker.remove() unbinds drag listeners, so a removal mid-drag would
+          // otherwise leave the shared dragging flag stuck true forever.
+          end.ref.current.remove();
+          end.ref.current = null;
+          isDraggingMarkerRef.current = false;
+        }
         continue;
       }
       if (end.ref.current) {
@@ -455,9 +470,11 @@ export function useLosCompute(params: LosComputeParams) {
         isDraggingMarkerRef.current = false;
         const ll = marker.getLngLat();
         if (dragStart) {
-          const dxM = shortestLngDelta(dragStart.lng, ll.lng) * 111_320 * Math.cos((ll.lat * Math.PI) / 180);
-          const dyM = (ll.lat - dragStart.lat) * 111_320;
-          if (Math.hypot(dxM, dyM) < 5) {
+          // Screen-space threshold: a ground-meter one would swallow deliberate
+          // fine-tuning drags at high zoom (5 m ≈ 33 px at z20).
+          const p0 = mb.project(dragStart);
+          const p1 = mb.project(ll);
+          if (Math.hypot(p1.x - p0.x, p1.y - p0.y) < 6) {
             // Wiggle: snap back instead of detaching a node-anchored endpoint
             marker.setLngLat(dragStart);
             return;

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -11,8 +11,9 @@ import { computeP2PLoss } from "./itm";
 import { DEFAULT_ITM_ENV } from "./itmEnv";
 import { analyzeLineOfSight, haversineKm, type LoSResult } from "./losAnalysis";
 import { losPointsToTubeData, LosTubeLayer, obstructionsToGeoJSON, pickObstructions } from "./losTubeLayer";
+import { buildCoverageRasters } from "./rasterBuildClient";
 import { type DEM, demBoundsAround, sampleDEMAt } from "./terrainDEM";
-import { buildDem, type DemSource } from "./terrainRgb";
+import type { DemSource } from "./terrainRgb";
 import type { IMapNode } from "./types";
 
 type LosComputeParams = {
@@ -159,9 +160,12 @@ export function useLosCompute(params: LosComputeParams) {
       const linkKm = 6371 * Math.sqrt(
         dLat * dLat + (dLng * Math.cos(midLatRad)) ** 2,
       );
-      // Square bbox, 15 km minimum so short links still get a useful bbox
-      const halfSpanKm = Math.max(15, linkKm / 2 + Math.max(15, linkKm * 0.15));
+      // Square bbox sized to the link (min 2 km pad) — a 500 m neighbor link
+      // shouldn't fetch a 30 km DEM. Grid targets ~30 m/px (source-native)
+      // capped at 2048, so short links also skip most of the resample cost.
+      const halfSpanKm = linkKm / 2 + Math.max(2, linkKm * 0.15);
       const demBounds = demBoundsAround([midLng, midLat], halfSpanKm, 1.0);
+      const demSize = Math.min(2048, Math.max(256, Math.ceil((2 * halfSpanKm * 1000) / 30)));
 
       const mapboxToken = env.MAPBOX_TOKEN;
       if (!mapboxToken) {
@@ -171,7 +175,7 @@ export function useLosCompute(params: LosComputeParams) {
         return;
       }
 
-      const demKey = `${demBounds.west.toFixed(4)},${demBounds.south.toFixed(4)},${demBounds.east.toFixed(4)},${demBounds.north.toFixed(4)}`;
+      const demKey = `${demSize}:${demBounds.west.toFixed(4)},${demBounds.south.toFixed(4)},${demBounds.east.toFixed(4)},${demBounds.north.toFixed(4)}`;
       let dem: DEM;
       let demSourceUsedForLos: DemSource;
       let demTilesFailed = 0;
@@ -183,20 +187,24 @@ export function useLosCompute(params: LosComputeParams) {
         setLosDemSource(demSourceUsedForLos);
       } else {
         try {
-          // 2048² → ~115 m/px at 200 km. buildDem tries Tilezen first, falls back to Mapbox.
-          const built = await buildDem({
+          // Worker-offloaded (same path as coverage, clutter rasters skipped) so the
+          // tile decode + resample doesn't freeze the map; falls back to main thread.
+          const built = await buildCoverageRasters({
             bounds: demBounds,
-            targetWidth: 2048,
-            targetHeight: 2048,
+            size: demSize,
+            maxTiles: 256,
             token: mapboxToken,
+            wantClutter: false,
+            wantCanopy: false,
+            wantBuildings: false,
           });
           if (cancelled) return;
           dem = built.dem;
-          demSourceUsedForLos = built.source;
-          demTilesFailed = built.tilesFailed;
-          demTilesTotal = built.tilesTotal;
+          demSourceUsedForLos = built.demSource;
+          demTilesFailed = built.demTilesFailed;
+          demTilesTotal = built.demTilesTotal;
           // A holed DEM would pin bad terrain under this bbox forever — let failed tiles retry.
-          if (built.tilesFailed === 0) {
+          if (built.demTilesFailed === 0) {
             losDemCacheRef.current = { key: demKey, dem, source: demSourceUsedForLos };
           }
           setLosDemSource(demSourceUsedForLos);
@@ -212,7 +220,7 @@ export function useLosCompute(params: LosComputeParams) {
 
       // Sample near the DEM's native resolution so narrow ridge crests can't fall
       // between profile points (a fixed 150 aliases out ridges past ~30 km links).
-      const demMetersPerPx = (2 * halfSpanKm * 1000) / 2048;
+      const demMetersPerPx = (2 * halfSpanKm * 1000) / demSize;
       const samples = Math.min(1000, Math.max(150, Math.ceil((linkKm * 1000) / demMetersPerPx)));
 
       let nullTerrainSamples = 0;
@@ -355,6 +363,7 @@ export function useLosCompute(params: LosComputeParams) {
     losToPosRef,
     losHoverMarkerRef,
     losFitKeyRef,
+    losDemCacheRef,
     handleLosProfileHover,
   };
 }

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -6,13 +6,15 @@ import { useCallback, useEffect, useRef } from "react";
 
 import { env } from "../../env";
 import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
+import { type BuildingRaster, sampleBuildingAt } from "./buildingTiles";
+import { type CanopyRaster, sampleCanopyAt } from "./canopyTiles";
 import { normalizeLng, shortestLngDelta } from "./geo";
 import { computeP2PLoss, isItmAvailable } from "./itm";
 import { DEFAULT_ITM_ENV } from "./itmEnv";
 import { analyzeLineOfSight, haversineKm, type LoSResult } from "./losAnalysis";
 import { losPointsToTubeData, LosTubeLayer, obstructionsToGeoJSON, pickObstructions } from "./losTubeLayer";
 import { buildCoverageRasters } from "./rasterBuildClient";
-import { type DEM, demBoundsAround, sampleDEMAt } from "./terrainDEM";
+import { type DEM, demBoundsAround, demBoundsContain, sampleDEMAt } from "./terrainDEM";
 import type { DemSource } from "./terrainRgb";
 import type { IMapNode } from "./types";
 
@@ -34,6 +36,10 @@ type LosComputeParams = {
   losResult: LoSResult | null;
   mbMapRef: React.RefObject<MlMap | null>;
   losTubeLayerRef: React.RefObject<LosTubeLayer | null>;
+  /** Suppresses map click handlers while an endpoint marker is dragged. */
+  isDraggingMarkerRef: React.RefObject<boolean>;
+  /** Dragging an endpoint marker commits it as a virtual pin (detaches node anchors). */
+  onEndpointDragged: (which: "from" | "to", pos: [number, number]) => void;
   setLosResult: (r: LoSResult | null) => void;
   setLosDemSource: (s: DemSource | null) => void;
   setLosError: (e: string | null) => void;
@@ -47,9 +53,13 @@ export function useLosCompute(params: LosComputeParams) {
     losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM,
     losFreqMhz, terrain3D, styleEpoch, nodes, losResult,
     mbMapRef, losTubeLayerRef,
+    isDraggingMarkerRef, onEndpointDragged,
     setLosResult, setLosDemSource, setLosError, setIsComputingLos,
     setLosTerrainWarning,
   } = params;
+
+  // Distinguishes "nodes not loaded yet" (URL-restored link) from "endpoint gone"
+  const nodesEmpty = Object.keys(nodes).length === 0;
 
   // Endpoint scalars (not the whole `nodes` object) drive the effects below, so
   // live SSE node churn can't retrigger a compute unless an endpoint actually moved.
@@ -75,13 +85,28 @@ export function useLosCompute(params: LosComputeParams) {
   const losHoverMarkerRef = useRef<maplibregl.Marker | null>(null);
   // Skips fitBounds re-zoom when the user changes config without moving endpoints
   const losFitKeyRef = useRef<string | null>(null);
-  // Cache the bbox-derived DEM so height tweaks reuse it instead of re-stitching.
-  const losDemCacheRef = useRef<{ key: string; dem: DEM; source: DemSource } | null>(null);
+  // Cached rasters for the last computed link; reused via containment + resolution
+  // checks so height tweaks and endpoint drags skip the re-fetch entirely.
+  const losDemCacheRef = useRef<{
+    dem: DEM;
+    source: DemSource;
+    /** Meters/pixel the cache was built at. */
+    mpp: number;
+    canopy: CanopyRaster | null;
+    buildings: BuildingRaster | null;
+  } | null>(null);
+  // Draggable endpoint markers (result step only)
+  const losFromMarkerRef = useRef<maplibregl.Marker | null>(null);
+  const losToMarkerRef = useRef<maplibregl.Marker | null>(null);
 
-  // Remove the hover marker on unmount (resetTool covers tool changes, not navigation away).
+  // Remove markers on unmount (resetTool covers tool changes, not navigation away).
   useEffect(() => () => {
     losHoverMarkerRef.current?.remove();
     losHoverMarkerRef.current = null;
+    losFromMarkerRef.current?.remove();
+    losFromMarkerRef.current = null;
+    losToMarkerRef.current?.remove();
+    losToMarkerRef.current = null;
   }, []);
 
   // Warm the ITM WASM while the user is still picking endpoints so the first
@@ -128,9 +153,12 @@ export function useLosCompute(params: LosComputeParams) {
       return;
     }
     if (fromLng == null || fromLat == null || toLng == null || toLat == null) {
+      setLosResult(null);
+      // Nodes not loaded yet (URL-restored link): stay in the loading state and
+      // let the nodes arrival retrigger via the endpoint-scalar/nodesEmpty deps.
+      if (nodesEmpty) return;
       // A picked endpoint lost its position (e.g. a live update dropped it) —
       // land on the error state, not an eternal spinner.
-      setLosResult(null);
       setLosError("An endpoint no longer has a map position.");
       setIsComputingLos(false);
       return;
@@ -171,9 +199,13 @@ export function useLosCompute(params: LosComputeParams) {
       // Square bbox sized to the link (min 2 km pad) — a 500 m neighbor link
       // shouldn't fetch a 30 km DEM. Grid targets ~30 m/px (source-native)
       // capped at 2048, so short links also skip most of the resample cost.
+      // The extra 25% fetch pad keeps nearby endpoint drags inside the cached
+      // rasters (containment check below) so they recompute without a fetch.
       const halfSpanKm = linkKm / 2 + Math.max(2, linkKm * 0.15);
-      const demBounds = demBoundsAround([midLng, midLat], halfSpanKm, 1.0);
-      const demSize = Math.min(2048, Math.max(256, Math.ceil((2 * halfSpanKm * 1000) / 30)));
+      const DEM_PAD = 1.25;
+      const demBounds = demBoundsAround([midLng, midLat], halfSpanKm, DEM_PAD);
+      const demWidthM = 2 * halfSpanKm * DEM_PAD * 1000;
+      const demSize = Math.min(2048, Math.max(256, Math.ceil(demWidthM / 30)));
 
       const mapboxToken = env.MAPBOX_TOKEN;
       if (!mapboxToken) {
@@ -183,37 +215,47 @@ export function useLosCompute(params: LosComputeParams) {
         return;
       }
 
-      const demKey = `${demSize}:${demBounds.west.toFixed(4)},${demBounds.south.toFixed(4)},${demBounds.east.toFixed(4)},${demBounds.north.toFixed(4)}`;
+      const neededMpp = demWidthM / demSize;
       let dem: DEM;
       let demSourceUsedForLos: DemSource;
       let demTilesFailed = 0;
       let demTilesTotal = 0;
+      let canopy: CanopyRaster | null = null;
+      let buildings: BuildingRaster | null = null;
+      let usedMpp = neededMpp;
       const demCache = losDemCacheRef.current;
-      if (demCache && demCache.key === demKey) {
+      if (demCache && demBoundsContain(demCache.dem.bounds, demBounds) && demCache.mpp <= neededMpp * 2) {
         dem = demCache.dem;
         demSourceUsedForLos = demCache.source;
+        canopy = demCache.canopy;
+        buildings = demCache.buildings;
+        usedMpp = demCache.mpp;
         setLosDemSource(demSourceUsedForLos);
       } else {
         try {
-          // Worker-offloaded (same path as coverage, clutter rasters skipped) so the
-          // tile decode + resample doesn't freeze the map; falls back to main thread.
+          // Worker-offloaded (same path as coverage) so the tile decode + resample
+          // doesn't freeze the map; falls back to main thread. Canopy/buildings are
+          // fetched for the profile's clutter bands (fault-tolerant: missing bakes
+          // just yield mask-0 rasters and no bands).
           const built = await buildCoverageRasters({
             bounds: demBounds,
             size: demSize,
             maxTiles: 256,
             token: mapboxToken,
             wantClutter: false,
-            wantCanopy: false,
-            wantBuildings: false,
+            wantCanopy: true,
+            wantBuildings: true,
           });
           if (cancelled) return;
           dem = built.dem;
           demSourceUsedForLos = built.demSource;
           demTilesFailed = built.demTilesFailed;
           demTilesTotal = built.demTilesTotal;
+          canopy = built.canopy;
+          buildings = built.buildings;
           // A holed DEM would pin bad terrain under this bbox forever — let failed tiles retry.
           if (built.demTilesFailed === 0) {
-            losDemCacheRef.current = { key: demKey, dem, source: demSourceUsedForLos };
+            losDemCacheRef.current = { dem, source: demSourceUsedForLos, mpp: neededMpp, canopy, buildings };
           }
           setLosDemSource(demSourceUsedForLos);
         } catch (err) {
@@ -228,9 +270,10 @@ export function useLosCompute(params: LosComputeParams) {
 
       // Sample near the DEM's native resolution so narrow ridge crests can't fall
       // between profile points (a fixed 150 aliases out ridges past ~30 km links).
-      const demMetersPerPx = (2 * halfSpanKm * 1000) / demSize;
-      const samples = Math.min(1000, Math.max(150, Math.ceil((linkKm * 1000) / demMetersPerPx)));
+      const samples = Math.min(1000, Math.max(150, Math.ceil((linkKm * 1000) / usedMpp)));
 
+      const canopyRaster = canopy;
+      const buildingRaster = buildings;
       let nullTerrainSamples = 0;
       let result: LoSResult;
       try {
@@ -251,6 +294,12 @@ export function useLosCompute(params: LosComputeParams) {
             }
             return elev;
           },
+          queryCanopyM: canopyRaster
+            ? (lng, lat) => sampleCanopyAt(canopyRaster, lng, lat)?.heightM ?? null
+            : undefined,
+          queryBuildingM: buildingRaster
+            ? (lng, lat) => sampleBuildingAt(buildingRaster, lng, lat)?.heightM ?? null
+            : undefined,
         });
       } catch (err) {
         console.warn("[Map] LoS analysis failed:", err);
@@ -319,7 +368,9 @@ export function useLosCompute(params: LosComputeParams) {
       if (!cancelled) console.warn("[Map] LoS run failed:", err);
     });
     return () => { cancelled = true; };
-  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, losFreqMhz, terrain3D, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
+    // styleEpoch: map-readiness signal — a URL-restored analysis mounts before the
+    // map exists and needs style.load to retrigger (DEM cache keeps re-runs cheap).
+  }, [activeTool, toolStep, fromLng, fromLat, fromAlt, toLng, toLat, toAlt, losFromHeightM, losToHeightM, losFreqMhz, terrain3D, styleEpoch, nodesEmpty, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
 
   // Push LoS result → 3D tube layer + obstruction source.
   // Altitudes are scaled by terrain exaggeration to stay pinned to the visual surface.
@@ -366,12 +417,66 @@ export function useLosCompute(params: LosComputeParams) {
     // tube layer's GL objects — this effect re-pushes both after style.load.
   }, [activeTool, toolStep, losResult, fromLng, fromLat, toLng, toLat, styleEpoch, mbMapRef, losTubeLayerRef]);
 
+  // Draggable endpoint markers while a result is shown; dragging one converts
+  // the endpoint to a virtual pin (with a micro-drag snap-back for wiggles).
+  useEffect(() => {
+    const mb = mbMapRef.current;
+    if (!mb) return;
+    const showing = activeTool === "los" && toolStep === "result";
+    const ends: Array<{
+      which: "from" | "to";
+      lng: number | null;
+      lat: number | null;
+      ref: React.RefObject<maplibregl.Marker | null>;
+      color: string;
+    }> = [
+      { which: "from", lng: fromLng, lat: fromLat, ref: losFromMarkerRef, color: "#06b6d4" },
+      { which: "to", lng: toLng, lat: toLat, ref: losToMarkerRef, color: "#d946ef" },
+    ];
+    for (const end of ends) {
+      if (!showing || end.lng == null || end.lat == null) {
+        end.ref.current?.remove();
+        end.ref.current = null;
+        continue;
+      }
+      if (end.ref.current) {
+        end.ref.current.setLngLat([end.lng, end.lat]);
+        continue;
+      }
+      const marker = new maplibregl.Marker({ color: end.color, draggable: true, scale: 0.75 })
+        .setLngLat([end.lng, end.lat])
+        .addTo(mb);
+      let dragStart: maplibregl.LngLat | null = null;
+      marker.on("dragstart", () => {
+        isDraggingMarkerRef.current = true;
+        dragStart = marker.getLngLat();
+      });
+      marker.on("dragend", () => {
+        isDraggingMarkerRef.current = false;
+        const ll = marker.getLngLat();
+        if (dragStart) {
+          const dxM = shortestLngDelta(dragStart.lng, ll.lng) * 111_320 * Math.cos((ll.lat * Math.PI) / 180);
+          const dyM = (ll.lat - dragStart.lat) * 111_320;
+          if (Math.hypot(dxM, dyM) < 5) {
+            // Wiggle: snap back instead of detaching a node-anchored endpoint
+            marker.setLngLat(dragStart);
+            return;
+          }
+        }
+        onEndpointDragged(end.which, [normalizeLng(ll.lng), ll.lat]);
+      });
+      end.ref.current = marker;
+    }
+  }, [activeTool, toolStep, fromLng, fromLat, toLng, toLat, styleEpoch, mbMapRef, isDraggingMarkerRef, onEndpointDragged]);
+
   return {
     losFromPosRef,
     losToPosRef,
     losHoverMarkerRef,
     losFitKeyRef,
     losDemCacheRef,
+    losFromMarkerRef,
+    losToMarkerRef,
     handleLosProfileHover,
   };
 }

--- a/frontend/src/pages/map/useLosCompute.ts
+++ b/frontend/src/pages/map/useLosCompute.ts
@@ -34,6 +34,7 @@ type LosComputeParams = {
   setLosDemSource: (s: DemSource | null) => void;
   setLosError: (e: string | null) => void;
   setIsComputingLos: (v: boolean) => void;
+  setLosTerrainWarning: (w: string | null) => void;
 };
 
 export function useLosCompute(params: LosComputeParams) {
@@ -43,6 +44,7 @@ export function useLosCompute(params: LosComputeParams) {
     provider, terrain3D, nodes, losResult,
     mbMapRef, losTubeLayerRef,
     setLosResult, setLosDemSource, setLosError, setIsComputingLos,
+    setLosTerrainWarning,
   } = params;
 
   // LOS endpoints from the compute effect; refs so the hover-marker callback reads them without deps churn
@@ -94,6 +96,7 @@ export function useLosCompute(params: LosComputeParams) {
     if (activeTool !== "los" || toolStep !== "result") {
       setLosResult(null);
       setLosError(null);
+      setLosTerrainWarning(null);
       return;
     }
     const hasFrom = toolFromId || losVirtualFrom;
@@ -164,6 +167,8 @@ export function useLosCompute(params: LosComputeParams) {
       const demKey = `${demBounds.west.toFixed(4)},${demBounds.south.toFixed(4)},${demBounds.east.toFixed(4)},${demBounds.north.toFixed(4)}`;
       let dem: DEM;
       let demSourceUsedForLos: DemSource;
+      let demTilesFailed = 0;
+      let demTilesTotal = 0;
       const demCache = losDemCacheRef.current;
       if (demCache && demCache.key === demKey) {
         dem = demCache.dem;
@@ -172,14 +177,21 @@ export function useLosCompute(params: LosComputeParams) {
       } else {
         try {
           // 2048² → ~115 m/px at 200 km. buildDem tries Tilezen first, falls back to Mapbox.
-          ({ dem, source: demSourceUsedForLos } = await buildDem({
+          const built = await buildDem({
             bounds: demBounds,
             targetWidth: 2048,
             targetHeight: 2048,
             token: mapboxToken,
-          }));
+          });
           if (cancelled) return;
-          losDemCacheRef.current = { key: demKey, dem, source: demSourceUsedForLos };
+          dem = built.dem;
+          demSourceUsedForLos = built.source;
+          demTilesFailed = built.tilesFailed;
+          demTilesTotal = built.tilesTotal;
+          // A holed DEM would pin bad terrain under this bbox forever — let failed tiles retry.
+          if (built.tilesFailed === 0) {
+            losDemCacheRef.current = { key: demKey, dem, source: demSourceUsedForLos };
+          }
           setLosDemSource(demSourceUsedForLos);
         } catch (err) {
           console.warn("[Map] LoS DEM fetch failed:", err);
@@ -189,6 +201,12 @@ export function useLosCompute(params: LosComputeParams) {
         }
       }
 
+      // Sample near the DEM's native resolution so narrow ridge crests can't fall
+      // between profile points (a fixed 150 aliases out ridges past ~30 km links).
+      const demMetersPerPx = (2 * halfSpanKm * 1000) / 2048;
+      const samples = Math.min(1000, Math.max(150, Math.ceil((linkKm * 1000) / demMetersPerPx)));
+
+      let nullTerrainSamples = 0;
       let result: LoSResult;
       try {
         result = analyzeLineOfSight({
@@ -199,10 +217,14 @@ export function useLosCompute(params: LosComputeParams) {
           fromAntennaHeightM: losFromHeightM,
           toAntennaHeightM: losToHeightM,
           freqGHz: 0.915,
-          samples: 150,
+          samples,
           queryTerrainM: (lng, lat) => {
             const elev = sampleDEMAt(dem, lng, lat);
-            return Number.isNaN(elev) ? null : elev;
+            if (Number.isNaN(elev)) {
+              nullTerrainSamples++;
+              return null;
+            }
+            return elev;
           },
         });
       } catch (err) {
@@ -213,6 +235,18 @@ export function useLosCompute(params: LosComputeParams) {
       }
       // Show geometric result immediately; ITM enhances async
       setLosResult(result);
+      // Missing terrain reads as sea level in the analysis — never let that pass silently.
+      if (demTilesFailed > 0) {
+        setLosTerrainWarning(
+          `${demTilesFailed} of ${demTilesTotal} terrain tiles failed to load — gaps read as sea level, so this result may be unreliable. Recompute to retry.`,
+        );
+      } else if (nullTerrainSamples > 0) {
+        setLosTerrainWarning(
+          `${nullTerrainSamples} of ${result.points.length} path samples had no terrain data and read as sea level.`,
+        );
+      } else {
+        setLosTerrainWarning(null);
+      }
 
       // ITM enhancement — silently skips if WASM isn't built
       try {
@@ -250,7 +284,8 @@ export function useLosCompute(params: LosComputeParams) {
       losFitKeyRef.current = fitKey;
       const bounds = new maplibregl.LngLatBounds();
       bounds.extend(fromPos);
-      bounds.extend(toPos);
+      // Unwrap so an antimeridian-crossing pair frames the short way, not the whole world
+      bounds.extend([fromPos[0] + shortestLngDelta(fromPos[0], toPos[0]), toPos[1]]);
       mb.fitBounds(bounds, { padding: 120, duration: 600, maxZoom: 11 });
     }
 
@@ -259,7 +294,7 @@ export function useLosCompute(params: LosComputeParams) {
       if (!cancelled) console.warn("[Map] LoS run failed:", err);
     });
     return () => { cancelled = true; };
-  }, [activeTool, toolStep, toolFromId, toolToId, losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM, provider, terrain3D, nodes, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos]);
+  }, [activeTool, toolStep, toolFromId, toolToId, losVirtualFrom, losVirtualTo, losFromHeightM, losToHeightM, provider, terrain3D, nodes, mbMapRef, setLosResult, setLosDemSource, setLosError, setIsComputingLos, setLosTerrainWarning]);
 
   // Push LoS result → 3D tube layer + obstruction source.
   // Altitudes are scaled by terrain exaggeration to stay pinned to the visual surface.

--- a/frontend/src/pages/map/useLosState.ts
+++ b/frontend/src/pages/map/useLosState.ts
@@ -80,8 +80,19 @@ export function useLosState() {
   const [losToAntIdx, setLosToAntIdx] = useState(saved?.toAntIdx ?? DEFAULT_ANT_IDX);
   const [losToHeightM, setLosToHeightM] = useState(saved?.toHeightM ?? 2);
 
+  // Heights/frequency applied from a shared URL must not overwrite the viewer's
+  // saved defaults. While the current trio is exactly what the URL set, skip the
+  // write; the first user-driven change resumes normal persistence.
+  const urlAppliedRef = useRef<{ f: number; t: number; q: number } | null>(null);
+  const markUrlAppliedSettings = (f: number, t: number, q: number) => {
+    urlAppliedRef.current = { f, t, q };
+  };
+
   // Write-through persistence (semantic labels, like coverageLastSettings)
   useEffect(() => {
+    const u = urlAppliedRef.current;
+    if (u && u.f === losFromHeightM && u.t === losToHeightM && u.q === losFreqMhz) return;
+    urlAppliedRef.current = null;
     const payload: LosSavedSettings = {
       freqMhz: losFreqMhz,
       modemId: MESHTASTIC_PRESETS[losPresetIdx]?.id ?? "LongFast",
@@ -109,6 +120,7 @@ export function useLosState() {
     isComputingLos, setIsComputingLos,
     losVirtualFrom, setLosVirtualFrom,
     losVirtualTo, setLosVirtualTo,
+    markUrlAppliedSettings,
     losFreqMhz, setLosFreqMhz,
     losPresetIdx, setLosPresetIdx,
     losFromHwIdx, setLosFromHwIdx,

--- a/frontend/src/pages/map/useLosState.ts
+++ b/frontend/src/pages/map/useLosState.ts
@@ -10,6 +10,8 @@ export function useLosState() {
   const [losDemSource, setLosDemSource] = useState<DemSource | null>(null);
   /** Last LoS compute error, or null. */
   const [losError, setLosError] = useState<string | null>(null);
+  /** Non-fatal terrain-quality warning (failed tiles / missing samples), or null. */
+  const [losTerrainWarning, setLosTerrainWarning] = useState<string | null>(null);
   /** True while a LoS compute (initial or config-recompute) is in flight. */
   const [isComputingLos, setIsComputingLos] = useState(false);
   // LOS virtual pins — endpoints can be arbitrary map points, not just nodes
@@ -27,6 +29,7 @@ export function useLosState() {
     losResult, setLosResult,
     losDemSource, setLosDemSource,
     losError, setLosError,
+    losTerrainWarning, setLosTerrainWarning,
     isComputingLos, setIsComputingLos,
     losVirtualFrom, setLosVirtualFrom,
     losVirtualTo, setLosVirtualTo,

--- a/frontend/src/pages/map/useLosState.ts
+++ b/frontend/src/pages/map/useLosState.ts
@@ -1,7 +1,52 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { COMMON_ANTENNAS, COMMON_HARDWARE, MESHTASTIC_PRESETS } from "./coverageAnalysis";
+import { resolveAntenna, resolveHardware } from "./coveragePresets";
 import type { LoSResult } from "./losAnalysis";
+import { LS_KEYS, readJson, writeJson } from "./storage";
 import type { DemSource } from "./terrainRgb";
+
+const DEFAULT_ANT_IDX = 3; // Rokland 5.8 dBi
+const DEFAULT_PRESET_IDX = Math.max(0, MESHTASTIC_PRESETS.findIndex((p) => p.id === "LongFast"));
+
+/** Semantic (label-based) persisted shape so catalog reordering can't corrupt saved choices. */
+interface LosSavedSettings {
+  freqMhz?: number;
+  modemId?: string;
+  from?: { hardware?: string; antenna?: string; dbi?: number; heightM?: number };
+  to?: { hardware?: string; antenna?: string; dbi?: number; heightM?: number };
+}
+
+interface ResolvedLosSettings {
+  freqMhz: number;
+  presetIdx: number;
+  fromHwIdx: number; fromAntIdx: number; fromHeightM: number;
+  toHwIdx: number; toAntIdx: number; toHeightM: number;
+}
+
+function resolveEnd(e: LosSavedSettings["from"]): { hwIdx: number; antIdx: number; heightM: number } {
+  const hwIdx = e?.hardware ? resolveHardware(e.hardware).idx : 0;
+  const antIdx = e?.antenna ? resolveAntenna(e.antenna, e.dbi ?? 0) : DEFAULT_ANT_IDX;
+  const heightM =
+    typeof e?.heightM === "number" && Number.isFinite(e.heightM)
+      ? Math.max(0, Math.min(300, e.heightM))
+      : 2;
+  return { hwIdx, antIdx, heightM };
+}
+
+function readSavedLosSettings(): ResolvedLosSettings | null {
+  const s = readJson<LosSavedSettings | null>(LS_KEYS.losSettings, null);
+  if (!s) return null;
+  const presetIdx = MESHTASTIC_PRESETS.findIndex((p) => p.id === s.modemId);
+  const from = resolveEnd(s.from);
+  const to = resolveEnd(s.to);
+  return {
+    freqMhz: typeof s.freqMhz === "number" && s.freqMhz >= 100 && s.freqMhz <= 2500 ? s.freqMhz : 915,
+    presetIdx: presetIdx >= 0 && !MESHTASTIC_PRESETS[presetIdx].isCustom ? presetIdx : DEFAULT_PRESET_IDX,
+    fromHwIdx: from.hwIdx, fromAntIdx: from.antIdx, fromHeightM: from.heightM,
+    toHwIdx: to.hwIdx, toAntIdx: to.antIdx, toHeightM: to.heightM,
+  };
+}
 
 /** LoS endpoint hardware/antenna/height + result state. */
 export function useLosState() {
@@ -17,13 +62,44 @@ export function useLosState() {
   // LOS virtual pins — endpoints can be arbitrary map points, not just nodes
   const [losVirtualFrom, setLosVirtualFrom] = useState<[number, number] | null>(null);
   const [losVirtualTo, setLosVirtualTo] = useState<[number, number] | null>(null);
+
+  // Config restores from localStorage (read once per mount)
+  const savedRef = useRef<ResolvedLosSettings | null | undefined>(undefined);
+  if (savedRef.current === undefined) savedRef.current = readSavedLosSettings();
+  const saved = savedRef.current;
+
+  /** Link frequency (MHz); drives Fresnel geometry and ITM. */
+  const [losFreqMhz, setLosFreqMhz] = useState(saved?.freqMhz ?? 915);
+  /** Modem preset index into MESHTASTIC_PRESETS; drives the margin readout. */
+  const [losPresetIdx, setLosPresetIdx] = useState(saved?.presetIdx ?? DEFAULT_PRESET_IDX);
   // Per-endpoint hardware/antenna/height for asymmetric LOS
-  const [losFromHwIdx, setLosFromHwIdx] = useState(0);
-  const [losFromAntIdx, setLosFromAntIdx] = useState(3); // Rokland 5.8 dBi
-  const [losFromHeightM, setLosFromHeightM] = useState(2);
-  const [losToHwIdx, setLosToHwIdx] = useState(0);
-  const [losToAntIdx, setLosToAntIdx] = useState(3);
-  const [losToHeightM, setLosToHeightM] = useState(2);
+  const [losFromHwIdx, setLosFromHwIdx] = useState(saved?.fromHwIdx ?? 0);
+  const [losFromAntIdx, setLosFromAntIdx] = useState(saved?.fromAntIdx ?? DEFAULT_ANT_IDX);
+  const [losFromHeightM, setLosFromHeightM] = useState(saved?.fromHeightM ?? 2);
+  const [losToHwIdx, setLosToHwIdx] = useState(saved?.toHwIdx ?? 0);
+  const [losToAntIdx, setLosToAntIdx] = useState(saved?.toAntIdx ?? DEFAULT_ANT_IDX);
+  const [losToHeightM, setLosToHeightM] = useState(saved?.toHeightM ?? 2);
+
+  // Write-through persistence (semantic labels, like coverageLastSettings)
+  useEffect(() => {
+    const payload: LosSavedSettings = {
+      freqMhz: losFreqMhz,
+      modemId: MESHTASTIC_PRESETS[losPresetIdx]?.id ?? "LongFast",
+      from: {
+        hardware: COMMON_HARDWARE[losFromHwIdx]?.label,
+        antenna: COMMON_ANTENNAS[losFromAntIdx]?.label,
+        dbi: COMMON_ANTENNAS[losFromAntIdx]?.dbi,
+        heightM: losFromHeightM,
+      },
+      to: {
+        hardware: COMMON_HARDWARE[losToHwIdx]?.label,
+        antenna: COMMON_ANTENNAS[losToAntIdx]?.label,
+        dbi: COMMON_ANTENNAS[losToAntIdx]?.dbi,
+        heightM: losToHeightM,
+      },
+    };
+    writeJson(LS_KEYS.losSettings, payload);
+  }, [losFreqMhz, losPresetIdx, losFromHwIdx, losFromAntIdx, losFromHeightM, losToHwIdx, losToAntIdx, losToHeightM]);
 
   return {
     losResult, setLosResult,
@@ -33,6 +109,8 @@ export function useLosState() {
     isComputingLos, setIsComputingLos,
     losVirtualFrom, setLosVirtualFrom,
     losVirtualTo, setLosVirtualTo,
+    losFreqMhz, setLosFreqMhz,
+    losPresetIdx, setLosPresetIdx,
     losFromHwIdx, setLosFromHwIdx,
     losFromAntIdx, setLosFromAntIdx,
     losFromHeightM, setLosFromHeightM,

--- a/frontend/src/pages/map/useScanCompute.ts
+++ b/frontend/src/pages/map/useScanCompute.ts
@@ -2,33 +2,47 @@ import maplibregl, {
   GeoJSONSource as MlGeoJSONSource,
   Map as MlMap,
 } from "maplibre-gl";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { env } from "../../env";
 import { ORIGIN_COLOR } from "../../palette";
 import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
-import { buildBuildingRaster, type BuildingRaster } from "./buildingTiles";
-import { buildCanopyRaster, type CanopyRaster } from "./canopyTiles";
+import type { BuildingRaster } from "./buildingTiles";
+import type { CanopyRaster } from "./canopyTiles";
 import { AGGRESSION_STOPS, type CoverageReliability, reliabilityPreset } from "./coverageAnalysis";
+import { normalizeLng } from "./geo";
 import { type ItmContext, loadItmContext } from "./itm";
 import { DEFAULT_ITM_ENV } from "./itmEnv";
-import { buildClutterRaster, type ClutterRaster } from "./landcoverTiles";
-import { runScan, type ScanClass, type ScanSummary, type ScanTarget, scanToGeoJSON } from "./scanAnalysis";
+import type { ClutterRaster } from "./landcoverTiles";
+import { buildCoverageRasters } from "./rasterBuildClient";
+import { MAX_SCAN_PATH_POINTS, runScanAsync, type ScanClass, type ScanSummary, type ScanTarget, scanToGeoJSON } from "./scanAnalysis";
 import { type DEM, demBoundsAround, sampleDEMAt } from "./terrainDEM";
-import { buildDem, type DemSource } from "./terrainRgb";
+import type { DemSource } from "./terrainRgb";
 import type { IMapNode } from "./types";
+
+/** Same 200 km radius as coverage; DEM is sized to it. */
+const SCAN_RADIUS_KM = 200;
+/** DEM/clutter tile budget per fetch (matches LOS/coverage standard). */
+const SCAN_MAX_TILES = 256;
+/** GPS altitude farther than this above sampled terrain is treated as bogus. */
+const MAX_ORIGIN_HEIGHT_ABOVE_TERRAIN_M = 1000;
 
 type ScanComputeParams = {
   activeTool: "los" | "traceroute" | "coverage" | "scan" | null;
   toolStep: "pickFrom" | "pickTo" | "result";
   toolFromId: string | null;
   toolVirtualPos: [number, number] | null;
-  provider: string;
   terrain3D: boolean;
+  /** Bumped on style.load — re-pushes scan lines + filter after setStyle wipes them. */
+  styleEpoch: number;
   nodes: Record<string, IMapNode>;
+  /** Nodes query errored — an empty `nodes` map is a load failure, not still-loading. */
+  nodesLoadFailed: boolean;
   scanTxDbm: number;
   scanAntennaDbi: number;
   scanRxAntennaDbi: number;
+  scanRxHeightM: number;
+  scanFreqMhz: number;
   scanEffectiveSensitivityDbm: number;
   scanAggressionIdx: number;
   scanClutterEnabled: boolean;
@@ -36,6 +50,8 @@ type ScanComputeParams = {
   scanBuildingsEnabled: boolean;
   scanAntennaHeightM: number;
   scanReliability: CoverageReliability;
+  /** Bumped by the Retry button to force a refetch after a failure. */
+  scanRetryNonce: number;
   hiddenScanClasses: Set<ScanClass>;
   scanSummary: ScanSummary | null;
   scanHoverId: string | null;
@@ -44,6 +60,7 @@ type ScanComputeParams = {
   setScanSummary: (s: ScanSummary | null) => void;
   setIsScanning: (b: boolean) => void;
   setScanError: (e: string | null) => void;
+  setScanTerrainWarning: (w: string | null) => void;
   setScanDemSource: (s: DemSource | null) => void;
   setScanClutterStatus: (s: { tilesPresent: number; tilesTotal: number } | null) => void;
   setScanCanopyStatus: (s: { tilesPresent: number; tilesTotal: number } | null) => void;
@@ -52,16 +69,28 @@ type ScanComputeParams = {
   setToolVirtualPos: (p: [number, number] | null) => void;
 };
 
+interface ScanRasterCache {
+  bboxKey: string;
+  retryNonce: number;
+  dem: DEM;
+  demSource: DemSource;
+  demMppM: number;
+  /** null = tier not fetched yet (fetched lazily as toggles enable it). */
+  clutter: ClutterRaster | null;
+  canopy: CanopyRaster | null;
+  buildings: BuildingRaster | null;
+}
+
 export function useScanCompute(params: ScanComputeParams) {
   const {
     activeTool, toolStep, toolFromId, toolVirtualPos,
-    provider, terrain3D, nodes,
-    scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
+    terrain3D, styleEpoch, nodes, nodesLoadFailed,
+    scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanRxHeightM, scanFreqMhz, scanEffectiveSensitivityDbm,
     scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled,
-    scanAntennaHeightM, scanReliability,
+    scanAntennaHeightM, scanReliability, scanRetryNonce,
     hiddenScanClasses, scanSummary, scanHoverId,
     mbMapRef, isDraggingMarkerRef,
-    setScanSummary, setIsScanning, setScanDemSource, setScanError,
+    setScanSummary, setIsScanning, setScanDemSource, setScanError, setScanTerrainWarning,
     setScanClutterStatus, setScanCanopyStatus, setScanBuildingsStatus,
     setToolFromId, setToolVirtualPos,
   } = params;
@@ -74,11 +103,47 @@ export function useScanCompute(params: ScanComputeParams) {
   // Lazily loaded, reused across scans; same WASM module as the coverage workers (main thread)
   const scanItmContextRef = useRef<ItmContext | null>(null);
   // Cache the bbox-derived rasters so link-budget tweaks reuse them (no refetch).
-  const scanRasterCacheRef = useRef<{
-    key: string;
-    dem: DEM; source: DemSource;
-    clutter: ClutterRaster | null; canopy: CanopyRaster | null; buildings: BuildingRaster | null;
-  } | null>(null);
+  const scanRasterCacheRef = useRef<ScanRasterCache | null>(null);
+  // Last feature index we set hover:true on, so we can clear just that one.
+  const prevHoverIdxRef = useRef<number | null>(null);
+  // Latest nodes, read inside the async body without making `nodes` a compute trigger
+  // (SSE flushes churn its identity ~2.5 Hz; only real position changes should re-scan).
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+
+  // Resolve the origin to stable scalars so the compute effect re-runs when the
+  // ORIGIN moves, not when unrelated node telemetry updates. (Shortname is read
+  // inside the async body from the live ref — it's display-only.)
+  let originLng: number | null = null;
+  let originLat: number | null = null;
+  let originAltitude: number | null = null;
+  if (toolFromId) {
+    const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
+    if (n?.map_position) {
+      originLng = n.map_position[0];
+      originLat = n.map_position[1];
+      originAltitude = effectiveAltitudeMslM(n.position);
+    }
+  } else if (toolVirtualPos) {
+    originLng = toolVirtualPos[0];
+    originLat = toolVirtualPos[1];
+  }
+
+  // Position-only signature of scan targets. Recomputed only when `nodes` identity
+  // changes (~400 ms), so mouse-move re-renders don't rebuild it; the expensive scan
+  // re-runs only when this VALUE changes (a node's position/altitude actually moved).
+  const targetsSig = useMemo(() => {
+    let sig = "";
+    for (const rawId in nodes) {
+      const n = nodes[rawId];
+      if (!n?.map_position) continue;
+      const alt = effectiveAltitudeMslM(n.position);
+      sig += `${rawId}:${n.map_position[0].toFixed(5)},${n.map_position[1].toFixed(5)},${alt == null ? "x" : Math.round(alt)};`;
+    }
+    return sig;
+  }, [nodes]);
+
+  const nodesEmpty = Object.keys(nodes).length === 0;
 
   // Scan tool: batch LoS to every node in radius from a chosen origin
   useEffect(() => {
@@ -86,32 +151,27 @@ export function useScanCompute(params: ScanComputeParams) {
       setScanSummary(null);
       setIsScanning(false);
       setScanError(null);
+      setScanTerrainWarning(null);
       return;
     }
     if (!terrain3D) {
       setScanSummary(null);
+      setIsScanning(false);
       return;
     }
     const mb = mbMapRef.current;
-    if (!mb) return;
+    if (!mb) { setIsScanning(false); return; }
 
-    let origin: [number, number] | null = null;
-    let originAltitude: number | null = null;
-    let originShortname: string | undefined;
-    if (toolFromId) {
-      const n = nodes[toolFromId] ?? nodes[`!${toolFromId}`];
-      if (n?.map_position) {
-        origin = [n.map_position[0], n.map_position[1]];
-        originAltitude = effectiveAltitudeMslM(n.position);
-        originShortname = n.shortname ?? undefined;
-      }
-    } else if (toolVirtualPos) {
-      origin = toolVirtualPos;
-    }
-    if (!origin) {
+    if (originLng == null || originLat == null) {
       setScanSummary(null);
+      // Origin came from a node that hasn't loaded yet (rare — scan picks require
+      // rendered nodes): stay quiet and let the nodes arrival retrigger.
+      if (nodesEmpty && !nodesLoadFailed) { setIsScanning(false); return; }
+      setScanError("The scan origin no longer has a map position.");
+      setIsScanning(false);
       return;
     }
+    const origin: [number, number] = [originLng, originLat];
 
     // Snapshot view per-origin so "return to overview" is stable across
     // config re-runs but re-captures when the origin moves.
@@ -131,7 +191,8 @@ export function useScanCompute(params: ScanComputeParams) {
     }
 
     if (scanOriginMarkerRef.current) {
-      scanOriginMarkerRef.current.setLngLat(origin);
+      // Don't yank the pin out from under a live drag.
+      if (!isDraggingMarkerRef.current) scanOriginMarkerRef.current.setLngLat(origin);
     } else {
       const marker = new maplibregl.Marker({ color: ORIGIN_COLOR, draggable: true })
         .setLngLat(origin)
@@ -143,23 +204,26 @@ export function useScanCompute(params: ScanComputeParams) {
         scanInitialViewRef.current = null;
         scanOriginKeyRef.current = null;
         setToolFromId(null);
-        setToolVirtualPos([ll.lng, ll.lat]);
+        // normalizeLng: a drag across the dateline can leave lng outside ±180.
+        setToolVirtualPos([normalizeLng(ll.lng), ll.lat]);
       });
       scanOriginMarkerRef.current = marker;
     }
 
-    setIsScanning(true);
-    setScanError(null);
     let cancelled = false;
 
-    const SCAN_RADIUS_KM = 200;
-
     const runAsync = async () => {
+      setIsScanning(true);
+      setScanError(null);
       try {
-        // Collect ALL nodes; runScan's maxDistanceKm applies the radius cutoff
+        // Collect ALL nodes (read live via ref); runScan's maxDistanceKm applies the radius cutoff
+        const liveNodes = nodesRef.current;
+        const originNode = toolFromId ? (liveNodes[toolFromId] ?? liveNodes[`!${toolFromId}`]) : undefined;
+        const originShortname = originNode?.shortname?.trim() || undefined;
         const targets: ScanTarget[] = [];
         const seen = new Set<string>();
-        for (const [rawId, node] of Object.entries(nodes)) {
+        for (const rawId in liveNodes) {
+          const node = liveNodes[rawId];
           if (!node?.map_position) continue;
           const [lng, lat] = node.map_position;
           const norm = rawId.startsWith("!") ? rawId.slice(1) : rawId;
@@ -168,27 +232,23 @@ export function useScanCompute(params: ScanComputeParams) {
           seen.add(norm);
           targets.push({
             id: norm,
-            shortname: node.shortname ?? undefined,
+            shortname: node.shortname?.trim() || undefined,
             position: [lng, lat],
             altitudeM: effectiveAltitudeMslM(node.position),
           });
         }
 
         if (targets.length === 0) {
+          // Distinguish "no nodes in range" from a failed nodes fetch.
+          setScanError(nodesLoadFailed ? "Couldn't load nodes. Check your connection and retry." : null);
           setScanSummary({
-            origin: origin!,
-            originShortname,
-            results: [],
-            clearCount: 0,
-            fresnelCount: 0,
-            diffractedCount: 0,
-            blockedCount: 0,
+            origin, originShortname,
+            results: [], clearCount: 0, fresnelCount: 0, diffractedCount: 0, blockedCount: 0,
           });
           setIsScanning(false);
           return;
         }
 
-        // Viewport-independent DEM around origin (same 200 km cap as coverage)
         const mapboxToken = env.MAPBOX_TOKEN;
         if (!mapboxToken) {
           console.warn("[Map] Scan aborted — Mapbox token missing.");
@@ -196,112 +256,139 @@ export function useScanCompute(params: ScanComputeParams) {
           setIsScanning(false);
           return;
         }
-        const scanBounds = demBoundsAround(origin!, SCAN_RADIUS_KM, 1.05);
-        // 2048² rasters match coverage's resolution so per-target ITM sees the same
-        // terrain detail. Cached by bbox + enabled flags so link-budget tweaks reuse
-        // them instead of refetching ~800 tiles per config change.
-        const rasterKey = `${scanBounds.west.toFixed(4)},${scanBounds.south.toFixed(4)},${scanBounds.east.toFixed(4)},${scanBounds.north.toFixed(4)}|${scanClutterEnabled}|${scanCanopyEnabled}|${scanBuildingsEnabled}`;
-        let dem: DEM;
-        let demSourceUsedForScan: DemSource;
-        let scanClutter: ClutterRaster | null;
-        let scanCanopy: CanopyRaster | null;
-        let scanBuildings: BuildingRaster | null;
-        const rasterCache = scanRasterCacheRef.current;
-        if (rasterCache && rasterCache.key === rasterKey) {
-          dem = rasterCache.dem;
-          demSourceUsedForScan = rasterCache.source;
-          scanClutter = rasterCache.clutter;
-          scanCanopy = rasterCache.canopy;
-          scanBuildings = rasterCache.buildings;
-        } else {
-          const [demRes, clutterRes, canopyRes, buildingsRes] = await Promise.all([
-            buildDem({ bounds: scanBounds, targetWidth: 2048, targetHeight: 2048, token: mapboxToken }),
-            // Skip individual fetches when their respective models are toggled off.
-            scanClutterEnabled ? buildClutterRaster({ bounds: scanBounds, targetWidth: 2048, targetHeight: 2048 }) : Promise.resolve(null),
-            scanCanopyEnabled ? buildCanopyRaster({ bounds: scanBounds, targetWidth: 2048, targetHeight: 2048 }) : Promise.resolve(null),
-            scanBuildingsEnabled ? buildBuildingRaster({ bounds: scanBounds, targetWidth: 2048, targetHeight: 2048 }) : Promise.resolve(null),
-          ]);
-          if (cancelled) return;
-          dem = demRes.dem;
-          demSourceUsedForScan = demRes.source;
-          scanClutter = clutterRes;
-          scanCanopy = canopyRes;
-          scanBuildings = buildingsRes;
-          scanRasterCacheRef.current = { key: rasterKey, dem, source: demSourceUsedForScan, clutter: scanClutter, canopy: scanCanopy, buildings: scanBuildings };
-        }
-        if (cancelled) return;
-        setScanDemSource(demSourceUsedForScan);
-        setScanClutterStatus(
-          scanClutter ? { tilesPresent: scanClutter.tilesPresent, tilesTotal: scanClutter.tilesTotal } : null,
-        );
-        setScanCanopyStatus(
-          scanCanopy ? { tilesPresent: scanCanopy.tilesPresent, tilesTotal: scanCanopy.tilesTotal } : null,
-        );
-        setScanBuildingsStatus(
-          scanBuildings ? { tilesPresent: scanBuildings.tilesPresent, tilesTotal: scanBuildings.tilesTotal } : null,
-        );
 
-        // Override GPS altitude with terrain + configured AGL (matches coverage).
-        // Falls back to GPS altitude if DEM sampling fails.
-        const originTerrainM = sampleDEMAt(dem, origin![0], origin![1]);
-        const terrainValid = Number.isFinite(originTerrainM) && !Number.isNaN(originTerrainM);
-        const effectiveOriginAltitude = terrainValid
-          ? originTerrainM + scanAntennaHeightM
-          : originAltitude;
+        // Viewport-independent DEM around origin (same 200 km cap as coverage).
+        const scanBounds = demBoundsAround(origin, SCAN_RADIUS_KM, 1.05);
+        const bboxKey = `${scanBounds.west.toFixed(4)},${scanBounds.south.toFixed(4)},${scanBounds.east.toFixed(4)},${scanBounds.north.toFixed(4)}`;
+
+        // Cache is keyed on bbox ONLY (rasters don't depend on the toggles). Toggling a
+        // tier off never refetches; re-enabling reuses the cached tier; only a genuinely
+        // new tier (or a moved origin / retry) triggers a fetch.
+        let cache = scanRasterCacheRef.current;
+        const cacheValid = !!cache && cache.bboxKey === bboxKey && cache.retryNonce === scanRetryNonce;
+        const missingTier =
+          (scanClutterEnabled && !(cacheValid && cache!.clutter)) ||
+          (scanCanopyEnabled && !(cacheValid && cache!.canopy)) ||
+          (scanBuildingsEnabled && !(cacheValid && cache!.buildings));
+
+        if (!cacheValid || missingTier) {
+          // Request the union of already-cached tiers and currently-enabled tiers so a
+          // re-enable keeps prior fetches and only the new tier is added.
+          const wantClutter = scanClutterEnabled || !!(cacheValid && cache!.clutter);
+          const wantCanopy = scanCanopyEnabled || !!(cacheValid && cache!.canopy);
+          const wantBuildings = scanBuildingsEnabled || !!(cacheValid && cache!.buildings);
+          // 2048² rasters match coverage's resolution; the tile fetch/decode/resample
+          // runs in the raster-build worker (main-thread fallback) so the map stays live.
+          const built = await buildCoverageRasters({
+            bounds: scanBounds,
+            size: 2048,
+            maxTiles: SCAN_MAX_TILES,
+            token: mapboxToken,
+            wantClutter, wantCanopy, wantBuildings,
+          });
+          const midLat = (built.dem.bounds.north + built.dem.bounds.south) / 2;
+          const demWidthM = (built.dem.bounds.east - built.dem.bounds.west) * (Math.PI / 180) * 6371000 * Math.cos(midLat * Math.PI / 180);
+          const demMppM = demWidthM / Math.max(1, built.dem.width - 1);
+          const fresh: ScanRasterCache = {
+            bboxKey, retryNonce: scanRetryNonce,
+            dem: built.dem, demSource: built.demSource, demMppM,
+            clutter: built.clutter, canopy: built.canopy, buildings: built.buildings,
+          };
+          // Persist BEFORE the cancel check so a superseded run's completed fetch isn't
+          // thrown away — but never cache a holed DEM (failed tiles read as sea level).
+          if (built.demTilesFailed === 0) scanRasterCacheRef.current = fresh;
+          else scanRasterCacheRef.current = null;
+          if (cancelled) return;
+          cache = fresh;
+          setScanTerrainWarning(
+            built.demTilesFailed > 0
+              ? `${built.demTilesFailed} of ${built.demTilesTotal} terrain tiles failed to load — gaps read as sea level, so results may be unreliable. Retry to refetch.`
+              : null,
+          );
+        } else {
+          setScanTerrainWarning(null);
+        }
+        if (cancelled || !cache) return;
+
+        const dem = cache.dem;
+        const scanClutter = scanClutterEnabled ? cache.clutter : null;
+        const scanCanopy = scanCanopyEnabled ? cache.canopy : null;
+        const scanBuildings = scanBuildingsEnabled ? cache.buildings : null;
+        setScanDemSource(cache.demSource);
+        setScanClutterStatus(scanClutter ? { tilesPresent: scanClutter.tilesPresent, tilesTotal: scanClutter.tilesTotal } : null);
+        setScanCanopyStatus(scanCanopy ? { tilesPresent: scanCanopy.tilesPresent, tilesTotal: scanCanopy.tilesTotal } : null);
+        setScanBuildingsStatus(scanBuildings ? { tilesPresent: scanBuildings.tilesPresent, tilesTotal: scanBuildings.tilesTotal } : null);
+
+        // Origin MSL: prefer the node's GPS altitude when it's plausible vs terrain
+        // (matches coverage's precedence), else terrain; then add the antenna height.
+        const originTerrainM = sampleDEMAt(dem, origin[0], origin[1]);
+        const groundOk = Number.isFinite(originTerrainM);
+        const gpsOk =
+          originAltitude != null && Number.isFinite(originAltitude) &&
+          (!groundOk || (originAltitude >= originTerrainM && originAltitude <= originTerrainM + MAX_ORIGIN_HEIGHT_ABOVE_TERRAIN_M));
+        const baseM = gpsOk ? (originAltitude as number) : (groundOk ? originTerrainM : 0);
+        const effectiveOriginAltitude = baseM + scanAntennaHeightM;
 
         if (!scanItmContextRef.current) {
           try {
-            scanItmContextRef.current = await loadItmContext(128);
+            scanItmContextRef.current = await loadItmContext(MAX_SCAN_PATH_POINTS);
           } catch (err) {
             console.warn("[Map] Scan ITM WASM unavailable — falling back to FSPL:", err);
           }
         }
         if (cancelled) return;
 
-        const summary = runScan({
-          origin: origin!,
-          originAltitudeM: effectiveOriginAltitude,
-          originShortname,
-          targets,
-          maxDistanceKm: SCAN_RADIUS_KM,
-          raySamples: 60,
-          freqGHz: 0.915,
-          txDbm: scanTxDbm,
-          txAntennaDbi: scanAntennaDbi,
-          rxAntennaDbi: scanRxAntennaDbi,
-          rxSensitivityDbm: scanEffectiveSensitivityDbm,
-          clutterRaster: scanClutter,
-          canopyRaster: scanCanopy,
-          buildingRaster: scanBuildings,
-          // aggression = 0 when the user has toggled the model off → ITM-only path loss.
-          clutterAggression: scanClutterEnabled
-            ? (AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0)
-            : 0,
-          queryTerrainM: (lng, lat) => {
-            const elev = sampleDEMAt(dem, lng, lat);
-            return Number.isNaN(elev) ? null : elev;
+        const rel = reliabilityPreset(scanReliability);
+        const summary = await runScanAsync(
+          {
+            origin,
+            originAltitudeM: effectiveOriginAltitude,
+            originShortname,
+            targets,
+            maxDistanceKm: SCAN_RADIUS_KM,
+            demMppM: cache.demMppM,
+            freqGHz: scanFreqMhz / 1000,
+            txDbm: scanTxDbm,
+            txAntennaDbi: scanAntennaDbi,
+            rxAntennaDbi: scanRxAntennaDbi,
+            rxAntennaHeightM: scanRxHeightM,
+            rxSensitivityDbm: scanEffectiveSensitivityDbm,
+            clutterRaster: scanClutter,
+            canopyRaster: scanCanopy,
+            buildingRaster: scanBuildings,
+            // aggression = 0 when the user has toggled the model off → ITM-only path loss.
+            clutterAggression: scanClutterEnabled ? (AGGRESSION_STOPS[scanAggressionIdx]?.value ?? 1.0) : 0,
+            queryTerrainM: (lng, lat) => {
+              const elev = sampleDEMAt(dem, lng, lat);
+              return Number.isNaN(elev) ? null : elev;
+            },
+            itm: scanItmContextRef.current
+              ? {
+                  context: scanItmContextRef.current,
+                  ...DEFAULT_ITM_ENV,
+                  // Without these, scanAnalysis falls back to 50/50/50 — much
+                  // more optimistic than coverage's 90/50/70 default.
+                  timePct: rel.time,
+                  locationPct: rel.location,
+                  situationPct: rel.situation,
+                }
+              : undefined,
           },
-          itm: scanItmContextRef.current
-            ? {
-                context: scanItmContextRef.current,
-                ...DEFAULT_ITM_ENV,
-                // Without these, scanAnalysis falls back to 50/50/50 — much
-                // more optimistic than coverage's 90/50/70 default.
-                timePct: reliabilityPreset(scanReliability).time,
-                locationPct: reliabilityPreset(scanReliability).location,
-                situationPct: reliabilityPreset(scanReliability).situation,
-              }
-            : undefined,
-        });
+          { shouldCancel: () => cancelled },
+        );
 
-        if (cancelled) return;
+        if (cancelled || !summary) return;
         setScanSummary(summary);
+        setScanError(null);
         const src = mb.getSource("scan-links") as MlGeoJSONSource | undefined;
         src?.setData(scanToGeoJSON(summary));
       } catch (err) {
+        // A stale run's late rejection must not clobber the newer run's state.
+        if (cancelled) return;
         console.warn("[Map] Scan failed:", err);
+        // Keep the previous summary + lines so map and panel don't disagree; the
+        // panel surfaces the error with a Retry affordance.
         setScanError("Scan failed. Adjust settings and try again.");
-        setScanSummary(null);
       } finally {
         if (!cancelled) setIsScanning(false);
       }
@@ -309,16 +396,29 @@ export function useScanCompute(params: ScanComputeParams) {
 
     runAsync();
     return () => { cancelled = true; };
-  }, [activeTool, toolStep, toolFromId, toolVirtualPos, provider, terrain3D, nodes,
-      scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanEffectiveSensitivityDbm,
+  }, [activeTool, toolStep, toolFromId, originLng, originLat, originAltitude, targetsSig,
+      terrain3D, nodesEmpty, nodesLoadFailed, scanRetryNonce,
+      scanTxDbm, scanAntennaDbi, scanRxAntennaDbi, scanRxHeightM, scanFreqMhz, scanEffectiveSensitivityDbm,
       scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled,
       scanAntennaHeightM, scanReliability,
       mbMapRef, isDraggingMarkerRef,
-      setScanSummary, setIsScanning, setScanDemSource, setScanError,
+      setScanSummary, setIsScanning, setScanDemSource, setScanError, setScanTerrainWarning,
       setScanClutterStatus, setScanCanopyStatus, setScanBuildingsStatus,
       setToolFromId, setToolVirtualPos]);
 
+  // Re-push the current scan geometry after a basemap style change recreated the
+  // (now-empty) scan-links source — without recomputing.
+  useEffect(() => {
+    const mb = mbMapRef.current;
+    if (!mb || activeTool !== "scan" || !scanSummary) return;
+    try {
+      const src = mb.getSource("scan-links") as MlGeoJSONSource | undefined;
+      src?.setData(scanToGeoJSON(scanSummary));
+    } catch {}
+  }, [styleEpoch, scanSummary, activeTool, mbMapRef]);
+
   // Per-class map visibility filter (compute still runs for hidden classes).
+  // styleEpoch dep re-applies the filter after style.load recreates the layer.
   useEffect(() => {
     const mb = mbMapRef.current;
     if (!mb) return;
@@ -332,7 +432,7 @@ export function useScanCompute(params: ScanComputeParams) {
         ["in", ["get", "cls"], ["literal", Array.from(hiddenScanClasses)]],
       ] as any);
     }
-  }, [hiddenScanClasses, activeTool, mbMapRef]);
+  }, [hiddenScanClasses, activeTool, styleEpoch, mbMapRef]);
 
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -349,31 +449,27 @@ export function useScanCompute(params: ScanComputeParams) {
       scanInitialViewRef.current = null;
       scanOriginKeyRef.current = null;
       scanRasterCacheRef.current = null;
+      prevHoverIdxRef.current = null;
+      // Drop stale tile-availability telemetry so the next session doesn't show it.
+      setScanClutterStatus(null);
+      setScanCanopyStatus(null);
+      setScanBuildingsStatus(null);
     }
-  }, [activeTool, mbMapRef]);
+  }, [activeTool, mbMapRef, setScanClutterStatus, setScanCanopyStatus, setScanBuildingsStatus]);
 
-  // Scan hover via feature-state
+  // Scan hover via feature-state — clear only the previously-set feature (O(1)).
   useEffect(() => {
     const mb = mbMapRef.current;
-    if (!mb) return;
-    if (!scanSummary) return;
-    for (let i = 0; i < scanSummary.results.length; i++) {
-      try {
-        mb.setFeatureState(
-          { source: "scan-links", id: i },
-          { hover: false },
-        );
-      } catch {}
+    if (!mb || !scanSummary) return;
+    if (prevHoverIdxRef.current != null) {
+      try { mb.setFeatureState({ source: "scan-links", id: prevHoverIdxRef.current }, { hover: false }); } catch {}
+      prevHoverIdxRef.current = null;
     }
     if (scanHoverId == null) return;
     const idx = scanSummary.results.findIndex((r) => r.id === scanHoverId);
     if (idx >= 0) {
-      try {
-        mb.setFeatureState(
-          { source: "scan-links", id: idx },
-          { hover: true },
-        );
-      } catch {}
+      try { mb.setFeatureState({ source: "scan-links", id: idx }, { hover: true }); } catch {}
+      prevHoverIdxRef.current = idx;
     }
   }, [scanHoverId, scanSummary, mbMapRef]);
 

--- a/frontend/src/pages/map/useScanState.ts
+++ b/frontend/src/pages/map/useScanState.ts
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, DEFAULT_AGGRESSION_IDX, effectiveSensitivityDbm, MESHTASTIC_PRESETS } from "./coverageAnalysis";
+import { COMMON_ANTENNAS, COMMON_HARDWARE, type CoverageReliability, DEFAULT_AGGRESSION_IDX, effectiveSensitivityDbm, MESHTASTIC_PRESETS, RELIABILITY_PRESETS } from "./coverageAnalysis";
+import { resolveAntenna, resolveHardware } from "./coveragePresets";
 import { clampAggressionIdx } from "./helpers";
 import type { ScanClass, ScanSummary } from "./scanAnalysis";
 import { LS_KEYS, readJson, writeJson } from "./storage";
@@ -8,62 +9,120 @@ import type { DemSource } from "./terrainRgb";
 
 type ClutterStatus = { tilesPresent: number; tilesTotal: number } | null;
 
+const DEFAULT_ANTENNA_IDX = 3; // Rokland 5.8 dBi
+const DEFAULT_RX_HW_IDX = 4;   // Heltec V3
+const DEFAULT_RX_ANT_IDX = 0;  // stock rubber duck
+
+/** Settings copied in from the coverage panel's "Scan from here" button. */
+export interface ScanMirrorSettings {
+  hardwareIdx: number;
+  antennaIdx: number;
+  antennaHeightM: number;
+  customTxDbm: number;
+  rxHardwareIdx: number;
+  rxAntennaIdx: number;
+  rxHeightM: number;
+  presetIdx: number;
+  customSensDbm: number;
+  aggressionIdx: number;
+  clutterEnabled: boolean;
+  canopyEnabled: boolean;
+  buildingsEnabled: boolean;
+  reliability: CoverageReliability;
+}
+
+/** Semantic (label-based) persisted shape so catalog reordering can't corrupt saved choices. */
+interface ScanSavedSettings {
+  freqMhz?: number;
+  modemId?: string;
+  customSensDbm?: number;
+  tx?: { hardware?: string; antenna?: string; dbi?: number; heightM?: number; customTxDbm?: number };
+  rx?: { hardware?: string; antenna?: string; dbi?: number; heightM?: number };
+  env?: { clutterEnabled?: boolean; canopyEnabled?: boolean; buildingsEnabled?: boolean; aggressionIdx?: number };
+  reliability?: string;
+}
+
+interface ResolvedScanSettings {
+  freqMhz: number;
+  presetIdx: number;
+  customSensDbm: number;
+  hardwareIdx: number; antennaIdx: number; antennaHeightM: number; customTxDbm: number;
+  rxHardwareIdx: number; rxAntennaIdx: number; rxHeightM: number;
+  aggressionIdx: number; clutterEnabled: boolean; canopyEnabled: boolean; buildingsEnabled: boolean;
+  reliability: CoverageReliability;
+}
+
+const clampHeight = (v: unknown, fallback: number): number =>
+  typeof v === "number" && Number.isFinite(v) ? Math.max(0, Math.min(300, v)) : fallback;
+
+function readSavedScanSettings(): ResolvedScanSettings | null {
+  const s = readJson<ScanSavedSettings | null>(LS_KEYS.scanSettings, null);
+  if (!s) return null;
+  const presetIdx = MESHTASTIC_PRESETS.findIndex((p) => p.id === s.modemId);
+  const tx = s.tx ?? {};
+  const rx = s.rx ?? {};
+  const env = s.env ?? {};
+  return {
+    freqMhz: typeof s.freqMhz === "number" && s.freqMhz >= 100 && s.freqMhz <= 2500 ? s.freqMhz : 915,
+    presetIdx: presetIdx >= 0 && !MESHTASTIC_PRESETS[presetIdx].isCustom ? presetIdx : 1,
+    customSensDbm: typeof s.customSensDbm === "number" ? Math.max(-150, Math.min(-100, s.customSensDbm)) : -133,
+    hardwareIdx: tx.hardware ? resolveHardware(tx.hardware).idx : 0,
+    antennaIdx: tx.antenna ? resolveAntenna(tx.antenna, tx.dbi ?? 0) : DEFAULT_ANTENNA_IDX,
+    antennaHeightM: clampHeight(tx.heightM, 2),
+    customTxDbm: typeof tx.customTxDbm === "number" ? Math.max(10, Math.min(35, tx.customTxDbm)) : 22,
+    rxHardwareIdx: rx.hardware ? resolveHardware(rx.hardware).idx : DEFAULT_RX_HW_IDX,
+    rxAntennaIdx: rx.antenna ? resolveAntenna(rx.antenna, rx.dbi ?? 0) : DEFAULT_RX_ANT_IDX,
+    rxHeightM: clampHeight(rx.heightM, 2),
+    aggressionIdx: clampAggressionIdx(env.aggressionIdx ?? DEFAULT_AGGRESSION_IDX),
+    clutterEnabled: env.clutterEnabled ?? true,
+    canopyEnabled: env.canopyEnabled ?? true,
+    buildingsEnabled: env.buildingsEnabled ?? true,
+    reliability: RELIABILITY_PRESETS.some((r) => r.id === s.reliability) ? (s.reliability as CoverageReliability) : "typical",
+  };
+}
+
 /** Scan tool link-budget config — independent from coverage. */
 export function useScanState() {
   const [scanSummary, setScanSummary] = useState<ScanSummary | null>(null);
   const [isScanning, setIsScanning] = useState(false);
   /** Last scan error, or null. */
   const [scanError, setScanError] = useState<string | null>(null);
+  /** Non-fatal terrain-quality warning (failed tiles), or null. */
+  const [scanTerrainWarning, setScanTerrainWarning] = useState<string | null>(null);
   const [scanHoverId, setScanHoverId] = useState<string | null>(null);
   /** DEM tile source used for the last scan. */
   const [scanDemSource, setScanDemSource] = useState<DemSource | null>(null);
+  /** Bumped by the panel's Retry button to force a refetch after a failure. */
+  const [scanRetryNonce, setScanRetryNonce] = useState(0);
 
   const [scanClutterStatus, setScanClutterStatus] = useState<ClutterStatus>(null);
   const [scanCanopyStatus, setScanCanopyStatus] = useState<ClutterStatus>(null);
   const [scanBuildingsStatus, setScanBuildingsStatus] = useState<ClutterStatus>(null);
 
-  const [scanAntennaIdx, setScanAntennaIdx] = useState(3);
+  // Config restores from localStorage once per mount (like coverage/LOS).
+  const savedRef = useRef<ResolvedScanSettings | null | undefined>(undefined);
+  if (savedRef.current === undefined) savedRef.current = readSavedScanSettings();
+  const saved = savedRef.current;
+
+  const [scanFreqMhz, setScanFreqMhz] = useState(saved?.freqMhz ?? 915);
+  const [scanAntennaIdx, setScanAntennaIdx] = useState(saved?.antennaIdx ?? DEFAULT_ANTENNA_IDX);
   const scanAntennaDbi = COMMON_ANTENNAS[scanAntennaIdx]?.dbi ?? 3;
-  const [scanHardwareIdx, setScanHardwareIdx] = useState(0);
-  const [scanAntennaHeightM, setScanAntennaHeightM] = useState(2);
-  const [scanRxHardwareIdx, setScanRxHardwareIdx] = useState(4);
-  const [scanRxAntennaIdx, setScanRxAntennaIdx] = useState(0);
+  const [scanHardwareIdx, setScanHardwareIdx] = useState(saved?.hardwareIdx ?? 0);
+  const [scanAntennaHeightM, setScanAntennaHeightM] = useState(saved?.antennaHeightM ?? 2);
+  const [scanRxHeightM, setScanRxHeightM] = useState(saved?.rxHeightM ?? 2);
+  const [scanRxHardwareIdx, setScanRxHardwareIdx] = useState(saved?.rxHardwareIdx ?? DEFAULT_RX_HW_IDX);
+  const [scanRxAntennaIdx, setScanRxAntennaIdx] = useState(saved?.rxAntennaIdx ?? DEFAULT_RX_ANT_IDX);
   const scanRxAntennaDbi = COMMON_ANTENNAS[scanRxAntennaIdx]?.dbi ?? 3;
-  const [scanCustomTxDbm, setScanCustomTxDbm] = useState(22);
+  const [scanCustomTxDbm, setScanCustomTxDbm] = useState(saved?.customTxDbm ?? 22);
   const scanTxDbm = COMMON_HARDWARE[scanHardwareIdx].isCustom
     ? scanCustomTxDbm
     : COMMON_HARDWARE[scanHardwareIdx].txDbm;
-  const [scanAggressionIdx, setScanAggressionIdxRaw] = useState(() =>
-    clampAggressionIdx(readJson<number>(LS_KEYS.scanAggressionIdx, DEFAULT_AGGRESSION_IDX)),
-  );
-  const setScanAggressionIdx = useCallback((idx: number) => {
-    const clamped = clampAggressionIdx(idx);
-    setScanAggressionIdxRaw(clamped);
-    writeJson(LS_KEYS.scanAggressionIdx, clamped);
-  }, []);
-  const [scanClutterEnabled, setScanClutterEnabledRaw] = useState(() =>
-    readJson<boolean>(LS_KEYS.scanClutterEnabled, true),
-  );
-  const setScanClutterEnabled = useCallback((v: boolean) => {
-    setScanClutterEnabledRaw(v);
-    writeJson(LS_KEYS.scanClutterEnabled, v);
-  }, []);
-  const [scanCanopyEnabled, setScanCanopyEnabledRaw] = useState(() =>
-    readJson<boolean>(LS_KEYS.scanCanopyEnabled, true),
-  );
-  const setScanCanopyEnabled = useCallback((v: boolean) => {
-    setScanCanopyEnabledRaw(v);
-    writeJson(LS_KEYS.scanCanopyEnabled, v);
-  }, []);
-  const [scanBuildingsEnabled, setScanBuildingsEnabledRaw] = useState(() =>
-    readJson<boolean>(LS_KEYS.scanBuildingsEnabled, true),
-  );
-  const setScanBuildingsEnabled = useCallback((v: boolean) => {
-    setScanBuildingsEnabledRaw(v);
-    writeJson(LS_KEYS.scanBuildingsEnabled, v);
-  }, []);
-  const [scanPresetIdx, setScanPresetIdx] = useState(0);
-  const [scanCustomSensDbm, setScanCustomSensDbm] = useState(-133);
+  const [scanAggressionIdx, setScanAggressionIdx] = useState(saved?.aggressionIdx ?? DEFAULT_AGGRESSION_IDX);
+  const [scanClutterEnabled, setScanClutterEnabled] = useState(saved?.clutterEnabled ?? true);
+  const [scanCanopyEnabled, setScanCanopyEnabled] = useState(saved?.canopyEnabled ?? true);
+  const [scanBuildingsEnabled, setScanBuildingsEnabled] = useState(saved?.buildingsEnabled ?? true);
+  const [scanPresetIdx, setScanPresetIdx] = useState(saved?.presetIdx ?? 1);
+  const [scanCustomSensDbm, setScanCustomSensDbm] = useState(saved?.customSensDbm ?? -133);
   const scanSensitivityDbm = MESHTASTIC_PRESETS[scanPresetIdx].isCustom
     ? scanCustomSensDbm
     : MESHTASTIC_PRESETS[scanPresetIdx].sensitivityDbm;
@@ -71,25 +130,101 @@ export function useScanState() {
     const hw = COMMON_HARDWARE[scanRxHardwareIdx];
     return effectiveSensitivityDbm(scanSensitivityDbm, hw.chipset, hw.sensitivityOffsetDb ?? 0);
   }, [scanSensitivityDbm, scanRxHardwareIdx]);
-  const [scanReliability, setScanReliability] = useState<CoverageReliability>("typical");
-  // Blocked hidden by default — the count can dominate on dense meshes.
+  const [scanReliability, setScanReliability] = useState<CoverageReliability>(saved?.reliability ?? "typical");
+  // Blocked hidden by default — the count can dominate on dense meshes. Session-only.
   const [hiddenScanClasses, setHiddenScanClasses] = useState<Set<ScanClass>>(() => new Set(["blocked"]));
+
+  // Scan-from-here mirrors coverage's settings for the overlay session; those must
+  // NOT be persisted over the user's own saved scan defaults. While the current
+  // settings exactly match the last-applied mirror, skip the write-through; the
+  // first user-driven change resumes persistence (same trick as LOS's URL-applied guard).
+  const mirrorSigRef = useRef<string | null>(null);
+
+  const settingsSig = [
+    scanFreqMhz, MESHTASTIC_PRESETS[scanPresetIdx]?.id, scanCustomSensDbm,
+    COMMON_HARDWARE[scanHardwareIdx]?.label, scanCustomTxDbm, COMMON_ANTENNAS[scanAntennaIdx]?.label, scanAntennaHeightM,
+    COMMON_HARDWARE[scanRxHardwareIdx]?.label, COMMON_ANTENNAS[scanRxAntennaIdx]?.label, scanRxHeightM,
+    scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled, scanReliability,
+  ].join("|");
+
+  useEffect(() => {
+    if (mirrorSigRef.current !== null && mirrorSigRef.current === settingsSig) return;
+    mirrorSigRef.current = null;
+    const payload: ScanSavedSettings = {
+      freqMhz: scanFreqMhz,
+      modemId: MESHTASTIC_PRESETS[scanPresetIdx]?.id ?? "LongFast",
+      customSensDbm: scanCustomSensDbm,
+      tx: {
+        hardware: COMMON_HARDWARE[scanHardwareIdx]?.label,
+        antenna: COMMON_ANTENNAS[scanAntennaIdx]?.label,
+        dbi: COMMON_ANTENNAS[scanAntennaIdx]?.dbi,
+        heightM: scanAntennaHeightM,
+        customTxDbm: scanCustomTxDbm,
+      },
+      rx: {
+        hardware: COMMON_HARDWARE[scanRxHardwareIdx]?.label,
+        antenna: COMMON_ANTENNAS[scanRxAntennaIdx]?.label,
+        dbi: COMMON_ANTENNAS[scanRxAntennaIdx]?.dbi,
+        heightM: scanRxHeightM,
+      },
+      env: {
+        clutterEnabled: scanClutterEnabled,
+        canopyEnabled: scanCanopyEnabled,
+        buildingsEnabled: scanBuildingsEnabled,
+        aggressionIdx: scanAggressionIdx,
+      },
+      reliability: scanReliability,
+    };
+    writeJson(LS_KEYS.scanSettings, payload);
+  }, [settingsSig, scanFreqMhz, scanPresetIdx, scanCustomSensDbm, scanHardwareIdx, scanCustomTxDbm,
+      scanAntennaIdx, scanAntennaHeightM, scanRxHardwareIdx, scanRxAntennaIdx, scanRxHeightM,
+      scanAggressionIdx, scanClutterEnabled, scanCanopyEnabled, scanBuildingsEnabled, scanReliability]);
+
+  /** Apply coverage settings for a Scan-from-here overlay without persisting them. */
+  const applyMirror = useCallback((m: ScanMirrorSettings) => {
+    // Coverage runs at the North-American default 915 MHz; match it so budgets agree.
+    setScanFreqMhz(915);
+    setScanHardwareIdx(m.hardwareIdx);
+    setScanAntennaIdx(m.antennaIdx);
+    setScanAntennaHeightM(m.antennaHeightM);
+    setScanCustomTxDbm(m.customTxDbm);
+    setScanRxHardwareIdx(m.rxHardwareIdx);
+    setScanRxAntennaIdx(m.rxAntennaIdx);
+    setScanRxHeightM(m.rxHeightM);
+    setScanPresetIdx(m.presetIdx);
+    setScanCustomSensDbm(m.customSensDbm);
+    setScanAggressionIdx(m.aggressionIdx);
+    setScanClutterEnabled(m.clutterEnabled);
+    setScanCanopyEnabled(m.canopyEnabled);
+    setScanBuildingsEnabled(m.buildingsEnabled);
+    setScanReliability(m.reliability);
+    mirrorSigRef.current = [
+      915, MESHTASTIC_PRESETS[m.presetIdx]?.id, m.customSensDbm,
+      COMMON_HARDWARE[m.hardwareIdx]?.label, m.customTxDbm, COMMON_ANTENNAS[m.antennaIdx]?.label, m.antennaHeightM,
+      COMMON_HARDWARE[m.rxHardwareIdx]?.label, COMMON_ANTENNAS[m.rxAntennaIdx]?.label, m.rxHeightM,
+      m.aggressionIdx, m.clutterEnabled, m.canopyEnabled, m.buildingsEnabled, m.reliability,
+    ].join("|");
+  }, []);
 
   return {
     // Results
     scanSummary, setScanSummary,
     isScanning, setIsScanning,
     scanError, setScanError,
+    scanTerrainWarning, setScanTerrainWarning,
     scanHoverId, setScanHoverId,
     scanDemSource, setScanDemSource,
+    scanRetryNonce, setScanRetryNonce,
     scanClutterStatus, setScanClutterStatus,
     scanCanopyStatus, setScanCanopyStatus,
     scanBuildingsStatus, setScanBuildingsStatus,
     // Settings
+    scanFreqMhz, setScanFreqMhz,
     scanAntennaIdx, setScanAntennaIdx,
     scanAntennaDbi,
     scanHardwareIdx, setScanHardwareIdx,
     scanAntennaHeightM, setScanAntennaHeightM,
+    scanRxHeightM, setScanRxHeightM,
     scanRxHardwareIdx, setScanRxHardwareIdx,
     scanRxAntennaIdx, setScanRxAntennaIdx,
     scanRxAntennaDbi,
@@ -105,6 +240,7 @@ export function useScanState() {
     scanEffectiveSensitivityDbm,
     scanReliability, setScanReliability,
     hiddenScanClasses, setHiddenScanClasses,
+    applyMirror,
   };
 }
 


### PR DESCRIPTION
## Summary

Sweep of the three map RF analysis tools (Coverage, Line of Sight, Scan-from-here). Fixes ~50 verified bugs across correctness, stability, and UX, moves heavy raster work off the main thread, and adds settings persistence, presets, and shareable analyses. Frontend-only; no backend changes.

### Coverage
- **Deterministic recomputes** — origin elevation resolves from the dedicated z15 fetch (viewport query is fallback-only) and is session-cached per pin, so identical settings paint identically; GPS-jitter hysteresis stops spontaneous recomputes.
- **Raster caching** — terrain rasters are reused across param-only recomputes (fetch cache by bounds/detail/layers) and inside workers by generation: param tweaks now ship ~200 B/slice instead of ~100 MB/worker. Stale queued slices are dropped, dead workers replaced, WASM pre-warmed.
- **Worker-offloaded raster builds** — DEM/clutter/canopy/buildings fetch+decode+resample runs in a dedicated worker (new `rasterBuildWorker`/`rasterBuildClient`, with main-thread fallback), eliminating the UI stall on first compute at a new origin.
- **Georegistration** — output raster, contours, and rays align to painted pixel centers (half-pixel skew gone); rays use per-axis meter scales on elongated merge bboxes; clutter/canopy/building samplers handle the antimeridian.
- **Presets & manual mode** — named settings presets with save/apply/delete and version-safe JSON export/import; persisted auto-recalculate toggle defers changes behind a "Settings changed — Recalculate" chip; Cancel works during terrain fetch.
- **Also** — DEM tile failures and provider swaps surfaced, edge-clipped coverage warning, all RF settings persist across reloads, tokenless (Tilezen-only) operation, micro-drag snapback keeps node anchor + GPS altitude, KML CDATA double-escape fix, double-Esc close guard, merge origins capped at 8.

### Line of Sight
- **Correctness** — antimeridian-crossing paths, ridge aliasing from undersampled profiles, silent DEM holes now surfaced, and a curved-earth profile chart so the chart agrees with the LOS verdict.
- **Stability** — SSE-driven recompute churn stopped, stale-run races and stuck spinners fixed, tube layer survives basemap style changes, shared-link restore race fixed, drag snap-back and stuck drag flag fixed.
- **Performance** — DEM build offloaded to the raster worker and right-sized to the link extent.
- **Features** — frequency/modem selectors with persisted settings, draggable endpoints, click-to-edit endpoint coordinates, clutter bands on the elevation profile, shareable analysis URLs (with clipboard fallback), plus an a11y/UX sweep.

### Scan (from here)
- SSE-driven rescan churn stopped; rasters built via the shared worker path; adaptive sampling; RF model and UX brought to parity with the coverage tool.
- Esc in the scan-from-here overlay returns to coverage instead of closing both tools.

### Tests
- New unit coverage for the scan analysis pipeline (`scanAnalysis.test.ts`).