### PR TITLE
Traceroute tool overhaul: terrain-graded routes, route history, live catching, and cinematic tours

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -221,7 +221,19 @@ class API:
 
         @app.get("/v1/traceroutes")
         async def traceroutes(request: Request) -> JSONResponse:
-            traceroutes_data = await self.data.pg_storage.query_all_traceroutes()
+            from_param = request.query_params.get("from")
+            to_param = request.query_params.get("to")
+            range_seconds = self._parse_range(request.query_params.get("range"))
+            try:
+                limit = int(request.query_params.get("limit", 1000))
+            except (TypeError, ValueError):
+                return JSONResponse({"error": "limit must be an integer"}, status_code=400)
+            traceroutes_data = await self.data.pg_storage.query_all_traceroutes(
+                limit=max(1, min(limit, 10000)),
+                from_node_id=self._coerce_node_id(from_param) if from_param else None,
+                to_node_id=self._coerce_node_id(to_param) if to_param else None,
+                range_seconds=range_seconds,
+            )
             return jsonable_encoder(traceroutes_data)
 
         @app.get("/v1/messages")

--- a/frontend/src/components/LiveEvents.tsx
+++ b/frontend/src/components/LiveEvents.tsx
@@ -7,6 +7,7 @@ import { apiSlice } from "../slices/apiSlice";
 import { chatPinged } from "../slices/appSlice";
 import { transformNode } from "../slices/nodeTransform";
 import { INode } from "../types";
+import { liveNodeFlushGate } from "../utils/liveGate";
 
 // Same base as RTK Query, so the stream uses the same proxy route as REST.
 const EVENTS_URL = `${env.API_BASE_URL ?? window.location.origin}/v1/events`;
@@ -28,6 +29,11 @@ export function LiveEventsProvider({ children }: { children: ReactNode }) {
     const flush = () => {
       flushTimer = null;
       if (pending.size === 0) return;
+      if (liveNodeFlushGate.suspended) {
+        // Camera tour in progress — keep coalescing, retry shortly
+        flushTimer = setTimeout(flush, 500);
+        return;
+      }
       const batch = Array.from(pending.values());
       pending.clear();
       // Patch both known getNodes args (no-op if uncached).

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -1094,21 +1094,39 @@ export function Map() {
           geometry: { type: "LineString", coordinates: [[aLng, A.pos[1]], [bLng, B.pos[1]]] },
         });
         if (isGap) {
-          // Ghost markers evenly spread along the estimated connector
+          // Ghost markers evenly spread along the estimated connector:
+          // shortname chip over a dashed '?' ring, so you can tell WHICH
+          // node's placement is estimated, not just that one is.
           for (let g = A.i + 1; g < B.i; g++) {
             const t = (g - A.i) / (B.i - A.i);
             const lng = normalizeLng(aLng + (bLng - aLng) * t);
             const lat = A.pos[1] + (B.pos[1] - A.pos[1]) * t;
+            const hopId = primary.hops[g];
+            const ghostNode = nodesRef.current[hopId] ?? nodesRef.current[`!${hopId}`];
+            const label =
+              ghostNode?.shortname?.trim() ||
+              (hopId.startsWith("?") ? hopId.slice(1, 11) : hopId.slice(0, 8));
             const el = document.createElement("div");
             el.setAttribute("aria-hidden", "true");
-            el.title = `${primary.hops[g]} — position unknown, placement estimated`;
+            el.title = `${label} — position unknown, placement estimated`;
             el.style.cssText =
+              "display:flex;flex-direction:column;align-items:center;gap:2px;pointer-events:auto;";
+            const chip = document.createElement("div");
+            chip.textContent = label;
+            chip.style.cssText =
+              "padding:1px 6px;border-radius:9999px;background:rgba(17,24,39,0.88);" +
+              "border:1px dashed rgba(156,163,175,0.6);color:#d1d5db;font-size:10px;" +
+              "font-weight:600;white-space:nowrap;";
+            const ring = document.createElement("div");
+            ring.textContent = "?";
+            ring.style.cssText =
               "width:18px;height:18px;border-radius:50%;border:2px dashed #9ca3af;" +
               "background:rgba(17,24,39,0.85);color:#d1d5db;font-size:11px;" +
-              "line-height:14px;text-align:center;font-weight:600;pointer-events:auto;";
-            el.textContent = "?";
+              "line-height:14px;text-align:center;font-weight:600;";
+            el.append(chip, ring);
             traceGhostMarkersRef.current.push(
-              new maplibregl.Marker({ element: el }).setLngLat([lng, lat]).addTo(mb),
+              // Offset keeps the '?' ring (not the stack's center) on the point
+              new maplibregl.Marker({ element: el, offset: [0, -10] }).setLngLat([lng, lat]).addTo(mb),
             );
           }
         }
@@ -2982,8 +3000,10 @@ export function Map() {
           if (!navOk) return;
           // Keyboard pan/zoom is user camera input — it takes the wheel back
           // from a running flyover (panBy/zoomIn carry no originalEvent, so
-          // the hook's own movestart gate can't see them).
-          if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "=", "+", "-", "_"].includes(e.key)) {
+          // the hook's own movestart gate can't see them). Gated on flying so
+          // camera nudges match pointer input during the label linger: they
+          // leave the breadcrumbs alone (Esc dismisses, the timer tidies).
+          if (flyoverFlyingRef.current && ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "=", "+", "-", "_"].includes(e.key)) {
             flyoverCancelRef.current();
           }
         }

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -25,6 +25,7 @@ import { FiltersResetPill } from "./map/FiltersResetPill";
 import { circularMeanLng, normalizeLng, unwrapLngTo } from "./map/geo";
 import { bestSnr, computeMaxRange, formatLatLng, geodesicCircleCoords, mbRoleColorExpr, queryTerrainElevationMSL, relativeTime, signalBarsHtml, TRANSPARENT_1PX_PNG } from "./map/helpers";
 import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId, recencyOpacityFromAgeMs } from "./map/linkFeatures";
+import { haversineKm } from "./map/losAnalysis";
 import { LosTubeLayer } from "./map/losTubeLayer";
 import { MapCoordinatePill } from "./map/MapCoordinatePill";
 import { MapCoveragePanel } from "./map/MapCoveragePanel";
@@ -35,10 +36,11 @@ import { MapScanPanel } from "./map/MapScanPanel";
 import { MapSearchBar } from "./map/MapSearchBar";
 import { MapSettingsPanel } from "./map/MapSettingsPanel";
 import { MapToolPrompt, MapToolsDrawer } from "./map/MapToolsDrawer";
+import { type CorridorSort, MapTraceCorridorsPanel, type TraceCorridor } from "./map/MapTraceCorridorsPanel";
 import { MapTraceroutePanel } from "./map/MapTraceroutePanel";
 import { type PacketArc, PacketCoalescer, type RawPacket } from "./map/packetCoalescer";
 import { packetColor } from "./map/packetColors";
-import { findPathsBetween, findRunsBetween, tsToMs } from "./map/pathAnalysis";
+import { computeTraceEdgeStats, findPathsBetween, findRunsBetween, tsToMs } from "./map/pathAnalysis";
 import type { ScanClass } from "./map/scanAnalysis";
 import {
   anyIdsFanned,
@@ -222,6 +224,10 @@ export function Map() {
   // and whether the direct-path counterfactual overlay is drawn.
   const [traceSelectedSig, setTraceSelectedSig] = useState<string | null>(null);
   const [traceShowDirect, setTraceShowDirect] = useState(true);
+  // Busiest-links column: viewport filter + a moveend tick to recompute on pan
+  const [traceCorridorsInView, setTraceCorridorsInView] = useState(true);
+  const [traceCorridorSort, setTraceCorridorSort] = useState<CorridorSort>("busiest");
+  const [mapMoveEpoch, setMapMoveEpoch] = useState(0);
 
   // Pair-scoped traceroute history for the tool — escapes the 1000-row global
   // window that makes most pairs come back empty. Merged with the global cache
@@ -545,6 +551,52 @@ export function Map() {
       .join("|");
   }, [traceSelectedPath, nodes]);
 
+  // Busiest observed links, ranked by traversal count — the tool's browse mode.
+  // Counted over rawTraceroutes (the uniform global window), NOT traceData:
+  // merging the open pair's deep history would self-inflate whichever corridor
+  // was clicked. Stats are split out so pan/zoom only re-runs the cheap filter.
+  const traceEdgeStats = useMemo(
+    () => (activeTool === "traceroute" ? computeTraceEdgeStats(rawTraceroutes) : []),
+    [activeTool, rawTraceroutes],
+  );
+  const traceCorridors = useMemo((): TraceCorridor[] => {
+    if (traceEdgeStats.length === 0) return [];
+    const bounds = traceCorridorsInView ? mbMapRef.current?.getBounds() : null;
+    // Seam-tolerant: wrapped node lngs must also match against ±360 aliases,
+    // since a viewport straddling the antimeridian has unwrapped bounds.
+    const inBounds = (p: [number, number]): boolean =>
+      !bounds ||
+      bounds.contains(p) ||
+      bounds.contains([p[0] + 360, p[1]]) ||
+      bounds.contains([p[0] - 360, p[1]]);
+    const out: TraceCorridor[] = [];
+    for (const e of traceEdgeStats) {
+      const na = nodes[e.aId] ?? nodes[`!${e.aId}`];
+      const nb = nodes[e.bId] ?? nodes[`!${e.bId}`];
+      if (!na?.map_position || !nb?.map_position) continue;
+      if (!(inBounds(na.map_position) && inBounds(nb.map_position))) continue;
+      out.push({
+        aId: e.aId,
+        bId: e.bId,
+        aLabel: na.shortname?.trim() || e.aId.slice(0, 8),
+        bLabel: nb.shortname?.trim() || e.bId.slice(0, 8),
+        aPos: na.map_position,
+        bPos: nb.map_position,
+        count: e.count,
+        distanceKm: haversineKm(na.map_position, nb.map_position),
+        lastTimestamp: e.lastTimestamp,
+      });
+    }
+    out.sort((x, y) =>
+      traceCorridorSort === "longest"
+        ? y.distanceKm - x.distanceKm || y.count - x.count
+        : y.count - x.count || y.lastTimestamp - x.lastTimestamp,
+    );
+    return out.slice(0, 15);
+    // mapMoveEpoch: pan/zoom re-runs the viewport filter
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [traceEdgeStats, nodes, traceCorridorsInView, traceCorridorSort, mapMoveEpoch]);
+
   // Traceroute per-hop RF analysis ("Why This Path") + graded tube / pylons / direct overlay
   const traceCompute = useTraceCompute({
     activeTool, toolStep,
@@ -561,6 +613,20 @@ export function Map() {
   const flyoverCancelRef = useRef(traceFlyover.cancelFlyover);
   flyoverCancelRef.current = traceFlyover.cancelFlyover;
   const flyoverFlyingRef = traceFlyover.flyingRef;
+
+  // Corridor row click → jump straight to the analysis for that pair
+  const handleCorridorPick = useCallback((aId: string, bId: string) => {
+    traceFlyover.cancelFlyover();
+    tracePendingPlayRef.current = false;
+    setTraceSelectedSig(null);
+    setToolFromId(aId);
+    setToolToId(bId);
+    setToolStep("result");
+    // The pick flow's crosshair must not survive a jump past pickTo
+    const canvas = mbMapRef.current?.getCanvas();
+    if (canvas) canvas.style.cursor = "";
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Scan compute + per-class visibility + clear-on-tool-change + hover effects
   const scanCompute = useScanCompute({
@@ -2418,6 +2484,9 @@ export function Map() {
       bindHover("unclustered-nodes");
       bindHover("plain-nodes");
 
+      // Recompute viewport-scoped panels (busiest links) after pan/zoom settles
+      map.on("moveend", () => setMapMoveEpoch((v) => v + 1));
+
       // Focus-on-hover: hovering a node highlights its ego-network (the node +
       // its neighbors + nodes that heard it) and dims everything else.
       const LINK_LAYER_BASE_OPACITY: Record<string, number> = {
@@ -3878,6 +3947,25 @@ export function Map() {
             coverage.setKeepCoveragePaint(true);
             setActiveTool("scan");
           }}
+        />
+      )}
+
+      {/* Busiest-links column — browse corridors while the traceroute tool is active */}
+      {activeTool === "traceroute" && (
+        <MapTraceCorridorsPanel
+          corridors={traceCorridors}
+          sortMode={traceCorridorSort}
+          onSortModeChange={setTraceCorridorSort}
+          inViewOnly={traceCorridorsInView}
+          onToggleInView={setTraceCorridorsInView}
+          activePair={
+            toolFromId && toolToId
+              ? [normNodeId(toolFromId), normNodeId(toolToId)]
+              : null
+          }
+          hideOnMobile={toolStep === "result"}
+          onHover={handleTraceHighlight}
+          onPick={handleCorridorPick}
         />
       )}
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -68,6 +68,7 @@ import { useLosState } from "./map/useLosState";
 import { useScanCompute } from "./map/useScanCompute";
 import { useScanState } from "./map/useScanState";
 import { useTraceCompute } from "./map/useTraceCompute";
+import { useTraceFlyover } from "./map/useTraceFlyover";
 import { useUrlMapSync } from "./map/useUrlMapSync";
 import {
   applyClusterVisibility,
@@ -137,6 +138,9 @@ export function Map() {
   const traceTubeLayerRef = useRef<LosTubeLayer | null>(null);
   /** '?' markers for position-less hops of the analyzed path. */
   const traceGhostMarkersRef = useRef<maplibregl.Marker[]>([]);
+  /** Deep-link state: one-shot URL restore + a pending play=1 tour request. */
+  const traceUrlRestoredRef = useRef(false);
+  const tracePendingPlayRef = useRef(false);
   const mbHandlersBoundRef = useRef(false);
   const mbCurrentStyleUrlRef = useRef<string | null>(null);
   const mbKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
@@ -514,6 +518,13 @@ export function Map() {
     nodesRef, mbMapRef, traceTubeLayerRef,
   });
 
+  // "Ride the Packet": camera chase along the analyzed route
+  const traceFlyover = useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef });
+  // Ref twins for the bind-once map handlers (Esc, ambient-spawn gate)
+  const flyoverCancelRef = useRef(traceFlyover.cancelFlyover);
+  flyoverCancelRef.current = traceFlyover.cancelFlyover;
+  const flyoverFlyingRef = traceFlyover.flyingRef;
+
   // Scan compute + per-class visibility + clear-on-tool-change + hover effects
   const scanCompute = useScanCompute({
     activeTool, toolStep, toolFromId, toolVirtualPos,
@@ -598,6 +609,8 @@ export function Map() {
       traceRefetchTimerRef.current = null;
     }
     setTraceSelectedSig(null);
+    traceFlyover.cancelFlyover();
+    tracePendingPlayRef.current = false;
     for (const m of traceGhostMarkersRef.current) m.remove();
     traceGhostMarkersRef.current = [];
     // Release the route's cached rasters (tens of MB on long routes)
@@ -848,6 +861,71 @@ export function Map() {
     setToolStep("result");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Shareable traceroute deep link: keep ?tool=traceroute&from&to in sync
+  // (same shared snapshot as LOS — the two tools are mutually exclusive).
+  useEffect(() => {
+    if (!traceUrlRestoredRef.current) return;
+    const showing = activeTool === "traceroute" && toolStep === "result" && !!toolFromId && !!toolToId;
+    const had = new URLSearchParams(window.location.search).get("tool") === "traceroute";
+    if (!showing && !had) return;
+    setSearchParamsLosRef.current((prev) => {
+      const sp = new URLSearchParams(prev);
+      if (showing) {
+        sp.set("tool", "traceroute");
+        sp.set("from", toolFromId);
+        sp.set("to", toolToId);
+        // play=1 is a one-shot request from a shared link — never persist it
+        sp.delete("play");
+      } else {
+        for (const k of ["tool", "from", "to", "play"]) sp.delete(k);
+      }
+      return sp;
+    }, { replace: true });
+  }, [activeTool, toolStep, toolFromId, toolToId]);
+
+  // Restore a shared traceroute analysis from the URL snapshot (once, on mount)
+  useEffect(() => {
+    if (traceUrlRestoredRef.current) return;
+    traceUrlRestoredRef.current = true;
+    const sp = losUrlSnapshotRef.current ?? new URLSearchParams();
+    if (sp.get("tool") !== "traceroute") return;
+    const idOf = (v: string | null): string | null =>
+      v && /^!?[0-9a-zA-Z_-]{1,32}$/.test(v) ? v.replace(/^!/, "") : null;
+    const f = idOf(sp.get("from"));
+    const t = idOf(sp.get("to"));
+    if (!f || !t || f === t) {
+      // Invalid share link: the write effect never re-runs (no state changed),
+      // so strip the stale params here or they linger in the URL forever.
+      setSearchParamsLosRef.current((prev) => {
+        const spx = new URLSearchParams(prev);
+        for (const k of ["tool", "from", "to", "play"]) spx.delete(k);
+        return spx;
+      }, { replace: true });
+      return;
+    }
+    setToolFromId(f);
+    setToolToId(t);
+    setActiveTool("traceroute");
+    setToolStep("result");
+    if (sp.get("play") === "1") tracePendingPlayRef.current = true;
+  }, []);
+
+  // A shared link with play=1 starts the tour once data + positions are in.
+  useEffect(() => {
+    if (!tracePendingPlayRef.current) return;
+    // The mount run precedes the restore's state commit — wait, don't clear.
+    // The one-shot flag is dropped on the real exits: resetTool + path select.
+    if (activeTool !== "traceroute" || toolStep !== "result") return;
+    if (prefersReducedMotion()) {
+      tracePendingPlayRef.current = false;
+      return;
+    }
+    if (!traceSelectedPath) return; // traceroutes still loading — retry on next change
+    if (traceFlyover.startFlyover(traceSelectedPath)) tracePendingPlayRef.current = false;
+    // tracePosKey: retries as hop positions stream in after a cold deep-link load
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTool, toolStep, traceSelectedPath, tracePosKey, styleEpoch]);
 
   // Draw the observed traceroute paths between the picked pair — the analyzed
   // (selected) path bold and per-leg with ghost markers for position-less hops,
@@ -2749,11 +2827,19 @@ export function Map() {
             ae === mapRef.current ||
             ae.classList?.contains("maplibregl-canvas");
           if (!navOk) return;
+          // Keyboard pan/zoom is user camera input — it takes the wheel back
+          // from a running flyover (panBy/zoomIn carry no originalEvent, so
+          // the hook's own movestart gate can't see them).
+          if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "=", "+", "-", "_"].includes(e.key)) {
+            flyoverCancelRef.current();
+          }
         }
 
         const PAN_PX = 100;
         switch (e.key) {
           case "Escape":
+            // A running flyover consumes Esc — stop the tour, keep the tool.
+            if (flyoverCancelRef.current()) break;
             if (activeToolRef.current) {
               // Merge-origin picking consumes Esc (the pick hook's own
               // listener cancels it) — don't also arm/close the tool.
@@ -3170,6 +3256,7 @@ export function Map() {
 
   useLiveEvent<RawPacket>("packet", (p) => {
     if (!livePacketsRef.current || prefersReducedMotion()) return;
+    if (flyoverFlyingRef.current) return; // spotlight: the tour owns the stage
     if (p.type === "traceroute") return; // handled by the dedicated multi-hop tracer
     const coalescer = (coalescerRef.current ??= new PacketCoalescer());
     const arc = coalescer.ingest(p, Date.now());
@@ -3220,6 +3307,7 @@ export function Map() {
   // routes; debounce by mesh id and draw only the single most complete path.
   useLiveEvent<TraceEv>("traceroute", (t) => {
     if (!livePacketsRef.current || prefersReducedMotion()) return;
+    if (flyoverFlyingRef.current) return; // spotlight: the tour owns the stage
     const buf = (tracerouteBufRef.current ??= new globalThis.Map());
     const key = t.id != null ? `id:${t.id}` : `ft:${t.from}:${t.to}`;
     const existing = buf.get(key);
@@ -3230,7 +3318,8 @@ export function Map() {
     const timer = setTimeout(() => {
       const entry = buf.get(key);
       buf.delete(key);
-      if (entry) animateTraceroute(entry.ev);
+      // The gate at ingest can't cover timers armed before the tour started
+      if (entry && !flyoverFlyingRef.current) animateTraceroute(entry.ev);
     }, TRACEROUTE_DEBOUNCE_MS);
     buf.set(key, { ev: t, timer });
   });
@@ -3684,7 +3773,11 @@ export function Map() {
           toColor="#d946ef"
           paths={tracePaths}
           selectedSig={traceSelectedPath ? traceSelectedPath.hops.join(">") : null}
-          onSelectPath={setTraceSelectedSig}
+          onSelectPath={(sig) => {
+            traceFlyover.cancelFlyover(); // a tour follows one path only
+            tracePendingPlayRef.current = false;
+            setTraceSelectedSig(sig);
+          }}
           analysis={traceCompute.traceAnalysis}
           isComputing={traceCompute.isComputingTrace}
           analysisError={traceCompute.traceError}
@@ -3693,6 +3786,12 @@ export function Map() {
           onEnableTerrain={openTerrainSetup}
           showDirect={traceShowDirect}
           onToggleDirect={setTraceShowDirect}
+          isFlying={traceFlyover.isFlying}
+          canFly={!prefersReducedMotion()}
+          onToggleFlyover={() => {
+            if (traceFlyover.isFlying) traceFlyover.cancelFlyover();
+            else if (traceSelectedPath) traceFlyover.startFlyover(traceSelectedPath);
+          }}
           loading={rawTraceroutesLoading || pairTraceroutesLoading}
           liveNodes={nodes}
           onNodeSelect={(id) => handleNodeSelectRef.current(id)}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -27,7 +27,7 @@ import { bestSnr, computeMaxRange, formatLatLng, geodesicCircleCoords, mbRoleCol
 import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId, recencyOpacityFromAgeMs } from "./map/linkFeatures";
 import { haversineKm } from "./map/losAnalysis";
 import { LosTubeLayer } from "./map/losTubeLayer";
-import { MapCoordinatePill } from "./map/MapCoordinatePill";
+import { type CoordPillSink, MapCoordinatePill } from "./map/MapCoordinatePill";
 import { MapCoveragePanel } from "./map/MapCoveragePanel";
 import { MapDetailsPanel } from "./map/MapDetailsPanel";
 import { MapHealthWidget } from "./map/MapHealthWidget";
@@ -278,12 +278,8 @@ export function Map() {
   const losTubeLayerRef = useRef<LosTubeLayer | null>(null);
   /** Suppresses the cursor-elevation mousemove handler so marker drag doesn't stutter. */
   const isDraggingMarkerRef = useRef(false);
-  /** Terrain elevation (MSL m) under the cursor. */
-  const [hoverElevationM, setHoverElevationM] = useState<number | null>(null);
-  /** Live cursor position [lng, lat]; null when the cursor isn't over the map. */
-  const [hoverCoord, setHoverCoord] = useState<[number, number] | null>(null);
-  /** Map-center [lng, lat] — the coordinate pill's fallback when not hovering. */
-  const [centerCoord, setCenterCoord] = useState<[number, number] | null>(null);
+  /** Hover/center feed for the coordinate pill (per-frame state lives there). */
+  const coordPillSinkRef = useRef<CoordPillSink | null>(null);
   /** Whether the jump-to-coordinate pin is currently dropped. */
   const [hasCoordPin, setHasCoordPin] = useState(false);
   /** Draggable jump-to pin; independent of tool state. */
@@ -609,10 +605,37 @@ export function Map() {
 
   // "Ride the Packet": camera chase along the analyzed route
   const traceFlyover = useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef });
+  /** View persistence (localStorage/URL/pill), set by the bind-once moveend block. */
+  const saveViewRef = useRef<() => void>(() => {});
+  // The tour's final moveend races the flying flag — sync once on tour end
+  useEffect(() => {
+    if (!traceFlyover.isFlying) saveViewRef.current();
+  }, [traceFlyover.isFlying]);
   // Ref twins for the bind-once map handlers (Esc, ambient-spawn gate)
   const flyoverCancelRef = useRef(traceFlyover.cancelFlyover);
   flyoverCancelRef.current = traceFlyover.cancelFlyover;
   const flyoverFlyingRef = traceFlyover.flyingRef;
+
+  // Stable callbacks for the memoized trace panels (same pattern as scan's)
+  const handleToolPanelClose = useCallback(() => resetToolRef.current(), []);
+  const handlePanelNodeSelect = useCallback((id: string) => handleNodeSelectRef.current(id), []);
+  const handleTraceSelectPath = useCallback((sig: string) => {
+    traceFlyover.cancelFlyover(); // a tour follows one path only
+    tracePendingPlayRef.current = false;
+    setTraceSelectedSig(sig);
+    // cancelFlyover is identity-stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const handleToggleFlyover = useCallback(() => {
+    if (traceFlyover.isFlying) traceFlyover.cancelFlyover();
+    else if (traceSelectedPath) traceFlyover.startFlyover(traceSelectedPath);
+    // start/cancel are identity-stable; only the data deps matter
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [traceFlyover.isFlying, traceSelectedPath]);
+  const traceActivePair = useMemo(
+    () => (toolFromId && toolToId ? ([normNodeId(toolFromId), normNodeId(toolToId)] as [string, string]) : null),
+    [toolFromId, toolToId],
+  );
 
   // Corridor row click → jump straight to the analysis for that pair
   const handleCorridorPick = useCallback((aId: string, bId: string) => {
@@ -1605,8 +1628,8 @@ export function Map() {
     }
 
     mbMapRef.current = map;
-    // Seed the coordinate pill's fallback before the first moveend fires.
-    setCenterCoord(initialCenter);
+    // Seed the pill before the first moveend (child effects registered the sink first)
+    coordPillSinkRef.current?.setCenter(initialCenter);
 
     // Surface style/source/tile load failures instead of a silent blank map.
     map.on("error", (e) => {
@@ -1672,16 +1695,22 @@ export function Map() {
       plain?.setData(data);
     };
 
-    map.on("moveend", () => {
+    const saveView = () => {
       const c = map.getCenter();
       localStorage.setItem("savedCenter", JSON.stringify([c.lng, c.lat]));
       localStorage.setItem("savedZoom", map.getZoom().toString());
       localStorage.setItem("savedPitch", map.getPitch().toString());
       localStorage.setItem("savedBearing", map.getBearing().toString());
       // Keep the coordinate pill's not-hovering fallback in sync with the view.
-      setCenterCoord([c.lng, c.lat]);
+      coordPillSinkRef.current?.setCenter([c.lng, c.lat]);
       // Mirror view into ?lat/lng/z (debounced); here so it follows recreation.
       pushViewToUrlRef.current();
+    };
+    saveViewRef.current = saveView;
+    map.on("moveend", () => {
+      // Tours fire one moveend per leg — save only when the camera is the user's
+      if (flyoverFlyingRef.current) return;
+      saveView();
     });
 
     const ensureSourcesAndLayers = () => {
@@ -2502,8 +2531,12 @@ export function Map() {
       bindHover("unclustered-nodes");
       bindHover("plain-nodes");
 
-      // Recompute viewport-scoped panels (busiest links) after pan/zoom settles
-      map.on("moveend", () => setMapMoveEpoch((v) => v + 1));
+      // Viewport refilter for the top-links panel — not per tour leg
+      map.on("moveend", () => {
+        if (activeToolRef.current === "traceroute" && !flyoverFlyingRef.current) {
+          setMapMoveEpoch((v) => v + 1);
+        }
+      });
 
       // Focus-on-hover: hovering a node highlights its ego-network (the node +
       // its neighbors + nodes that heard it) and dims everything else.
@@ -2913,6 +2946,8 @@ export function Map() {
         if (spiderfyDebounce != null) window.clearTimeout(spiderfyDebounce);
         spiderfyDebounce = window.setTimeout(() => {
           spiderfyDebounce = null;
+          // Chase zoom is below the spiderfy threshold — skip the O(N) pool per leg
+          if (flyoverFlyingRef.current) return;
           if (clusterEnabledRef.current) {
             const pool = buildNodesGeoJSON(nodesRef.current, recentDaysRef.current, getFilters()).features
               .filter((f) => f.geometry?.type === "Point") as any;
@@ -3098,24 +3133,20 @@ export function Map() {
           if (!pendingElevE || !mbMapRef.current) return;
           const lng = Math.round(pendingElevE.lng * 1e5) / 1e5;
           const lat = Math.round(pendingElevE.lat * 1e5) / 1e5;
-          if (lng !== lastHoverLng || lat !== lastHoverLat) {
-            lastHoverLng = lng;
-            lastHoverLat = lat;
-            setHoverCoord([lng, lat]);
-          }
+          if (lng === lastHoverLng && lat === lastHoverLat) return;
+          lastHoverLng = lng;
+          lastHoverLat = lat;
+          let elev: number | null = null;
           try {
             // Real MSL meters — users expect the elevation pill to match a topo map,
             // not the rendered terrain's exaggerated value. See queryTerrainElevationMSL.
-            const elev = queryTerrainElevationMSL(mbMapRef.current, [pendingElevE.lng, pendingElevE.lat]);
-            setHoverElevationM(elev);
-          } catch {
-            setHoverElevationM(null);
-          }
+            elev = queryTerrainElevationMSL(mbMapRef.current, [pendingElevE.lng, pendingElevE.lat]);
+          } catch {}
+          coordPillSinkRef.current?.setHover([lng, lat], terrain3DRef.current ? elev : null);
         });
       };
       const onMapMouseOut = () => {
-        setHoverElevationM(null);
-        setHoverCoord(null);
+        coordPillSinkRef.current?.setHover(null, null);
         lastHoverLng = NaN;
         lastHoverLat = NaN;
       };
@@ -3145,7 +3176,8 @@ export function Map() {
             `<strong>${escapeHtml(p.shortname || nodeId)}</strong>` +
             `</div>` +
             (role ? `<span style="opacity:0.6">${role}</span><br/>` : "") +
-            `<span style="opacity:0.6">${relativeTime(p.last_seen)}</span>`
+            // Store, not feature props — last_seen isn't in the setData signature
+            `<span style="opacity:0.6">${relativeTime((nodesRef.current[nodeId] ?? nodesRef.current[`!${nodeId}`])?.last_seen ?? p.last_seen)}</span>`
           )
           .addTo(map);
       };
@@ -3738,9 +3770,7 @@ export function Map() {
       </button>
 
       <MapCoordinatePill
-        coord={hoverCoord}
-        centerCoord={centerCoord}
-        elevationM={terrain3D ? hoverElevationM : null}
+        sinkRef={coordPillSinkRef}
         hasPin={hasCoordPin}
         onJump={jumpToCoord}
         onClearPin={clearCoordPin}
@@ -3978,11 +4008,7 @@ export function Map() {
           onSortModeChange={setTraceCorridorSort}
           inViewOnly={traceCorridorsInView}
           onToggleInView={setTraceCorridorsInView}
-          activePair={
-            toolFromId && toolToId
-              ? [normNodeId(toolFromId), normNodeId(toolToId)]
-              : null
-          }
+          activePair={traceActivePair}
           hideOnMobile={toolStep === "result"}
           onHover={handleTraceHighlight}
           onPick={handleCorridorPick}
@@ -4001,11 +4027,7 @@ export function Map() {
           paths={tracePaths}
           runs={traceRuns}
           selectedSig={traceSelectedPath ? traceSelectedPath.hops.join(">") : null}
-          onSelectPath={(sig) => {
-            traceFlyover.cancelFlyover(); // a tour follows one path only
-            tracePendingPlayRef.current = false;
-            setTraceSelectedSig(sig);
-          }}
+          onSelectPath={handleTraceSelectPath}
           analysis={traceCompute.traceAnalysis}
           isComputing={traceCompute.isComputingTrace}
           analysisError={traceCompute.traceError}
@@ -4016,15 +4038,12 @@ export function Map() {
           onToggleDirect={setTraceShowDirect}
           isFlying={traceFlyover.isFlying}
           canFly={!prefersReducedMotion()}
-          onToggleFlyover={() => {
-            if (traceFlyover.isFlying) traceFlyover.cancelFlyover();
-            else if (traceSelectedPath) traceFlyover.startFlyover(traceSelectedPath);
-          }}
+          onToggleFlyover={handleToggleFlyover}
           loading={rawTraceroutesLoading || pairTraceroutesLoading}
           liveNodes={nodes}
-          onNodeSelect={(id) => handleNodeSelectRef.current(id)}
+          onNodeSelect={handlePanelNodeSelect}
           onHighlight={handleTraceHighlight}
-          onClose={resetTool}
+          onClose={handleToolPanelClose}
         />
       )}
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -67,6 +67,7 @@ import { useLosCompute } from "./map/useLosCompute";
 import { useLosState } from "./map/useLosState";
 import { useScanCompute } from "./map/useScanCompute";
 import { useScanState } from "./map/useScanState";
+import { useTraceCompute } from "./map/useTraceCompute";
 import { useUrlMapSync } from "./map/useUrlMapSync";
 import {
   applyClusterVisibility,
@@ -132,6 +133,10 @@ export function Map() {
   const traceFitKeyRef = useRef<string | null>(null);
   const traceRefetchAtRef = useRef(0);
   const traceRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** 3D graded tube for the analyzed route; created once per map. */
+  const traceTubeLayerRef = useRef<LosTubeLayer | null>(null);
+  /** '?' markers for position-less hops of the analyzed path. */
+  const traceGhostMarkersRef = useRef<maplibregl.Marker[]>([]);
   const mbHandlersBoundRef = useRef(false);
   const mbCurrentStyleUrlRef = useRef<string | null>(null);
   const mbKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
@@ -207,6 +212,10 @@ export function Map() {
   const [toolFromId, setToolFromId] = useState<string | null>(null);
   const [toolToId, setToolToId] = useState<string | null>(null);
   const [toolVirtualPos, setToolVirtualPos] = useState<[number, number] | null>(null);
+  // Traceroute tool: which observed path is analyzed/bold (null = most recent),
+  // and whether the direct-path counterfactual overlay is drawn.
+  const [traceSelectedSig, setTraceSelectedSig] = useState<string | null>(null);
+  const [traceShowDirect, setTraceShowDirect] = useState(true);
 
   // Pair-scoped traceroute history for the tool — escapes the 1000-row global
   // window that makes most pairs come back empty. Merged with the global cache
@@ -225,7 +234,16 @@ export function Map() {
     for (const tr of [...rawTraceroutes, ...pairTraceroutes]) byKey.set(`${tr.id}:${tr.from}`, tr);
     return [...byKey.values()];
   }, [rawTraceroutes, pairTraceroutes]);
-
+  const tracePaths = useMemo(
+    () => (activeTool === "traceroute" && toolFromId && toolToId
+      ? findPathsBetween(toolFromId, toolToId, traceData)
+      : []),
+    [activeTool, toolFromId, toolToId, traceData],
+  );
+  const traceSelectedPath = useMemo(
+    () => tracePaths.find((p) => p.hops.join(">") === traceSelectedSig) ?? tracePaths[0] ?? null,
+    [tracePaths, traceSelectedSig],
+  );
   // 3D terrain
   const [terrain3D, setTerrain3D] = useState<boolean>(() => readJson<boolean>(LS_KEYS.terrain3D, true));
   const terrainExaggeration = 1.5;
@@ -474,6 +492,28 @@ export function Map() {
     setLosTerrainWarning: losState.setLosTerrainWarning,
   });
 
+  // Position signature of the analyzed hops: a value-stable string, so SSE
+  // identity churn doesn't retrigger grading but a hop actually moving does.
+  const tracePosKey = useMemo(() => {
+    if (!traceSelectedPath) return "";
+    return traceSelectedPath.hops
+      .map((id) => {
+        const p = (nodes[id] ?? nodes[`!${id}`])?.map_position;
+        return p ? `${p[0].toFixed(5)},${p[1].toFixed(5)}` : "?";
+      })
+      .join("|");
+  }, [traceSelectedPath, nodes]);
+
+  // Traceroute per-hop RF analysis ("Why This Path") + graded tube / pylons / direct overlay
+  const traceCompute = useTraceCompute({
+    activeTool, toolStep,
+    path: traceSelectedPath,
+    posKey: tracePosKey,
+    terrain3D, styleEpoch,
+    showDirect: traceShowDirect,
+    nodesRef, mbMapRef, traceTubeLayerRef,
+  });
+
   // Scan compute + per-class visibility + clear-on-tool-change + hover effects
   const scanCompute = useScanCompute({
     activeTool, toolStep, toolFromId, toolVirtualPos,
@@ -557,6 +597,12 @@ export function Map() {
       clearTimeout(traceRefetchTimerRef.current);
       traceRefetchTimerRef.current = null;
     }
+    setTraceSelectedSig(null);
+    for (const m of traceGhostMarkersRef.current) m.remove();
+    traceGhostMarkersRef.current = [];
+    // Release the route's cached rasters (tens of MB on long routes)
+    traceCompute.traceDemCacheRef.current = null;
+    try { traceTubeLayerRef.current?.setData(null); } catch {}
     // Removing a marker mid-drag skips its dragend; unstick the shared flag
     isDraggingMarkerRef.current = false;
     losState.setLosResult(null);
@@ -592,6 +638,12 @@ export function Map() {
       // A hop/path spotlight from the traceroute panel must not outlive the tool
       try {
         (mb.getSource("link-highlight") as MlGeoJSONSource | undefined)?.setData(empty);
+      } catch {}
+      try {
+        (mb.getSource("trace-obstructions") as MlGeoJSONSource | undefined)?.setData(empty);
+      } catch {}
+      try {
+        (mb.getSource("trace-direct") as MlGeoJSONSource | undefined)?.setData(empty);
       } catch {}
       if (coverageCompute.coverageOriginMarkerRef.current) {
         coverageCompute.coverageOriginMarkerRef.current.remove();
@@ -797,7 +849,8 @@ export function Map() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Draw all observed traceroute paths between the picked pair — newest on top,
+  // Draw the observed traceroute paths between the picked pair — the analyzed
+  // (selected) path bold and per-leg with ghost markers for position-less hops,
   // alternates recency-faded — plus endpoint markers and a one-shot fitBounds.
   useEffect(() => {
     const mb = mbMapRef.current;
@@ -809,11 +862,16 @@ export function Map() {
       traceToMarkerRef.current?.remove();
       traceToMarkerRef.current = null;
     };
+    const clearGhostMarkers = () => {
+      for (const m of traceGhostMarkersRef.current) m.remove();
+      traceGhostMarkersRef.current = [];
+    };
 
     const src = mb.getSource("path-analysis") as MlGeoJSONSource | undefined;
     if (activeTool !== "traceroute" || toolStep !== "result" || !toolFromId || !toolToId) {
       src?.setData({ type: "FeatureCollection", features: [] });
       clearTraceMarkers();
+      clearGhostMarkers();
       traceFitKeyRef.current = null;
       return;
     }
@@ -826,32 +884,79 @@ export function Map() {
       return n?.map_position ? [n.map_position[0], n.map_position[1]] : null;
     };
 
-    const paths = findPathsBetween(toolFromId, toolToId, traceData);
+    const primary = traceSelectedPath;
     const now = Date.now();
     const features: GeoJSON.Feature[] = [];
-    paths.slice(0, 6).forEach((p, rank) => {
-      const coords: [number, number][] = [];
-      for (const hop of p.hops) {
-        const pos = posOf(hop);
-        if (!pos) continue; // hop with unknown position — skip (honest gap)
-        const prev = coords[coords.length - 1];
-        // Chain-unwrap so seam-crossing legs draw the short way
-        coords.push(prev ? [unwrapLngTo(prev[0], pos[0]), pos[1]] : pos);
+    clearGhostMarkers();
+
+    // Selected path: one feature per drawn segment so legs spanning ghost hops
+    // render dashed, with '?' markers spread across each gap run.
+    if (primary) {
+      const positions = primary.hops.map(posOf);
+      const positioned = positions
+        .map((pos, i) => ({ pos, i }))
+        .filter((x): x is { pos: [number, number]; i: number } => x.pos != null);
+      let prevLng: number | null = null;
+      for (let k = 0; k + 1 < positioned.length; k++) {
+        const A = positioned[k];
+        const B = positioned[k + 1];
+        const aLng = prevLng == null ? A.pos[0] : unwrapLngTo(prevLng, A.pos[0]);
+        const bLng = unwrapLngTo(aLng, B.pos[0]);
+        prevLng = bLng;
+        const isGap = B.i - A.i > 1;
+        features.push({
+          type: "Feature",
+          properties: { primary: true, gap: isGap, sort: 1000, opacity: 0.95 },
+          geometry: { type: "LineString", coordinates: [[aLng, A.pos[1]], [bLng, B.pos[1]]] },
+        });
+        if (isGap) {
+          // Ghost markers evenly spread along the estimated connector
+          for (let g = A.i + 1; g < B.i; g++) {
+            const t = (g - A.i) / (B.i - A.i);
+            const lng = normalizeLng(aLng + (bLng - aLng) * t);
+            const lat = A.pos[1] + (B.pos[1] - A.pos[1]) * t;
+            const el = document.createElement("div");
+            el.setAttribute("aria-hidden", "true");
+            el.title = `${primary.hops[g]} — position unknown, placement estimated`;
+            el.style.cssText =
+              "width:18px;height:18px;border-radius:50%;border:2px dashed #9ca3af;" +
+              "background:rgba(17,24,39,0.85);color:#d1d5db;font-size:11px;" +
+              "line-height:14px;text-align:center;font-weight:600;pointer-events:auto;";
+            el.textContent = "?";
+            traceGhostMarkersRef.current.push(
+              new maplibregl.Marker({ element: el }).setLngLat([lng, lat]).addTo(mb),
+            );
+          }
+        }
       }
-      if (coords.length < 2) return;
-      features.push({
-        type: "Feature",
-        properties: {
-          primary: rank === 0,
-          // Higher sort key renders later → newest path on top
-          sort: -rank,
-          opacity: rank === 0
-            ? 0.95
-            : Math.min(0.55, 0.55 * recencyOpacityFromAgeMs(now - tsToMs(p.timestamp))),
-        },
-        geometry: { type: "LineString", coordinates: coords },
+    }
+
+    // Alternates: whole-path lines, recency-faded, thinner
+    const primarySig = primary ? primary.hops.join(">") : null;
+    tracePaths
+      .filter((p) => p.hops.join(">") !== primarySig)
+      .slice(0, 5)
+      .forEach((p, rank) => {
+        const coords: [number, number][] = [];
+        for (const hop of p.hops) {
+          const pos = posOf(hop);
+          if (!pos) continue; // hop with unknown position — skip (honest gap)
+          const prev = coords[coords.length - 1];
+          // Chain-unwrap so seam-crossing legs draw the short way
+          coords.push(prev ? [unwrapLngTo(prev[0], pos[0]), pos[1]] : pos);
+        }
+        if (coords.length < 2) return;
+        features.push({
+          type: "Feature",
+          properties: {
+            primary: false,
+            gap: false,
+            sort: -rank,
+            opacity: Math.min(0.55, 0.55 * recencyOpacityFromAgeMs(now - tsToMs(p.timestamp))),
+          },
+          geometry: { type: "LineString", coordinates: coords },
+        });
       });
-    });
     src.setData({ type: "FeatureCollection", features });
 
     const fromPos = posOf(toolFromId);
@@ -880,7 +985,17 @@ export function Map() {
       mb.fitBounds(bounds, { padding: 120, duration: 600, maxZoom: 12 });
     }
     // styleEpoch: setStyle recreates the path-analysis source empty — redraw after style.load
-  }, [activeTool, toolStep, toolFromId, toolToId, traceData, pairTraceroutesLoading, styleEpoch]);
+  }, [activeTool, toolStep, toolFromId, toolToId, tracePaths, traceSelectedPath, pairTraceroutesLoading, styleEpoch]);
+
+  // Opens the settings panel at the terrain section (drawer + trace panel share it).
+  const openTerrainSetup = useCallback(() => {
+    setSettingsOpenSections((prev) => {
+      const next = new Set(prev);
+      next.add("terrain");
+      return next;
+    });
+    setSettingsPanelOpen(true);
+  }, []);
 
   // Traceroute panel hover → spotlight the hovered leg / alternate path.
   const handleTraceHighlight = useCallback((coords: [number, number][] | null) => {
@@ -1410,6 +1525,7 @@ export function Map() {
           id: "path-analysis-line",
           type: "line",
           source: "path-analysis",
+          filter: ["!=", ["get", "gap"], true],
           layout: {
             "line-join": "round",
             "line-cap": "round",
@@ -1420,6 +1536,22 @@ export function Map() {
             "line-color": ["case", ["get", "primary"], "#06b6d4", "#38bdf8"],
             "line-width": ["case", ["get", "primary"], 4, 2],
             "line-opacity": ["get", "opacity"],
+          },
+        });
+      }
+      // Legs spanning position-less (ghost) hops: dashed gray — estimated, not observed geometry
+      if (!map.getLayer("path-analysis-line-gap")) {
+        map.addLayer({
+          id: "path-analysis-line-gap",
+          type: "line",
+          source: "path-analysis",
+          filter: ["==", ["get", "gap"], true],
+          layout: { "line-join": "round", "line-cap": "round" },
+          paint: {
+            "line-color": "#9ca3af",
+            "line-width": 2.5,
+            "line-opacity": 0.7,
+            "line-dasharray": [1.5, 2],
           },
         });
       }
@@ -1599,6 +1731,67 @@ export function Map() {
           map.addLayer(losTubeLayerRef.current);
         } catch (err) {
           console.warn("[Map] Failed to add LoS tube layer:", err);
+        }
+      }
+
+      // Traceroute per-hop analysis: obstruction pylons + direct-path
+      // counterfactual + 3D graded tube (own instances so LOS and traceroute
+      // never clear each other's geometry)
+      if (!map.getSource("trace-obstructions")) {
+        map.addSource("trace-obstructions", {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        });
+      }
+      if (!map.getLayer("trace-obstructions-fill")) {
+        map.addLayer({
+          id: "trace-obstructions-fill",
+          type: "fill-extrusion",
+          source: "trace-obstructions",
+          paint: {
+            "fill-extrusion-color": [
+              "interpolate", ["linear"], ["get", "severity"],
+              0, "#f87171",
+              1, "#b91c1c",
+            ],
+            "fill-extrusion-base": ["get", "baseM"],
+            "fill-extrusion-height": ["get", "topM"],
+            "fill-extrusion-opacity": 0.75,
+            "fill-extrusion-vertical-gradient": true,
+          },
+        });
+      }
+      if (!map.getSource("trace-direct")) {
+        map.addSource("trace-direct", {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        });
+      }
+      if (!map.getLayer("trace-direct-line")) {
+        map.addLayer({
+          id: "trace-direct-line",
+          type: "line",
+          source: "trace-direct",
+          layout: { "line-join": "round", "line-cap": "round" },
+          paint: {
+            "line-color": [
+              "match", ["get", "verdict"],
+              "blocked", "#ef4444",
+              "fresnel", "#f97316",
+              "#22c55e",
+            ],
+            "line-width": 2.5,
+            "line-opacity": 0.7,
+            "line-dasharray": [2, 2],
+          },
+        });
+      }
+      if (!map.getLayer("trace-tube")) {
+        try {
+          if (!traceTubeLayerRef.current) traceTubeLayerRef.current = new LosTubeLayer("trace-tube");
+          map.addLayer(traceTubeLayerRef.current);
+        } catch (err) {
+          console.warn("[Map] Failed to add trace tube layer:", err);
         }
       }
 
@@ -1909,6 +2102,7 @@ export function Map() {
       // Tube altitudes are scaled by exaggeration at upload time; onAdd ran before
       // terrain was re-applied above, so re-upload against the final exaggeration.
       losTubeLayerRef.current?.refresh();
+      traceTubeLayerRef.current?.refresh();
 
       // Ensure sources have current data (important after style changes)
       refreshMapboxNodeData();
@@ -3268,14 +3462,7 @@ export function Map() {
           }
         }}
         terrainEnabled={terrain3D}
-        onRequestTerrainSetup={() => {
-          setSettingsOpenSections((prev) => {
-            const next = new Set(prev);
-            next.add("terrain");
-            return next;
-          });
-          setSettingsPanelOpen(true);
-        }}
+        onRequestTerrainSetup={openTerrainSetup}
       />
 
       {/* Tool prompts — guide the user through picks */}
@@ -3495,7 +3682,17 @@ export function Map() {
           toLabel={(nodes[toolToId] ?? nodes[`!${toolToId}`])?.shortname ?? toolToId.slice(0, 8)}
           fromColor="#06b6d4"
           toColor="#d946ef"
-          traceroutes={traceData}
+          paths={tracePaths}
+          selectedSig={traceSelectedPath ? traceSelectedPath.hops.join(">") : null}
+          onSelectPath={setTraceSelectedSig}
+          analysis={traceCompute.traceAnalysis}
+          isComputing={traceCompute.isComputingTrace}
+          analysisError={traceCompute.traceError}
+          analysisWarning={traceCompute.traceWarning}
+          terrain3D={terrain3D}
+          onEnableTerrain={openTerrainSetup}
+          showDirect={traceShowDirect}
+          onToggleDirect={setTraceShowDirect}
           loading={rawTraceroutesLoading || pairTraceroutesLoading}
           liveNodes={nodes}
           onNodeSelect={(id) => handleNodeSelectRef.current(id)}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -9,11 +9,12 @@ import { useSearchParams } from "react-router";
 
 import { toast } from "../components/toastStore";
 import { env } from "../env";
+import { useAppDispatch } from "../hooks";
 import { useLiveEvent } from "../hooks/useLiveEvent";
 import { reverseGeocode } from "../maps/geocoder";
 import { buildMapStyle, ensureBuildings3D, ensureTerrain, isDarkBasemap, type OsmBasemap, removeBuildings3D, removeTerrain } from "../maps/mapStyle";
-import { useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
-import { NodeRole, roleTitles } from "../types";
+import { apiSlice, useGetConfigQuery, useGetNodesQuery, useGetTraceroutesQuery } from "../slices/apiSlice";
+import { type ITraceroutesResponse, NodeRole, roleTitles } from "../types";
 import { convertNodeIdFromIntToHex } from "../utils/convertNodeId";
 import { normalizeNodeId8 } from "../utils/normalizeNodeId8";
 import { prefersReducedMotion } from "../utils/reducedMotion";
@@ -21,9 +22,9 @@ import { ActivityLayer } from "./map/activityLayer";
 import { ClusterDonutLayer } from "./map/clusterDonutLayer";
 import { type ClusterHover,ClusterHoverCard } from "./map/ClusterHoverCard";
 import { FiltersResetPill } from "./map/FiltersResetPill";
-import { circularMeanLng, normalizeLng } from "./map/geo";
+import { circularMeanLng, normalizeLng, unwrapLngTo } from "./map/geo";
 import { bestSnr, computeMaxRange, formatLatLng, geodesicCircleCoords, mbRoleColorExpr, queryTerrainElevationMSL, relativeTime, signalBarsHtml, TRANSPARENT_1PX_PNG } from "./map/helpers";
-import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId } from "./map/linkFeatures";
+import { buildAllLinksFeatureCollection, buildMapboxLinkFeatureCollection, buildTracerouteLinkFeatureCollection, computeHeardByIds, normNodeId, recencyOpacityFromAgeMs } from "./map/linkFeatures";
 import { LosTubeLayer } from "./map/losTubeLayer";
 import { MapCoordinatePill } from "./map/MapCoordinatePill";
 import { MapCoveragePanel } from "./map/MapCoveragePanel";
@@ -37,7 +38,7 @@ import { MapToolPrompt, MapToolsDrawer } from "./map/MapToolsDrawer";
 import { MapTraceroutePanel } from "./map/MapTraceroutePanel";
 import { type PacketArc, PacketCoalescer, type RawPacket } from "./map/packetCoalescer";
 import { packetColor } from "./map/packetColors";
-import { findPathsBetween } from "./map/pathAnalysis";
+import { findPathsBetween, tsToMs } from "./map/pathAnalysis";
 import type { ScanClass } from "./map/scanAnalysis";
 import {
   anyIdsFanned,
@@ -125,6 +126,12 @@ export function Map() {
   const flushRafRef = useRef<number | null>(null);
   // Per-mesh-id debounce of multi-gateway traceroute copies → one comet, longest route.
   const tracerouteBufRef = useRef<Map<string, { ev: TraceEv; timer: ReturnType<typeof setTimeout> }> | null>(null);
+  // Traceroute tool: endpoint markers, one-shot fit per pair, live-refetch throttle.
+  const traceFromMarkerRef = useRef<maplibregl.Marker | null>(null);
+  const traceToMarkerRef = useRef<maplibregl.Marker | null>(null);
+  const traceFitKeyRef = useRef<string | null>(null);
+  const traceRefetchAtRef = useRef(0);
+  const traceRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mbHandlersBoundRef = useRef(false);
   const mbCurrentStyleUrlRef = useRef<string | null>(null);
   const mbKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
@@ -135,6 +142,7 @@ export function Map() {
   const handleLinkHoverRef = useRef<(otherId: string | null) => void>(() => {});
   const selectedNodeIdRef = useRef<string | null>(null);
 
+  const dispatch = useAppDispatch();
   const { data: rawNodes = {}, isError: nodesQueryFailed } = useGetNodesQuery();
   const { data: config } = useGetConfigQuery();
   const { data: rawTraceroutes = [], isLoading: rawTraceroutesLoading } = useGetTraceroutesQuery();
@@ -199,6 +207,24 @@ export function Map() {
   const [toolFromId, setToolFromId] = useState<string | null>(null);
   const [toolToId, setToolToId] = useState<string | null>(null);
   const [toolVirtualPos, setToolVirtualPos] = useState<[number, number] | null>(null);
+
+  // Pair-scoped traceroute history for the tool — escapes the 1000-row global
+  // window that makes most pairs come back empty. Merged with the global cache
+  // so routes crossing the pair as intermediate hops still count.
+  const tracePairActive = activeTool === "traceroute" && !!toolFromId && !!toolToId;
+  // isLoading (not isFetching): true only on a pair's first fetch, so throttled
+  // background refetches neither flicker the panel nor re-gate the fitBounds.
+  const { data: pairTraceroutes = [], isLoading: pairTraceroutesLoading } = useGetTraceroutesQuery(
+    { from: toolFromId ?? "", to: toolToId ?? "", limit: 500 },
+    { skip: !tracePairActive },
+  );
+  const traceData = useMemo(() => {
+    if (pairTraceroutes.length === 0) return rawTraceroutes;
+    // globalThis: the component name shadows the Map constructor
+    const byKey = new globalThis.Map<string, ITraceroutesResponse>();
+    for (const tr of [...rawTraceroutes, ...pairTraceroutes]) byKey.set(`${tr.id}:${tr.from}`, tr);
+    return [...byKey.values()];
+  }, [rawTraceroutes, pairTraceroutes]);
 
   // 3D terrain
   const [terrain3D, setTerrain3D] = useState<boolean>(() => readJson<boolean>(LS_KEYS.terrain3D, true));
@@ -522,6 +548,15 @@ export function Map() {
     losCompute.losFromMarkerRef.current = null;
     losCompute.losToMarkerRef.current?.remove();
     losCompute.losToMarkerRef.current = null;
+    traceFromMarkerRef.current?.remove();
+    traceFromMarkerRef.current = null;
+    traceToMarkerRef.current?.remove();
+    traceToMarkerRef.current = null;
+    traceFitKeyRef.current = null;
+    if (traceRefetchTimerRef.current) {
+      clearTimeout(traceRefetchTimerRef.current);
+      traceRefetchTimerRef.current = null;
+    }
     // Removing a marker mid-drag skips its dragend; unstick the shared flag
     isDraggingMarkerRef.current = false;
     losState.setLosResult(null);
@@ -553,6 +588,10 @@ export function Map() {
       } catch {}
       try {
         (mb.getSource("path-analysis") as MlGeoJSONSource | undefined)?.setData(empty);
+      } catch {}
+      // A hop/path spotlight from the traceroute panel must not outlive the tool
+      try {
+        (mb.getSource("link-highlight") as MlGeoJSONSource | undefined)?.setData(empty);
       } catch {}
       if (coverageCompute.coverageOriginMarkerRef.current) {
         coverageCompute.coverageOriginMarkerRef.current.remove();
@@ -758,36 +797,101 @@ export function Map() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Draw shortest traceroute path on both providers
+  // Draw all observed traceroute paths between the picked pair — newest on top,
+  // alternates recency-faded — plus endpoint markers and a one-shot fitBounds.
   useEffect(() => {
-    const computePathCoords = (): [number, number][] | null => {
-      if (activeTool !== "traceroute" || toolStep !== "result") return null;
-      if (!toolFromId || !toolToId) return null;
-      const paths = findPathsBetween(toolFromId, toolToId, rawTraceroutes);
-      if (paths.length === 0) return null;
-      const shortest = paths[0];
-      const coords: [number, number][] = [];
-      for (const hop of shortest.hops) {
-        const n = nodes[hop] ?? nodes[`!${hop}`];
-        if (n?.map_position) coords.push([n.map_position[0], n.map_position[1]]);
-      }
-      return coords.length >= 2 ? coords : null;
+    const mb = mbMapRef.current;
+    if (!mb) return;
+
+    const clearTraceMarkers = () => {
+      traceFromMarkerRef.current?.remove();
+      traceFromMarkerRef.current = null;
+      traceToMarkerRef.current?.remove();
+      traceToMarkerRef.current = null;
     };
 
-    const mb = mbMapRef.current;
-    if (mb) {
-      const src = mb.getSource("path-analysis") as MlGeoJSONSource | undefined;
-      if (src) {
-        const coords = computePathCoords();
-        src.setData(
-          coords
-            ? { type: "FeatureCollection", features: [{ type: "Feature", properties: {}, geometry: { type: "LineString", coordinates: coords } }] }
-            : { type: "FeatureCollection", features: [] },
-        );
-      }
+    const src = mb.getSource("path-analysis") as MlGeoJSONSource | undefined;
+    if (activeTool !== "traceroute" || toolStep !== "result" || !toolFromId || !toolToId) {
+      src?.setData({ type: "FeatureCollection", features: [] });
+      clearTraceMarkers();
+      traceFitKeyRef.current = null;
+      return;
     }
+    if (!src) return;
 
-  }, [activeTool, toolStep, toolFromId, toolToId, rawTraceroutes, nodes]);
+    // nodesRef, not the nodes memo: SSE flushes rebuild `nodes` every 400 ms,
+    // which would churn setData/markers here for no visual change.
+    const posOf = (id: string): [number, number] | null => {
+      const n = nodesRef.current[id] ?? nodesRef.current[`!${id}`];
+      return n?.map_position ? [n.map_position[0], n.map_position[1]] : null;
+    };
+
+    const paths = findPathsBetween(toolFromId, toolToId, traceData);
+    const now = Date.now();
+    const features: GeoJSON.Feature[] = [];
+    paths.slice(0, 6).forEach((p, rank) => {
+      const coords: [number, number][] = [];
+      for (const hop of p.hops) {
+        const pos = posOf(hop);
+        if (!pos) continue; // hop with unknown position — skip (honest gap)
+        const prev = coords[coords.length - 1];
+        // Chain-unwrap so seam-crossing legs draw the short way
+        coords.push(prev ? [unwrapLngTo(prev[0], pos[0]), pos[1]] : pos);
+      }
+      if (coords.length < 2) return;
+      features.push({
+        type: "Feature",
+        properties: {
+          primary: rank === 0,
+          // Higher sort key renders later → newest path on top
+          sort: -rank,
+          opacity: rank === 0
+            ? 0.95
+            : Math.min(0.55, 0.55 * recencyOpacityFromAgeMs(now - tsToMs(p.timestamp))),
+        },
+        geometry: { type: "LineString", coordinates: coords },
+      });
+    });
+    src.setData({ type: "FeatureCollection", features });
+
+    const fromPos = posOf(toolFromId);
+    const toPos = posOf(toolToId);
+    if (!fromPos || !toPos) {
+      clearTraceMarkers();
+      return;
+    }
+    if (traceFromMarkerRef.current) traceFromMarkerRef.current.setLngLat(fromPos);
+    else traceFromMarkerRef.current = new maplibregl.Marker({ color: "#06b6d4", scale: 0.75 }).setLngLat(fromPos).addTo(mb);
+    if (traceToMarkerRef.current) traceToMarkerRef.current.setLngLat(toPos);
+    else traceToMarkerRef.current = new maplibregl.Marker({ color: "#d946ef", scale: 0.75 }).setLngLat(toPos).addTo(mb);
+
+    // Fit once per pair, not on every data refresh — but not before the
+    // pair-scoped history lands, or the fit would exclude the actual routes.
+    const fitKey = `${toolFromId}-${toolToId}`;
+    if (!pairTraceroutesLoading && traceFitKeyRef.current !== fitKey) {
+      traceFitKeyRef.current = fitKey;
+      const bounds = new maplibregl.LngLatBounds();
+      bounds.extend(fromPos);
+      // Unwrap so an antimeridian-crossing pair frames the short way
+      bounds.extend([unwrapLngTo(fromPos[0], toPos[0]), toPos[1]]);
+      for (const f of features) {
+        for (const c of (f.geometry as GeoJSON.LineString).coordinates) bounds.extend(c as [number, number]);
+      }
+      mb.fitBounds(bounds, { padding: 120, duration: 600, maxZoom: 12 });
+    }
+    // styleEpoch: setStyle recreates the path-analysis source empty — redraw after style.load
+  }, [activeTool, toolStep, toolFromId, toolToId, traceData, pairTraceroutesLoading, styleEpoch]);
+
+  // Traceroute panel hover → spotlight the hovered leg / alternate path.
+  const handleTraceHighlight = useCallback((coords: [number, number][] | null) => {
+    const src = mbMapRef.current?.getSource("link-highlight") as MlGeoJSONSource | undefined;
+    if (!src) return;
+    src.setData(
+      coords && coords.length >= 2
+        ? { type: "FeatureCollection", features: [{ type: "Feature", properties: {}, geometry: { type: "LineString", coordinates: coords } }] }
+        : { type: "FeatureCollection", features: [] },
+    );
+  }, []);
 
   /** Cluster donut + count text dim. Combines the tool-active dim (when an RF
    *  tool is in result step, so the raster reads clearly) with focus-on-hover
@@ -969,16 +1073,22 @@ export function Map() {
         const coverageSrc = map.getSource("coverage") as MlGeoJSONSource | undefined;
         coverageSrc?.setData({ type: "FeatureCollection", features: [] });
       } catch {}
-      // Clear link highlight
-      try {
-        const hlSrc = map.getSource("link-highlight") as MlGeoJSONSource | undefined;
-        hlSrc?.setData({ type: "FeatureCollection", features: [] });
-      } catch {}
-      // Clear path analysis
-      try {
-        const paSrc = map.getSource("path-analysis") as MlGeoJSONSource | undefined;
-        paSrc?.setData({ type: "FeatureCollection", features: [] });
-      } catch {}
+      // The traceroute tool owns link-highlight + path-analysis while showing
+      // results (empty-map clicks and panel closes must not wipe its routes —
+      // nothing would redraw them).
+      const traceResultActive = activeToolRef.current === "traceroute" && toolStepRef.current === "result";
+      if (!traceResultActive) {
+        // Clear link highlight
+        try {
+          const hlSrc = map.getSource("link-highlight") as MlGeoJSONSource | undefined;
+          hlSrc?.setData({ type: "FeatureCollection", features: [] });
+        } catch {}
+        // Clear path analysis
+        try {
+          const paSrc = map.getSource("path-analysis") as MlGeoJSONSource | undefined;
+          paSrc?.setData({ type: "FeatureCollection", features: [] });
+        } catch {}
+      }
     }
 
     // Hide the panel
@@ -1300,11 +1410,16 @@ export function Map() {
           id: "path-analysis-line",
           type: "line",
           source: "path-analysis",
-          layout: { "line-join": "round", "line-cap": "round" },
+          layout: {
+            "line-join": "round",
+            "line-cap": "round",
+            // Higher key renders later → the newest (primary) path sits on top
+            "line-sort-key": ["get", "sort"],
+          },
           paint: {
-            "line-color": "#06b6d4",
-            "line-width": 4,
-            "line-opacity": 0.95,
+            "line-color": ["case", ["get", "primary"], "#06b6d4", "#38bdf8"],
+            "line-width": ["case", ["get", "primary"], 4, 2],
+            "line-opacity": ["get", "opacity"],
           },
         });
       }
@@ -2926,9 +3041,36 @@ export function Map() {
     buf.set(key, { ev: t, timer });
   });
 
+  // Keep traceroute data fresh while the tool is open: the Map page never
+  // polls, so refetch on tool entry and throttle-refetch on live events.
+  // Tag invalidation refreshes every active traceroutes query (global + pair).
+  const invalidateTraceroutes = useCallback(() => {
+    traceRefetchAtRef.current = Date.now();
+    dispatch(apiSlice.util.invalidateTags([{ type: "Traceroutes", id: "LIST" }]));
+  }, [dispatch]);
+  useEffect(() => {
+    if (activeTool === "traceroute") invalidateTraceroutes();
+  }, [activeTool, invalidateTraceroutes]);
+  useLiveEvent<TraceEv>("traceroute", () => {
+    if (activeToolRef.current !== "traceroute") return;
+    // Leading + trailing throttle: an event inside the window schedules one
+    // deferred refetch instead of being dropped (the page never polls, so a
+    // dropped event would leave the just-run traceroute invisible).
+    const remaining = 10_000 - (Date.now() - traceRefetchAtRef.current);
+    if (remaining > 0) {
+      traceRefetchTimerRef.current ??= setTimeout(() => {
+        traceRefetchTimerRef.current = null;
+        if (activeToolRef.current === "traceroute") invalidateTraceroutes();
+      }, remaining);
+      return;
+    }
+    invalidateTraceroutes();
+  });
+
   useEffect(
     () => () => {
       if (flushRafRef.current != null) cancelAnimationFrame(flushRafRef.current);
+      if (traceRefetchTimerRef.current) clearTimeout(traceRefetchTimerRef.current);
       const buf = tracerouteBufRef.current;
       if (buf) {
         for (const { timer } of buf.values()) clearTimeout(timer);
@@ -3353,11 +3495,11 @@ export function Map() {
           toLabel={(nodes[toolToId] ?? nodes[`!${toolToId}`])?.shortname ?? toolToId.slice(0, 8)}
           fromColor="#06b6d4"
           toColor="#d946ef"
-          traceroutes={rawTraceroutes}
-          loading={rawTraceroutesLoading}
+          traceroutes={traceData}
+          loading={rawTraceroutesLoading || pairTraceroutesLoading}
           liveNodes={nodes}
           onNodeSelect={(id) => handleNodeSelectRef.current(id)}
-          onHoverLink={(id) => handleLinkHoverRef.current(id)}
+          onHighlight={handleTraceHighlight}
           onClose={resetTool}
         />
       )}

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -38,7 +38,7 @@ import { MapToolPrompt, MapToolsDrawer } from "./map/MapToolsDrawer";
 import { MapTraceroutePanel } from "./map/MapTraceroutePanel";
 import { type PacketArc, PacketCoalescer, type RawPacket } from "./map/packetCoalescer";
 import { packetColor } from "./map/packetColors";
-import { findPathsBetween, tsToMs } from "./map/pathAnalysis";
+import { findPathsBetween, findRunsBetween, tsToMs } from "./map/pathAnalysis";
 import type { ScanClass } from "./map/scanAnalysis";
 import {
   anyIdsFanned,
@@ -128,6 +128,8 @@ export function Map() {
   const flushRafRef = useRef<number | null>(null);
   // Per-mesh-id debounce of multi-gateway traceroute copies → one comet, longest route.
   const tracerouteBufRef = useRef<Map<string, { ev: TraceEv; timer: ReturnType<typeof setTimeout> }> | null>(null);
+  // Rate-limits the catcher's "new traceroute" toast (request+reply = two packet ids).
+  const traceCatchToastAtRef = useRef(0);
   // Traceroute tool: endpoint markers, one-shot fit per pair, live-refetch throttle.
   const traceFromMarkerRef = useRef<maplibregl.Marker | null>(null);
   const traceToMarkerRef = useRef<maplibregl.Marker | null>(null);
@@ -247,6 +249,13 @@ export function Map() {
   const traceSelectedPath = useMemo(
     () => tracePaths.find((p) => p.hops.join(">") === traceSelectedSig) ?? tracePaths[0] ?? null,
     [tracePaths, traceSelectedSig],
+  );
+  // Chronological run history for the time-machine strip (oldest first)
+  const traceRuns = useMemo(
+    () => (activeTool === "traceroute" && toolFromId && toolToId
+      ? findRunsBetween(toolFromId, toolToId, traceData)
+      : []),
+    [activeTool, toolFromId, toolToId, traceData],
   );
   // 3D terrain
   const [terrain3D, setTerrain3D] = useState<boolean>(() => readJson<boolean>(LS_KEYS.terrain3D, true));
@@ -417,6 +426,7 @@ export function Map() {
   const activeToolRef = useRef(activeTool);
   const toolStepRef = useRef(toolStep);
   const toolFromIdRef = useRef(toolFromId);
+  const toolToIdRef = useRef(toolToId);
   // Merge-origin pick mode, read by the bind-once node/cluster click handlers
   const pickingMergeOriginRef = useRef(mergeOrigins.pickingMergeOrigin);
   const addMergeOriginByIdRef = useRef(mergeOrigins.addCoverageMergeOriginById);
@@ -451,6 +461,7 @@ export function Map() {
   useEffect(() => { keepCoveragePaintRef.current = coverage.keepCoveragePaint; }, [coverage.keepCoveragePaint]);
   useEffect(() => { toolStepRef.current = toolStep; }, [toolStep]);
   useEffect(() => { toolFromIdRef.current = toolFromId; }, [toolFromId]);
+  useEffect(() => { toolToIdRef.current = toolToId; }, [toolToId]);
   useEffect(() => { terrain3DRef.current = terrain3D; }, [terrain3D]);
   useEffect(() => { buildings3DRef.current = buildings3D; }, [buildings3D]);
   useEffect(() => { channelFilterRef.current = channelFilter; }, [channelFilter]);
@@ -495,6 +506,32 @@ export function Map() {
     setIsComputingLos: losState.setIsComputingLos,
     setLosTerrainWarning: losState.setLosTerrainWarning,
   });
+
+  // Lit-up picking: nodes sharing any observed route with the picked origin
+  const traceCandidates = useMemo(() => {
+    if (activeTool !== "traceroute" || toolStep !== "pickTo" || !toolFromId) return [];
+    const a = normNodeId(toolFromId);
+    if (!a) return [];
+    const set = new Set<string>();
+    for (const tr of traceData) {
+      const tFrom = normNodeId(tr?.from);
+      const tTo = normNodeId(tr?.to);
+      if (!tFrom || !tTo) continue;
+      const path = [
+        tFrom,
+        ...((tr.route_ids ?? tr.route ?? []) as (string | number)[]).map((r) => normNodeId(r)).filter(Boolean),
+        tTo,
+      ];
+      if (!path.includes(a)) continue;
+      // Positioned candidates only — the rings and the prompt count must agree
+      for (const h of path) {
+        if (!h || h === a) continue;
+        const n = nodes[h] ?? nodes[`!${h}`];
+        if (n?.map_position) set.add(h);
+      }
+    }
+    return [...set];
+  }, [activeTool, toolStep, toolFromId, traceData, nodes]);
 
   // Position signature of the analyzed hops: a value-stable string, so SSE
   // identity churn doesn't retrigger grading but a hop actually moving does.
@@ -657,6 +694,9 @@ export function Map() {
       } catch {}
       try {
         (mb.getSource("trace-direct") as MlGeoJSONSource | undefined)?.setData(empty);
+      } catch {}
+      try {
+        (mb.getSource("trace-candidates") as MlGeoJSONSource | undefined)?.setData(empty);
       } catch {}
       if (coverageCompute.coverageOriginMarkerRef.current) {
         coverageCompute.coverageOriginMarkerRef.current.remove();
@@ -984,7 +1024,7 @@ export function Map() {
         const isGap = B.i - A.i > 1;
         features.push({
           type: "Feature",
-          properties: { primary: true, gap: isGap, sort: 1000, opacity: 0.95 },
+          properties: { primary: true, gap: isGap, sort: 1000, opacity: 0.95, width: 4 },
           geometry: { type: "LineString", coordinates: [[aLng, A.pos[1]], [bLng, B.pos[1]]] },
         });
         if (isGap) {
@@ -1009,8 +1049,10 @@ export function Map() {
       }
     }
 
-    // Alternates: whole-path lines, recency-faded, thinner
+    // Alternates: whole-path lines, recency-faded, braid-style usage-weighted
+    // widths so the strand the mesh actually favors reads thicker.
     const primarySig = primary ? primary.hops.join(">") : null;
+    const totalCount = tracePaths.reduce((s, p) => s + p.count, 0) || 1;
     tracePaths
       .filter((p) => p.hops.join(">") !== primarySig)
       .slice(0, 5)
@@ -1031,6 +1073,8 @@ export function Map() {
             gap: false,
             sort: -rank,
             opacity: Math.min(0.55, 0.55 * recencyOpacityFromAgeMs(now - tsToMs(p.timestamp))),
+            // Capped below the primary's 4 so a dominant alternate can't outweigh it
+            width: Math.min(3.4, 1.4 + 3.2 * Math.min(1, p.count / totalCount)),
           },
           geometry: { type: "LineString", coordinates: coords },
         });
@@ -1074,6 +1118,24 @@ export function Map() {
     });
     setSettingsPanelOpen(true);
   }, []);
+
+  // Lit-up picking: ring every node with an observed route through the origin
+  useEffect(() => {
+    const mb = mbMapRef.current;
+    const src = mb?.getSource("trace-candidates") as MlGeoJSONSource | undefined;
+    if (!src) return;
+    if (traceCandidates.length === 0) {
+      src.setData({ type: "FeatureCollection", features: [] });
+      return;
+    }
+    const features: GeoJSON.Feature[] = [];
+    for (const id of traceCandidates) {
+      const p = (nodesRef.current[id] ?? nodesRef.current[`!${id}`])?.map_position;
+      if (p) features.push({ type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [p[0], p[1]] } });
+    }
+    src.setData({ type: "FeatureCollection", features });
+    // styleEpoch: setStyle recreates the source empty — repaint after style.load
+  }, [traceCandidates, styleEpoch]);
 
   // Traceroute panel hover → spotlight the hovered leg / alternate path.
   const handleTraceHighlight = useCallback((coords: [number, number][] | null) => {
@@ -1612,7 +1674,7 @@ export function Map() {
           },
           paint: {
             "line-color": ["case", ["get", "primary"], "#06b6d4", "#38bdf8"],
-            "line-width": ["case", ["get", "primary"], 4, 2],
+            "line-width": ["coalesce", ["get", "width"], 2],
             "line-opacity": ["get", "opacity"],
           },
         });
@@ -1871,6 +1933,28 @@ export function Map() {
         } catch (err) {
           console.warn("[Map] Failed to add trace tube layer:", err);
         }
+      }
+      // Lit-up picking: rings on nodes with observed routes through the origin
+      if (!map.getSource("trace-candidates")) {
+        map.addSource("trace-candidates", {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        });
+      }
+      if (!map.getLayer("trace-candidates-ring")) {
+        map.addLayer({
+          id: "trace-candidates-ring",
+          type: "circle",
+          source: "trace-candidates",
+          paint: {
+            "circle-radius": 11,
+            "circle-color": "rgba(0,0,0,0)",
+            "circle-stroke-color": "#06b6d4",
+            "circle-stroke-width": 2,
+            "circle-stroke-opacity": 0.85,
+            "circle-pitch-alignment": "map",
+          },
+        });
       }
 
       if (!map.getSource("scan-links")) {
@@ -3303,26 +3387,18 @@ export function Map() {
     layer.spawnPath(pts, packetColor("traceroute"), 0.9, performance.now());
   }, []);
 
-  // The same traceroute is uploaded by many gateways with divergent recorded
-  // routes; debounce by mesh id and draw only the single most complete path.
-  useLiveEvent<TraceEv>("traceroute", (t) => {
-    if (!livePacketsRef.current || prefersReducedMotion()) return;
-    if (flyoverFlyingRef.current) return; // spotlight: the tour owns the stage
-    const buf = (tracerouteBufRef.current ??= new globalThis.Map());
-    const key = t.id != null ? `id:${t.id}` : `ft:${t.from}:${t.to}`;
-    const existing = buf.get(key);
-    if (existing) {
-      if ((t.route_ids?.length ?? 0) > (existing.ev.route_ids?.length ?? 0)) existing.ev = t;
-      return;
-    }
-    const timer = setTimeout(() => {
-      const entry = buf.get(key);
-      buf.delete(key);
-      // The gate at ingest can't cover timers armed before the tour started
-      if (entry && !flyoverFlyingRef.current) animateTraceroute(entry.ev);
-    }, TRACEROUTE_DEBOUNCE_MS);
-    buf.set(key, { ev: t, timer });
-  });
+  // True when a live traceroute involves BOTH picked endpoints of the open tool.
+  const tracePairMatches = (t: TraceEv): boolean => {
+    if (activeToolRef.current !== "traceroute" || toolStepRef.current !== "result") return false;
+    const a = normNodeId(toolFromIdRef.current ?? "");
+    const b = normNodeId(toolToIdRef.current ?? "");
+    if (!a || !b) return false;
+    const path = [t.from, ...(t.route_ids ?? []), t.to].map((x) => normNodeId(x ?? ""));
+    return path.includes(a) && path.includes(b);
+  };
+
+  // (Live traceroute comets are handled by the unified buffer further down,
+  // after the refetch plumbing it depends on is declared.)
 
   // Keep traceroute data fresh while the tool is open: the Map page never
   // polls, so refetch on tool entry and throttle-refetch on live events.
@@ -3348,6 +3424,47 @@ export function Map() {
       return;
     }
     invalidateTraceroutes();
+  });
+
+  // One debounce buffer for live traceroutes: multi-gateway copies merge to
+  // the longest route, and ambient-vs-catcher is decided at FLUSH time on the
+  // merged copy — deciding at ingest split one traceroute across two buffers
+  // (double or zero comets when gateway copies disagreed or the tool state
+  // changed mid-debounce).
+  useLiveEvent<TraceEv>("traceroute", (t) => {
+    const interesting =
+      tracePairMatches(t) ||
+      (livePacketsRef.current && !prefersReducedMotion() && !flyoverFlyingRef.current);
+    if (!interesting) return;
+    const buf = (tracerouteBufRef.current ??= new globalThis.Map());
+    const key = t.id != null ? `id:${t.id}` : `ft:${t.from}:${t.to}`;
+    const existing = buf.get(key);
+    if (existing) {
+      if ((t.route_ids?.length ?? 0) > (existing.ev.route_ids?.length ?? 0)) existing.ev = t;
+      return;
+    }
+    const timer = setTimeout(() => {
+      const entry = buf.get(key);
+      buf.delete(key);
+      if (!entry) return;
+      if (tracePairMatches(entry.ev)) {
+        // Catch It Live: the open pair's traceroute lands the moment it's
+        // heard. The refetch trails the debounce so the DB write has landed;
+        // one shared timer coalesces request+reply bursts.
+        traceRefetchTimerRef.current ??= setTimeout(() => {
+          traceRefetchTimerRef.current = null;
+          if (activeToolRef.current === "traceroute") invalidateTraceroutes();
+        }, 2_000);
+        if (Date.now() - traceCatchToastAtRef.current > 8_000) {
+          traceCatchToastAtRef.current = Date.now();
+          toast("New traceroute observed for this pair.");
+        }
+        if (!prefersReducedMotion() && !flyoverFlyingRef.current) animateTraceroute(entry.ev);
+      } else if (livePacketsRef.current && !prefersReducedMotion() && !flyoverFlyingRef.current) {
+        animateTraceroute(entry.ev);
+      }
+    }, TRACEROUTE_DEBOUNCE_MS);
+    buf.set(key, { ev: t, timer });
   });
 
   useEffect(
@@ -3575,7 +3692,9 @@ export function Map() {
           message={
             activeTool === "los"
               ? "LOS: pick the second node (or click anywhere on the map)"
-              : "Traceroute: pick the second node"
+              : traceCandidates.length > 0
+                ? `Traceroute: pick the second node — ${traceCandidates.length} ringed ${traceCandidates.length === 1 ? "node has" : "nodes have"} observed routes`
+                : "Traceroute: pick the second node (no routes in the recent window touch this origin)"
           }
           hint="Press Esc to cancel"
           onCancel={resetTool}
@@ -3772,6 +3891,7 @@ export function Map() {
           fromColor="#06b6d4"
           toColor="#d946ef"
           paths={tracePaths}
+          runs={traceRuns}
           selectedSig={traceSelectedPath ? traceSelectedPath.hops.join(">") : null}
           onSelectPath={(sig) => {
             traceFlyover.cancelFlyover(); // a tour follows one path only

--- a/frontend/src/pages/map/MapCoordinatePill.tsx
+++ b/frontend/src/pages/map/MapCoordinatePill.tsx
@@ -4,30 +4,49 @@ import { toast } from "../../components/toastStore";
 import { copyTextToClipboard } from "../../utils/clipboard";
 import { formatLatLng, parseLatLng } from "./helpers";
 
+/** Imperative feed for the pill's per-frame values — held here (not in
+ *  Map.tsx) so cursor movement re-renders only the pill. */
+export interface CoordPillSink {
+  /** Cursor [lng, lat] + terrain elevation (MSL m); nulls on mouse-out. */
+  setHover: (coord: [number, number] | null, elevationM: number | null) => void;
+  /** Map-center fallback, updated on moveend. */
+  setCenter: (coord: [number, number]) => void;
+}
+
 /**
  * Live-coordinate pill: shows the lat/lng under the cursor (plus terrain
  * elevation when 3D is on), or the map center when not hovering. Click to paste
  * a "lat, lng" and jump-to-center with a pin, without disturbing the active tool.
  */
 export function MapCoordinatePill({
-  coord,
-  centerCoord,
-  elevationM,
+  sinkRef,
   hasPin,
   onJump,
   onClearPin,
 }: {
-  /** Live cursor position [lng, lat], or null when not hovering the map. */
-  coord: [number, number] | null;
-  /** Map-center [lng, lat] fallback shown when not hovering. */
-  centerCoord: [number, number] | null;
-  /** Terrain elevation (MSL m) under the cursor, or null. */
-  elevationM: number | null;
+  /** Registration point for the map's hover/center publishers. */
+  sinkRef: React.MutableRefObject<CoordPillSink | null>;
   /** Whether a jump-to pin is currently dropped. */
   hasPin: boolean;
   onJump: (lngLat: [number, number]) => void;
   onClearPin: () => void;
 }) {
+  const [coord, setCoord] = useState<[number, number] | null>(null);
+  const [elevationM, setElevationM] = useState<number | null>(null);
+  const [centerCoord, setCenterCoord] = useState<[number, number] | null>(null);
+  useEffect(() => {
+    sinkRef.current = {
+      setHover: (c, e) => {
+        setCoord(c);
+        setElevationM(e);
+      },
+      setCenter: setCenterCoord,
+    };
+    return () => {
+      sinkRef.current = null;
+    };
+  }, [sinkRef]);
+
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [error, setError] = useState(false);

--- a/frontend/src/pages/map/MapToolsDrawer.tsx
+++ b/frontend/src/pages/map/MapToolsDrawer.tsx
@@ -53,7 +53,6 @@ const TOOLS: ToolDef[] = [
     id: "traceroute",
     label: "Traceroute",
     description: "Observed mesh routing between two nodes",
-    comingSoon: true,
     icon: (
       <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />

--- a/frontend/src/pages/map/MapTraceCorridorsPanel.tsx
+++ b/frontend/src/pages/map/MapTraceCorridorsPanel.tsx
@@ -1,7 +1,7 @@
 /** Traceroute corridors panel: the mesh's busiest observed links, ranked by
  *  how many runs traverse them. Hover spotlights the link; click opens the
  *  traceroute analysis for that pair. */
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 
 import { unwrapLngTo } from "./geo";
 import { relativeTime } from "./helpers";
@@ -22,7 +22,7 @@ export interface TraceCorridor {
 
 export type CorridorSort = "busiest" | "longest";
 
-export function MapTraceCorridorsPanel({
+function MapTraceCorridorsPanelInner({
   corridors,
   sortMode,
   onSortModeChange,
@@ -180,3 +180,6 @@ export function MapTraceCorridorsPanel({
     </div>
   );
 }
+
+/** Memoized: the Map page re-renders far more often than these props change. */
+export const MapTraceCorridorsPanel = memo(MapTraceCorridorsPanelInner);

--- a/frontend/src/pages/map/MapTraceCorridorsPanel.tsx
+++ b/frontend/src/pages/map/MapTraceCorridorsPanel.tsx
@@ -1,0 +1,182 @@
+/** Traceroute corridors panel: the mesh's busiest observed links, ranked by
+ *  how many runs traverse them. Hover spotlights the link; click opens the
+ *  traceroute analysis for that pair. */
+import { useEffect, useState } from "react";
+
+import { unwrapLngTo } from "./geo";
+import { relativeTime } from "./helpers";
+import { tsToMs } from "./pathAnalysis";
+import { Segmented } from "./Segmented";
+
+export interface TraceCorridor {
+  aId: string;
+  bId: string;
+  aLabel: string;
+  bLabel: string;
+  aPos: [number, number];
+  bPos: [number, number];
+  count: number;
+  distanceKm: number;
+  lastTimestamp: number;
+}
+
+export type CorridorSort = "busiest" | "longest";
+
+export function MapTraceCorridorsPanel({
+  corridors,
+  sortMode,
+  onSortModeChange,
+  inViewOnly,
+  onToggleInView,
+  activePair,
+  hideOnMobile,
+  onHover,
+  onPick,
+}: {
+  corridors: TraceCorridor[];
+  sortMode: CorridorSort;
+  onSortModeChange: (v: CorridorSort) => void;
+  inViewOnly: boolean;
+  onToggleInView: (v: boolean) => void;
+  /** Normalized [from, to] of the open analysis, for row highlighting. */
+  activePair: [string, string] | null;
+  /** The result bottom sheet owns small screens — yield to it there. */
+  hideOnMobile: boolean;
+  onHover: (coords: [number, number][] | null) => void;
+  onPick: (aId: string, bId: string) => void;
+}) {
+  // Bars scale to the active metric's max (the list isn't count-sorted in
+  // longest mode, so "first row" is not "biggest count").
+  const maxCount = corridors.reduce((m, c) => Math.max(m, c.count), 0) || 1;
+  const maxKm = corridors.reduce((m, c) => Math.max(m, c.distanceKm), 0) || 1;
+  const activeKey = activePair
+    ? [...activePair].sort().join("|")
+    : null;
+  const [collapsed, setCollapsed] = useState(false);
+
+  // A row hidden or unmounted mid-hover never fires mouseleave — don't leave
+  // its spotlight stuck on the map.
+  useEffect(() => () => onHover(null), [onHover]);
+
+  return (
+    <div
+      className={`fixed z-1040 shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl flex flex-col
+        inset-x-0 bottom-0 rounded-t-2xl max-h-[38dvh]
+        animate-[slideInUp_200ms_ease-out]
+        sm:inset-x-auto sm:left-[calc(var(--map-pad)+1rem)] sm:top-16 sm:bottom-16 sm:w-72
+        sm:rounded-xl sm:max-h-none
+        sm:animate-[slideInLeft_220ms_ease-out]
+        ${collapsed ? "sm:bottom-auto" : ""}
+        ${hideOnMobile ? "max-lg:hidden" : ""}`}
+    >
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-white/5 shrink-0">
+        <span className="text-[10px] uppercase tracking-wider text-gray-400 font-medium">
+          Top Links
+          {corridors.length > 0 && !collapsed && (
+            <span className="normal-case tracking-normal text-gray-600 ml-1.5">top {corridors.length}</span>
+          )}
+        </span>
+        <span className="flex items-center gap-2 shrink-0">
+          <label className="flex items-center gap-1.5 text-[10px] text-gray-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={inViewOnly}
+              onChange={(e) => onToggleInView(e.target.checked)}
+              className="accent-cyan-500 w-3 h-3"
+            />
+            in view
+          </label>
+          <button
+            type="button"
+            onClick={() => {
+              onHover(null); // a hovered row is about to disappear
+              setCollapsed((v) => !v);
+            }}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand top links" : "Collapse top links"}
+            className="p-0.5 rounded text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+          >
+            <svg
+              className={`w-3 h-3 transition-transform ${collapsed ? "" : "rotate-180"}`}
+              fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+        </span>
+      </div>
+
+      {!collapsed && (
+        <div className="px-1.5 pt-1.5 shrink-0">
+          <Segmented
+            ariaLabel="Rank links by"
+            value={sortMode}
+            onChange={onSortModeChange}
+            options={[
+              { value: "busiest", label: "Busiest", title: "Most traversed by observed runs" },
+              { value: "longest", label: "Longest", title: "Greatest hop distance" },
+            ]}
+          />
+        </div>
+      )}
+
+      {!collapsed && (
+      <div className="p-1.5 overflow-y-auto overscroll-contain flex-1 min-h-0 space-y-0.5">
+        {corridors.length === 0 ? (
+          <div className="px-2 py-3 text-[11px] text-gray-500">
+            No observed links {inViewOnly ? "in view — pan out or untick “in view”." : "yet."}
+          </div>
+        ) : (
+          corridors.map((c) => {
+            const isActive = activeKey === `${c.aId}|${c.bId}`;
+            const coords: [number, number][] = [c.aPos, [unwrapLngTo(c.aPos[0], c.bPos[0]), c.bPos[1]]];
+            return (
+              <button
+                key={`${c.aId}|${c.bId}`}
+                type="button"
+                onClick={() => onPick(c.aId, c.bId)}
+                onMouseEnter={() => onHover(coords)}
+                onMouseLeave={() => onHover(null)}
+                onFocus={() => onHover(coords)}
+                onBlur={() => onHover(null)}
+                className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-left transition-colors
+                  focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400 ${
+                    isActive
+                      ? "bg-cyan-500/15 border border-cyan-500/30"
+                      : "border border-transparent hover:bg-white/10"
+                  }`}
+                title={`Analyze ${c.aLabel} ↔ ${c.bLabel}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-[11px] text-gray-200 truncate">
+                    {c.aLabel}
+                    <span className="text-gray-500 mx-1">↔</span>
+                    {c.bLabel}
+                  </div>
+                  <div className="mt-1 h-1 rounded bg-white/10">
+                    <div
+                      className="h-1 rounded bg-cyan-500/70"
+                      style={{
+                        width: `${Math.max(6, Math.round((sortMode === "longest" ? c.distanceKm / maxKm : c.count / maxCount) * 100))}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <div className="text-[10px] tabular-nums">
+                    <span className="text-cyan-300">{c.count}×</span>
+                    <span className="text-gray-500"> · {c.distanceKm >= 10 ? c.distanceKm.toFixed(0) : c.distanceKm.toFixed(1)} km</span>
+                  </div>
+                  <div className="text-[9px] text-gray-500 tabular-nums">
+                    {c.lastTimestamp ? relativeTime(new Date(tsToMs(c.lastTimestamp)).toISOString()) : ""}
+                  </div>
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/map/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/MapTraceroutePanel.tsx
@@ -4,7 +4,7 @@ import { toast } from "../../components/toastStore";
 import { copyTextToClipboard } from "../../utils/clipboard";
 import { unwrapLngTo } from "./geo";
 import { relativeTime } from "./helpers";
-import { type AnalyzedPath, tsToMs } from "./pathAnalysis";
+import { type AnalyzedPath, type TraceRun, tsToMs } from "./pathAnalysis";
 import { PathHopList } from "./PathHopList";
 import type { IMapNode } from "./types";
 import { useBottomSheetGesture } from "./useBottomSheet";
@@ -43,6 +43,7 @@ export function MapTraceroutePanel({
   fromColor = "#22c55e",
   toColor = "#06b6d4",
   paths,
+  runs,
   selectedSig,
   onSelectPath,
   analysis,
@@ -69,6 +70,8 @@ export function MapTraceroutePanel({
   fromColor?: string;
   toColor?: string;
   paths: AnalyzedPath[];
+  /** Chronological observed runs (oldest first) for the history strip. */
+  runs?: TraceRun[];
   selectedSig: string | null;
   onSelectPath: (sig: string) => void;
   analysis: TraceAnalysis | null;
@@ -140,6 +143,37 @@ export function MapTraceroutePanel({
   const observedAgo = (ts: number): string | null =>
     ts ? relativeTime(new Date(tsToMs(ts)).toISOString()) : null;
 
+  // Time-machine strip state: chronological runs, change count, step cursor
+  const runsList = useMemo(() => runs ?? [], [runs]);
+  const displayRuns = runsList.slice(-60);
+  const routeChanges = useMemo(() => {
+    let n = 0;
+    for (let i = 1; i < runsList.length; i++) if (runsList[i].sig !== runsList[i - 1].sig) n++;
+    return n;
+  }, [runsList]);
+  const [runCursor, setRunCursor] = useState<number | null>(null);
+  const cursorIdx = runCursor != null ? Math.min(runCursor, displayRuns.length - 1) : null;
+  const selectedSigStr = selected ? selected.hops.join(">") : null;
+  // A slid window or an external selection change makes a raw index lie —
+  // restart stepping from the newest run of the (new) selected signature.
+  useEffect(() => {
+    setRunCursor(null);
+  }, [selectedSigStr, runsList.length]);
+  const stepRun = (dir: -1 | 1) => {
+    if (displayRuns.length === 0) return;
+    let base = cursorIdx;
+    if (base == null) {
+      // Start stepping from the newest run of the selected signature
+      for (let i = displayRuns.length - 1; i >= 0; i--) {
+        if (displayRuns[i].sig === selectedSigStr) { base = i; break; }
+      }
+      if (base == null) base = displayRuns.length - 1;
+    }
+    const next = Math.max(0, Math.min(displayRuns.length - 1, base + dir));
+    setRunCursor(next);
+    onSelectPath(displayRuns[next].sig);
+  };
+
   const totalKm = legRows
     ? legRows.reduce((s, l) => s + (l.distanceKm ?? 0), 0)
     : null;
@@ -185,6 +219,13 @@ export function MapTraceroutePanel({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
             </svg>
             Traceroute
+          </span>
+          <span
+            className="inline-flex items-center gap-1 text-[9px] text-emerald-300/90 shrink-0"
+            title="Listening — a new traceroute on this pair lands here the moment a gateway hears it"
+          >
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" aria-hidden="true" />
+            live
           </span>
           <div className="text-[11px] text-gray-300 truncate">
             <span style={{ color: fromColor }} className="font-medium">{fromLabel}</span>
@@ -256,6 +297,7 @@ export function MapTraceroutePanel({
             No traceroute has been observed between these nodes yet.
             <div className="mt-1 text-[10px] text-gray-600">
               Routes appear when a traceroute crossing both nodes is heard on the mesh.
+              Trigger one from your Meshtastic app — it will land here the moment a gateway hears it.
             </div>
           </div>
         ) : (
@@ -283,7 +325,13 @@ export function MapTraceroutePanel({
                 <div className="text-gray-200">
                   {selected.hopCount} {selected.hopCount === 1 ? "hop" : "hops"}
                   {totalKm != null && totalKm > 0 && <span className="text-gray-500 ml-2">{totalKm.toFixed(1)} km</span>}
-                  {selected.count > 1 && <span className="text-gray-500 ml-2">seen {selected.count}×</span>}
+                  {runsList.length > 1 ? (
+                    <span className="text-gray-500 ml-2">
+                      {selected.count}/{runsList.length} runs · {Math.round((selected.count / runsList.length) * 100)}%
+                    </span>
+                  ) : selected.count > 1 ? (
+                    <span className="text-gray-500 ml-2">seen {selected.count}×</span>
+                  ) : null}
                   {selected.snr != null && <span className="text-gray-500 ml-2">rx SNR {selected.snr.toFixed(1)} dB</span>}
                 </div>
                 <PathHopList
@@ -364,6 +412,82 @@ export function MapTraceroutePanel({
                 {analysisWarning && (
                   <div className="mt-1.5 text-[10px] text-amber-300/90">{analysisWarning}</div>
                 )}
+              </div>
+            )}
+
+            {displayRuns.length > 1 && (
+              <div className="px-2 py-1.5 rounded bg-white/5 border border-white/10 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-gray-500 text-[10px] uppercase tracking-wider truncate">
+                    Route History
+                    <span className="normal-case tracking-normal text-gray-600 ml-1.5">
+                      {runsList.length} runs · {routeChanges} {routeChanges === 1 ? "change" : "changes"}
+                      {runsList.length > displayRuns.length ? ` · last ${displayRuns.length}` : ""}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-0.5 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => stepRun(-1)}
+                      aria-label="Previous run"
+                      className="p-0.5 rounded text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+                    >
+                      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => stepRun(1)}
+                      aria-label="Next run"
+                      className="p-0.5 rounded text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+                    >
+                      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                  </span>
+                </div>
+                <div
+                  className="flex items-stretch gap-px mt-1.5 h-3.5"
+                  onMouseLeave={() => onHighlight?.(null)}
+                >
+                  {displayRuns.map((run, i) => {
+                    const isSel = run.sig === selectedSigStr;
+                    // First visible tick compares against the run just outside
+                    // the window, or a change at the boundary is never marked
+                    const prevRun = i > 0
+                      ? displayRuns[i - 1]
+                      : runsList.length > displayRuns.length
+                        ? runsList[runsList.length - displayRuns.length - 1]
+                        : null;
+                    const changed = prevRun != null && run.sig !== prevRun.sig;
+                    return (
+                      <button
+                        key={`${run.timestamp}-${i}`}
+                        type="button"
+                        onClick={() => {
+                          setRunCursor(i);
+                          onSelectPath(run.sig);
+                        }}
+                        onMouseEnter={() => onHighlight?.(toCoords(run.hops))}
+                        title={`${observedAgo(run.timestamp) ?? "age unknown"} · ${run.hopCount} ${run.hopCount === 1 ? "hop" : "hops"}${changed ? " · route changed" : ""}`}
+                        aria-label={`Run ${i + 1} of ${displayRuns.length}, ${run.hopCount} hops${changed ? ", route changed" : ""}`}
+                        className={`flex-1 min-w-0.75 rounded-[1px] transition-colors ${
+                          isSel
+                            ? "bg-cyan-400/90"
+                            : changed
+                              ? "bg-amber-400/60 hover:bg-amber-300/80"
+                              : "bg-white/15 hover:bg-white/35"
+                        }`}
+                      />
+                    );
+                  })}
+                </div>
+                <div className="flex justify-between mt-0.5 text-[9px] text-gray-600 tabular-nums">
+                  <span>{observedAgo(displayRuns[0].timestamp) ?? ""}</span>
+                  <span>{observedAgo(displayRuns[displayRuns.length - 1].timestamp) ?? ""}</span>
+                </div>
               </div>
             )}
 

--- a/frontend/src/pages/map/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/MapTraceroutePanel.tsx
@@ -1,34 +1,79 @@
 import { useEffect, useMemo, useState } from "react";
 
-import type { ITraceroutesResponse } from "../../types";
 import { unwrapLngTo } from "./geo";
 import { relativeTime } from "./helpers";
-import { type AnalyzedPath, findPathsBetween, tsToMs } from "./pathAnalysis";
+import { type AnalyzedPath, tsToMs } from "./pathAnalysis";
 import { PathHopList } from "./PathHopList";
 import type { IMapNode } from "./types";
 import { useBottomSheetGesture } from "./useBottomSheet";
+import type { TraceAnalysis, TraceLegVerdict } from "./useTraceCompute";
+
+const VERDICT_STYLE: Record<TraceLegVerdict, string> = {
+  clear: "border-emerald-500/30 bg-emerald-500/15 text-emerald-300",
+  fresnel: "border-orange-500/30 bg-orange-500/15 text-orange-300",
+  blocked: "border-red-500/30 bg-red-500/15 text-red-300",
+  gap: "border-white/10 bg-white/5 text-gray-400",
+};
+const VERDICT_LABEL: Record<TraceLegVerdict, string> = {
+  clear: "Clear",
+  fresnel: "Fresnel",
+  blocked: "Blocked",
+  gap: "Not graded",
+};
+
+function VerdictBadge({ v }: { v: TraceLegVerdict }) {
+  return (
+    <span className={`px-1.5 py-px rounded text-[9px] font-medium border shrink-0 ${VERDICT_STYLE[v]}`}>
+      {VERDICT_LABEL[v]}
+    </span>
+  );
+}
+
+function snrTint(db: number): string {
+  if (db >= 0) return "text-emerald-300";
+  if (db >= -10) return "text-amber-300";
+  return "text-red-300";
+}
 
 export function MapTraceroutePanel({
-  fromId,
-  toId,
   fromLabel,
   toLabel,
   fromColor = "#22c55e",
   toColor = "#06b6d4",
-  traceroutes,
+  paths,
+  selectedSig,
+  onSelectPath,
+  analysis,
+  isComputing,
+  analysisError,
+  analysisWarning,
+  terrain3D,
+  onEnableTerrain,
+  showDirect,
+  onToggleDirect,
   loading,
   liveNodes,
   onNodeSelect,
   onHighlight,
   onClose,
 }: {
-  fromId: string;
-  toId: string;
+  fromId?: string;
+  toId?: string;
   fromLabel: string;
   toLabel: string;
   fromColor?: string;
   toColor?: string;
-  traceroutes: ITraceroutesResponse[];
+  paths: AnalyzedPath[];
+  selectedSig: string | null;
+  onSelectPath: (sig: string) => void;
+  analysis: TraceAnalysis | null;
+  isComputing: boolean;
+  analysisError: string | null;
+  analysisWarning: string | null;
+  terrain3D: boolean;
+  onEnableTerrain?: () => void;
+  showDirect: boolean;
+  onToggleDirect: (v: boolean) => void;
   loading?: boolean;
   liveNodes: Record<string, IMapNode>;
   onNodeSelect: (id: string) => void;
@@ -36,15 +81,18 @@ export function MapTraceroutePanel({
   onHighlight?: (coords: [number, number][] | null) => void;
   onClose: () => void;
 }) {
-  // `traceroutes` arrives pre-merged from Map.tsx (global window + pair-scoped
-  // history), so the list here always matches what's drawn on the map.
-  const paths = useMemo(
-    () => findPathsBetween(fromId, toId, traceroutes),
-    [fromId, toId, traceroutes],
+  const selected = useMemo(
+    () => paths.find((p) => p.hops.join(">") === selectedSig) ?? paths[0] ?? null,
+    [paths, selectedSig],
   );
+  const alternates = useMemo(() => {
+    const sig = selected ? selected.hops.join(">") : null;
+    return paths.filter((p) => p.hops.join(">") !== sig).slice(0, 5);
+  }, [paths, selected]);
+  const isLatest = selected != null && selected === paths[0];
+  // Dossier rows only apply to the path they were computed for
+  const legRows = analysis && selected && analysis.sig === selected.hops.join(">") ? analysis.legs : null;
 
-  const latest = paths[0];
-  const alternates = paths.slice(1, 6);
   const [minimized, setMinimized] = useState(false);
   const sheet = useBottomSheetGesture({
     onClose,
@@ -60,6 +108,8 @@ export function MapTraceroutePanel({
     const n = liveNodes[id] ?? liveNodes[`!${id}`];
     return n?.map_position ? [n.map_position[0], n.map_position[1]] : null;
   };
+  const labelOf = (id: string): string =>
+    (liveNodes[id] ?? liveNodes[`!${id}`])?.shortname ?? id.slice(0, 8);
   /** Known-position coords, chain-unwrapped so seam-crossing legs draw short. */
   const toCoords = (ids: string[]): [number, number][] => {
     const out: [number, number][] = [];
@@ -75,9 +125,24 @@ export function MapTraceroutePanel({
   // Chip leave falls back to the whole path (the cursor is still in the card).
   const highlightHop = (p: AnalyzedPath, i: number | null) =>
     i == null ? highlightPath(p) : onHighlight?.(toCoords(p.hops.slice(Math.max(0, i - 1), i + 2)));
+  const highlightLeg = (p: AnalyzedPath, i: number | null) =>
+    i == null ? highlightPath(p) : onHighlight?.(toCoords(p.hops.slice(i, i + 2)));
 
   const observedAgo = (ts: number): string | null =>
     ts ? relativeTime(new Date(tsToMs(ts)).toISOString()) : null;
+
+  const totalKm = legRows
+    ? legRows.reduce((s, l) => s + (l.distanceKm ?? 0), 0)
+    : null;
+  const weakest: TraceLegVerdict | null = legRows
+    ? legRows.some((l) => l.verdict === "blocked")
+      ? "blocked"
+      : legRows.some((l) => l.verdict === "fresnel")
+        ? "fresnel"
+        : legRows.some((l) => l.verdict === "clear")
+          ? "clear"
+          : "gap"
+    : null;
 
   return (
     <div
@@ -87,8 +152,8 @@ export function MapTraceroutePanel({
       className="fixed z-1050 flex flex-col shadow-2xl border border-white/10 bg-gray-900/90 backdrop-blur-xl
         inset-x-0 bottom-0 rounded-t-2xl max-h-[70dvh]
         animate-[slideInUp_200ms_ease-out]
-        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(520px,calc(100vw-2rem))]
-        sm:rounded-xl sm:max-h-[60vh]">
+        sm:inset-x-auto sm:bottom-3 sm:left-1/2 sm:-translate-x-1/2 sm:w-[min(560px,calc(100vw-2rem))]
+        sm:rounded-xl sm:max-h-[64vh]">
 
       <div
         className="sm:hidden flex justify-center pt-2 pb-1 cursor-grab active:cursor-grabbing touch-none shrink-0"
@@ -144,29 +209,142 @@ export function MapTraceroutePanel({
           </div>
         ) : (
           <div className="space-y-1.5">
-            {latest && (
+            {selected && (
               <div
                 className="px-2 py-1.5 rounded bg-cyan-500/10 border border-cyan-500/20 text-xs"
-                onMouseEnter={() => highlightPath(latest)}
+                onMouseEnter={() => highlightPath(selected)}
                 onMouseLeave={() => onHighlight?.(null)}
               >
                 <div className="flex items-center justify-between gap-2 mb-0.5">
-                  <div className="text-cyan-400 text-[10px] uppercase tracking-wider">Latest Route</div>
-                  {observedAgo(latest.timestamp) && (
-                    <div className="text-[10px] text-gray-500 tabular-nums shrink-0">observed {observedAgo(latest.timestamp)}</div>
+                  <div className="flex items-center gap-2">
+                    <div className="text-cyan-400 text-[10px] uppercase tracking-wider">
+                      {isLatest ? "Latest Route" : "Selected Route"}
+                    </div>
+                    {weakest && weakest !== "gap" && (
+                      <span className="text-[9px] text-gray-500">weakest link:</span>
+                    )}
+                    {weakest && weakest !== "gap" && <VerdictBadge v={weakest} />}
+                  </div>
+                  {observedAgo(selected.timestamp) && (
+                    <div className="text-[10px] text-gray-500 tabular-nums shrink-0">observed {observedAgo(selected.timestamp)}</div>
                   )}
                 </div>
                 <div className="text-gray-200">
-                  {latest.hopCount} {latest.hopCount === 1 ? "hop" : "hops"}
-                  {latest.count > 1 && <span className="text-gray-500 ml-2">seen {latest.count}×</span>}
-                  {latest.snr != null && <span className="text-gray-500 ml-2">SNR {latest.snr.toFixed(1)} dB</span>}
+                  {selected.hopCount} {selected.hopCount === 1 ? "hop" : "hops"}
+                  {totalKm != null && totalKm > 0 && <span className="text-gray-500 ml-2">{totalKm.toFixed(1)} km</span>}
+                  {selected.count > 1 && <span className="text-gray-500 ml-2">seen {selected.count}×</span>}
+                  {selected.snr != null && <span className="text-gray-500 ml-2">rx SNR {selected.snr.toFixed(1)} dB</span>}
                 </div>
                 <PathHopList
-                  hops={latest.hops}
+                  hops={selected.hops}
                   liveNodes={liveNodes}
                   onNodeSelect={onNodeSelect}
-                  onHoverHop={(i) => highlightHop(latest, i)}
+                  onHoverHop={(i) => highlightHop(selected, i)}
                 />
+
+                {!terrain3D && (
+                  <div className="mt-1.5 px-2 py-1.5 rounded bg-white/5 text-[10px] text-gray-400 flex items-center justify-between gap-2">
+                    <span>Enable 3D terrain to grade each hop against real terrain.</span>
+                    {onEnableTerrain && (
+                      <button
+                        type="button"
+                        onClick={onEnableTerrain}
+                        className="px-1.5 py-0.5 rounded border border-cyan-500/30 bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 transition-colors shrink-0"
+                      >
+                        Set up
+                      </button>
+                    )}
+                  </div>
+                )}
+                {terrain3D && isComputing && !legRows && (
+                  <div className="mt-1.5 text-[10px] text-cyan-300/80 animate-pulse">
+                    Grading route against terrain…
+                  </div>
+                )}
+                {analysisError && (
+                  <div className="mt-1.5 text-[10px] text-red-400">{analysisError}</div>
+                )}
+
+                {legRows && (
+                  <div className="mt-1.5 space-y-0.5">
+                    {legRows.map((leg) => {
+                      const snr = selected.legSnrDb?.[leg.index] ?? null;
+                      return (
+                        <div
+                          key={leg.index}
+                          className="flex items-center gap-2 px-1.5 py-1 rounded bg-white/5 hover:bg-white/10 transition-colors text-[10px]"
+                          onMouseEnter={() => highlightLeg(selected, leg.index)}
+                          onMouseLeave={() => highlightPath(selected)}
+                        >
+                          <span className="text-gray-400 truncate min-w-0">
+                            {labelOf(leg.fromId)}
+                            <span className="text-gray-600 mx-0.5">›</span>
+                            {labelOf(leg.toId)}
+                          </span>
+                          <span className="flex items-center gap-1.5 ml-auto shrink-0 tabular-nums">
+                            {leg.distanceKm != null && (
+                              <span className="text-gray-400">{leg.distanceKm.toFixed(1)} km</span>
+                            )}
+                            <VerdictBadge v={leg.verdict} />
+                            {leg.verdict === "blocked" && leg.worstObstructionM > 0 && (
+                              <span className="text-red-300/90">+{Math.round(leg.worstObstructionM)} m</span>
+                            )}
+                            {leg.verdict !== "gap" && leg.minClearanceRatio != null && leg.verdict !== "blocked" && (
+                              <span className="text-gray-500">F₁ {Math.round(Math.max(0, Math.min(9.99, leg.minClearanceRatio)) * 100)}%</span>
+                            )}
+                            {leg.diffractionLossDb > 0.5 && (
+                              <span className="text-orange-300/90">−{leg.diffractionLossDb.toFixed(0)} dB</span>
+                            )}
+                            {leg.itmLossDb != null && (
+                              <span className="text-gray-500">ITM {leg.itmLossDb.toFixed(0)} dB</span>
+                            )}
+                            {snr != null && (
+                              <span className={snrTint(snr)}>
+                                {selected.legSnrReversed ? "←" : "→"} {snr.toFixed(1)} dB
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {analysisWarning && (
+                  <div className="mt-1.5 text-[10px] text-amber-300/90">{analysisWarning}</div>
+                )}
+              </div>
+            )}
+
+            {analysis?.direct && analysis.sig === (selected?.hops.join(">") ?? "") && (
+              <div className="px-2 py-1.5 rounded bg-white/5 border border-white/10 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-gray-400 text-[10px] uppercase tracking-wider shrink-0">Direct Path</span>
+                    <VerdictBadge v={analysis.direct.verdict} />
+                    <span className="text-gray-400 text-[10px] tabular-nums">
+                      {analysis.direct.distanceKm.toFixed(1)} km
+                      {analysis.direct.verdict === "blocked" && analysis.direct.worstObstructionM > 0 && (
+                        <> · terrain +{Math.round(analysis.direct.worstObstructionM)} m at {analysis.direct.worstObstructionDistKm.toFixed(1)} km</>
+                      )}
+                      {analysis.direct.itmLossDb != null && <> · ITM {analysis.direct.itmLossDb.toFixed(0)} dB</>}
+                    </span>
+                  </div>
+                  <label className="flex items-center gap-1.5 text-[10px] text-gray-400 cursor-pointer select-none shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={showDirect}
+                      onChange={(e) => onToggleDirect(e.target.checked)}
+                      className="accent-cyan-500 w-3 h-3"
+                    />
+                    Show on map
+                  </label>
+                </div>
+                {analysis.direct.verdict === "blocked" && (
+                  <div className="mt-0.5 text-[10px] text-gray-500">
+                    The direct line is blocked — the mesh routed around it in {selected?.hopCount ?? "?"} hops.
+                  </div>
+                )}
               </div>
             )}
 
@@ -174,12 +352,26 @@ export function MapTraceroutePanel({
               <div className="px-2 pt-1">
                 <div className="text-gray-500 text-[10px] uppercase tracking-wider mb-1">
                   Other Observed Paths ({paths.length - 1 > 5 ? `showing 5 of ${paths.length - 1}` : paths.length - 1})
+                  <span className="normal-case tracking-normal text-gray-600 ml-1.5">click to analyze</span>
                 </div>
                 <div className="space-y-1">
                   {alternates.map((p) => (
                     <div
                       key={p.hops.join(">")}
-                      className="text-xs px-2 py-1 rounded bg-white/5 hover:bg-white/10 transition-colors"
+                      role="button"
+                      tabIndex={0}
+                      className="text-xs px-2 py-1 rounded bg-white/5 hover:bg-white/10 transition-colors cursor-pointer
+                        focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400"
+                      onClick={() => onSelectPath(p.hops.join(">"))}
+                      onKeyDown={(e) => {
+                        // Hop-chip buttons handle their own Enter/Space — a bubbled
+                        // keydown must not hijack node-select into path-select
+                        if (e.target !== e.currentTarget) return;
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onSelectPath(p.hops.join(">"));
+                        }
+                      }}
                       onMouseEnter={() => highlightPath(p)}
                       onMouseLeave={() => onHighlight?.(null)}
                     >
@@ -187,18 +379,21 @@ export function MapTraceroutePanel({
                         <div className="text-gray-300">
                           {p.hopCount} {p.hopCount === 1 ? "hop" : "hops"}
                           {p.count > 1 && <span className="text-gray-500 ml-2">seen {p.count}×</span>}
-                          {p.snr != null && <span className="text-gray-500 ml-2">SNR {p.snr.toFixed(1)} dB</span>}
+                          {p.snr != null && <span className="text-gray-500 ml-2">rx SNR {p.snr.toFixed(1)} dB</span>}
                         </div>
                         {observedAgo(p.timestamp) && (
                           <div className="text-[10px] text-gray-500 tabular-nums shrink-0">{observedAgo(p.timestamp)}</div>
                         )}
                       </div>
-                      <PathHopList
-                        hops={p.hops}
-                        liveNodes={liveNodes}
-                        onNodeSelect={onNodeSelect}
-                        onHoverHop={(i) => highlightHop(p, i)}
-                      />
+                      {/* Hop-chip clicks open node details — don't let them bubble into path selection */}
+                      <div onClick={(e) => e.stopPropagation()}>
+                        <PathHopList
+                          hops={p.hops}
+                          liveNodes={liveNodes}
+                          onNodeSelect={onNodeSelect}
+                          onHoverHop={(i) => highlightHop(p, i)}
+                        />
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/frontend/src/pages/map/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/MapTraceroutePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 
 import { toast } from "../../components/toastStore";
 import { copyTextToClipboard } from "../../utils/clipboard";
@@ -37,7 +37,7 @@ function snrTint(db: number): string {
   return "text-red-300";
 }
 
-export function MapTraceroutePanel({
+function MapTraceroutePanelInner({
   fromLabel,
   toLabel,
   fromColor = "#22c55e",
@@ -580,3 +580,6 @@ export function MapTraceroutePanel({
     </div>
   );
 }
+
+/** Memoized: the Map page re-renders far more often than these props change. */
+export const MapTraceroutePanel = memo(MapTraceroutePanelInner);

--- a/frontend/src/pages/map/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/MapTraceroutePanel.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { ITraceroutesResponse } from "../../types";
-import { findPathsBetween } from "./pathAnalysis";
+import { unwrapLngTo } from "./geo";
+import { relativeTime } from "./helpers";
+import { type AnalyzedPath, findPathsBetween, tsToMs } from "./pathAnalysis";
 import { PathHopList } from "./PathHopList";
 import type { IMapNode } from "./types";
 import { useBottomSheetGesture } from "./useBottomSheet";
@@ -17,7 +19,7 @@ export function MapTraceroutePanel({
   loading,
   liveNodes,
   onNodeSelect,
-  onHoverLink,
+  onHighlight,
   onClose,
 }: {
   fromId: string;
@@ -30,11 +32,19 @@ export function MapTraceroutePanel({
   loading?: boolean;
   liveNodes: Record<string, IMapNode>;
   onNodeSelect: (id: string) => void;
-  onHoverLink?: (id: string | null) => void;
+  /** Spotlight the given path segment on the map (null clears). */
+  onHighlight?: (coords: [number, number][] | null) => void;
   onClose: () => void;
 }) {
-  const paths = findPathsBetween(fromId, toId, traceroutes);
-  const shortest = paths[0];
+  // `traceroutes` arrives pre-merged from Map.tsx (global window + pair-scoped
+  // history), so the list here always matches what's drawn on the map.
+  const paths = useMemo(
+    () => findPathsBetween(fromId, toId, traceroutes),
+    [fromId, toId, traceroutes],
+  );
+
+  const latest = paths[0];
+  const alternates = paths.slice(1, 6);
   const [minimized, setMinimized] = useState(false);
   const sheet = useBottomSheetGesture({
     onClose,
@@ -42,6 +52,32 @@ export function MapTraceroutePanel({
     onMinimize: () => setMinimized(true),
     onExpand: () => setMinimized(false),
   });
+
+  // Don't leave a stale spotlight behind when the sheet closes.
+  useEffect(() => () => onHighlight?.(null), [onHighlight]);
+
+  const posOf = (id: string): [number, number] | null => {
+    const n = liveNodes[id] ?? liveNodes[`!${id}`];
+    return n?.map_position ? [n.map_position[0], n.map_position[1]] : null;
+  };
+  /** Known-position coords, chain-unwrapped so seam-crossing legs draw short. */
+  const toCoords = (ids: string[]): [number, number][] => {
+    const out: [number, number][] = [];
+    for (const id of ids) {
+      const pos = posOf(id);
+      if (!pos) continue;
+      const prev = out[out.length - 1];
+      out.push(prev ? [unwrapLngTo(prev[0], pos[0]), pos[1]] : pos);
+    }
+    return out;
+  };
+  const highlightPath = (p: AnalyzedPath) => onHighlight?.(toCoords(p.hops));
+  // Chip leave falls back to the whole path (the cursor is still in the card).
+  const highlightHop = (p: AnalyzedPath, i: number | null) =>
+    i == null ? highlightPath(p) : onHighlight?.(toCoords(p.hops.slice(Math.max(0, i - 1), i + 2)));
+
+  const observedAgo = (ts: number): string | null =>
+    ts ? relativeTime(new Date(tsToMs(ts)).toISOString()) : null;
 
   return (
     <div
@@ -95,40 +131,74 @@ export function MapTraceroutePanel({
       </div>
 
       <div className={`p-3 overflow-y-auto overscroll-contain flex-1 min-h-0 ${minimized ? "max-sm:hidden" : ""}`}>
-        {loading && traceroutes.length === 0 ? (
+        {loading && paths.length === 0 ? (
           <div className="px-2 py-3 text-xs text-gray-500">
             Loading traceroutes…
           </div>
         ) : paths.length === 0 ? (
           <div className="px-2 py-3 text-xs text-gray-500">
-            No known traceroute path between these nodes.
+            No traceroute has been observed between these nodes yet.
+            <div className="mt-1 text-[10px] text-gray-600">
+              Routes appear when a traceroute crossing both nodes is heard on the mesh.
+            </div>
           </div>
         ) : (
           <div className="space-y-1.5">
-            {shortest && (
-              <div className="px-2 py-1.5 rounded bg-cyan-500/10 border border-cyan-500/20 text-xs">
-                <div className="text-cyan-400 text-[10px] uppercase tracking-wider mb-0.5">Shortest Path</div>
-                <div className="text-gray-200">
-                  {shortest.hopCount} {shortest.hopCount === 1 ? "hop" : "hops"}
-                  {shortest.snr != null && <span className="text-gray-500 ml-2">SNR {shortest.snr.toFixed(1)} dB</span>}
+            {latest && (
+              <div
+                className="px-2 py-1.5 rounded bg-cyan-500/10 border border-cyan-500/20 text-xs"
+                onMouseEnter={() => highlightPath(latest)}
+                onMouseLeave={() => onHighlight?.(null)}
+              >
+                <div className="flex items-center justify-between gap-2 mb-0.5">
+                  <div className="text-cyan-400 text-[10px] uppercase tracking-wider">Latest Route</div>
+                  {observedAgo(latest.timestamp) && (
+                    <div className="text-[10px] text-gray-500 tabular-nums shrink-0">observed {observedAgo(latest.timestamp)}</div>
+                  )}
                 </div>
-                <PathHopList hops={shortest.hops} liveNodes={liveNodes} onNodeSelect={onNodeSelect} onHoverLink={onHoverLink} />
+                <div className="text-gray-200">
+                  {latest.hopCount} {latest.hopCount === 1 ? "hop" : "hops"}
+                  {latest.count > 1 && <span className="text-gray-500 ml-2">seen {latest.count}×</span>}
+                  {latest.snr != null && <span className="text-gray-500 ml-2">SNR {latest.snr.toFixed(1)} dB</span>}
+                </div>
+                <PathHopList
+                  hops={latest.hops}
+                  liveNodes={liveNodes}
+                  onNodeSelect={onNodeSelect}
+                  onHoverHop={(i) => highlightHop(latest, i)}
+                />
               </div>
             )}
 
-            {paths.length > 1 && (
+            {alternates.length > 0 && (
               <div className="px-2 pt-1">
                 <div className="text-gray-500 text-[10px] uppercase tracking-wider mb-1">
-                  Alternative Paths ({paths.length - 1 > 5 ? `showing 5 of ${paths.length - 1}` : paths.length - 1})
+                  Other Observed Paths ({paths.length - 1 > 5 ? `showing 5 of ${paths.length - 1}` : paths.length - 1})
                 </div>
                 <div className="space-y-1">
-                  {paths.slice(1, 6).map((p) => (
-                    <div key={p.hops.join(">")} className="text-xs px-2 py-1 rounded bg-white/5">
-                      <div className="text-gray-300">
-                        {p.hopCount} {p.hopCount === 1 ? "hop" : "hops"}
-                        {p.snr != null && <span className="text-gray-500 ml-2">SNR {p.snr.toFixed(1)} dB</span>}
+                  {alternates.map((p) => (
+                    <div
+                      key={p.hops.join(">")}
+                      className="text-xs px-2 py-1 rounded bg-white/5 hover:bg-white/10 transition-colors"
+                      onMouseEnter={() => highlightPath(p)}
+                      onMouseLeave={() => onHighlight?.(null)}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-gray-300">
+                          {p.hopCount} {p.hopCount === 1 ? "hop" : "hops"}
+                          {p.count > 1 && <span className="text-gray-500 ml-2">seen {p.count}×</span>}
+                          {p.snr != null && <span className="text-gray-500 ml-2">SNR {p.snr.toFixed(1)} dB</span>}
+                        </div>
+                        {observedAgo(p.timestamp) && (
+                          <div className="text-[10px] text-gray-500 tabular-nums shrink-0">{observedAgo(p.timestamp)}</div>
+                        )}
                       </div>
-                      <PathHopList hops={p.hops} liveNodes={liveNodes} onNodeSelect={onNodeSelect} onHoverLink={onHoverLink} />
+                      <PathHopList
+                        hops={p.hops}
+                        liveNodes={liveNodes}
+                        onNodeSelect={onNodeSelect}
+                        onHoverHop={(i) => highlightHop(p, i)}
+                      />
                     </div>
                   ))}
                 </div>

--- a/frontend/src/pages/map/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/MapTraceroutePanel.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
+import { toast } from "../../components/toastStore";
+import { copyTextToClipboard } from "../../utils/clipboard";
 import { unwrapLngTo } from "./geo";
 import { relativeTime } from "./helpers";
 import { type AnalyzedPath, tsToMs } from "./pathAnalysis";
@@ -51,6 +53,9 @@ export function MapTraceroutePanel({
   onEnableTerrain,
   showDirect,
   onToggleDirect,
+  isFlying,
+  canFly,
+  onToggleFlyover,
   loading,
   liveNodes,
   onNodeSelect,
@@ -74,6 +79,10 @@ export function MapTraceroutePanel({
   onEnableTerrain?: () => void;
   showDirect: boolean;
   onToggleDirect: (v: boolean) => void;
+  /** "Ride the Packet" camera tour along the selected route. */
+  isFlying?: boolean;
+  canFly?: boolean;
+  onToggleFlyover?: () => void;
   loading?: boolean;
   liveNodes: Record<string, IMapNode>;
   onNodeSelect: (id: string) => void;
@@ -183,16 +192,58 @@ export function MapTraceroutePanel({
             <span style={{ color: toColor }} className="font-medium">{toLabel}</span>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors shrink-0"
-          aria-label="Close"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
+        <div className="flex items-center gap-0.5 shrink-0">
+          {canFly && onToggleFlyover && selected && toCoords(selected.hops).length >= 2 && (
+            <button
+              type="button"
+              onClick={onToggleFlyover}
+              className={`p-1 rounded-md transition-colors ${
+                isFlying
+                  ? "text-cyan-300 bg-cyan-500/15 hover:bg-cyan-500/25"
+                  : "text-gray-500 hover:text-gray-300 hover:bg-white/10"
+              }`}
+              aria-label={isFlying ? "Stop the route tour" : "Ride the packet — camera tour along this route"}
+              title={isFlying ? "Stop tour (Esc)" : "Ride the packet"}
+            >
+              {isFlying ? (
+                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="7" y="7" width="10" height="10" rx="1" />
+                </svg>
+              ) : (
+                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M8 5.5v13l11-6.5-11-6.5z" />
+                </svg>
+              )}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              // copyTextToClipboard has an execCommand fallback for plain-HTTP installs
+              void copyTextToClipboard(window.location.href).then((ok) => {
+                if (ok) toast("Link to this traceroute copied.");
+                else toast("Couldn't copy the link.", { kind: "error" });
+              });
+            }}
+            className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+            aria-label="Copy a shareable link to this traceroute"
+            title="Copy a shareable link"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 11-5.656-5.656l1.5-1.5m3.5-2.344a4 4 0 010-5.656l3-3a4 4 0 115.656 5.656l-1.5 1.5" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       <div className={`p-3 overflow-y-auto overscroll-contain flex-1 min-h-0 ${minimized ? "max-sm:hidden" : ""}`}>

--- a/frontend/src/pages/map/PathHopList.tsx
+++ b/frontend/src/pages/map/PathHopList.tsx
@@ -5,12 +5,14 @@ export function PathHopList({
   hops,
   liveNodes,
   onNodeSelect,
-  onHoverLink,
+  onHoverHop,
 }: {
   hops: string[];
   liveNodes: Record<string, IMapNode>;
   onNodeSelect: (id: string) => void;
-  onHoverLink?: (id: string | null) => void;
+  /** Reports the hovered hop's index (null on leave) so the parent can
+   *  highlight that hop's actual path legs on the map. */
+  onHoverHop?: (index: number | null) => void;
 }) {
   return (
     <div className="flex items-center gap-1 mt-1 overflow-x-auto">
@@ -23,15 +25,21 @@ export function PathHopList({
               <button
                 type="button"
                 onClick={() => onNodeSelect(hop)}
-                onMouseEnter={() => onHoverLink?.(hop)}
-                onMouseLeave={() => onHoverLink?.(null)}
+                onMouseEnter={() => onHoverHop?.(i)}
+                onMouseLeave={() => onHoverHop?.(null)}
                 aria-label={`Node ${label}`}
                 className="text-cyan-400 hover:text-cyan-300 text-[11px] rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400"
               >
                 {label}
               </button>
             ) : (
-              <span className="text-gray-500 text-[11px]">{label}</span>
+              <span
+                className="text-gray-500 text-[11px]"
+                onMouseEnter={() => onHoverHop?.(i)}
+                onMouseLeave={() => onHoverHop?.(null)}
+              >
+                {label}
+              </span>
             )}
             {i < hops.length - 1 && (
               <svg className="w-2.5 h-2.5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/pages/map/activityLayer.ts
+++ b/frontend/src/pages/map/activityLayer.ts
@@ -340,6 +340,17 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
     this.scheduleNextFrame();
   }
 
+  /** One comet leg + landing ripple; returns the leg's duration (ms) so a
+   *  caller can choreograph a camera chase against it. */
+  spawnLeg(from: LngLat, to: LngLat, color: RGB, weight: number, now: number): number {
+    if (!this.gl || !this.buffer) return 0;
+    const dur = this.arcDur(from, to);
+    this.writeArc(from, to, color, weight, now, dur);
+    this.spawnRing(to, color, now + dur * 0.9, RIPPLE_MS, 0.8);
+    this.scheduleNextFrame();
+    return dur;
+  }
+
   /** Sequential comet through a resolved multi-hop path (traceroute), hop by hop. */
   spawnPath(points: LngLat[], color: RGB, weight: number, now: number): void {
     if (!this.gl || !this.buffer || points.length === 0) return;

--- a/frontend/src/pages/map/activityLayer.ts
+++ b/frontend/src/pages/map/activityLayer.ts
@@ -341,12 +341,24 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
   }
 
   /** One comet leg + landing ripple; returns the leg's duration (ms) so a
-   *  caller can choreograph a camera chase against it. */
-  spawnLeg(from: LngLat, to: LngLat, color: RGB, weight: number, now: number): number {
+   *  caller can choreograph a camera chase against it. `speedScale` slows the
+   *  comet below ambient speed (0.5 = half speed) with its own clamps — a
+   *  guided tour reads better slower than background traffic. */
+  spawnLeg(
+    from: LngLat,
+    to: LngLat,
+    color: RGB,
+    weight: number,
+    now: number,
+    opts?: { speedScale?: number; minMs?: number; maxMs?: number; landingRing?: boolean },
+  ): number {
     if (!this.gl || !this.buffer) return 0;
-    const dur = this.arcDur(from, to);
+    const base = this.arcDur(from, to) / (opts?.speedScale ?? 1);
+    const dur = Math.min(opts?.maxMs ?? MAX_ARC_MS, Math.max(opts?.minMs ?? MIN_ARC_MS, base));
     this.writeArc(from, to, color, weight, now, dur);
-    this.spawnRing(to, color, now + dur * 0.9, RIPPLE_MS, 0.8);
+    // landingRing: false lets a caller that fires its own arrival pulse skip
+    // the built-in one (two concurrent rings read as a doubled ping)
+    if (opts?.landingRing !== false) this.spawnRing(to, color, now + dur * 0.9, RIPPLE_MS, 0.8);
     this.scheduleNextFrame();
     return dur;
   }

--- a/frontend/src/pages/map/activityLayer.ts
+++ b/frontend/src/pages/map/activityLayer.ts
@@ -135,6 +135,7 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
   private cpu = new Float32Array(MAX_POINTS * FLOATS);
   private writeHead = 0;
   private maxExpiry = 0; // performance.now() ms of the last live primitive
+  private arcExpiry = 0; // last live COMET's end — rings alone tolerate a lower fps
   private alpha = 1;
   private repaintHandle: number | null = null;
   private lastRenderTs = 0; // performance.now() of the last actual render (fps cap)
@@ -211,12 +212,15 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
   }
 
   /** Keep-alive repaint, vsync-aligned via rAF, capped to ~30fps by frame-skip.
-   *  Uniform spacing avoids the jitter a setTimeout clock produced. */
+   *  Halves to ~15fps when the camera is idle and only rings remain — each
+   *  triggerRepaint redraws the whole scene (terrain + satellite). */
   private scheduleNextFrame(): void {
     if (this.repaintHandle != null || !this.map) return;
     this.repaintHandle = requestAnimationFrame((ts) => {
       this.repaintHandle = null;
-      if (ts - this.lastRenderTs < FRAME_MS - 1) {
+      const ringsOnly = performance.now() > this.arcExpiry;
+      const cap = ringsOnly && this.map && !this.map.isMoving() ? FRAME_MS * 2 : FRAME_MS;
+      if (ts - this.lastRenderTs < cap - 1) {
         this.scheduleNextFrame(); // too soon — wait for the next vsync, don't render yet
         return;
       }
@@ -319,6 +323,7 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
     }
     this.emit(d, ARC_SAMPLES);
     this.maxExpiry = Math.max(this.maxExpiry, t0 + dur);
+    this.arcExpiry = Math.max(this.arcExpiry, t0 + dur);
   }
 
   /** Comet duration from on-screen distance → constant travel speed at any zoom. */
@@ -340,10 +345,8 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
     this.scheduleNextFrame();
   }
 
-  /** One comet leg + landing ripple; returns the leg's duration (ms) so a
-   *  caller can choreograph a camera chase against it. `speedScale` slows the
-   *  comet below ambient speed (0.5 = half speed) with its own clamps — a
-   *  guided tour reads better slower than background traffic. */
+  /** One comet leg + landing ripple; returns its duration (ms) for camera
+   *  choreography. speedScale slows below ambient (0.5 = half speed). */
   spawnLeg(
     from: LngLat,
     to: LngLat,
@@ -356,8 +359,7 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
     const base = this.arcDur(from, to) / (opts?.speedScale ?? 1);
     const dur = Math.min(opts?.maxMs ?? MAX_ARC_MS, Math.max(opts?.minMs ?? MIN_ARC_MS, base));
     this.writeArc(from, to, color, weight, now, dur);
-    // landingRing: false lets a caller that fires its own arrival pulse skip
-    // the built-in one (two concurrent rings read as a doubled ping)
+    // landingRing:false — caller fires its own arrival pulse (two rings read doubled)
     if (opts?.landingRing !== false) this.spawnRing(to, color, now + dur * 0.9, RIPPLE_MS, 0.8);
     this.scheduleNextFrame();
     return dur;

--- a/frontend/src/pages/map/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/clusterDonutLayer.ts
@@ -398,8 +398,12 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     } else if (this.hasActiveTween(now)) {
       this.uploadVerts(); // ratio tween: re-evaluate every frame
     } else if (terrainOn && this.lastClusters.length > 0 && camSig !== this.lastCamSig) {
-      this.uploadVerts(); // camera moved (or DEM arrived): re-drape once
-      this.lastCamSig = camSig;
+      // Re-drape costs queryTerrainElevation per cluster per camera frame;
+      // while dimmed ≤0.3 (RF tool active) a stale drape is invisible — skip
+      if (this.alpha > 0.3) {
+        this.uploadVerts(); // camera moved (or DEM arrived): re-drape once
+        this.lastCamSig = camSig;
+      }
     }
 
     if (this.vertexCount === 0) return;

--- a/frontend/src/pages/map/linkFeatures.ts
+++ b/frontend/src/pages/map/linkFeatures.ts
@@ -15,7 +15,7 @@ function straightCoords(from: [number, number], to: [number, number]): [number, 
 }
 
 /** Time-since-heard → opacity multiplier. Stale links taper to 0.3 (still visible). */
-function recencyOpacityFromAgeMs(ageMs: number | null): number {
+export function recencyOpacityFromAgeMs(ageMs: number | null): number {
   if (ageMs == null || !Number.isFinite(ageMs)) return 0.6;
   const m = ageMs / 60_000;
   if (m <= 15) return 1.0;

--- a/frontend/src/pages/map/losTubeLayer.ts
+++ b/frontend/src/pages/map/losTubeLayer.ts
@@ -6,7 +6,7 @@ import maplibregl, { type CustomRenderMethodInput } from "maplibre-gl";
 
 import { normalizeLng, shortestLngDelta } from "./geo";
 
-export type LosSegmentColor = "clear" | "fresnel" | "blocked";
+export type LosSegmentColor = "clear" | "fresnel" | "blocked" | "gap";
 
 export interface LosTubePoint {
   lng: number;
@@ -23,12 +23,14 @@ export interface LosTubeData {
 const COLOR_CLEAR: [number, number, number] = [0.024, 0.714, 0.831]; // #06b6d4 cyan
 const COLOR_FRESNEL: [number, number, number] = [0.976, 0.451, 0.086]; // #f97316 orange
 const COLOR_BLOCKED: [number, number, number] = [0.94, 0.27, 0.27]; // #ef4444 red
+const COLOR_GAP: [number, number, number] = [0.42, 0.45, 0.5]; // #6b7280 gray — unanalyzed (ghost-hop) leg
 
 function colorFor(cls: LosSegmentColor): [number, number, number] {
   switch (cls) {
     case "clear": return COLOR_CLEAR;
     case "fresnel": return COLOR_FRESNEL;
     case "blocked": return COLOR_BLOCKED;
+    case "gap": return COLOR_GAP;
   }
 }
 
@@ -46,9 +48,13 @@ function compile(gl: WebGLRenderingContext, type: number, source: string): WebGL
 }
 
 export class LosTubeLayer implements maplibregl.CustomLayerInterface {
-  readonly id = "los-tube";
+  readonly id: string;
   readonly type = "custom" as const;
   readonly renderingMode = "3d" as const;
+
+  constructor(id = "los-tube") {
+    this.id = id;
+  }
 
   private map: maplibregl.Map | null = null;
   private gl: WebGLRenderingContext | null = null;

--- a/frontend/src/pages/map/pathAnalysis.test.ts
+++ b/frontend/src/pages/map/pathAnalysis.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { ITraceroutesResponse } from "../../types";
-import { decodeSnr, findPathsBetween } from "./pathAnalysis";
+import { computeTraceEdgeStats, decodeSnr, findPathsBetween } from "./pathAnalysis";
 
-/** Minimal traceroute row; O=requester, D=destination. */
+/** Minimal traceroute row; O=0000000a requester, D=0000000d destination. */
 function row(overrides: Partial<ITraceroutesResponse>): ITraceroutesResponse {
   return {
     channel: 0,
-    from: "0000000o",
+    from: "0000000a",
     to: "0000000d",
     id: 1,
     payload: { route: [] },
@@ -32,11 +32,11 @@ describe("decodeSnr", () => {
 
 describe("findPathsBetween", () => {
   it("orients request rows as from → route → to", () => {
-    const paths = findPathsBetween("0000000o", "0000000d", [
-      row({ route_ids: ["000000r1", "000000r2"] }),
+    const paths = findPathsBetween("0000000a", "0000000d", [
+      row({ route_ids: ["000000b1", "000000b2"] }),
     ]);
     expect(paths).toHaveLength(1);
-    expect(paths[0].hops).toEqual(["0000000o", "000000r1", "000000r2", "0000000d"]);
+    expect(paths[0].hops).toEqual(["0000000a", "000000b1", "000000b2", "0000000d"]);
     expect(paths[0].legSnrDb).toBeUndefined();
   });
 
@@ -44,14 +44,14 @@ describe("findPathsBetween", () => {
     // Reply for trace O→R1→R2→D: header from=D, to=O; route stays request-order.
     const reply = row({
       from: "0000000d",
-      to: "0000000o",
-      route_ids: ["000000r1", "000000r2"],
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
       payload: { route: [], snr_towards: [-29, 8, -128] },
     });
-    const paths = findPathsBetween("0000000o", "0000000d", [reply]);
+    const paths = findPathsBetween("0000000a", "0000000d", [reply]);
     expect(paths).toHaveLength(1);
     // True travel order O→R1→R2→D, not the scrambled D-header order
-    expect(paths[0].hops).toEqual(["0000000o", "000000r1", "000000r2", "0000000d"]);
+    expect(paths[0].hops).toEqual(["0000000a", "000000b1", "000000b2", "0000000d"]);
     expect(paths[0].legSnrDb).toEqual([-7.25, 2, null]);
     expect(paths[0].legSnrReversed).toBe(false);
   });
@@ -59,12 +59,12 @@ describe("findPathsBetween", () => {
   it("reverses hops and legs when picked opposite to travel order", () => {
     const reply = row({
       from: "0000000d",
-      to: "0000000o",
-      route_ids: ["000000r1"],
+      to: "0000000a",
+      route_ids: ["000000b1"],
       payload: { route: [], snr_towards: [-29, 8] },
     });
-    const paths = findPathsBetween("0000000d", "0000000o", [reply]);
-    expect(paths[0].hops).toEqual(["0000000d", "000000r1", "0000000o"]);
+    const paths = findPathsBetween("0000000d", "0000000a", [reply]);
+    expect(paths[0].hops).toEqual(["0000000d", "000000b1", "0000000a"]);
     expect(paths[0].legSnrDb).toEqual([2, -7.25]);
     expect(paths[0].legSnrReversed).toBe(true);
   });
@@ -72,23 +72,61 @@ describe("findPathsBetween", () => {
   it("keeps unresolvable hops as placeholders so alignment holds", () => {
     const reply = row({
       from: "0000000d",
-      to: "0000000o",
-      route_ids: ["Some Longname", "000000r2"] as string[],
+      to: "0000000a",
+      route_ids: ["Some Longname", "000000b2"] as string[],
       payload: { route: [], snr_towards: [4, 8, 12] },
     });
-    const paths = findPathsBetween("0000000o", "0000000d", [reply]);
+    const paths = findPathsBetween("0000000a", "0000000d", [reply]);
     expect(paths[0].hops).toHaveLength(4);
     expect(paths[0].legSnrDb).toEqual([1, 2, 3]);
   });
 
   it("ranks newest first with hop count as tiebreak, counting repeats", () => {
     const stale1hop = row({ id: 1, route_ids: [], timestamp: 100 });
-    const fresh2hopA = row({ id: 2, route_ids: ["000000r1"], timestamp: 900 });
-    const fresh2hopB = row({ id: 3, route_ids: ["000000r1"], timestamp: 950 });
-    const paths = findPathsBetween("0000000o", "0000000d", [stale1hop, fresh2hopA, fresh2hopB]);
-    expect(paths[0].hops).toEqual(["0000000o", "000000r1", "0000000d"]);
+    const fresh2hopA = row({ id: 2, route_ids: ["000000b1"], timestamp: 900 });
+    const fresh2hopB = row({ id: 3, route_ids: ["000000b1"], timestamp: 950 });
+    const paths = findPathsBetween("0000000a", "0000000d", [stale1hop, fresh2hopA, fresh2hopB]);
+    expect(paths[0].hops).toEqual(["0000000a", "000000b1", "0000000d"]);
     expect(paths[0].count).toBe(2);
     expect(paths[0].timestamp).toBe(950);
     expect(paths[1].hopCount).toBe(1);
+  });
+});
+
+describe("computeTraceEdgeStats", () => {
+  it("counts undirected edge traversals once per run", () => {
+    const runs = [
+      row({ id: 1, route_ids: ["000000b1"], timestamp: 100 }),
+      // Reverse direction — same undirected edges
+      row({ id: 2, from: "0000000d", to: "0000000a", route_ids: ["000000b1"], timestamp: 200 }),
+      row({ id: 3, route_ids: [], timestamp: 300 }),
+    ];
+    const stats = computeTraceEdgeStats(runs);
+    const byKey = new Map(stats.map((e) => [`${e.aId}|${e.bId}`, e]));
+    expect(byKey.get("0000000a|000000b1")?.count).toBe(2);
+    expect(byKey.get("0000000d|000000b1")?.count).toBe(2);
+    expect(byKey.get("0000000a|0000000d")?.count).toBe(1);
+    expect(byKey.get("0000000a|000000b1")?.lastTimestamp).toBe(200);
+  });
+
+  it("orients reply rows before counting edges (header swap ≠ reversal)", () => {
+    // Reply for O→R1→R2→D: header from=D, to=O, request-ordered route
+    const reply = row({
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+    });
+    const stats = computeTraceEdgeStats([reply]);
+    const keys = stats.map((e) => `${e.aId}|${e.bId}`).sort();
+    // Real legs O–R1, R1–R2, R2–D — not the phantom D–R1 / R2–O
+    expect(keys).toEqual(["0000000a|000000b1", "0000000d|000000b2", "000000b1|000000b2"]);
+  });
+
+  it("skips edges touching unresolved hops", () => {
+    const stats = computeTraceEdgeStats([
+      row({ id: 9, route_ids: ["Some Longname"] as string[], timestamp: 50 }),
+    ]);
+    expect(stats).toEqual([]);
   });
 });

--- a/frontend/src/pages/map/pathAnalysis.test.ts
+++ b/frontend/src/pages/map/pathAnalysis.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import type { ITraceroutesResponse } from "../../types";
+import { decodeSnr, findPathsBetween } from "./pathAnalysis";
+
+/** Minimal traceroute row; O=requester, D=destination. */
+function row(overrides: Partial<ITraceroutesResponse>): ITraceroutesResponse {
+  return {
+    channel: 0,
+    from: "0000000o",
+    to: "0000000d",
+    id: 1,
+    payload: { route: [] },
+    route: [],
+    route_ids: [],
+    rssi: -80,
+    snr: -5,
+    timestamp: 1000,
+    type: "traceroute",
+    ...overrides,
+  } as ITraceroutesResponse;
+}
+
+describe("decodeSnr", () => {
+  it("decodes ×4 scaling and the -128 sentinel", () => {
+    expect(decodeSnr(-29)).toBe(-7.25);
+    expect(decodeSnr(0)).toBe(0);
+    expect(decodeSnr(-128)).toBeNull();
+    expect(decodeSnr(undefined)).toBeNull();
+  });
+});
+
+describe("findPathsBetween", () => {
+  it("orients request rows as from → route → to", () => {
+    const paths = findPathsBetween("0000000o", "0000000d", [
+      row({ route_ids: ["000000r1", "000000r2"] }),
+    ]);
+    expect(paths).toHaveLength(1);
+    expect(paths[0].hops).toEqual(["0000000o", "000000r1", "000000r2", "0000000d"]);
+    expect(paths[0].legSnrDb).toBeUndefined();
+  });
+
+  it("orients reply rows (full snr_towards) as to → route → from", () => {
+    // Reply for trace O→R1→R2→D: header from=D, to=O; route stays request-order.
+    const reply = row({
+      from: "0000000d",
+      to: "0000000o",
+      route_ids: ["000000r1", "000000r2"],
+      payload: { route: [], snr_towards: [-29, 8, -128] },
+    });
+    const paths = findPathsBetween("0000000o", "0000000d", [reply]);
+    expect(paths).toHaveLength(1);
+    // True travel order O→R1→R2→D, not the scrambled D-header order
+    expect(paths[0].hops).toEqual(["0000000o", "000000r1", "000000r2", "0000000d"]);
+    expect(paths[0].legSnrDb).toEqual([-7.25, 2, null]);
+    expect(paths[0].legSnrReversed).toBe(false);
+  });
+
+  it("reverses hops and legs when picked opposite to travel order", () => {
+    const reply = row({
+      from: "0000000d",
+      to: "0000000o",
+      route_ids: ["000000r1"],
+      payload: { route: [], snr_towards: [-29, 8] },
+    });
+    const paths = findPathsBetween("0000000d", "0000000o", [reply]);
+    expect(paths[0].hops).toEqual(["0000000d", "000000r1", "0000000o"]);
+    expect(paths[0].legSnrDb).toEqual([2, -7.25]);
+    expect(paths[0].legSnrReversed).toBe(true);
+  });
+
+  it("keeps unresolvable hops as placeholders so alignment holds", () => {
+    const reply = row({
+      from: "0000000d",
+      to: "0000000o",
+      route_ids: ["Some Longname", "000000r2"] as string[],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+    });
+    const paths = findPathsBetween("0000000o", "0000000d", [reply]);
+    expect(paths[0].hops).toHaveLength(4);
+    expect(paths[0].legSnrDb).toEqual([1, 2, 3]);
+  });
+
+  it("ranks newest first with hop count as tiebreak, counting repeats", () => {
+    const stale1hop = row({ id: 1, route_ids: [], timestamp: 100 });
+    const fresh2hopA = row({ id: 2, route_ids: ["000000r1"], timestamp: 900 });
+    const fresh2hopB = row({ id: 3, route_ids: ["000000r1"], timestamp: 950 });
+    const paths = findPathsBetween("0000000o", "0000000d", [stale1hop, fresh2hopA, fresh2hopB]);
+    expect(paths[0].hops).toEqual(["0000000o", "000000r1", "0000000d"]);
+    expect(paths[0].count).toBe(2);
+    expect(paths[0].timestamp).toBe(950);
+    expect(paths[1].hopCount).toBe(1);
+  });
+});

--- a/frontend/src/pages/map/pathAnalysis.ts
+++ b/frontend/src/pages/map/pathAnalysis.ts
@@ -7,10 +7,15 @@ export interface AnalyzedPath {
   hopCount: number;
   snr?: number;
   rssi?: number;
+  /** Newest observation of this exact hop sequence (epoch, s or ms as stored). */
   timestamp: number;
+  /** Observations of this exact hop sequence in the fetched window. */
+  count: number;
 }
 
-/** Unique traceroute paths between two nodes (either direction), sorted by hopCount asc. */
+/** Unique traceroute paths between two nodes (either direction), newest first.
+ *  Freshness outranks hop count: a stale one-hop fluke must not beat the route
+ *  the mesh is actually using now. */
 export function findPathsBetween(
   fromId: string,
   toId: string,
@@ -20,8 +25,7 @@ export function findPathsBetween(
   const b = normNodeId(toId);
   if (!a || !b || a === b) return [];
 
-  const paths: AnalyzedPath[] = [];
-  const seenSignatures = new Set<string>();
+  const bySig = new Map<string, AnalyzedPath>();
 
   for (const tr of traceroutes) {
     const tFrom = normNodeId(tr?.from);
@@ -41,18 +45,33 @@ export function findPathsBetween(
     const hops = idxA < idxB ? sub : sub.slice().reverse();
 
     const sig = hops.join(">");
-    if (seenSignatures.has(sig)) continue;
-    seenSignatures.add(sig);
-
-    paths.push({
+    const ts = tr.timestamp ?? 0;
+    const existing = bySig.get(sig);
+    if (existing) {
+      existing.count += 1;
+      if (ts > existing.timestamp) {
+        existing.timestamp = ts;
+        existing.snr = tr.snr;
+        existing.rssi = tr.rssi;
+      }
+      continue;
+    }
+    bySig.set(sig, {
       hops,
       hopCount: hops.length - 1,
       snr: tr.snr,
       rssi: tr.rssi,
-      timestamp: tr.timestamp ?? 0,
+      timestamp: ts,
+      count: 1,
     });
   }
 
-  paths.sort((x, y) => x.hopCount - y.hopCount || y.timestamp - x.timestamp);
+  const paths = [...bySig.values()];
+  paths.sort((x, y) => y.timestamp - x.timestamp || x.hopCount - y.hopCount);
   return paths;
+}
+
+/** Epoch that may be seconds or milliseconds → milliseconds. */
+export function tsToMs(ts: number): number {
+  return ts > 1e12 ? ts : ts * 1000;
 }

--- a/frontend/src/pages/map/pathAnalysis.ts
+++ b/frontend/src/pages/map/pathAnalysis.ts
@@ -2,7 +2,8 @@ import type { ITraceroutesResponse } from "../../types";
 import { normNodeId } from "./linkFeatures";
 
 export interface AnalyzedPath {
-  /** Normalized IDs: [from, ...intermediates, to]. */
+  /** Normalized IDs: [from, ...intermediates, to]. Unresolvable hops are kept
+   *  as `?<raw>` placeholders so hop counts and per-leg SNR stay aligned. */
   hops: string[];
   hopCount: number;
   snr?: number;
@@ -11,6 +12,19 @@ export interface AnalyzedPath {
   timestamp: number;
   /** Observations of this exact hop sequence in the fetched window. */
   count: number;
+  /** Per-leg SNR in dB (decoded ÷4; null = unknown), aligned so legSnrDb[i] is
+   *  the hops[i]→hops[i+1] leg. Taken from the newest observation carrying it. */
+  legSnrDb?: (number | null)[];
+  /** True when the SNR was measured opposite to the displayed a→b orientation. */
+  legSnrReversed?: boolean;
+}
+
+const SNR_UNKNOWN_SENTINEL = -128;
+
+/** Decode a firmware ×4-scaled SNR value; -128 sentinel → null (unknown). */
+export function decodeSnr(raw: number | null | undefined): number | null {
+  if (raw == null || !Number.isFinite(raw) || raw === SNR_UNKNOWN_SENTINEL) return null;
+  return raw / 4;
 }
 
 /** Unique traceroute paths between two nodes (either direction), newest first.
@@ -30,19 +44,37 @@ export function findPathsBetween(
   for (const tr of traceroutes) {
     const tFrom = normNodeId(tr?.from);
     const tTo = normNodeId(tr?.to);
-    const route: string[] = (tr?.route_ids ?? tr?.route ?? [])
-      .map(normNodeId)
-      .filter(Boolean);
-    const fullPath = [tFrom, ...route, tTo].filter(Boolean);
+    if (!tFrom || !tTo) continue;
+    // Keep unresolvable hops as placeholders instead of dropping them — a drop
+    // would shrink the hop count and shift per-leg SNR alignment.
+    const route: string[] = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
+      .map((r) => normNodeId(r) || `?${String(r)}`);
+
+    // Reply rows (the only ones carrying the full per-leg SNR: the destination
+    // appends its own reading, so snr_towards = route + 1) keep the REQUEST's
+    // route order but swap the header endpoints — the towards path is
+    // to → route → from, matching the official client's rendering.
+    const snrTow = tr?.payload?.snr_towards;
+    const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
+    const fullPath = isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo];
 
     const idxA = fullPath.indexOf(a);
     const idxB = fullPath.indexOf(b);
-    if (idxA === -1 || idxB === -1) continue;
+    if (idxA === -1 || idxB === -1 || idxA === idxB) continue;
 
-    const [lo, hi] = idxA < idxB ? [idxA, idxB] : [idxB, idxA];
+    const forward = idxA < idxB;
+    const [lo, hi] = forward ? [idxA, idxB] : [idxB, idxA];
     const sub = fullPath.slice(lo, hi + 1);
     // Orient a → b
-    const hops = idxA < idxB ? sub : sub.slice().reverse();
+    const hops = forward ? sub : sub.slice().reverse();
+
+    // snr_towards has one entry per leg of the request-oriented full path;
+    // slice the legs covering [lo, hi] and flip them when we flipped the hops.
+    let legSnrDb: (number | null)[] | undefined;
+    if (isReply) {
+      const legs = snrTow.slice(lo, hi).map(decodeSnr);
+      legSnrDb = forward ? legs : legs.slice().reverse();
+    }
 
     const sig = hops.join(">");
     const ts = tr.timestamp ?? 0;
@@ -53,6 +85,14 @@ export function findPathsBetween(
         existing.timestamp = ts;
         existing.snr = tr.snr;
         existing.rssi = tr.rssi;
+        if (legSnrDb) {
+          existing.legSnrDb = legSnrDb;
+          existing.legSnrReversed = !forward;
+        }
+      } else if (legSnrDb && !existing.legSnrDb) {
+        // An older observation is better than none for per-leg SNR
+        existing.legSnrDb = legSnrDb;
+        existing.legSnrReversed = !forward;
       }
       continue;
     }
@@ -63,6 +103,8 @@ export function findPathsBetween(
       rssi: tr.rssi,
       timestamp: ts,
       count: 1,
+      legSnrDb,
+      legSnrReversed: legSnrDb ? !forward : undefined,
     });
   }
 

--- a/frontend/src/pages/map/pathAnalysis.ts
+++ b/frontend/src/pages/map/pathAnalysis.ts
@@ -45,6 +45,24 @@ interface ExtractedPath {
   forward: boolean;
 }
 
+/** Travel-ordered full path for one row. Reply rows (the only ones carrying
+ *  the full per-leg SNR: the destination appends its own reading, so
+ *  snr_towards = route + 1) keep the REQUEST's route order but swap the header
+ *  endpoints — the towards path is to → route → from, matching the official
+ *  client. EVERY consumer of a row's hop sequence must route through here: a
+ *  header swap is NOT a path reversal, so an ad-hoc [from,...route,to] walk
+ *  attributes endpoint-adjacent legs to the wrong nodes on reply rows. */
+function orientRow(
+  tr: ITraceroutesResponse,
+  tFrom: string,
+  tTo: string,
+  route: string[],
+): { fullPath: string[]; isReply: boolean } {
+  const snrTow = tr?.payload?.snr_towards;
+  const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
+  return { fullPath: isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo], isReply };
+}
+
 /** Extract the a→b sub-path of one traceroute row, or null if it doesn't
  *  contain both nodes. Shared by the dedup (paths) and chronological (runs)
  *  views so orientation semantics can never drift apart. */
@@ -57,13 +75,8 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
   const route: string[] = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
     .map((r) => normNodeId(r) || `?${String(r)}`);
 
-  // Reply rows (the only ones carrying the full per-leg SNR: the destination
-  // appends its own reading, so snr_towards = route + 1) keep the REQUEST's
-  // route order but swap the header endpoints — the towards path is
-  // to → route → from, matching the official client's rendering.
   const snrTow = tr?.payload?.snr_towards;
-  const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
-  const fullPath = isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo];
+  const { fullPath, isReply } = orientRow(tr, tFrom, tTo, route);
 
   const idxA = fullPath.indexOf(a);
   const idxB = fullPath.indexOf(b);
@@ -78,7 +91,7 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
   // snr_towards has one entry per leg of the request-oriented full path;
   // slice the legs covering [lo, hi] and flip them when we flipped the hops.
   let legSnrDb: (number | null)[] | undefined;
-  if (isReply) {
+  if (isReply && Array.isArray(snrTow)) {
     const legs = snrTow.slice(lo, hi).map(decodeSnr);
     legSnrDb = forward ? legs : legs.slice().reverse();
   }
@@ -171,6 +184,55 @@ export function findRunsBetween(
   }
   runs.sort((x, y) => x.timestamp - y.timestamp);
   return runs;
+}
+
+/** Undirected hop-edge traversal stats across all observed traceroutes. */
+export interface TraceEdgeStat {
+  /** Sorted pair (aId < bId). */
+  aId: string;
+  bId: string;
+  /** Observed runs traversing this edge (an edge counts once per run). */
+  count: number;
+  lastTimestamp: number;
+}
+
+/** Resolved node ids normalize to bare lowercase hex; longnames and `?<raw>`
+ *  placeholders don't, and their edges can't be positioned or clicked. */
+const RESOLVED_ID = /^[0-9a-f]{1,8}$/;
+
+/** Count how often each adjacent hop pair appears across runs — the mesh's
+ *  busiest links. Edges touching an unresolved hop are skipped, and reply
+ *  rows are travel-ordered via orientRow (endpoint-adjacent edges would
+ *  otherwise be attributed to the wrong nodes). */
+export function computeTraceEdgeStats(traceroutes: ITraceroutesResponse[]): TraceEdgeStat[] {
+  const byKey = new Map<string, TraceEdgeStat>();
+  for (const tr of traceroutes) {
+    const tFrom = normNodeId(tr?.from);
+    const tTo = normNodeId(tr?.to);
+    if (!tFrom || !tTo) continue;
+    const route = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
+      .map((r) => normNodeId(r) || `?${String(r)}`);
+    const { fullPath } = orientRow(tr, tFrom, tTo, route);
+    const ts = tr.timestamp ?? 0;
+    const seenInRun = new Set<string>();
+    for (let i = 0; i + 1 < fullPath.length; i++) {
+      const a = fullPath[i];
+      const b = fullPath[i + 1];
+      if (a === b || !RESOLVED_ID.test(a) || !RESOLVED_ID.test(b)) continue;
+      const [ka, kb] = a < b ? [a, b] : [b, a];
+      const key = `${ka}|${kb}`;
+      if (seenInRun.has(key)) continue;
+      seenInRun.add(key);
+      const e = byKey.get(key);
+      if (e) {
+        e.count += 1;
+        if (ts > e.lastTimestamp) e.lastTimestamp = ts;
+      } else {
+        byKey.set(key, { aId: ka, bId: kb, count: 1, lastTimestamp: ts });
+      }
+    }
+  }
+  return [...byKey.values()];
 }
 
 /** Epoch that may be seconds or milliseconds → milliseconds. */

--- a/frontend/src/pages/map/pathAnalysis.ts
+++ b/frontend/src/pages/map/pathAnalysis.ts
@@ -19,12 +19,79 @@ export interface AnalyzedPath {
   legSnrReversed?: boolean;
 }
 
+/** One observed traceroute run between the pair, oriented a → b. */
+export interface TraceRun {
+  sig: string;
+  hops: string[];
+  hopCount: number;
+  timestamp: number;
+}
+
 const SNR_UNKNOWN_SENTINEL = -128;
 
 /** Decode a firmware ×4-scaled SNR value; -128 sentinel → null (unknown). */
 export function decodeSnr(raw: number | null | undefined): number | null {
   if (raw == null || !Number.isFinite(raw) || raw === SNR_UNKNOWN_SENTINEL) return null;
   return raw / 4;
+}
+
+interface ExtractedPath {
+  hops: string[];
+  sig: string;
+  timestamp: number;
+  snr?: number;
+  rssi?: number;
+  legSnrDb?: (number | null)[];
+  forward: boolean;
+}
+
+/** Extract the a→b sub-path of one traceroute row, or null if it doesn't
+ *  contain both nodes. Shared by the dedup (paths) and chronological (runs)
+ *  views so orientation semantics can never drift apart. */
+function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): ExtractedPath | null {
+  const tFrom = normNodeId(tr?.from);
+  const tTo = normNodeId(tr?.to);
+  if (!tFrom || !tTo) return null;
+  // Keep unresolvable hops as placeholders instead of dropping them — a drop
+  // would shrink the hop count and shift per-leg SNR alignment.
+  const route: string[] = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
+    .map((r) => normNodeId(r) || `?${String(r)}`);
+
+  // Reply rows (the only ones carrying the full per-leg SNR: the destination
+  // appends its own reading, so snr_towards = route + 1) keep the REQUEST's
+  // route order but swap the header endpoints — the towards path is
+  // to → route → from, matching the official client's rendering.
+  const snrTow = tr?.payload?.snr_towards;
+  const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
+  const fullPath = isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo];
+
+  const idxA = fullPath.indexOf(a);
+  const idxB = fullPath.indexOf(b);
+  if (idxA === -1 || idxB === -1 || idxA === idxB) return null;
+
+  const forward = idxA < idxB;
+  const [lo, hi] = forward ? [idxA, idxB] : [idxB, idxA];
+  const sub = fullPath.slice(lo, hi + 1);
+  // Orient a → b
+  const hops = forward ? sub : sub.slice().reverse();
+
+  // snr_towards has one entry per leg of the request-oriented full path;
+  // slice the legs covering [lo, hi] and flip them when we flipped the hops.
+  let legSnrDb: (number | null)[] | undefined;
+  if (isReply) {
+    const legs = snrTow.slice(lo, hi).map(decodeSnr);
+    legSnrDb = forward ? legs : legs.slice().reverse();
+  }
+
+  return {
+    hops,
+    sig: hops.join(">"),
+    timestamp: tr.timestamp ?? 0,
+    snr: tr.snr,
+    rssi: tr.rssi,
+    legSnrDb,
+    forward,
+  };
 }
 
 /** Unique traceroute paths between two nodes (either direction), newest first.
@@ -42,75 +109,68 @@ export function findPathsBetween(
   const bySig = new Map<string, AnalyzedPath>();
 
   for (const tr of traceroutes) {
-    const tFrom = normNodeId(tr?.from);
-    const tTo = normNodeId(tr?.to);
-    if (!tFrom || !tTo) continue;
-    // Keep unresolvable hops as placeholders instead of dropping them — a drop
-    // would shrink the hop count and shift per-leg SNR alignment.
-    const route: string[] = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
-      .map((r) => normNodeId(r) || `?${String(r)}`);
+    const ex = extractPathFromRow(a, b, tr);
+    if (!ex) continue;
 
-    // Reply rows (the only ones carrying the full per-leg SNR: the destination
-    // appends its own reading, so snr_towards = route + 1) keep the REQUEST's
-    // route order but swap the header endpoints — the towards path is
-    // to → route → from, matching the official client's rendering.
-    const snrTow = tr?.payload?.snr_towards;
-    const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
-    const fullPath = isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo];
-
-    const idxA = fullPath.indexOf(a);
-    const idxB = fullPath.indexOf(b);
-    if (idxA === -1 || idxB === -1 || idxA === idxB) continue;
-
-    const forward = idxA < idxB;
-    const [lo, hi] = forward ? [idxA, idxB] : [idxB, idxA];
-    const sub = fullPath.slice(lo, hi + 1);
-    // Orient a → b
-    const hops = forward ? sub : sub.slice().reverse();
-
-    // snr_towards has one entry per leg of the request-oriented full path;
-    // slice the legs covering [lo, hi] and flip them when we flipped the hops.
-    let legSnrDb: (number | null)[] | undefined;
-    if (isReply) {
-      const legs = snrTow.slice(lo, hi).map(decodeSnr);
-      legSnrDb = forward ? legs : legs.slice().reverse();
-    }
-
-    const sig = hops.join(">");
-    const ts = tr.timestamp ?? 0;
-    const existing = bySig.get(sig);
+    const existing = bySig.get(ex.sig);
     if (existing) {
       existing.count += 1;
-      if (ts > existing.timestamp) {
-        existing.timestamp = ts;
-        existing.snr = tr.snr;
-        existing.rssi = tr.rssi;
-        if (legSnrDb) {
-          existing.legSnrDb = legSnrDb;
-          existing.legSnrReversed = !forward;
+      if (ex.timestamp > existing.timestamp) {
+        existing.timestamp = ex.timestamp;
+        existing.snr = ex.snr;
+        existing.rssi = ex.rssi;
+        if (ex.legSnrDb) {
+          existing.legSnrDb = ex.legSnrDb;
+          existing.legSnrReversed = !ex.forward;
         }
-      } else if (legSnrDb && !existing.legSnrDb) {
+      } else if (ex.legSnrDb && !existing.legSnrDb) {
         // An older observation is better than none for per-leg SNR
-        existing.legSnrDb = legSnrDb;
-        existing.legSnrReversed = !forward;
+        existing.legSnrDb = ex.legSnrDb;
+        existing.legSnrReversed = !ex.forward;
       }
       continue;
     }
-    bySig.set(sig, {
-      hops,
-      hopCount: hops.length - 1,
-      snr: tr.snr,
-      rssi: tr.rssi,
-      timestamp: ts,
+    bySig.set(ex.sig, {
+      hops: ex.hops,
+      hopCount: ex.hops.length - 1,
+      snr: ex.snr,
+      rssi: ex.rssi,
+      timestamp: ex.timestamp,
       count: 1,
-      legSnrDb,
-      legSnrReversed: legSnrDb ? !forward : undefined,
+      legSnrDb: ex.legSnrDb,
+      legSnrReversed: ex.legSnrDb ? !ex.forward : undefined,
     });
   }
 
   const paths = [...bySig.values()];
   paths.sort((x, y) => y.timestamp - x.timestamp || x.hopCount - y.hopCount);
   return paths;
+}
+
+/** Every observed run between the pair, oldest first — the time-machine view.
+ *  No dedup: repeated signatures are the point (stability over time). */
+export function findRunsBetween(
+  fromId: string,
+  toId: string,
+  traceroutes: ITraceroutesResponse[],
+): TraceRun[] {
+  const a = normNodeId(fromId);
+  const b = normNodeId(toId);
+  if (!a || !b || a === b) return [];
+
+  const runs: TraceRun[] = [];
+  for (const tr of traceroutes) {
+    const ex = extractPathFromRow(a, b, tr);
+    if (!ex) continue;
+    runs.push({
+      sig: ex.sig,
+      hops: ex.hops,
+      hopCount: ex.hops.length - 1,
+      timestamp: ex.timestamp,
+    });
+  }
+  runs.sort((x, y) => x.timestamp - y.timestamp);
+  return runs;
 }
 
 /** Epoch that may be seconds or milliseconds → milliseconds. */

--- a/frontend/src/pages/map/useTraceCompute.ts
+++ b/frontend/src/pages/map/useTraceCompute.ts
@@ -1,0 +1,561 @@
+/**
+ * Per-hop RF analysis for the traceroute tool ("Why This Path").
+ *
+ * Fetches one union-bounds raster set (DEM + canopy + buildings) covering the
+ * whole route, grades every adjacent positioned hop pair with the LOS engine,
+ * analyzes the straight A→B counterfactual, and (async) enhances each leg with
+ * ITM loss. Results feed a multi-hop graded tube, obstruction pylons, and the
+ * panel's per-hop dossier.
+ */
+import {
+  GeoJSONSource as MlGeoJSONSource,
+  Map as MlMap,
+} from "maplibre-gl";
+import { useEffect, useRef, useState } from "react";
+
+import { env } from "../../env";
+import { effectiveAltitudeMslM } from "../nodes/altitudeAssessment";
+import { type BuildingRaster, sampleBuildingAt } from "./buildingTiles";
+import { type CanopyRaster, sampleCanopyAt } from "./canopyTiles";
+import { normalizeLng, unwrapLngTo } from "./geo";
+import { computeP2PLoss, isItmAvailable } from "./itm";
+import { DEFAULT_ITM_ENV } from "./itmEnv";
+import { analyzeLineOfSight, haversineKm, type LoSResult } from "./losAnalysis";
+import {
+  type LosTubeData,
+  type LosTubeLayer,
+  type ObstructionFeature,
+  obstructionsToGeoJSON,
+  pickObstructions,
+} from "./losTubeLayer";
+import type { ToolId } from "./MapToolsDrawer";
+import type { AnalyzedPath } from "./pathAnalysis";
+import { buildCoverageRasters } from "./rasterBuildClient";
+import { type DEM, demBoundsAround, demBoundsContain, sampleDEMAt } from "./terrainDEM";
+import type { DemSource } from "./terrainRgb";
+import type { IMapNode } from "./types";
+
+/** Matches LOS tool defaults: 2 m antennas, 915 MHz. */
+const TRACE_ANTENNA_HEIGHT_M = 2;
+const TRACE_FREQ_GHZ = 0.915;
+
+export type TraceLegVerdict = "clear" | "fresnel" | "blocked" | "gap";
+
+/** One dossier row: the hops[index] → hops[index+1] leg of the analyzed path. */
+export interface TraceLeg {
+  index: number;
+  fromId: string;
+  toId: string;
+  /** null when either end lacks a position (verdict "gap"). */
+  distanceKm: number | null;
+  verdict: TraceLegVerdict;
+  /** Worst first-Fresnel clearance along the leg as a ratio of F₁ (≥0.6 = clear enough). */
+  minClearanceRatio: number | null;
+  worstObstructionM: number;
+  diffractionLossDb: number;
+  itmLossDb?: number;
+  itmMode?: string;
+}
+
+export interface TraceDirect {
+  distanceKm: number;
+  verdict: Exclude<TraceLegVerdict, "gap">;
+  worstObstructionM: number;
+  worstObstructionDistKm: number;
+  diffractionLossDb: number;
+  itmLossDb?: number;
+  itmMode?: string;
+}
+
+export interface TraceAnalysis {
+  /** Path signature this analysis belongs to (hops.join(">")). */
+  sig: string;
+  legs: TraceLeg[];
+  direct: TraceDirect | null;
+  /** Hops in the path with no known position. */
+  ghostHops: number;
+  /** Finished render artifacts (unscaled MSL heights). */
+  tubeData: LosTubeData | null;
+  obstructions: ObstructionFeature[];
+  /** Direct-line coords (destination unwrapped), for the counterfactual overlay. */
+  directCoords: [number, number][] | null;
+}
+
+type TraceComputeParams = {
+  activeTool: ToolId | null;
+  toolStep: "pickFrom" | "pickTo" | "result";
+  /** Path selected for analysis (primary or user-chosen alternate). */
+  path: AnalyzedPath | null;
+  /** Position signature of the path's hops — a hop position arriving or moving
+   *  must regrade, or tube/pylons/dossier diverge from the drawn line. */
+  posKey: string;
+  terrain3D: boolean;
+  styleEpoch: number;
+  showDirect: boolean;
+  nodesRef: React.RefObject<Record<string, IMapNode>>;
+  mbMapRef: React.RefObject<MlMap | null>;
+  traceTubeLayerRef: React.RefObject<LosTubeLayer | null>;
+};
+
+export function useTraceCompute(params: TraceComputeParams) {
+  const {
+    activeTool, toolStep, path, posKey, terrain3D, styleEpoch, showDirect,
+    nodesRef, mbMapRef, traceTubeLayerRef,
+  } = params;
+
+  const [traceAnalysis, setTraceAnalysis] = useState<TraceAnalysis | null>(null);
+  const [isComputingTrace, setIsComputingTrace] = useState(false);
+  const [traceError, setTraceError] = useState<string | null>(null);
+  const [traceWarning, setTraceWarning] = useState<string | null>(null);
+
+  // Cached rasters for the last analyzed route; containment + resolution reuse
+  // makes switching between alternates of the same pair free.
+  const traceDemCacheRef = useRef<{
+    dem: DEM;
+    source: DemSource;
+    mpp: number;
+    canopy: CanopyRaster | null;
+    buildings: BuildingRaster | null;
+  } | null>(null);
+
+  // Warm the ITM WASM while the user is picking so results don't pay the load.
+  useEffect(() => {
+    if (activeTool === "traceroute") void isItmAvailable();
+  }, [activeTool]);
+
+  // Path identity — recompute only when the analyzed sequence itself changes.
+  const pathKey = path ? path.hops.join(">") : "";
+
+  useEffect(() => {
+    if (activeTool !== "traceroute" || toolStep !== "result" || !path || !pathKey) {
+      setTraceAnalysis(null);
+      setTraceError(null);
+      setTraceWarning(null);
+      setIsComputingTrace(false);
+      return;
+    }
+    if (!terrain3D) {
+      // Panel shows the enable-terrain hint; the 2D path stays useful.
+      setTraceAnalysis(null);
+      setTraceError(null);
+      setTraceWarning(null);
+      setIsComputingTrace(false);
+      return;
+    }
+    // A different path was selected — drop the previous path's artifacts now,
+    // not when the new grade lands (the push effect renders whatever is set).
+    setTraceAnalysis((prev) => (prev && prev.sig !== pathKey ? null : prev));
+
+    // The real array, not pathKey.split(">") — hop ids can contain ">"
+    // (unresolved longnames), and any hops change also changes pathKey.
+    const hops = path.hops;
+    const liveNodes = nodesRef.current ?? {};
+    const posOf = (id: string): [number, number] | null => {
+      const n = liveNodes[id] ?? liveNodes[`!${id}`];
+      return n?.map_position ? [n.map_position[0], n.map_position[1]] : null;
+    };
+    const altOf = (id: string): number | null => {
+      const n = liveNodes[id] ?? liveNodes[`!${id}`];
+      return n ? effectiveAltitudeMslM(n.position) : null;
+    };
+
+    const positions = hops.map(posOf);
+    const positioned = positions
+      .map((pos, i) => ({ pos, i }))
+      .filter((x): x is { pos: [number, number]; i: number } => x.pos != null);
+    const ghostHops = hops.length - positioned.length;
+
+    if (positioned.length < 2) {
+      setTraceAnalysis({
+        sig: pathKey,
+        legs: hops.slice(0, -1).map((id, i) => ({
+          index: i, fromId: id, toId: hops[i + 1], distanceKm: null, verdict: "gap" as const,
+          minClearanceRatio: null, worstObstructionM: 0, diffractionLossDb: 0,
+        })),
+        direct: null, ghostHops, tubeData: null, obstructions: [], directCoords: null,
+      });
+      setTraceError(null);
+      setTraceWarning("Too few hops have known positions to grade this route.");
+      setIsComputingTrace(false);
+      return;
+    }
+
+    const token = env.MAPBOX_TOKEN;
+    if (!token) {
+      setTraceAnalysis(null);
+      setTraceError("Terrain elevation source unavailable (Mapbox token not configured).");
+      setTraceWarning(null);
+      setIsComputingTrace(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      setTraceError(null);
+      setTraceWarning(null);
+      setIsComputingTrace(true);
+      try {
+        // Union bbox of every positioned hop, unwrapped into the first hop's
+        // longitude frame so seam-crossing routes stay one tight box.
+        const ref = positioned[0].pos;
+        let minLng = Infinity, maxLng = -Infinity, minLat = Infinity, maxLat = -Infinity;
+        for (const { pos } of positioned) {
+          const lngU = unwrapLngTo(ref[0], pos[0]);
+          if (lngU < minLng) minLng = lngU;
+          if (lngU > maxLng) maxLng = lngU;
+          if (pos[1] < minLat) minLat = pos[1];
+          if (pos[1] > maxLat) maxLat = pos[1];
+        }
+        const midLng = normalizeLng((minLng + maxLng) / 2);
+        const midLat = (minLat + maxLat) / 2;
+        const halfWKm = ((maxLng - minLng) / 2) * 111 * Math.max(0.05, Math.cos((midLat * Math.PI) / 180));
+        const halfHKm = ((maxLat - minLat) / 2) * 111;
+        // Min 2 km pad; 15% of span keeps re-fetches rare as data refreshes.
+        const spanKm = Math.max(halfWKm, halfHKm) * 2;
+        const halfSpanKm = Math.max(halfWKm, halfHKm) + Math.max(2, spanKm * 0.15);
+        const DEM_PAD = 1.25;
+        const demBounds = demBoundsAround([midLng, midLat], halfSpanKm, DEM_PAD);
+        const demWidthM = 2 * halfSpanKm * DEM_PAD * 1000;
+        const demSize = Math.min(2048, Math.max(256, Math.ceil(demWidthM / 30)));
+        const neededMpp = demWidthM / demSize;
+
+        let dem: DEM;
+        let canopy: CanopyRaster | null = null;
+        let buildings: BuildingRaster | null = null;
+        let usedMpp = neededMpp;
+        let demTilesFailed = 0;
+        let demTilesTotal = 0;
+        const cache = traceDemCacheRef.current;
+        if (cache && demBoundsContain(cache.dem.bounds, demBounds) && cache.mpp <= neededMpp * 2) {
+          dem = cache.dem;
+          canopy = cache.canopy;
+          buildings = cache.buildings;
+          usedMpp = cache.mpp;
+        } else {
+          const built = await buildCoverageRasters({
+            bounds: demBounds,
+            size: demSize,
+            maxTiles: 256,
+            token,
+            wantClutter: false,
+            wantCanopy: true,
+            wantBuildings: true,
+          });
+          if (cancelled) return;
+          dem = built.dem;
+          demTilesFailed = built.demTilesFailed;
+          demTilesTotal = built.demTilesTotal;
+          canopy = built.canopy ? { ...built.canopy, stdM: new Float32Array(0) } : null;
+          buildings = built.buildings;
+          // A holed DEM would pin bad terrain under this bbox — let failed tiles retry.
+          if (built.demTilesFailed === 0) {
+            traceDemCacheRef.current = { dem, source: built.demSource, mpp: neededMpp, canopy, buildings };
+          }
+        }
+
+        let nullTerrainSamples = 0;
+        let totalSamples = 0;
+        const queryTerrainM = (lng: number, lat: number): number | null => {
+          const elev = sampleDEMAt(dem, lng, lat);
+          if (Number.isNaN(elev)) {
+            nullTerrainSamples++;
+            return null;
+          }
+          return elev;
+        };
+        const canopyRaster = canopy;
+        const buildingRaster = buildings;
+        const queryCanopyM = canopyRaster
+          ? (lng: number, lat: number) => sampleCanopyAt(canopyRaster, lng, lat)?.heightM ?? null
+          : undefined;
+        const queryBuildingM = buildingRaster
+          ? (lng: number, lat: number) => sampleBuildingAt(buildingRaster, lng, lat)?.heightM ?? null
+          : undefined;
+
+        const analyzeLeg = (from: [number, number], to: [number, number], fromAlt: number | null, toAlt: number | null): LoSResult => {
+          const legKm = haversineKm(from, to);
+          const samples = Math.min(600, Math.max(64, Math.ceil((legKm * 1000) / usedMpp)));
+          totalSamples += samples;
+          return analyzeLineOfSight({
+            from, to,
+            fromAltitudeM: fromAlt,
+            toAltitudeM: toAlt,
+            fromAntennaHeightM: TRACE_ANTENNA_HEIGHT_M,
+            toAntennaHeightM: TRACE_ANTENNA_HEIGHT_M,
+            freqGHz: TRACE_FREQ_GHZ,
+            samples,
+            queryTerrainM,
+            queryCanopyM,
+            queryBuildingM,
+          });
+        };
+
+        const verdictOf = (r: LoSResult): Exclude<TraceLegVerdict, "gap"> =>
+          !r.losClear ? "blocked" : !r.fresnelClear ? "fresnel" : "clear";
+        const minClearanceOf = (r: LoSResult): number => {
+          let min = Infinity;
+          // Endpoints have fresnelRadius 0 → ratio Infinity; interior points decide.
+          for (const p of r.points) if (p.clearanceRatio < min) min = p.clearanceRatio;
+          return Number.isFinite(min) ? min : 1;
+        };
+
+        // Drawn segments: consecutive positioned hops. A span > 1 crosses ghost
+        // hops — drawn gray, never graded (no real endpoints to grade).
+        type Seg = { fromIdx: number; toIdx: number; result: LoSResult | null };
+        const segs: Seg[] = [];
+        for (let k = 0; k + 1 < positioned.length; k++) {
+          const A = positioned[k];
+          const B = positioned[k + 1];
+          const isGap = B.i - A.i > 1;
+          let result: LoSResult | null = null;
+          if (!isGap) {
+            result = analyzeLeg(A.pos, B.pos, altOf(hops[A.i]), altOf(hops[B.i]));
+            // Yield periodically so long routes can't jank the frame.
+            if (k % 4 === 3) await new Promise((r) => setTimeout(r, 0));
+            if (cancelled) return;
+          }
+          segs.push({ fromIdx: A.i, toIdx: B.i, result });
+        }
+
+        // Dossier rows — one per hop pair of the path.
+        const legs: TraceLeg[] = [];
+        for (let i = 0; i + 1 < hops.length; i++) {
+          const seg = segs.find((s) => s.fromIdx === i && s.toIdx === i + 1);
+          if (seg?.result) {
+            const r = seg.result;
+            legs.push({
+              index: i, fromId: hops[i], toId: hops[i + 1],
+              distanceKm: r.totalDistanceKm,
+              verdict: verdictOf(r),
+              minClearanceRatio: minClearanceOf(r),
+              worstObstructionM: r.worstObstructionM,
+              diffractionLossDb: r.diffractionLossDb,
+            });
+          } else {
+            legs.push({
+              index: i, fromId: hops[i], toId: hops[i + 1], distanceKm: null,
+              verdict: "gap", minClearanceRatio: null, worstObstructionM: 0, diffractionLossDb: 0,
+            });
+          }
+        }
+
+        // Direct A→B counterfactual (endpoints are picked nodes → positioned).
+        // A 1-hop route IS the direct line — no counterfactual to show.
+        const endFrom = positions[0];
+        const endTo = positions[positions.length - 1];
+        let direct: TraceDirect | null = null;
+        let directResult: LoSResult | null = null;
+        let directCoords: [number, number][] | null = null;
+        if (hops.length > 2 && endFrom && endTo && haversineKm(endFrom, endTo) >= 0.01) {
+          directResult = analyzeLeg(endFrom, endTo, altOf(hops[0]), altOf(hops[hops.length - 1]));
+          direct = {
+            distanceKm: directResult.totalDistanceKm,
+            verdict: verdictOf(directResult),
+            worstObstructionM: directResult.worstObstructionM,
+            worstObstructionDistKm: directResult.worstObstructionDistKm,
+            diffractionLossDb: directResult.diffractionLossDb,
+          };
+          directCoords = [endFrom, [unwrapLngTo(endFrom[0], endTo[0]), endTo[1]]];
+        }
+
+        // Multi-hop tube: concat per-segment strips in ONE continuous unwrapped
+        // longitude frame (per-vertex normalizeLng would streak a seam-crossing
+        // strip across the world; MercatorCoordinate maps out-of-range lngs
+        // continuously). Boundary vertices are duplicated around gap connectors
+        // (zero-length transitions) so gray never bleeds into graded colors.
+        const tubePoints: LosTubeData["points"] = [];
+        let prevWasGap = false;
+        let chainLng: number | null = null;
+        for (const seg of segs) {
+          const A = positions[seg.fromIdx]!;
+          const B = positions[seg.toIdx]!;
+          const aLng = chainLng == null ? A[0] : unwrapLngTo(chainLng, A[0]);
+          const bLng = unwrapLngTo(aLng, B[0]);
+          chainLng = bLng;
+          if (seg.result) {
+            const r = seg.result;
+            const total = r.totalDistanceKm;
+            const startJ = tubePoints.length > 0 && !prevWasGap ? 1 : 0;
+            for (let j = startJ; j < r.points.length; j++) {
+              const p = r.points[j];
+              const t = total > 0 ? p.distanceKm / total : 0;
+              tubePoints.push({
+                lng: aLng + (bLng - aLng) * t,
+                lat: A[1] + (B[1] - A[1]) * t,
+                altitude: p.chord,
+                color: p.blocked ? "blocked" : p.fresnelIntruded ? "fresnel" : "clear",
+              });
+            }
+            prevWasGap = false;
+          } else {
+            const hB = (queryTerrainM(B[0], B[1]) ?? 0) + TRACE_ANTENNA_HEIGHT_M;
+            if (tubePoints.length === 0) {
+              const hA = (queryTerrainM(A[0], A[1]) ?? 0) + TRACE_ANTENNA_HEIGHT_M;
+              tubePoints.push({ lng: aLng, lat: A[1], altitude: hA, color: "gap" });
+            } else {
+              // Duplicate the boundary vertex in gray to start the connector
+              tubePoints.push({ ...tubePoints[tubePoints.length - 1], color: "gap" });
+            }
+            tubePoints.push({ lng: bLng, lat: B[1], altitude: hB, color: "gap" });
+            prevWasGap = true;
+          }
+        }
+
+        // Obstruction pylons: worst offenders across all graded legs.
+        const allObs: ObstructionFeature[] = [];
+        for (const seg of segs) {
+          if (!seg.result) continue;
+          const A = positions[seg.fromIdx]!;
+          const B = positions[seg.toIdx]!;
+          allObs.push(...pickObstructions(A, B, seg.result.points, seg.result.totalDistanceKm, 2));
+        }
+        allObs.sort((x, y) => y.violationM - x.violationM);
+        const topObs = allObs.slice(0, 5);
+        const worstV = topObs[0]?.violationM || 1;
+        for (const o of topObs) o.severity = Math.min(1, o.violationM / worstV);
+
+        const geometric: TraceAnalysis = {
+          sig: pathKey, legs, direct, ghostHops,
+          tubeData: tubePoints.length >= 2 ? { points: tubePoints } : null,
+          obstructions: topObs,
+          directCoords,
+        };
+        if (cancelled) return;
+        setTraceAnalysis(geometric);
+
+        if (demTilesFailed > 0) {
+          setTraceWarning(
+            `${demTilesFailed} of ${demTilesTotal} terrain tiles failed to load — gaps read as sea level, so grades may be unreliable.`,
+          );
+        } else if (nullTerrainSamples > 0) {
+          setTraceWarning(
+            `${nullTerrainSamples} of ${totalSamples} samples had no terrain data and read as sea level.`,
+          );
+        } else if (ghostHops > 0) {
+          setTraceWarning(
+            `${ghostHops} ${ghostHops === 1 ? "hop has" : "hops have"} no known position — gray segments are estimated, not graded.`,
+          );
+        } else {
+          setTraceWarning(null);
+        }
+
+        // ITM enhancement per leg + direct (silently skips if WASM missing).
+        try {
+          const enhanced = geometric.legs.map((l) => ({ ...l }));
+          let anyItm = false;
+          for (const seg of segs) {
+            if (!seg.result || seg.toIdx - seg.fromIdx > 1) continue;
+            const r = seg.result;
+            const profileM = new Float64Array(r.points.map((p) => p.ground));
+            if (profileM.length < 2) continue;
+            const itm = await computeP2PLoss({
+              txHeightM: Math.max(0.5, r.fromHeightM - r.points[0].ground),
+              rxHeightM: Math.max(0.5, r.toHeightM - r.points[r.points.length - 1].ground),
+              profileM,
+              pointSpacingM: (r.totalDistanceKm * 1000) / (profileM.length - 1),
+              ...DEFAULT_ITM_ENV,
+              freqMhz: TRACE_FREQ_GHZ * 1000,
+            });
+            if (cancelled) return;
+            const leg = enhanced.find((l) => l.index === seg.fromIdx);
+            if (leg) {
+              leg.itmLossDb = itm.lossDb;
+              leg.itmMode = itm.intermediate.mode;
+              anyItm = true;
+            }
+          }
+          let directEnhanced = geometric.direct;
+          if (directResult && directEnhanced) {
+            const profileM = new Float64Array(directResult.points.map((p) => p.ground));
+            if (profileM.length >= 2) {
+              const itm = await computeP2PLoss({
+                txHeightM: Math.max(0.5, directResult.fromHeightM - directResult.points[0].ground),
+                rxHeightM: Math.max(0.5, directResult.toHeightM - directResult.points[directResult.points.length - 1].ground),
+                profileM,
+                pointSpacingM: (directResult.totalDistanceKm * 1000) / (profileM.length - 1),
+                ...DEFAULT_ITM_ENV,
+                freqMhz: TRACE_FREQ_GHZ * 1000,
+              });
+              if (cancelled) return;
+              directEnhanced = { ...directEnhanced, itmLossDb: itm.lossDb, itmMode: itm.intermediate.mode };
+              anyItm = true;
+            }
+          }
+          if (anyItm && !cancelled) {
+            setTraceAnalysis({ ...geometric, legs: enhanced, direct: directEnhanced });
+          }
+        } catch (itmErr) {
+          console.warn("[Map] Trace ITM enhancement unavailable:", itmErr);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.warn("[Map] Trace analysis failed:", err);
+        setTraceError("Couldn't load terrain data for this route. Check your connection and try again.");
+        setTraceAnalysis(null);
+      } finally {
+        if (!cancelled) setIsComputingTrace(false);
+      }
+    };
+
+    run().catch((err) => {
+      if (!cancelled) console.warn("[Map] Trace run failed:", err);
+    });
+    return () => { cancelled = true; };
+    // styleEpoch: map-readiness signal (URL-restored analyses mount pre-map);
+    // nodes are read via ref on purpose — SSE churn must not retrigger grading,
+    // but posKey (a value-stable string) re-grades when a hop actually moves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTool, toolStep, pathKey, posKey, terrain3D, styleEpoch]);
+
+  // Push artifacts → tube layer + obstruction pylons + direct-line overlay.
+  useEffect(() => {
+    const mb = mbMapRef.current;
+    if (!mb) return;
+    const tube = traceTubeLayerRef.current;
+    const obsSrc = mb.getSource("trace-obstructions") as MlGeoJSONSource | undefined;
+    const directSrc = mb.getSource("trace-direct") as MlGeoJSONSource | undefined;
+    const empty: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
+
+    if (activeTool !== "traceroute" || toolStep !== "result" || !traceAnalysis) {
+      tube?.setData(null);
+      obsSrc?.setData(empty);
+      directSrc?.setData(empty);
+      return;
+    }
+
+    tube?.setData(traceAnalysis.tubeData);
+
+    // fill-extrusion doesn't auto-scale to terrain exaggeration — scale manually
+    const exagRaw = mb.getTerrain()?.exaggeration;
+    const exag = typeof exagRaw === "number" ? exagRaw : 1;
+    const obsGeo = obstructionsToGeoJSON(traceAnalysis.obstructions);
+    obsGeo.features.forEach((f) => {
+      f.properties.baseM *= exag;
+      f.properties.topM *= exag;
+    });
+    obsSrc?.setData(obsGeo);
+
+    directSrc?.setData(
+      showDirect && traceAnalysis.directCoords && traceAnalysis.direct
+        ? {
+            type: "FeatureCollection",
+            features: [{
+              type: "Feature",
+              properties: { verdict: traceAnalysis.direct.verdict },
+              geometry: { type: "LineString", coordinates: traceAnalysis.directCoords },
+            }],
+          }
+        : empty,
+    );
+    // styleEpoch: setStyle recreates sources empty and strips the tube's GL objects.
+  }, [activeTool, toolStep, traceAnalysis, showDirect, styleEpoch, mbMapRef, traceTubeLayerRef]);
+
+  return {
+    traceAnalysis,
+    isComputingTrace,
+    traceError,
+    traceWarning,
+    traceDemCacheRef,
+  };
+}

--- a/frontend/src/pages/map/useTraceFlyover.ts
+++ b/frontend/src/pages/map/useTraceFlyover.ts
@@ -1,0 +1,156 @@
+/**
+ * "Ride the Packet": a camera chase along the analyzed traceroute path.
+ *
+ * For each leg, one comet is spawned (its duration comes from the layer's
+ * constant on-screen speed) and the camera eases to the landing hop over the
+ * same duration, pitched and facing the direction of travel. Any user camera
+ * input, Esc, tool close, or path change cancels the tour; it ends framing
+ * the whole route. Real data only — the comet is the same primitive live
+ * traceroutes draw, just choreographed.
+ */
+import maplibregl, { Map as MlMap } from "maplibre-gl";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { prefersReducedMotion } from "../../utils/reducedMotion";
+import type { ActivityLayer } from "./activityLayer";
+import { shortestLngDelta, unwrapLngTo } from "./geo";
+import { packetColor } from "./packetColors";
+import type { AnalyzedPath } from "./pathAnalysis";
+import type { IMapNode } from "./types";
+
+const CHASE_PITCH = 60;
+const OUTRO_PITCH = 55;
+const INTRO_MS = 1300;
+const HOP_PAUSE_MS = 250;
+const OUTRO_MS = 1400;
+
+/** Initial great-circle bearing a → b (degrees), seam-aware. */
+function bearingTo(a: [number, number], b: [number, number]): number {
+  const toRad = Math.PI / 180;
+  const dLng = shortestLngDelta(a[0], b[0]) * toRad;
+  const lat1 = a[1] * toRad;
+  const lat2 = b[1] * toRad;
+  const y = Math.sin(dLng) * Math.cos(lat2);
+  const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
+  return (Math.atan2(y, x) * 180) / Math.PI;
+}
+
+type FlyoverParams = {
+  mbMapRef: React.RefObject<MlMap | null>;
+  activityLayerRef: React.RefObject<ActivityLayer | null>;
+  nodesRef: React.RefObject<Record<string, IMapNode>>;
+};
+
+export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: FlyoverParams) {
+  const [isFlying, setIsFlying] = useState(false);
+  /** Ref twin of isFlying for bind-once handlers (Esc, ambient-spawn gate). */
+  const flyingRef = useRef(false);
+  /** Generation token — bumping it makes the in-flight run loop bail. */
+  const genRef = useRef(0);
+
+  /** Stops a running tour; returns whether one was running. */
+  const cancelFlyover = useCallback((): boolean => {
+    if (!flyingRef.current) return false;
+    genRef.current++;
+    flyingRef.current = false;
+    setIsFlying(false);
+    mbMapRef.current?.stop();
+    return true;
+  }, [mbMapRef]);
+
+  // The user grabbing the camera takes the wheel back. originalEvent is only
+  // present on user-initiated camera events, so the tour's own easeTo calls
+  // can't self-cancel; this one gate covers drag, wheel, dblclick, pinch, and
+  // right-drag rotate/pitch in a single pair of listeners.
+  useEffect(() => {
+    if (!isFlying) return;
+    const mb = mbMapRef.current;
+    if (!mb) return;
+    const onUserCamera = (e: { originalEvent?: unknown }) => {
+      if (e.originalEvent) cancelFlyover();
+    };
+    mb.on("movestart", onUserCamera);
+    mb.on("zoomstart", onUserCamera);
+    return () => {
+      mb.off("movestart", onUserCamera);
+      mb.off("zoomstart", onUserCamera);
+    };
+  }, [isFlying, mbMapRef, cancelFlyover]);
+
+  // Never leave the flying flag stuck if the page navigates away mid-tour.
+  useEffect(() => () => { genRef.current++; flyingRef.current = false; }, []);
+
+  /** Starts the tour along the path's positioned hops; false if it can't fly. */
+  const startFlyover = useCallback((path: AnalyzedPath): boolean => {
+    const mb = mbMapRef.current;
+    const layer = activityLayerRef.current;
+    if (!mb || !layer || prefersReducedMotion()) return false;
+
+    // Positioned hops in one continuous unwrapped longitude frame
+    const liveNodes = nodesRef.current ?? {};
+    const pts: [number, number][] = [];
+    for (const id of path.hops) {
+      const p = (liveNodes[id] ?? liveNodes[`!${id}`])?.map_position;
+      if (!p) continue;
+      const prev = pts[pts.length - 1];
+      pts.push(prev ? [unwrapLngTo(prev[0], p[0]), p[1]] : [p[0], p[1]]);
+    }
+    if (pts.length < 2) return false;
+
+    cancelFlyover(); // restart cleanly if a tour is already running
+    const gen = ++genRef.current;
+    flyingRef.current = true;
+    setIsFlying(true);
+
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    const live = () => genRef.current === gen && mbMapRef.current === mb;
+    const color = packetColor("traceroute");
+
+    const run = async () => {
+      // Intro: drop onto the origin, facing the first leg
+      const chaseZoom = Math.min(13.5, Math.max(10.5, mb.getZoom() + 1.5));
+      mb.easeTo({
+        center: pts[0],
+        zoom: chaseZoom,
+        pitch: CHASE_PITCH,
+        bearing: bearingTo(pts[0], pts[1]),
+        duration: INTRO_MS,
+      });
+      await sleep(INTRO_MS + 80);
+      if (!live()) return;
+
+      layer.spawnPulse(pts[0], color, performance.now());
+      for (let i = 0; i + 1 < pts.length; i++) {
+        const A = pts[i];
+        const B = pts[i + 1];
+        const dur = layer.spawnLeg(A, B, color, 0.9, performance.now());
+        if (dur <= 0) break;
+        // Linear ease so the camera tracks the comet's constant speed
+        mb.easeTo({
+          center: B,
+          bearing: bearingTo(A, B),
+          pitch: CHASE_PITCH,
+          zoom: chaseZoom,
+          duration: dur,
+          easing: (t) => t,
+        });
+        await sleep(dur + HOP_PAUSE_MS);
+        if (!live()) return;
+      }
+
+      // Outro: frame the whole route, still pitched
+      const bounds = new maplibregl.LngLatBounds();
+      for (const p of pts) bounds.extend(p);
+      const cam = mb.cameraForBounds(bounds, { padding: 120, maxZoom: 12 });
+      if (cam) mb.easeTo({ ...cam, pitch: OUTRO_PITCH, duration: OUTRO_MS });
+      await sleep(OUTRO_MS);
+      if (!live()) return;
+      flyingRef.current = false;
+      setIsFlying(false);
+    };
+    void run();
+    return true;
+  }, [mbMapRef, activityLayerRef, nodesRef, cancelFlyover]);
+
+  return { isFlying, flyingRef, startFlyover, cancelFlyover };
+}

--- a/frontend/src/pages/map/useTraceFlyover.ts
+++ b/frontend/src/pages/map/useTraceFlyover.ts
@@ -1,18 +1,13 @@
 /**
- * "Ride the Packet": a camera chase along the analyzed traceroute path.
- *
- * For each leg, one comet is spawned (slowed below ambient speed — this is a
- * guided tour, not background traffic) and the camera eases to the landing
- * hop over the same duration, pitched and facing the direction of travel.
- * Each landing gets a dwell beat, an arrival pulse, and a persistent
- * shortname chip, so the route annotates itself behind the packet and the
- * final framed shot shows every stop. Any user camera input, Esc, tool
- * close, or path change cancels the tour. Real data only — the comet is the
- * same primitive live traceroutes draw, just choreographed.
+ * "Ride the Packet": camera chase along the analyzed path. Per leg: one comet
+ * (tour-paced) + camera ease over the same duration; each landing gets a
+ * pulse, a dwell, and a persistent shortname chip. Esc / user camera input /
+ * tool close / path change cancels.
  */
 import maplibregl, { Map as MlMap } from "maplibre-gl";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { liveNodeFlushGate } from "../../utils/liveGate";
 import { prefersReducedMotion } from "../../utils/reducedMotion";
 import type { ActivityLayer } from "./activityLayer";
 import { shortestLngDelta, unwrapLngTo } from "./geo";
@@ -23,14 +18,14 @@ import type { IMapNode } from "./types";
 const CHASE_PITCH = 60;
 const OUTRO_PITCH = 55;
 const INTRO_MS = 1600;
-/** Dwell at each hop — long enough to read its chip, short enough to keep pace. */
+/** Dwell at each hop stop. */
 const HOP_PAUSE_MS = 900;
 const OUTRO_MS = 1400;
 /** Tour comet pacing: slower than ambient traffic, with its own clamps. */
 const TOUR_SPEED_SCALE = 0.55;
 const TOUR_MIN_LEG_MS = 1100;
 const TOUR_MAX_LEG_MS = 4500;
-/** Breadcrumb chips outlive the tour briefly so the framed finale stays labeled. */
+/** Chips linger past the outro so the framed finale stays labeled. */
 const LABEL_LINGER_MS = 3500;
 
 /** Initial great-circle bearing a → b (degrees), seam-aware. */
@@ -69,27 +64,27 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
     labelMarkersRef.current = [];
   }, []);
 
-  /** Stops a running tour or dismisses lingering breadcrumbs; returns whether
-   *  it had anything to cancel (the Esc chain consumes the keypress on true —
-   *  the labeled finale visually extends the tour, so Esc must too). */
+  /** Stops a running tour or dismisses lingering chips; true if it consumed
+   *  anything (the Esc chain relies on this). */
   const cancelFlyover = useCallback((): boolean => {
     if (!flyingRef.current) {
+      // A stuck latch freezes live node updates app-wide — never leave it set while idle
+      liveNodeFlushGate.suspended = false;
       const hadLabels = labelMarkersRef.current.length > 0 || labelLingerTimerRef.current !== null;
       clearLabels();
       return hadLabels;
     }
     genRef.current++;
     flyingRef.current = false;
+    liveNodeFlushGate.suspended = false;
     setIsFlying(false);
     clearLabels();
     mbMapRef.current?.stop();
     return true;
   }, [mbMapRef, clearLabels]);
 
-  // The user grabbing the camera takes the wheel back. originalEvent is only
-  // present on user-initiated camera events, so the tour's own easeTo calls
-  // can't self-cancel; this one gate covers drag, wheel, dblclick, pinch, and
-  // right-drag rotate/pitch in a single pair of listeners.
+  // originalEvent exists only on user gestures (drag/wheel/dblclick/pinch/rotate),
+  // so the tour's own easeTo calls can't self-cancel.
   useEffect(() => {
     if (!isFlying) return;
     const mb = mbMapRef.current;
@@ -105,11 +100,11 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
     };
   }, [isFlying, mbMapRef, cancelFlyover]);
 
-  // Never leave the flying flag stuck (or chips behind) if the page navigates
-  // away mid-tour.
+  // Unmount mid-tour: release the flag, latch, and chips
   useEffect(() => () => {
     genRef.current++;
     flyingRef.current = false;
+    liveNodeFlushGate.suspended = false;
     clearLabels();
   }, [clearLabels]);
 
@@ -137,36 +132,41 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
     cancelFlyover(); // restart cleanly if a tour is already running
     const gen = ++genRef.current;
     flyingRef.current = true;
+    // Pause SSE node flushes (full-page re-render + source re-cluster each)
+    liveNodeFlushGate.suspended = true;
     setIsFlying(true);
 
     const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
     const live = () => genRef.current === gen && mbMapRef.current === mb;
     const color = packetColor("traceroute");
 
-    /** Persistent glass chip above a visited hop, popped in on arrival. */
+    // Pop-in lives on an inner div — MapLibre rewrites the root transform every frame
     const dropLabel = (stop: { pos: [number, number]; label: string }) => {
       const el = document.createElement("div");
       el.setAttribute("aria-hidden", "true");
-      el.textContent = stop.label;
-      el.style.cssText =
+      const chip = document.createElement("div");
+      chip.textContent = stop.label;
+      chip.style.cssText =
         "padding:2px 7px;border-radius:9999px;background:rgba(17,24,39,0.92);" +
         "border:1px solid rgba(34,211,238,0.45);color:#a5f3fc;font-size:11px;" +
         "font-weight:600;white-space:nowrap;pointer-events:none;" +
         "box-shadow:0 2px 8px rgba(0,0,0,0.5);opacity:0;transform:scale(0.7);" +
         "transition:opacity 240ms ease-out, transform 240ms ease-out;";
+      el.appendChild(chip);
       const marker = new maplibregl.Marker({ element: el, offset: [0, -18] })
         .setLngLat(stop.pos)
         .addTo(mb);
       labelMarkersRef.current.push(marker);
       requestAnimationFrame(() => {
-        el.style.opacity = "1";
-        el.style.transform = "scale(1)";
+        chip.style.opacity = "1";
+        chip.style.transform = "scale(1)";
       });
     };
 
     const run = async () => {
-      // Intro: drop onto the origin, facing the first leg
-      const chaseZoom = Math.min(13.5, Math.max(10.5, mb.getZoom() + 1.5));
+      try {
+      // Modest zoom boost — each extra level means cold tiles along the corridor
+      const chaseZoom = Math.min(13, Math.max(10.5, mb.getZoom() + 1));
       mb.easeTo({
         center: stops[0].pos,
         zoom: chaseZoom,
@@ -203,7 +203,7 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
         });
         await sleep(dur);
         if (!live()) return;
-        // The stop: arrival pulse + its chip, then a beat to take it in
+        // Arrival: pulse + chip, then dwell
         layer.spawnPulse(B.pos, color, performance.now());
         dropLabel(B);
         await sleep(HOP_PAUSE_MS);
@@ -216,9 +216,15 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
       const cam = mb.cameraForBounds(bounds, { padding: 120, maxZoom: 12 });
       if (cam) mb.easeTo({ ...cam, pitch: OUTRO_PITCH, duration: OUTRO_MS });
       await sleep(OUTRO_MS);
-      if (!live()) return;
-      flyingRef.current = false;
-      setIsFlying(false);
+      } finally {
+        // Only the owning generation releases the flags (cancel/unmount handle theirs)
+        if (genRef.current === gen) {
+          flyingRef.current = false;
+          liveNodeFlushGate.suspended = false;
+          setIsFlying(false);
+        }
+      }
+      if (genRef.current !== gen) return;
       // Let the labeled finale breathe, then tidy up
       labelLingerTimerRef.current = setTimeout(() => {
         labelLingerTimerRef.current = null;

--- a/frontend/src/pages/map/useTraceFlyover.ts
+++ b/frontend/src/pages/map/useTraceFlyover.ts
@@ -1,12 +1,14 @@
 /**
  * "Ride the Packet": a camera chase along the analyzed traceroute path.
  *
- * For each leg, one comet is spawned (its duration comes from the layer's
- * constant on-screen speed) and the camera eases to the landing hop over the
- * same duration, pitched and facing the direction of travel. Any user camera
- * input, Esc, tool close, or path change cancels the tour; it ends framing
- * the whole route. Real data only — the comet is the same primitive live
- * traceroutes draw, just choreographed.
+ * For each leg, one comet is spawned (slowed below ambient speed — this is a
+ * guided tour, not background traffic) and the camera eases to the landing
+ * hop over the same duration, pitched and facing the direction of travel.
+ * Each landing gets a dwell beat, an arrival pulse, and a persistent
+ * shortname chip, so the route annotates itself behind the packet and the
+ * final framed shot shows every stop. Any user camera input, Esc, tool
+ * close, or path change cancels the tour. Real data only — the comet is the
+ * same primitive live traceroutes draw, just choreographed.
  */
 import maplibregl, { Map as MlMap } from "maplibre-gl";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -20,9 +22,16 @@ import type { IMapNode } from "./types";
 
 const CHASE_PITCH = 60;
 const OUTRO_PITCH = 55;
-const INTRO_MS = 1300;
-const HOP_PAUSE_MS = 250;
+const INTRO_MS = 1600;
+/** Dwell at each hop — long enough to read its chip, short enough to keep pace. */
+const HOP_PAUSE_MS = 900;
 const OUTRO_MS = 1400;
+/** Tour comet pacing: slower than ambient traffic, with its own clamps. */
+const TOUR_SPEED_SCALE = 0.55;
+const TOUR_MIN_LEG_MS = 1100;
+const TOUR_MAX_LEG_MS = 4500;
+/** Breadcrumb chips outlive the tour briefly so the framed finale stays labeled. */
+const LABEL_LINGER_MS = 3500;
 
 /** Initial great-circle bearing a → b (degrees), seam-aware. */
 function bearingTo(a: [number, number], b: [number, number]): number {
@@ -47,16 +56,35 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
   const flyingRef = useRef(false);
   /** Generation token — bumping it makes the in-flight run loop bail. */
   const genRef = useRef(0);
+  /** Breadcrumb shortname chips dropped at each visited hop. */
+  const labelMarkersRef = useRef<maplibregl.Marker[]>([]);
+  const labelLingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  /** Stops a running tour; returns whether one was running. */
+  const clearLabels = useCallback(() => {
+    if (labelLingerTimerRef.current) {
+      clearTimeout(labelLingerTimerRef.current);
+      labelLingerTimerRef.current = null;
+    }
+    for (const m of labelMarkersRef.current) m.remove();
+    labelMarkersRef.current = [];
+  }, []);
+
+  /** Stops a running tour or dismisses lingering breadcrumbs; returns whether
+   *  it had anything to cancel (the Esc chain consumes the keypress on true —
+   *  the labeled finale visually extends the tour, so Esc must too). */
   const cancelFlyover = useCallback((): boolean => {
-    if (!flyingRef.current) return false;
+    if (!flyingRef.current) {
+      const hadLabels = labelMarkersRef.current.length > 0 || labelLingerTimerRef.current !== null;
+      clearLabels();
+      return hadLabels;
+    }
     genRef.current++;
     flyingRef.current = false;
     setIsFlying(false);
+    clearLabels();
     mbMapRef.current?.stop();
     return true;
-  }, [mbMapRef]);
+  }, [mbMapRef, clearLabels]);
 
   // The user grabbing the camera takes the wheel back. originalEvent is only
   // present on user-initiated camera events, so the tour's own easeTo calls
@@ -77,8 +105,13 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
     };
   }, [isFlying, mbMapRef, cancelFlyover]);
 
-  // Never leave the flying flag stuck if the page navigates away mid-tour.
-  useEffect(() => () => { genRef.current++; flyingRef.current = false; }, []);
+  // Never leave the flying flag stuck (or chips behind) if the page navigates
+  // away mid-tour.
+  useEffect(() => () => {
+    genRef.current++;
+    flyingRef.current = false;
+    clearLabels();
+  }, [clearLabels]);
 
   /** Starts the tour along the path's positioned hops; false if it can't fly. */
   const startFlyover = useCallback((path: AnalyzedPath): boolean => {
@@ -86,16 +119,20 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
     const layer = activityLayerRef.current;
     if (!mb || !layer || prefersReducedMotion()) return false;
 
-    // Positioned hops in one continuous unwrapped longitude frame
+    // Positioned hops (with labels) in one continuous unwrapped longitude frame
     const liveNodes = nodesRef.current ?? {};
-    const pts: [number, number][] = [];
+    const stops: { pos: [number, number]; label: string }[] = [];
     for (const id of path.hops) {
-      const p = (liveNodes[id] ?? liveNodes[`!${id}`])?.map_position;
+      const n = liveNodes[id] ?? liveNodes[`!${id}`];
+      const p = n?.map_position;
       if (!p) continue;
-      const prev = pts[pts.length - 1];
-      pts.push(prev ? [unwrapLngTo(prev[0], p[0]), p[1]] : [p[0], p[1]]);
+      const prev = stops[stops.length - 1];
+      stops.push({
+        pos: prev ? [unwrapLngTo(prev.pos[0], p[0]), p[1]] : [p[0], p[1]],
+        label: n?.shortname?.trim() || id.slice(0, 8),
+      });
     }
-    if (pts.length < 2) return false;
+    if (stops.length < 2) return false;
 
     cancelFlyover(); // restart cleanly if a tour is already running
     const gen = ++genRef.current;
@@ -106,51 +143,91 @@ export function useTraceFlyover({ mbMapRef, activityLayerRef, nodesRef }: Flyove
     const live = () => genRef.current === gen && mbMapRef.current === mb;
     const color = packetColor("traceroute");
 
+    /** Persistent glass chip above a visited hop, popped in on arrival. */
+    const dropLabel = (stop: { pos: [number, number]; label: string }) => {
+      const el = document.createElement("div");
+      el.setAttribute("aria-hidden", "true");
+      el.textContent = stop.label;
+      el.style.cssText =
+        "padding:2px 7px;border-radius:9999px;background:rgba(17,24,39,0.92);" +
+        "border:1px solid rgba(34,211,238,0.45);color:#a5f3fc;font-size:11px;" +
+        "font-weight:600;white-space:nowrap;pointer-events:none;" +
+        "box-shadow:0 2px 8px rgba(0,0,0,0.5);opacity:0;transform:scale(0.7);" +
+        "transition:opacity 240ms ease-out, transform 240ms ease-out;";
+      const marker = new maplibregl.Marker({ element: el, offset: [0, -18] })
+        .setLngLat(stop.pos)
+        .addTo(mb);
+      labelMarkersRef.current.push(marker);
+      requestAnimationFrame(() => {
+        el.style.opacity = "1";
+        el.style.transform = "scale(1)";
+      });
+    };
+
     const run = async () => {
       // Intro: drop onto the origin, facing the first leg
       const chaseZoom = Math.min(13.5, Math.max(10.5, mb.getZoom() + 1.5));
       mb.easeTo({
-        center: pts[0],
+        center: stops[0].pos,
         zoom: chaseZoom,
         pitch: CHASE_PITCH,
-        bearing: bearingTo(pts[0], pts[1]),
+        bearing: bearingTo(stops[0].pos, stops[1].pos),
         duration: INTRO_MS,
       });
       await sleep(INTRO_MS + 80);
       if (!live()) return;
 
-      layer.spawnPulse(pts[0], color, performance.now());
-      for (let i = 0; i + 1 < pts.length; i++) {
-        const A = pts[i];
-        const B = pts[i + 1];
-        const dur = layer.spawnLeg(A, B, color, 0.9, performance.now());
+      layer.spawnPulse(stops[0].pos, color, performance.now());
+      dropLabel(stops[0]);
+      await sleep(HOP_PAUSE_MS * 0.6); // shorter beat at the origin
+      if (!live()) return;
+
+      for (let i = 0; i + 1 < stops.length; i++) {
+        const A = stops[i];
+        const B = stops[i + 1];
+        const dur = layer.spawnLeg(A.pos, B.pos, color, 0.9, performance.now(), {
+          speedScale: TOUR_SPEED_SCALE,
+          minMs: TOUR_MIN_LEG_MS,
+          maxMs: TOUR_MAX_LEG_MS,
+          landingRing: false, // the arrival pulse below owns the landing beat
+        });
         if (dur <= 0) break;
         // Linear ease so the camera tracks the comet's constant speed
         mb.easeTo({
-          center: B,
-          bearing: bearingTo(A, B),
+          center: B.pos,
+          bearing: bearingTo(A.pos, B.pos),
           pitch: CHASE_PITCH,
           zoom: chaseZoom,
           duration: dur,
           easing: (t) => t,
         });
-        await sleep(dur + HOP_PAUSE_MS);
+        await sleep(dur);
+        if (!live()) return;
+        // The stop: arrival pulse + its chip, then a beat to take it in
+        layer.spawnPulse(B.pos, color, performance.now());
+        dropLabel(B);
+        await sleep(HOP_PAUSE_MS);
         if (!live()) return;
       }
 
-      // Outro: frame the whole route, still pitched
+      // Outro: frame the whole route, still pitched, chips as breadcrumbs
       const bounds = new maplibregl.LngLatBounds();
-      for (const p of pts) bounds.extend(p);
+      for (const s of stops) bounds.extend(s.pos);
       const cam = mb.cameraForBounds(bounds, { padding: 120, maxZoom: 12 });
       if (cam) mb.easeTo({ ...cam, pitch: OUTRO_PITCH, duration: OUTRO_MS });
       await sleep(OUTRO_MS);
       if (!live()) return;
       flyingRef.current = false;
       setIsFlying(false);
+      // Let the labeled finale breathe, then tidy up
+      labelLingerTimerRef.current = setTimeout(() => {
+        labelLingerTimerRef.current = null;
+        if (genRef.current === gen) clearLabels();
+      }, LABEL_LINGER_MS);
     };
     void run();
     return true;
-  }, [mbMapRef, activityLayerRef, nodesRef, cancelFlyover]);
+  }, [mbMapRef, activityLayerRef, nodesRef, cancelFlyover, clearLabels]);
 
   return { isFlying, flyingRef, startFlyover, cancelFlyover };
 }

--- a/frontend/src/pages/map/utils.ts
+++ b/frontend/src/pages/map/utils.ts
@@ -129,8 +129,10 @@ export function nodesDataSignature(
   for (const f of fc.features) {
     const p = f.properties ?? {};
     const c = (f.geometry as GeoPoint).coordinates;
+    // No raw last_seen (would re-cluster per flush; `dim` carries recency,
+    // tooltips read the store). shortname IS hashed — renames must re-upload.
     mix(
-      `${f.id}|${p.last_seen ?? ""}|${p.online ? 1 : 0}|${p.role ?? ""}|${p.dim ?? ""}|` +
+      `${f.id}|${p.shortname ?? ""}|${p.online ? 1 : 0}|${p.role ?? ""}|${p.dim ?? ""}|` +
         `${Math.round((c[0] ?? 0) * 1e5)}|${Math.round((c[1] ?? 0) * 1e5)}`,
     );
   }

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -132,8 +132,19 @@ export const apiSlice = createApi({
       transformResponse: (response: { telemetry: ITelemetryResponse[] }) => response.telemetry ?? [],
       providesTags: (_result, _err, id) => [{ type: "Telemetry", id }],
     }),
-    getTraceroutes: builder.query<ITraceroutesResponse[], void>({
-      query: () => "traceroutes",
+    getTraceroutes: builder.query<
+      ITraceroutesResponse[],
+      { from?: string; to?: string; range?: string; limit?: number } | void
+    >({
+      query: (params) => {
+        const sp = new URLSearchParams();
+        if (params && params.from) sp.set("from", params.from);
+        if (params && params.to) sp.set("to", params.to);
+        if (params && params.range && params.range !== "all") sp.set("range", params.range);
+        if (params && params.limit) sp.set("limit", String(params.limit));
+        const qs = sp.toString();
+        return qs ? `traceroutes?${qs}` : "traceroutes";
+      },
       providesTags: [{ type: "Traceroutes", id: "LIST" }],
     }),
     getMessages: builder.query<

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,8 +45,15 @@ export interface ITraceroutesResponse {
   from: string;
   hop_start?: number;
   id: number;
+  /** Full RouteDiscovery. SNR arrays are firmware-scaled ×4 with -128 = unknown.
+   *  Rows carrying the full snr_towards (length = route + 1) are REPLY packets:
+   *  their towards path reads header `to` → route → header `from` (the route
+   *  stays request-oriented while the reply header swaps the endpoints). */
   payload: {
-    route: string[];
+    route: (string | number)[];
+    route_back?: (string | number)[];
+    snr_towards?: number[];
+    snr_back?: number[];
   };
   route: string[];
   route_ids?: string[];

--- a/frontend/src/utils/liveGate.ts
+++ b/frontend/src/utils/liveGate.ts
@@ -1,0 +1,4 @@
+/** Latch pausing the 400ms SSE node flush during camera tours (each flush
+ *  re-renders the Map page + re-clusters the source). Events keep coalescing
+ *  while suspended and apply shortly after resume. */
+export const liveNodeFlushGate = { suspended: false };

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -2004,20 +2004,52 @@ class PostgresStorage:
             logger.error(f"Failed to query telemetry from PostgreSQL: {e}")
             return []
 
-    async def query_all_traceroutes(self, limit: int = 1000) -> List[Dict[str, Any]]:
-        """Query all traceroutes."""
+    async def query_all_traceroutes(
+        self,
+        limit: int = 1000,
+        from_node_id: Optional[str] = None,
+        to_node_id: Optional[str] = None,
+        range_seconds: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Query traceroutes, newest first, optionally filtered.
+
+        With both endpoints given, the pair matches in either direction
+        (consumers orient the path client-side). A single endpoint filters
+        just that column. `range_seconds` windows on created_at.
+        """
         if not self.enabled or not self.pool:
             return []
+
+        where = []
+        params: List[Any] = []
+        if from_node_id and to_node_id:
+            params += [from_node_id, to_node_id]
+            where.append(
+                "((from_node_id = $1 AND to_node_id = $2)"
+                " OR (from_node_id = $2 AND to_node_id = $1))"
+            )
+        elif from_node_id:
+            params.append(from_node_id)
+            where.append(f"from_node_id = ${len(params)}")
+        elif to_node_id:
+            params.append(to_node_id)
+            where.append(f"to_node_id = ${len(params)}")
+        if range_seconds:
+            params.append(range_seconds)
+            where.append(f"created_at >= NOW() - make_interval(secs => ${len(params)})")
+        where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+        params.append(limit)
 
         try:
             async with self.pool.acquire() as conn:
                 rows = await conn.fetch(
-                    """
+                    f"""
                     SELECT * FROM traceroutes
+                    {where_sql}
                     ORDER BY created_at DESC
-                    LIMIT $1
+                    LIMIT ${len(params)}
                     """,
-                    limit,
+                    *params,
                 )
 
                 traceroutes = []


### PR DESCRIPTION
Rebuilds the map's Traceroute tool from a disabled stub ("coming soon") into a robust analysis tool. Every feature is derived from observed packets and terrain physics.

## What it does now

**Pick any two nodes (or click a corridor) and the tool explains the route:**
- **Terrain-graded analysis** — every hop is graded clear / Fresnel-intruded / blocked by the existing LOS engine (one union-bounds DEM+canopy+buildings fetch per route), rendered as a color-graded 3D tube with red obstruction pylons on the terrain that forced the detour, plus async ITM path loss per leg
- **Direct-path comparison** — a dashed overlay and verdict card showing what the mesh routed around ("direct is 319 km, blocked by +2,208 m of terrain — the mesh went around it in 5 hops")
- **Per-hop SNR** — decoded from the stored RouteDiscovery `snr_towards`/`snr_back` payloads (×4 scale, −128 sentinel) with correct reply-packet orientation (`to → route → from`), shown as directional dB chips per leg
- **Route history strip** — every observed run between the pair on a scrubbable timeline with route-change ticks; click any run to analyze it, with stability stats ("12/17 runs · 71%")
- **Top Links column** — Scan-style panel ranking the mesh's busiest (or longest) observed links, viewport-filtered, hover-spotlit, one click to analyze
- **Catch It Live** — an armed listener: trigger a traceroute from your Meshtastic app and it lands on the map with a comet the moment a gateway hears it, even with ambient live packets off
- **Ride the Packet** — a cinematic camera tour chasing a real comet hop-to-hop over 3D terrain, with arrival pulses, dwell stops, and persistent shortname breadcrumb chips; Esc/any camera input cancels
- **Shareable deep links** — `?tool=traceroute&from&to` (+`&play=1` to auto-run the tour for the recipient)
- **Honest uncertainty** — position-less hops render as labeled '?' ghost markers on dashed estimated segments; they are never silently dropped, and per-leg SNR alignment is preserved through them

## Backend
- `/v1/traceroutes` gains `from`/`to`/`range`/`limit` params (pair matches either direction) — the tool merges pair-scoped history with the global window so busy meshes don't starve pair lookups

## Performance
- Tour-time churn eliminated: SSE node flushes pause during camera tours (coalesce + resume), node-source re-clustering keyed on quantized state instead of raw `last_seen`, moveend side-effects and auto-spiderfy gated during flight, coordinate-pill hover state isolated from the Map page render, cluster-donut terrain re-drape skipped while dimmed, panels memoized

## Testing
- 158 unit tests pass (new regression coverage for reply-row orientation, per-leg SNR decoding/alignment, edge traversal counting)
