### PR TITLE
ci: run yarn lint in frontend tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
       # Corepack picks the yarn version up from frontend/package.json `packageManager`.
       - run: corepack enable
       - run: yarn install
+      - run: yarn lint
       - run: yarn tsc --noEmit
       - run: yarn test
       # Production bundle — catches asset/dynamic-import issues vitest doesn't.


### PR DESCRIPTION
## Summary

Adds `yarn lint` to the Frontend Tests job. The `lint` script (`eslint . --report-unused-disable-directives --max-warnings 0`) has existed in `frontend/package.json`, but CI never invoked it — so lint-only breakage can't turn a PR red.

## Changes

- Add `- run: yarn lint` to the frontend job, after `yarn install` and before `yarn tsc --noEmit`.
