### PR TITLE
Packet-loss hardening: buffer archive writes through DB outages, decode MAP_REPORT properly

### DIFF
--- a/config.py
+++ b/config.py
@@ -73,7 +73,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "server": {
         "node_id": "",
         "base_url": "",
-        "log_level": "INFO",  # TODO: Wire into logging setup (e.g., logging.getLogger().setLevel(...))
+        "log_level": "INFO",
         "node_activity_prune_threshold": 259200,
         "timezone": "UTC",
         "intervals": {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -355,6 +355,13 @@ export const Chat = () => {
   const defaultViewKey =
     views.find((v) => v.isDefault)?.key ?? views[0]?.key ?? "";
 
+  // Stable identity: a fresh array here would defeat useChatSearchParams'
+  // internal memos on every render.
+  const viewParams = useMemo(
+    () => views.map((v) => ({ key: v.key, aliases: v.aliases })),
+    [views]
+  );
+
   // ── 9. URL + canonicalization (ch becomes preset slug) ──
   const {
     searchParams,
@@ -378,7 +385,7 @@ export const Chat = () => {
     setParams,
     clearFilters,
   } = useChatSearchParams({
-    views: views.map((v) => ({ key: v.key, aliases: v.aliases })),
+    views: viewParams,
     defaultCh: defaultViewKey,
   });
 

--- a/frontend/src/pages/chat/useChatSearchParams.ts
+++ b/frontend/src/pages/chat/useChatSearchParams.ts
@@ -40,8 +40,8 @@ export function useChatSearchParams(args?: {
   views?: ChatViewParam[];
   defaultCh?: string;
 }) {
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: memoize views to avoid re-renders
-  const views = args?.views ?? [];
+  // Callers pass a memoized array; this only pins the `?? []` fallback identity.
+  const views = useMemo(() => args?.views ?? [], [args?.views]);
   const [searchParams, setSearchParams] = useSearchParams();
 
   const rawCh = (searchParams.get("ch") ?? "").trim();

--- a/mqtt.py
+++ b/mqtt.py
@@ -182,16 +182,17 @@ class MQTT:
 
                 elif mp.decoded.portnum == portnums_pb2.MAP_REPORT_APP:
                     try:
-                        report = mesh_pb2.Position().FromString(mp.decoded.payload)
-                        out = json.loads(MessageToJson(report, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True, always_print_fields_with_no_presence=True))
+                        report = mqtt_pb2.MapReport().FromString(mp.decoded.payload)
+                        out = json.loads(MessageToJson(report, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True))
                         outs["type"] = "mapreport"
                         outs["payload"] = out
                         logger.debug("Decoded protobuf message: mapreport: %s", outs)
-                        # self.handle_mapreport(outs)
                     except UnicodeDecodeError as e:
                         logger.debug("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
                         logger.debug("Protobuf decode error: text: %s", e)
+                    else:
+                        await self._safe_handle("handle_mapreport", self.handle_mapreport(outs))
 
                 elif mp.decoded.portnum == portnums_pb2.NEIGHBORINFO_APP:
                     try:
@@ -496,6 +497,50 @@ class MQTT:
             node['last_channel'] = str(msg['channel'])
 
         await self.data.update_node(id, node)
+
+    async def handle_mapreport(self, msg):
+        from_id = self._normalize_msg_addrs(msg)
+        if from_id is None:
+            logger.debug("handle_mapreport: missing/invalid 'from'; skipping: %s", msg)
+            return
+        payload = msg.get('payload')
+        if not isinstance(payload, dict):
+            logger.debug("handle_mapreport: missing/invalid payload; skipping: %s", msg)
+            return
+
+        node = await self.data.pg_storage.get_node_cached(from_id)
+        if node is None:
+            node = Node.default_node(from_id)
+            logger.debug("Discovered node %s via mapreport", from_id)
+
+        if payload.get('long_name'):
+            node['longname'] = payload['long_name']
+        if payload.get('short_name'):
+            node['shortname'] = payload['short_name']
+        if 'hw_model' in payload:
+            node['hardware'] = payload['hw_model']
+        # proto3 omits zero enums: an absent role means CLIENT (0), same as NODEINFO.
+        node['role'] = payload.get('role', 0)
+
+        # Map reports carry no timestamp, so only fill a position for nodes
+        # that have none — a real POSITION packet owns the field once seen
+        # (the node_positions upsert rejects timeless updates over timestamped
+        # ones; this guard keeps the node cache consistent with that).
+        if not node.get('position') and payload.get('latitude_i') and payload.get('longitude_i'):
+            node['position'] = {
+                'latitude_i': payload['latitude_i'],
+                'longitude_i': payload['longitude_i'],
+                'altitude': payload.get('altitude'),
+                'precision_bits': payload.get('position_precision'),
+            }
+
+        if msg.get('sender'):
+            node['gateway'] = msg['sender']
+
+        if 'channel' in msg:
+            node['last_channel'] = str(msg['channel'])
+
+        await self.data.update_node(from_id, node)
 
     async def handle_position(self, msg):
         id = self._normalize_msg_addrs(msg)

--- a/mqtt.py
+++ b/mqtt.py
@@ -234,7 +234,6 @@ class MQTT:
                         outs["type"] = "routing"
                         outs["payload"] = out
                         logger.debug("Decoded protobuf message: routing: %s", outs)
-                        # self.handle_routing(outs)
                     except UnicodeDecodeError as e:
                         logger.debug("Unicode decoding error: text: %s", e)
                     except DecodeError as e:
@@ -358,23 +357,6 @@ class MQTT:
                         await self._safe_handle("handle_traceroute", self.handle_traceroute(j))
                 except Exception as e:
                     logger.error("JSON message processing error: %s", e, exc_info=True)
-
-    async def publish(self, client, topic, msg):
-        result = await client.publish(topic, msg)
-        status = result[0]
-        if status == 0:
-            logger.debug("Sent message to topic %s", topic)
-            return True
-        else:
-            logger.warning("Failed to send message to topic %s", topic)
-            return False
-
-    async def subscribe(self, client, topic):
-        client.subscribe(topic)
-        logger.info("Subscribed to topic %s", topic)
-
-    async def unsubscribe(self, client, topic):
-        client.unsubscribe(topic)
 
     ### message handlers
 

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -9,10 +9,13 @@ schema/migration lifecycle. All node/chat/telemetry state lives here.
 import asyncio
 import asyncpg
 import base64
+import contextvars
+import copy
 import datetime
 import json
 import logging
 import math
+import time
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Optional, List, Tuple
@@ -27,6 +30,7 @@ from storage.db.uplink_dedup import (
     reception_template,
     reconstruct_copy,
 )
+from storage.db.write_retry import WriteRetryQueue, WriteStillFailing
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +62,42 @@ def _finite_or_none(value: Any) -> Any:
         except (TypeError, ValueError):
             pass
     return value
+
+
+# Buffered-write kinds the replay dispatcher understands; enqueue validates
+# against this so a typo'd kind fails in tests, not silently during recovery.
+_RETRY_KINDS = frozenset({"mqtt_message", "telemetry", "chat_message", "traceroute"})
+
+# True while the current *task* is the retry drain replaying a buffered write —
+# a ContextVar, not an instance flag, because live ingest writes interleave
+# with replays on the same loop and must not inherit the replay behavior.
+_REPLAYING: "contextvars.ContextVar[bool]" = contextvars.ContextVar("write_replaying", default=False)
+
+
+def _is_retryable_write_error(e: BaseException) -> bool:
+    """True for unavailability-shaped errors: the write would succeed verbatim
+    once the DB answers again, so it is worth buffering. Data-shaped errors
+    (bad bind, constraint violation) would fail identically on replay and
+    must never be buffered — they'd poison the queue."""
+    if isinstance(e, (
+        asyncpg.PostgresConnectionError,   # connection died mid-query
+        asyncpg.CannotConnectNowError,     # "the database system is starting up"
+        asyncpg.AdminShutdownError,        # "the database system is shutting down"
+        asyncpg.TooManyConnectionsError,   # reconnect stampede right after recovery
+    )):
+        return True
+    if isinstance(e, asyncpg.InterfaceError):
+        # asyncpg's client-side bind failures (exceptions._base.DataError,
+        # e.g. "invalid input for query argument") subclass InterfaceError AND
+        # ValueError — those are data-shaped, not outage-shaped.
+        return not isinstance(e, ValueError)
+    if isinstance(e, TimeoutError):
+        # command_timeout on a reachable-but-slow DB (lock contention, vacuum,
+        # partition maintenance): replaying piles load onto the stall, and the
+        # timed-out INSERT may still have committed server-side.
+        return False
+    # OS-level refused/reset on (re)connect; ConnectionError is an OSError.
+    return isinstance(e, OSError)
 
 
 def _encode_cursor(created_at: datetime.datetime, row_id: int) -> str:
@@ -169,6 +209,16 @@ class PostgresStorage:
         # this task errors mid-batch with "InterfaceError: pool is closing").
         self._backfill_task: Optional[asyncio.Task] = None
 
+        # Archive writes that failed on a DB outage, replayed on recovery so a
+        # postgres bounce doesn't drop packets. See storage/db/write_retry.py.
+        self._write_retry = WriteRetryQueue(self._replay_write, self._probe_connection)
+        self._retry_enqueues = 0
+        # The retry drain is a second writer through the dedup check-then-act
+        # sequence (cache/DB lookup -> canonical insert spans awaits); this
+        # lock keeps the "one canonical per packet" invariant that the
+        # MQTT-loop-is-the-only-writer assumption used to provide.
+        self._dedup_lock = asyncio.Lock()
+
         # Uplink dedup (#526): one canonical mqtt_messages row per mesh packet,
         # per-gateway copies recorded in packet_receptions. Safe as a plain
         # in-memory cache because the MQTT loop is the only (serial) writer.
@@ -227,8 +277,83 @@ class PostgresStorage:
             self.pool = None
             return False
 
+    async def _probe_connection(self) -> bool:
+        """One cheap round-trip; the write-retry drain gates replays on this.
+        Bounded acquire so an exhausted pool can't wedge the drain task."""
+        if self.pool is None:
+            return False
+        try:
+            async with self.pool.acquire(timeout=5.0) as conn:
+                await conn.fetchval("SELECT 1")
+            return True
+        except Exception:
+            return False
+
+    async def _replay_write(self, kind: str, args: Tuple[Any, ...], failed_at: float) -> None:
+        """Re-run a buffered archive write via its public method. Runs with
+        _REPLAYING set so a still-down DB surfaces as WriteStillFailing to the
+        drain (requeue + backoff) instead of re-buffering."""
+        token = _REPLAYING.set(True)
+        try:
+            if kind == "mqtt_message":
+                # The canonical row for this packet may have been written
+                # before the outage — widen the dedup lookup to cover the time
+                # this item spent buffered, or every replayed copy of an
+                # older packet would elect a duplicate canonical.
+                age = max(0.0, time.time() - failed_at)
+                await self.write_mqtt_message(args[0], _dedup_lookback_s=age + self.dedup_window)
+            elif kind == "telemetry":
+                await self.write_telemetry(args[0], args[1])
+            elif kind == "chat_message":
+                await self.write_chat_message(args[0], args[1])
+            elif kind == "traceroute":
+                await self.write_traceroute(args[0], args[1])
+            else:
+                logger.error("Write-retry: unknown kind %r; dropping", kind)
+        finally:
+            _REPLAYING.reset(token)
+
+    def _handle_write_failure(self, label: str, kind: Optional[str],
+                              args: Optional[Tuple[Any, ...]], e: Exception) -> None:
+        """Shared failure policy for the four archive writes. Must be called
+        from an active except block (the bare raise re-raises `e`)."""
+        if self.raise_on_write_error:
+            logger.error(f"Failed to write {label} to PostgreSQL: {e}")
+            raise
+        if kind is not None and args is not None and _is_retryable_write_error(e):
+            if _REPLAYING.get():
+                raise WriteStillFailing(f"{kind}: {e}") from e
+            self._queue_write_retry(kind, args, e)
+            return
+        logger.error(f"Failed to write {label} to PostgreSQL: {e}")
+
+    def _queue_write_retry(self, kind: str, args: Tuple[Any, ...], err: BaseException) -> None:
+        """Snapshot the args (callers mutate message dicts after the write
+        call) and buffer the write for replay."""
+        if kind not in _RETRY_KINDS:
+            raise ValueError(f"unknown write-retry kind {kind!r}")
+        try:
+            args = copy.deepcopy(args)
+        except Exception:
+            logger.error("Failed to write %s to PostgreSQL and could not snapshot it for retry: %s", kind, err)
+            return
+        if not self._write_retry.put(kind, args, failed_at=time.time()):
+            logger.error("Failed to write %s to PostgreSQL during shutdown; dropped: %s", kind, err)
+            return
+        self._retry_enqueues += 1
+        if self._retry_enqueues == 1 or self._retry_enqueues % 100 == 0:
+            # ERROR so operators alerting on write failures still see the
+            # outage; per-write lines stay at debug to avoid a log flood.
+            logger.error(
+                "DB unavailable (%s); buffering archive writes for replay (%d queued)",
+                err, len(self._write_retry),
+            )
+        else:
+            logger.debug("DB unavailable; queued %s for retry (%d pending)", kind, len(self._write_retry))
+
     async def close(self):
         """Cancel background tasks (so they don't touch a closing pool) and tear down."""
+        await self._write_retry.close()
         if self._backfill_task is not None and not self._backfill_task.done():
             self._backfill_task.cancel()
             try:
@@ -970,9 +1095,7 @@ class PostgresStorage:
                 )
 
         except Exception as e:
-            logger.error(f"Failed to write telemetry to PostgreSQL: {e}")
-            if self.raise_on_write_error:
-                raise
+            self._handle_write_failure("telemetry", "telemetry", (node_id, telemetry_msg), e)
 
     async def write_chat_message(self, node_id: str, chat_msg: Dict[str, Any]) -> None:
         """
@@ -1057,9 +1180,7 @@ class PostgresStorage:
                     )
 
         except Exception as e:
-            logger.error(f"Failed to write chat message to PostgreSQL: {e}")
-            if self.raise_on_write_error:
-                raise
+            self._handle_write_failure("chat message", "chat_message", (node_id, chat_msg), e)
 
     async def write_traceroute(self, node_id: str, traceroute_msg: Dict[str, Any]) -> None:
         """
@@ -1152,9 +1273,7 @@ class PostgresStorage:
                 )
 
         except Exception as e:
-            logger.error(f"Failed to write traceroute to PostgreSQL: {e}")
-            if self.raise_on_write_error:
-                raise
+            self._handle_write_failure("traceroute", "traceroute", (node_id, traceroute_msg), e)
 
     def _coerce_mqtt_payload_text(self, value: Any) -> Optional[str]:
         """
@@ -1183,7 +1302,8 @@ class PostgresStorage:
 
         return str(value)
 
-    async def write_mqtt_message(self, mqtt_msg: Any) -> Optional[int]:
+    async def write_mqtt_message(self, mqtt_msg: Any, *,
+                                 _dedup_lookback_s: Optional[float] = None) -> Optional[int]:
         """
         Write a raw MQTT message (or decoded/log dict) into mqtt_messages.
 
@@ -1192,6 +1312,9 @@ class PostgresStorage:
 
         Returns the inserted row's id (the `mqtt_row_id` the read path exposes),
         or None if storage is unavailable or the write failed.
+
+        _dedup_lookback_s: retry-replay only — widens the canonical lookup
+        window to cover the time the message spent buffered.
         """
         if not self._ready("write_mqtt_message"):
             return None
@@ -1250,11 +1373,17 @@ class PostgresStorage:
                 # below so a copy is never lost to a dedup bug.
                 if self.dedup_enabled and from_node_id is not None and packet_id is not None:
                     try:
-                        return await self._write_deduped(
-                            conn, clean, topic, payload_text, qos_i, retain_b,
-                            ts_i, from_node_id, to_node_id, packet_id,
-                        )
+                        # Serialized: the retry drain is a second writer, and
+                        # the dedup check-then-insert must stay atomic per task.
+                        async with self._dedup_lock:
+                            return await self._write_deduped(
+                                conn, clean, topic, payload_text, qos_i, retain_b,
+                                ts_i, from_node_id, to_node_id, packet_id,
+                                lookback_s=_dedup_lookback_s,
+                            )
                     except Exception as e:
+                        if _is_retryable_write_error(e):
+                            raise  # outage, not a dedup bug — buffer the write
                         logger.warning("Uplink dedup failed (storing copy verbatim): %s", e)
 
                 row_id = await self._insert_mqtt_row(
@@ -1263,9 +1392,10 @@ class PostgresStorage:
                 )
             return int(row_id) if row_id is not None else None
         except Exception as e:
-            logger.error(f"Failed to write mqtt message to PostgreSQL: {e}")
-            if self.raise_on_write_error:
-                raise
+            self._handle_write_failure(
+                "mqtt message", "mqtt_message",
+                (mqtt_msg,) if isinstance(mqtt_msg, dict) else None, e,
+            )
             return None
 
     @staticmethod
@@ -1304,18 +1434,22 @@ class PostgresStorage:
         from_node_id: str,
         to_node_id: Optional[str],
         packet_id: int,
+        lookback_s: Optional[float] = None,
     ) -> Optional[int]:
         """Dedup-aware archive write: returns the canonical row id for every
-        uplink copy of a packet, inserting a canonical row only for the first."""
+        uplink copy of a packet, inserting a canonical row only for the first.
+
+        lookback_s widens the DB lookup beyond dedup_window for retry replays,
+        whose packet may have been canonicalized before the outage."""
         key = (from_node_id, packet_id)
         hit = self._dedup_cache.get(key)
         if hit is None:
             # Cache miss (e.g. app restart mid-window): the canonical row may
             # still exist in the DB — window-bounded lookup via idx_mqtt_messages_packet.
-            db_hit = await self._dedup_lookup_db(conn, from_node_id, packet_id)
+            db_hit = await self._dedup_lookup_db(conn, from_node_id, packet_id, lookback_s)
             if db_hit is not None:
                 row_id, canonical, age = db_hit
-                self._dedup_cache.put(key, row_id, canonical, ttl=self.dedup_window - age)
+                self._dedup_cache.put(key, row_id, canonical, ttl=max(0.0, self.dedup_window - age))
                 hit = (row_id, canonical)
 
         if hit is not None:
@@ -1343,10 +1477,12 @@ class PostgresStorage:
         return int(row_id)
 
     async def _dedup_lookup_db(
-        self, conn: asyncpg.Connection, from_node_id: str, packet_id: int
+        self, conn: asyncpg.Connection, from_node_id: str, packet_id: int,
+        lookback_s: Optional[float] = None,
     ) -> Optional[Tuple[int, Dict[str, Any], float]]:
         """Find a live canonical row for (from, packet id) inside the dedup
-        window. Returns (row_id, canonical dict, age seconds) or None."""
+        window (or a wider retry-replay lookback). Returns (row_id, canonical
+        dict, age seconds) or None."""
         # ASC: adopt the first-heard row — it's the one carrying receptions if a
         # rare verbatim-fallback row also exists for this key in the window.
         row = await conn.fetchrow(
@@ -1356,7 +1492,7 @@ class PostgresStorage:
                WHERE from_node_id = $1 AND packet_id = $2
                  AND created_at > now() - make_interval(secs => $3)
                ORDER BY created_at ASC LIMIT 1""",
-            from_node_id, packet_id, float(self.dedup_window),
+            from_node_id, packet_id, max(float(lookback_s or 0.0), float(self.dedup_window)),
         )
         if row is None or not row["payload"]:
             return None

--- a/storage/db/write_retry.py
+++ b/storage/db/write_retry.py
@@ -1,0 +1,154 @@
+"""
+Bounded retry buffer for archive writes that failed on a database outage.
+
+When Postgres bounces (restart, failover, host maintenance) the ingest loop
+used to drop packets: every write_* method caught the connection error, logged
+it, and moved on. This queue buffers the failed *append-only* writes — the
+mqtt_messages archive plus telemetry/chat/traceroute history, i.e. the rows
+that cannot be regenerated — and replays them once the database answers again.
+
+State upserts (write_node, node_telemetry_current) are deliberately NOT
+retried: the next packet from a node rewrites them within minutes, and
+replaying a stale snapshot after recovery could clobber fresher state.
+
+Replay protocol: the replay callback re-runs the write and raises
+WriteStillFailing if the database is still (or again) unavailable — the item
+goes back to the head of the queue and the drain backs off. Any other
+exception drops that item (it would fail identically forever). This is an
+explicit signal rather than queue-growth inference, so live writes failing
+concurrently can never be mistaken for replay failures.
+
+Known, accepted semantics:
+- At-least-once: an ambiguous failure (connection dies after the server
+  committed but before the client read the result) replays a write that
+  already landed. telemetry/chat/traceroute inserts are idempotent
+  (ON CONFLICT DO NOTHING); a replayed mqtt_message can in rare cases add a
+  duplicate reception/row — weighed against certain loss, we take it.
+- Replayed rows get created_at = replay time (they sort/partition by when
+  they were actually stored).
+- Live SSE broadcasts for replayed writes are not re-emitted; the archive
+  backfills, open dashboards show the outage gap until reload.
+
+Memory bound: at most ``max_items`` entries, drop-oldest beyond that with a
+running counter. At typical mesh ingest rates the default cap holds roughly
+half an hour of full-rate traffic, far beyond a normal restart window.
+"""
+
+import asyncio
+import logging
+from collections import deque
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class WriteStillFailing(Exception):
+    """Raised by the replay callback when the DB is still unavailable — the
+    item is requeued at the head and the drain backs off."""
+
+
+class WriteRetryQueue:
+    DROP_LOG_EVERY = 100
+
+    def __init__(
+        self,
+        replay: Callable[[str, Tuple[Any, ...], float], Awaitable[None]],
+        probe: Callable[[], Awaitable[bool]],
+        *,
+        max_items: int = 10_000,
+        base_delay_s: float = 1.0,
+        max_delay_s: float = 30.0,
+    ):
+        self._replay = replay
+        self._probe = probe
+        self._items: "deque[Tuple[str, Tuple[Any, ...], float]]" = deque()
+        self._max_items = max_items
+        self._base_delay_s = base_delay_s
+        self._max_delay_s = max_delay_s
+        self._drops_total = 0
+        self._task: Optional[asyncio.Task] = None
+        self._closed = False
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    @property
+    def drops_total(self) -> int:
+        return self._drops_total
+
+    def put(self, kind: str, args: Tuple[Any, ...], failed_at: float) -> bool:
+        """Buffer one failed write; starts the drain task if idle.
+
+        Returns False (write NOT buffered) after close(), so shutdown can't
+        resurrect the drain task and callers can log the loss honestly.
+        Must be called from a running event loop (the write methods always are).
+        """
+        if self._closed:
+            return False
+        self._items.append((kind, args, failed_at))
+        while len(self._items) > self._max_items:
+            self._items.popleft()
+            self._drops_total += 1
+            if self._drops_total == 1 or self._drops_total % self.DROP_LOG_EVERY == 0:
+                logger.error(
+                    "Write-retry queue full; dropped %d oldest buffered writes so far",
+                    self._drops_total,
+                )
+        if self._task is None or self._task.done():
+            self._task = asyncio.get_running_loop().create_task(self._drain())
+        return True
+
+    async def close(self) -> None:
+        """Stop draining. Anything still queued is lost (process is exiting)."""
+        self._closed = True
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await asyncio.wait_for(self._task, timeout=5.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                pass  # best-effort; shutdown shouldn't block on this
+        self._task = None
+
+    async def _drain(self) -> None:
+        try:
+            delay = self._base_delay_s
+            while self._items and not self._closed:
+                if not await self._probe():
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self._max_delay_s)
+                    continue
+
+                # One snapshot's worth per probe round: items appended by live
+                # writes during the round wait for the next probe.
+                made_progress = False
+                for _ in range(len(self._items)):
+                    if not self._items or self._closed:
+                        break
+                    item = self._items.popleft()
+                    try:
+                        await self._replay(*item)
+                    except WriteStillFailing as e:
+                        self._items.appendleft(item)
+                        logger.debug("Write-retry: %s still failing (%s); backing off", item[0], e)
+                        break
+                    except Exception as e:
+                        logger.error("Write-retry replay of %s failed; dropping item: %s", item[0], e)
+                        continue
+                    made_progress = True
+                    # Yield so live ingest interleaves with a large backlog.
+                    await asyncio.sleep(0)
+
+                if made_progress:
+                    delay = self._base_delay_s
+                else:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self._max_delay_s)
+
+            if not self._items:
+                logger.info("Write-retry queue drained")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # The queue must never die silently with items buffered; the next
+            # failed write's put() restarts the task.
+            logger.exception("Write-retry drain task crashed; will restart on next failed write")

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -165,6 +165,81 @@ class TestHandleNodeinfo:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# handle_mapreport — NODEINFO-like enrichment from MAP_REPORT_APP packets
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHandleMapreport:
+    def _ok_msg(self, **payload_overrides):
+        payload = {
+            "long_name": "Ridge Repeater",
+            "short_name": "RDG",
+            "hw_model": 31,
+            "role": 2,
+            "firmware_version": "2.5.3",
+            "latitude_i": 371234567,
+            "longitude_i": -1219876543,
+            "altitude": 812,
+            "position_precision": 16,
+        }
+        payload.update(payload_overrides)
+        # sender is the ServiceEnvelope gateway_id — always a "!hex" string.
+        return {"from": 0x11223344, "sender": "!aabbccdd", "channel": 0, "payload": payload}
+
+    def test_happy_path_enriches_node_and_fills_position(self):
+        mqtt, data = make_mqtt()
+        run(mqtt.handle_mapreport(self._ok_msg()))
+        node = data.pg_storage._nodes["11223344"]
+        assert node["longname"] == "Ridge Repeater"
+        assert node["shortname"] == "RDG"
+        assert node["hardware"] == 31
+        assert node["role"] == 2
+        assert node["position"]["latitude_i"] == 371234567
+        assert node["position"]["longitude_i"] == -1219876543
+        assert node["position"]["altitude"] == 812
+        # MapReport calls it position_precision; node_positions stores precision_bits.
+        assert node["position"]["precision_bits"] == 16
+        assert node["gateway"] == "aabbccdd"
+        assert node["last_channel"] == "0"
+
+    def test_role_defaults_to_client_when_omitted(self):
+        """proto3 omits zero enums, so an absent role IS role CLIENT (0)."""
+        mqtt, data = make_mqtt()
+        msg = self._ok_msg()
+        del msg["payload"]["role"]
+        run(mqtt.handle_mapreport(msg))
+        assert data.pg_storage._nodes["11223344"]["role"] == 0
+
+    def test_does_not_overwrite_existing_position(self):
+        """Map reports are timeless; a position learned from a real POSITION
+        packet must win over them, cache included."""
+        existing = {"latitude_i": 1, "longitude_i": 2, "time": 1234}
+        seed = {"id": "11223344", "longname": "X", "shortname": "Y",
+                "position": dict(existing)}
+        mqtt, data = make_mqtt(nodes={"11223344": seed})
+        run(mqtt.handle_mapreport(self._ok_msg()))
+        assert data.pg_storage._nodes["11223344"]["position"] == existing
+
+    def test_absent_coords_leave_position_unset(self):
+        mqtt, data = make_mqtt()
+        msg = self._ok_msg()
+        for key in ("latitude_i", "longitude_i", "altitude", "position_precision"):
+            del msg["payload"][key]
+        run(mqtt.handle_mapreport(msg))
+        assert data.pg_storage._nodes["11223344"]["position"] is None
+
+    def test_missing_payload_skips_without_write(self):
+        mqtt, data = make_mqtt()
+        run(mqtt.handle_mapreport({"from": 0x11223344}))
+        assert data.pg_storage.writes == []
+
+    def test_missing_from_skips_without_write(self):
+        mqtt, data = make_mqtt()
+        run(mqtt.handle_mapreport({"payload": {"long_name": "Ghost"}}))
+        assert data.pg_storage.writes == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # handle_text — chat path with required-field guards
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_write_retry.py
+++ b/tests/test_write_retry.py
@@ -1,0 +1,308 @@
+"""
+Tests for the DB-write retry queue: a postgres bounce must buffer failed
+archive writes and replay them on recovery instead of dropping packets
+(observed in production: a DB restart permanently lost in-flight
+mqtt_messages writes). Covers the queue mechanics, the retryable-error
+classification (including the asyncpg exception-hierarchy traps), and the
+write_mqtt_message integration end to end.
+"""
+
+import asyncio
+import time
+
+import asyncpg
+import asyncpg.exceptions._base as asyncpg_base
+
+from storage.db.postgres import PostgresStorage, _is_retryable_write_error
+from storage.db.write_retry import WriteRetryQueue, WriteStillFailing
+
+
+def run(coro):
+    """Drive an async function without pytest-asyncio (not in requirements-dev)."""
+    return asyncio.run(coro)
+
+
+async def wait_for(predicate, timeout=2.0):
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("condition not met within timeout")
+        await asyncio.sleep(0.005)
+
+
+class Harness:
+    """WriteRetryQueue wired to a controllable probe and a recording replay."""
+
+    def __init__(self, db_up=True, replay=None, **queue_kwargs):
+        self.db_up = db_up
+        self.replayed = []
+        self.probes = 0
+        self.queue = WriteRetryQueue(
+            replay or self._record,
+            self._probe,
+            base_delay_s=0.01,
+            max_delay_s=0.02,
+            **queue_kwargs,
+        )
+
+    async def _probe(self):
+        self.probes += 1
+        return self.db_up
+
+    async def _record(self, kind, args, failed_at):
+        self.replayed.append((kind, args))
+
+
+class TestWriteRetryQueue:
+    def test_replays_in_order_once_db_answers(self):
+        async def scenario():
+            h = Harness(db_up=True)
+            h.queue.put("telemetry", ("a", {"n": 1}), failed_at=1.0)
+            h.queue.put("telemetry", ("b", {"n": 2}), failed_at=2.0)
+            await wait_for(lambda: len(h.replayed) == 2)
+            assert [args[0] for _, args in h.replayed] == ["a", "b"]
+            assert len(h.queue) == 0
+        run(scenario())
+
+    def test_backs_off_while_down_then_drains(self):
+        async def scenario():
+            h = Harness(db_up=False)
+            h.queue.put("chat_message", ("a", {}), failed_at=1.0)
+            await wait_for(lambda: h.probes >= 3)
+            assert h.replayed == []
+            assert len(h.queue) == 1
+            h.db_up = True
+            await wait_for(lambda: len(h.replayed) == 1)
+            assert len(h.queue) == 0
+        run(scenario())
+
+    def test_bounded_drops_oldest_beyond_cap(self):
+        async def scenario():
+            h = Harness(db_up=False, max_items=3)
+            for i in range(5):
+                h.queue.put("telemetry", (f"n{i}", {}), failed_at=float(i))
+            assert len(h.queue) == 3
+            assert h.queue.drops_total == 2
+            h.db_up = True
+            await wait_for(lambda: len(h.replayed) == 3)
+            assert [args[0] for _, args in h.replayed] == ["n2", "n3", "n4"]
+        run(scenario())
+
+    def test_still_failing_requeues_at_head_and_backs_off(self):
+        """WriteStillFailing = DB dropped again mid-drain: the item must go
+        back to the head (order preserved) and the drain must back off, not
+        hot-spin."""
+        async def scenario():
+            attempts = []
+            h = Harness(db_up=True)
+
+            async def replay(kind, args, failed_at):
+                attempts.append(args[0])
+                if len(attempts) < 3:
+                    raise WriteStillFailing("db dropped again")
+                h.replayed.append((kind, args))
+
+            h.queue._replay = replay
+            h.queue.put("mqtt_message", ("first",), failed_at=1.0)
+            h.queue.put("mqtt_message", ("second",), failed_at=2.0)
+            await wait_for(lambda: len(h.replayed) == 2)
+            # 'first' failed twice, was requeued at the head both times, and
+            # still replayed before 'second'.
+            assert attempts == ["first", "first", "first", "second"]
+            # Each failed round required a fresh probe cycle — no hot spin.
+            assert h.probes >= 3
+        run(scenario())
+
+    def test_unexpected_replay_error_drops_item_and_continues(self):
+        async def scenario():
+            seen = []
+
+            async def replay(kind, args, failed_at):
+                seen.append(args[0])
+                if args[0] == "bad":
+                    raise ValueError("boom")
+
+            h = Harness(db_up=True, replay=replay)
+            h.queue.put("telemetry", ("bad", {}), failed_at=1.0)
+            h.queue.put("telemetry", ("good", {}), failed_at=2.0)
+            await wait_for(lambda: seen == ["bad", "good"])
+            assert len(h.queue) == 0  # 'bad' dropped, not retried forever
+        run(scenario())
+
+    def test_put_after_close_is_refused(self):
+        async def scenario():
+            h = Harness(db_up=True)
+            await h.queue.close()
+            assert h.queue.put("telemetry", ("a", {}), failed_at=1.0) is False
+            assert len(h.queue) == 0
+        run(scenario())
+
+
+class TestRetryableClassification:
+    def test_unavailability_errors_are_retryable(self):
+        for e in (
+            asyncpg.CannotConnectNowError("the database system is starting up"),
+            asyncpg.AdminShutdownError("terminating connection"),
+            asyncpg.TooManyConnectionsError("sorry, too many clients already"),
+            asyncpg.InterfaceError("connection is closed"),
+            ConnectionRefusedError("refused"),
+            ConnectionResetError("reset"),
+        ):
+            assert _is_retryable_write_error(e), e
+
+    def test_data_errors_are_not_retryable(self):
+        for e in (
+            asyncpg.DataError("server-side data error"),
+            asyncpg.UniqueViolationError("duplicate key"),
+            ValueError("bad"),
+            KeyError("missing"),
+        ):
+            assert not _is_retryable_write_error(e), e
+
+    def test_client_side_bind_error_is_not_retryable(self):
+        """asyncpg's client-side bind failure ('invalid input for query
+        argument') subclasses InterfaceError AND ValueError. Classifying it
+        retryable would poison the queue: the same bad value fails on every
+        replay, forever."""
+        e = asyncpg_base.DataError("invalid input for query argument $15")
+        assert isinstance(e, asyncpg.InterfaceError)  # guards the premise
+        assert not _is_retryable_write_error(e)
+
+    def test_command_timeout_is_not_retryable(self):
+        """A reachable-but-slow DB (lock contention, vacuum) raises
+        TimeoutError via command_timeout; replaying piles onto the stall and
+        the statement may have committed server-side."""
+        assert not _is_retryable_write_error(asyncio.TimeoutError())
+        assert not _is_retryable_write_error(TimeoutError())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# write_mqtt_message integration — outage buffers, recovery replays
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class FakeConn:
+    def __init__(self):
+        self.fetchvals = []
+
+    async def fetchval(self, sql, *args):
+        self.fetchvals.append(sql.strip().split()[0].upper())
+        return 1 if "SELECT 1" in sql else 42
+
+    async def execute(self, sql, *args):
+        return None
+
+
+class FlakyPool:
+    """acquire() raises ConnectionRefusedError while .fail is True."""
+
+    def __init__(self):
+        self.fail = True
+        self.conn = FakeConn()
+
+    async def close(self):
+        pass
+
+    def acquire(self, timeout=None):
+        pool = self
+
+        class _CM:
+            async def __aenter__(self):
+                if pool.fail:
+                    raise ConnectionRefusedError("db down")
+                return pool.conn
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _CM()
+
+
+def make_storage():
+    storage = PostgresStorage({
+        # dedup off: exercise the plain-insert path without dedup fakes
+        "storage": {"dedup_uplinks": False, "postgres": {"enabled": True}},
+        "server": {"timezone": "UTC"},
+    })
+    storage.pool = FlakyPool()
+    return storage
+
+
+class TestWriteMqttMessageRetry:
+    def test_outage_buffers_then_recovery_replays(self):
+        async def scenario():
+            storage = make_storage()
+            msg = {"topic": "msh/US/2/e/LongFast/!aabbccdd", "text": "x"}
+            row_id = await storage.write_mqtt_message(msg)
+            assert row_id is None
+            assert len(storage._write_retry) == 1
+
+            storage.pool.fail = False
+            await wait_for(lambda: len(storage._write_retry) == 0)
+            assert "INSERT" in storage.pool.conn.fetchvals
+            await storage.close()
+        run(scenario())
+
+    def test_snapshot_is_immune_to_caller_mutation(self):
+        """handle_log keeps using the msg dict after the write call; the
+        buffered copy must reflect the failure-time state."""
+        async def scenario():
+            storage = make_storage()
+            msg = {"topic": "msh/x", "text": "original"}
+            await storage.write_mqtt_message(msg)
+            msg["text"] = "mutated-after-write"
+            _, (queued,), _failed_at = storage._write_retry._items[0]
+            assert queued["text"] == "original"
+            await storage.close()
+        run(scenario())
+
+    def test_non_retryable_error_is_not_buffered(self):
+        async def scenario():
+            storage = make_storage()
+
+            class BadPool(FlakyPool):
+                def acquire(self, timeout=None):
+                    raise ValueError("programming bug")
+
+            storage.pool = BadPool()
+            row_id = await storage.write_mqtt_message({"topic": "msh/x"})
+            assert row_id is None
+            assert len(storage._write_retry) == 0
+            await storage.close()
+        run(scenario())
+
+    def test_replay_widens_dedup_lookback_by_item_age(self):
+        """A packet buffered through an outage may have been canonicalized
+        before it — the replay must look further back than dedup_window or it
+        elects a duplicate canonical."""
+        async def scenario():
+            storage = make_storage()
+            captured = {}
+
+            async def fake_write(msg, *, _dedup_lookback_s=None):
+                captured["lookback"] = _dedup_lookback_s
+
+            storage.write_mqtt_message = fake_write
+            await storage._replay_write(
+                "mqtt_message", ({"topic": "msh/x"},), failed_at=time.time() - 1200)
+            assert captured["lookback"] >= 1200 + storage.dedup_window - 5
+            await storage.close()
+        run(scenario())
+
+    def test_replay_reraises_still_down_as_write_still_failing(self):
+        """While replaying, a still-down DB must surface to the drain (which
+        requeues at head + backs off) instead of re-buffering a fresh copy."""
+        async def scenario():
+            storage = make_storage()  # pool.fail is True
+            try:
+                await storage._replay_write(
+                    "chat_message", ("aabbccdd", {"id": 1, "text": "x"}), failed_at=time.time())
+            except WriteStillFailing:
+                pass
+            else:
+                raise AssertionError("expected WriteStillFailing")
+            # Nothing re-buffered: the drain owns the requeue.
+            assert len(storage._write_retry) == 0
+            await storage.close()
+        run(scenario())


### PR DESCRIPTION
## fix(mqtt): decode MAP_REPORT with the right protobuf type and handle it
MAP_REPORT_APP payloads were decoded as `mesh_pb2.Position` instead of
`mqtt_pb2.MapReport`, so stored mapreport payloads were field-misaligned
garbage, and the handler call was a commented-out stub with no handler behind
it. Now decoded correctly, with a `handle_mapreport` that enriches nodes
(name, hardware, role, position) — including nodes that never send NODEINFO
and currently sit as anonymous hex IDs. Map reports carry no timestamp, so a
position is only filled for nodes that have none; a real POSITION packet owns
the field once seen. Rows stored as `type='mapreport'` before this fix remain
misparsed (raw bytes weren't kept). Six handler tests.

## feat(storage): buffer archive writes during DB outages and replay on recovery
A postgres bounce used to drop in-flight packets (an observed restart lost 9
mqtt_messages writes). This adds a bounded retry queue (10k items,
drop-oldest, hot path untouched) that buffers failed *append-only* writes —
mqtt_messages, telemetry, chat, traceroutes — and replays them with backoff
once a `SELECT 1` probe succeeds. State upserts are deliberately not retried
(the next packet rewrites them; replaying stale state could clobber fresher).

Careful bits, all tested:
- Only unavailability-shaped errors are buffered. asyncpg's client-side bind
  failures subclass InterfaceError *and* ValueError and are excluded (they'd
  poison the queue); command timeouts are excluded (slow-but-alive DB);
  TooManyConnectionsError (reconnect stampede) is included.
- The replay drain is a second writer through the #526 canonical
  check-then-insert, so that section now takes a lock, and replays widen the
  canonical lookup by the item's buffered age so copies of pre-outage packets
  don't elect duplicate canonicals.
- A still-down DB surfaces as an explicit WriteStillFailing (requeue at head,
  back off) rather than being inferred from queue growth.

Documented, accepted semantics: at-least-once (an ambiguous commit-vs-ack
failure can rarely duplicate a reception row — preferred over certain loss);
replayed rows get created_at = replay time; SSE events aren't re-emitted for
replays. 15 new tests.

## chore: drop dead MQTT code, stale TODO; memoize chat view params
Remove the never-implemented `handle_routing` stub (the decode stays — it
feeds the archive), the uncalled-and-broken `MQTT.publish/subscribe/
unsubscribe` helpers, and config.py's stale log_level TODO (main.py already
wires it). Chat now passes a memoized `views` array into
`useChatSearchParams` and the hook pins its fallback identity, removing the
exhaustive-deps suppression.
