### PR TITLE
fix(deps)!: migrate to maplibre-gl v6

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "highlight.js": "^11.11.1",
-    "maplibre-gl": "^5.23.0",
+    "maplibre-gl": "^6.0.0",
     "postcss": "^8.5.8",
     "react": "^19.2.4",
     "react-dom": "^19",

--- a/frontend/src/maps/maplibreWorker.ts
+++ b/frontend/src/maps/maplibreWorker.ts
@@ -1,0 +1,12 @@
+/** MapLibre v6's ESM build loads its worker from a real URL instead of
+ *  inlining it in the bundle, and inside Vite's module graph that URL can't
+ *  be derived automatically — without this bootstrap the map boots but no
+ *  tiles ever load. Must run before the first `new Map()`; importing this
+ *  module from every Map-constructing module guarantees that.
+ *  `?worker&url` (not plain `?url`) is required: the worker imports its
+ *  maplibre-gl-shared.mjs sibling, and `?url` would emit it unbundled — a
+ *  break that only shows up in production builds, never in dev. */
+import { setWorkerUrl } from "maplibre-gl";
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
+
+setWorkerUrl(workerUrl);

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -1,6 +1,8 @@
 import "maplibre-gl/dist/maplibre-gl.css";
+import "../maps/maplibreWorker";
 
-import maplibregl, {
+import * as maplibregl from "maplibre-gl";
+import {
   GeoJSONSource as MlGeoJSONSource,
   Map as MlMap,
 } from "maplibre-gl";

--- a/frontend/src/pages/map/hooks/useCoverageCompute.ts
+++ b/frontend/src/pages/map/hooks/useCoverageCompute.ts
@@ -1,4 +1,5 @@
-import maplibregl, {
+import * as maplibregl from "maplibre-gl";
+import {
   GeoJSONSource as MlGeoJSONSource,
   Map as MlMap,
 } from "maplibre-gl";

--- a/frontend/src/pages/map/hooks/useLosCompute.ts
+++ b/frontend/src/pages/map/hooks/useLosCompute.ts
@@ -1,4 +1,5 @@
-import maplibregl, {
+import * as maplibregl from "maplibre-gl";
+import {
   GeoJSONSource as MlGeoJSONSource,
   Map as MlMap,
 } from "maplibre-gl";

--- a/frontend/src/pages/map/hooks/useScanCompute.ts
+++ b/frontend/src/pages/map/hooks/useScanCompute.ts
@@ -1,4 +1,5 @@
-import maplibregl, {
+import * as maplibregl from "maplibre-gl";
+import {
   GeoJSONSource as MlGeoJSONSource,
   Map as MlMap,
 } from "maplibre-gl";

--- a/frontend/src/pages/map/hooks/useTraceDraw.ts
+++ b/frontend/src/pages/map/hooks/useTraceDraw.ts
@@ -2,7 +2,8 @@
  *  over ghost gaps, '?' chip markers), alternates recency-faded with
  *  usage-weighted widths, endpoint markers, one-shot fitBounds per pair, and
  *  the lit-up picking rings. Owns the marker/fit refs so resetTool can clear them. */
-import maplibregl, { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl";
 import { useEffect, useRef } from "react";
 
 import { normalizeLng, unwrapLngTo } from "../lib/geo";

--- a/frontend/src/pages/map/hooks/useTraceFlyover.ts
+++ b/frontend/src/pages/map/hooks/useTraceFlyover.ts
@@ -4,7 +4,8 @@
  * pulse, a dwell, and a persistent shortname chip. Esc / user camera input /
  * tool close / path change cancels.
  */
-import maplibregl, { Map as MlMap } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import { Map as MlMap } from "maplibre-gl";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { liveNodeFlushGate } from "../../../utils/liveGate";

--- a/frontend/src/pages/map/layers/activityLayer.ts
+++ b/frontend/src/pages/map/layers/activityLayer.ts
@@ -16,7 +16,8 @@
  *  it). Note the overlay composites above ALL map layers (labels, spiderfy
  *  fans included) — acceptable for ephemeral translucent effects; DOM markers
  *  and panels still paint above it. */
-import maplibregl, { type CustomRenderMethodInput } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import { type CustomRenderMethodInput } from "maplibre-gl";
 
 type RGB = [number, number, number];
 type LngLat = [number, number];
@@ -641,8 +642,8 @@ export class ActivityLayer implements maplibregl.CustomLayerInterface {
    *  arcs stay glued to the basemap during pans; draws NOTHING into the map's
    *  own context, and never asks the map to repaint. */
   render(_gl: WebGLRenderingContext | WebGL2RenderingContext, options: CustomRenderMethodInput): void {
-    const tr = (this.map as unknown as { transform?: { mercatorMatrix?: Float32List | number[] } })?.transform;
-    const src = (tr?.mercatorMatrix ?? options.modelViewProjectionMatrix) as ArrayLike<number>;
+    // 0..1 Mercator → clip (see clusterDonutLayer.ts for the matrix story).
+    const src = options.defaultProjectionData.mainMatrix as ArrayLike<number>;
     // Copy — maplibre mutates its matrices between frames.
     if (this.matrix?.length !== 16) this.matrix = new Float32Array(16);
     for (let i = 0; i < 16; i++) this.matrix[i] = src[i];

--- a/frontend/src/pages/map/layers/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/layers/clusterDonutLayer.ts
@@ -4,7 +4,8 @@
  * sizing happens in the shader.
  * Hit-testing is handled by the companion "clusters" circle layer.
  */
-import maplibregl, { type CustomRenderMethodInput } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import { type CustomRenderMethodInput } from "maplibre-gl";
 
 import { MAP_STYLE_IDS } from "../../../maps/mapStyle";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
@@ -366,8 +367,9 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     const terrainEnabled = !!map.getTerrain?.();
     const elevationAt = (lng: number, lat: number): number => {
       if (!terrainEnabled) return 0;
-      // Want exaggerated elevation here: mercatorMatrix doesn't scale terrain,
-      // so vertex z must already be in the same exaggerated space as the rendered mesh.
+      // Want exaggerated elevation here: the projection matrix doesn't scale
+      // terrain, so vertex z must already be in the same exaggerated space as
+      // the rendered mesh.
       const e = map.queryTerrainElevation?.({ lng, lat });
       return Number.isFinite(e) ? (e as number) : 0;
     };
@@ -437,10 +439,10 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
 
     if (this.vertexCount === 0) return;
 
-    // Shader expects 0..1 Mercator → clip; the public `modelViewProjectionMatrix`
-    // expects coord×worldSize. Internal `mercatorMatrix` has the worldSize baked in.
-    const tr = this.map ? (this.map as unknown as { transform?: { mercatorMatrix?: Float32List | number[] } }).transform : undefined;
-    const matrix = (tr?.mercatorMatrix ?? options.modelViewProjectionMatrix) as Float32List;
+    // Shader expects 0..1 Mercator → clip. `defaultProjectionData.mainMatrix`
+    // is exactly that under mercator projection (conformal z in "3d" mode);
+    // `modelViewProjectionMatrix` won't do — it expects coord×worldSize.
+    const matrix = options.defaultProjectionData.mainMatrix as Float32List;
 
     gl.useProgram(this.program);
     gl.uniformMatrix4fv(this.uMatrix, false, matrix);

--- a/frontend/src/pages/map/layers/losTubeLayer.ts
+++ b/frontend/src/pages/map/layers/losTubeLayer.ts
@@ -2,7 +2,8 @@
  * 3D LoS "tube" custom layer: GL_LINE_STRIP in Mercator world space,
  * color-coded per vertex (clear/fresnel/blocked). Sits in the depth buffer.
  */
-import maplibregl, { type CustomRenderMethodInput } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import { type CustomRenderMethodInput } from "maplibre-gl";
 
 import { normalizeLng, shortestLngDelta } from "../lib/geo";
 
@@ -171,9 +172,8 @@ export class LosTubeLayer implements maplibregl.CustomLayerInterface {
   render(gl: WebGLRenderingContext | WebGL2RenderingContext, options: CustomRenderMethodInput): void {
     if (!this.program || !this.buffer || this.vertexCount < 2) return;
 
-    // See clusterDonutLayer.ts for the mercatorMatrix vs modelViewProjectionMatrix story.
-    const tr = this.map ? (this.map as unknown as { transform?: { mercatorMatrix?: Float32List | number[] } }).transform : undefined;
-    const matrix = (tr?.mercatorMatrix ?? options.modelViewProjectionMatrix) as Float32List;
+    // See clusterDonutLayer.ts for the matrix story (0..1 Mercator → clip).
+    const matrix = options.defaultProjectionData.mainMatrix as Float32List;
 
     gl.useProgram(this.program);
     gl.uniformMatrix4fv(this.uMatrix, false, matrix);

--- a/frontend/src/pages/map/layers/mapHoverUi.ts
+++ b/frontend/src/pages/map/layers/mapHoverUi.ts
@@ -1,5 +1,6 @@
 /** Bind-once hover UI: cursor elevation feed, node tooltips, link hover cards. */
-import maplibregl, { Map as MlMap } from "maplibre-gl";
+import * as maplibregl from "maplibre-gl";
+import { Map as MlMap } from "maplibre-gl";
 
 import { NodeRole, roleTitles } from "../../../types";
 import type { CoordPillSink } from "../components/MapCoordinatePill";

--- a/frontend/src/pages/nodes/NodeMap.tsx
+++ b/frontend/src/pages/nodes/NodeMap.tsx
@@ -1,6 +1,8 @@
 import "maplibre-gl/dist/maplibre-gl.css";
+import "../../maps/maplibreWorker";
 
-import maplibregl, {
+import * as maplibregl from "maplibre-gl";
+import {
   GeoJSONSource as MlGeoJSONSource,
   Map as MlMap,
 } from "maplibre-gl";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1017,10 +1017,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/jsonlint-lines-primitives@npm:^2.0.2, @mapbox/jsonlint-lines-primitives@npm:~2.0.2":
-  version: 2.0.2
-  resolution: "@mapbox/jsonlint-lines-primitives@npm:2.0.2"
-  checksum: 10c0/5814e42fc453700132f93ea742aabcef9a3c98d9bf17d4c1106f82d1dcd91bbc93052e66e29014323b9b2a41b020c743d897e4a96cc4ed2f734482d587d8c2b2
+"@mapbox/jsonlint-lines-primitives@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@mapbox/jsonlint-lines-primitives@npm:2.0.3"
+  checksum: 10c0/e114b27757a21ccbf20e3c99761e8b48d2527cb321f47e5a4d9aa4b5781b16f15b1f6f4ab678a4329f93668956281a05b56387331dc0260981a2ef695414fc1d
   languageName: node
   linkType: hard
 
@@ -1031,94 +1031,75 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/tiny-sdf@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@mapbox/tiny-sdf@npm:2.1.0"
-  checksum: 10c0/8303c005fc0f1022c44b8b6cd8a3334a3e18f3d3cb56104df3633778e7dd032dc52b2e0712eca92b3b73a40d0bf66f5c2143abe8706a6af7cd0c5ea983d356a8
+"@mapbox/tiny-sdf@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mapbox/tiny-sdf@npm:2.2.0"
+  checksum: 10c0/9cfddf94bcdbedb047cd5e1bf17b8d90cdfe3e5d0286282769f697d8972955be33cc3e49c23f60d977c99439f3de80ed429b4bf73599cec441cb493ba3c6c8ed
   languageName: node
   linkType: hard
 
-"@mapbox/unitbezier@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@mapbox/unitbezier@npm:0.0.1"
-  checksum: 10c0/97f39d4fbdf9579d0a1a8be0d536eb113a805d36459e774014f488a7ca6cc9dcfc77ab7a2ebe5af395ad50da6efb4dbf2566de0db3f62b6b8675cddbace8f86a
+"@mapbox/unitbezier@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@mapbox/unitbezier@npm:1.0.0"
+  checksum: 10c0/40749dd7f4fa2a3e6e3a881faf0cdfb14d47fefdea028e0191c750fca8e2203f976d8ef07ab7f704a59b9e7a4354d088fc92b86316d5479e0c49b5d3263dfc60
   languageName: node
   linkType: hard
 
-"@mapbox/vector-tile@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@mapbox/vector-tile@npm:2.0.4"
+"@mapbox/vector-tile@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@mapbox/vector-tile@npm:3.0.0"
   dependencies:
     "@mapbox/point-geometry": "npm:~1.1.0"
     "@types/geojson": "npm:^7946.0.16"
-    pbf: "npm:^4.0.1"
-  checksum: 10c0/3cade1c8c3a4e0896bbe8ee1d6bcdb78cb34dc2257bc0151ba85d06f2cb96c87b5bddfd28f8b8a20131a85aa26af7091965da19ac356bf126eb66e20d48542fa
+    pbf: "npm:^5.0.0"
+  checksum: 10c0/ccede784967394a171956376de98b9cc9d5683ae67e3516246082d7bd5a157f711777955d111cd4885cc9dc4e22ef26e8b9af70ef6c8746392dd8de84e201ba6
   languageName: node
   linkType: hard
 
-"@mapbox/whoots-js@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@mapbox/whoots-js@npm:3.1.0"
-  checksum: 10c0/fe9e959a9049bcbc2c05d9d1156e050191ad697a1bd95e41cdfa069051ff1d6f2930ced234a8d68d5a0bf78091feab30d76497418ec800d90f0aac8691fe4fd4
-  languageName: node
-  linkType: hard
-
-"@maplibre/geojson-vt@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "@maplibre/geojson-vt@npm:5.0.4"
-  checksum: 10c0/74cf4e1ee0fee23b6a6946b03eeb01ae6fc55e8490cea80c1184387fae3be14dab8383c203d12b05687a1b33fc9b9b9796808c873ed5c9deef82c247bd49e5b3
-  languageName: node
-  linkType: hard
-
-"@maplibre/geojson-vt@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@maplibre/geojson-vt@npm:6.1.0"
+"@maplibre/geojson-vt@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "@maplibre/geojson-vt@npm:6.1.1"
   dependencies:
-    kdbush: "npm:^4.0.2"
-  checksum: 10c0/c772cc6620ace6058ec5cfc47a885d79910c183470fe39fc9133da8c0ff84218d7c3e5f8d65202dac01df88c591fadad7430d2a60b3a4a2b5eeeed6570b7b3db
+    kdbush: "npm:^4.1.0"
+  checksum: 10c0/75f2fcfd0c25e1c92f83609affefa762aaf52995f86c6b5258d797050b39392b2f39bc7462ef015c82884e2b2c329bef823b614a1c9fbc8d98ddb8fa8c042854
   languageName: node
   linkType: hard
 
-"@maplibre/maplibre-gl-style-spec@npm:^24.8.1":
-  version: 24.8.1
-  resolution: "@maplibre/maplibre-gl-style-spec@npm:24.8.1"
+"@maplibre/maplibre-gl-style-spec@npm:^26.1.0":
+  version: 26.2.1
+  resolution: "@maplibre/maplibre-gl-style-spec@npm:26.2.1"
   dependencies:
-    "@mapbox/jsonlint-lines-primitives": "npm:~2.0.2"
-    "@mapbox/unitbezier": "npm:^0.0.1"
+    "@mapbox/jsonlint-lines-primitives": "npm:^2.0.3"
+    "@mapbox/unitbezier": "npm:^1.0.0"
     json-stringify-pretty-compact: "npm:^4.0.0"
     minimist: "npm:^1.2.8"
     quickselect: "npm:^3.0.0"
-    rw: "npm:^1.3.3"
     tinyqueue: "npm:^3.0.0"
   bin:
     gl-style-format: dist/gl-style-format.mjs
     gl-style-migrate: dist/gl-style-migrate.mjs
     gl-style-validate: dist/gl-style-validate.mjs
-  checksum: 10c0/07d2ebabe07a0c93113bc1450fa4698fda20e6570a83941cb776f70d0ab75af83e3cc61d8da5c336f45c9eab1bac67bb2b4f2f0ac22865cbb66abcc9e3db622e
+  checksum: 10c0/73a019f8bbdd64fd9da014baf68a38c80821de4339203000e0b417ff3350b95da80c5de21d48bcee34f44b1f5950c2c31a913b968f0ad765331f3fecb075cedf
   languageName: node
   linkType: hard
 
-"@maplibre/mlt@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "@maplibre/mlt@npm:1.1.8"
+"@maplibre/mlt@npm:^1.1.12":
+  version: 1.1.12
+  resolution: "@maplibre/mlt@npm:1.1.12"
   dependencies:
     "@mapbox/point-geometry": "npm:^1.1.0"
-  checksum: 10c0/633eaad44b26cbc2404cd4867b2050766c5ed9dcbcb886e7ba3ae407a7958a5df2209317a1fc24bf0f40cf4ad3079f084f1baa91c917e3b7ab6a066bbec28400
+  checksum: 10c0/778515a530585998dc3c45b49c2b0da5f23c12994ac1f538c0b7bef5098284c69a35d7b67bbe8a42c3a89e5328dc206457d3efb8788f6b89d6d3c3d2e93b782e
   languageName: node
   linkType: hard
 
-"@maplibre/vt-pbf@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@maplibre/vt-pbf@npm:4.3.0"
+"@maplibre/vt-pbf@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@maplibre/vt-pbf@npm:4.3.2"
   dependencies:
     "@mapbox/point-geometry": "npm:^1.1.0"
-    "@mapbox/vector-tile": "npm:^2.0.4"
-    "@maplibre/geojson-vt": "npm:^5.0.4"
     "@types/geojson": "npm:^7946.0.16"
-    "@types/supercluster": "npm:^7.1.3"
-    pbf: "npm:^4.0.1"
-    supercluster: "npm:^8.0.1"
-  checksum: 10c0/0164f793237ef30a90301e176ca2eefa833f2aa0201bc87a558e1db6f75ab598a7e2746c745e4d8a61a270dcc248d03aaeef1d2297c0defec25c0c16c7c6b777
+    pbf: "npm:^5.1.0"
+  checksum: 10c0/3fd235b16f8070b2c1eabc8c68b44d60d4585db59f28821c846d25b2c84eabc3dc78c9a417b711e104819962ea0bede36770bc22a92c17e530c5ecce84a66ec5
   languageName: node
   linkType: hard
 
@@ -1556,7 +1537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/geojson@npm:*, @types/geojson@npm:^7946.0.16":
+"@types/geojson@npm:^7946.0.16":
   version: 7946.0.16
   resolution: "@types/geojson@npm:7946.0.16"
   checksum: 10c0/1ff24a288bd5860b766b073ead337d31d73bdc715e5b50a2cee5cb0af57a1ed02cc04ef295f5fa68dc40fe3e4f104dd31282b2b818a5ba3231bc1001ba084e3c
@@ -1594,15 +1575,6 @@ __metadata:
   dependencies:
     csstype: "npm:^3.2.2"
   checksum: 10c0/bc2c4af96b3e480604424de70d5ebda90c5f4b485df471858c0bc2d7d70364b606ec3c4d8579f94f01aa0c6c0591f56bcf14cba5689f5eea4b74250ccdc3a232
-  languageName: node
-  linkType: hard
-
-"@types/supercluster@npm:^7.1.3":
-  version: 7.1.3
-  resolution: "@types/supercluster@npm:7.1.3"
-  dependencies:
-    "@types/geojson": "npm:*"
-  checksum: 10c0/0d55dad98df0990fc38a7bb64dc23dda46014187c0d7638e6f2b6717ba8931b13e5b1d394789833a2ac822014c977ef64623dffd81a0bbf39e52c53c8183741f
   languageName: node
   linkType: hard
 
@@ -2192,10 +2164,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"earcut@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "earcut@npm:3.0.2"
-  checksum: 10c0/3d76da3d8a935244d59713edc70de71cdb5326a80b31c5c5cb96bc5b61f56b86ed35f032fffb66be7a4558e06efe1e94934f43ba6ca1b6c2af1420e87dd7ad71
+"earcut@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "earcut@npm:3.2.3"
+  checksum: 10c0/38660ec1ce55eecbbbf11d5a0072934c9f33851527bf5e40923c6656c3a0c6b00bb449ae8f4b28f89a0b249fe18568e630a8ea9ee39ce2707a50a89531a2f995
   languageName: node
   linkType: hard
 
@@ -3007,10 +2979,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kdbush@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "kdbush@npm:4.0.2"
-  checksum: 10c0/d50183b299c57e2573114e902ab47aed7494be3ca41b66d456779ecc3b2f153f491de341f9609965414784f728894f9a9001152eb9f3a40cd3755521c06a45a3
+"kdbush@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "kdbush@npm:4.1.0"
+  checksum: 10c0/b47c8a27de438df1e60080f73e3793217b4542a62bed7f07c8c29b0bf53359bbdba1e97305e396f7f4d28f98e31ce3fd21500dc3de03a44d8cda71a3d70ff7bb
   languageName: node
   linkType: hard
 
@@ -3214,30 +3186,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"maplibre-gl@npm:^5.23.0":
-  version: 5.24.0
-  resolution: "maplibre-gl@npm:5.24.0"
+"maplibre-gl@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "maplibre-gl@npm:6.0.0"
   dependencies:
-    "@mapbox/jsonlint-lines-primitives": "npm:^2.0.2"
     "@mapbox/point-geometry": "npm:^1.1.0"
-    "@mapbox/tiny-sdf": "npm:^2.1.0"
-    "@mapbox/unitbezier": "npm:^0.0.1"
-    "@mapbox/vector-tile": "npm:^2.0.4"
-    "@mapbox/whoots-js": "npm:^3.1.0"
-    "@maplibre/geojson-vt": "npm:^6.1.0"
-    "@maplibre/maplibre-gl-style-spec": "npm:^24.8.1"
-    "@maplibre/mlt": "npm:^1.1.8"
-    "@maplibre/vt-pbf": "npm:^4.3.0"
+    "@mapbox/tiny-sdf": "npm:^2.2.0"
+    "@mapbox/unitbezier": "npm:^1.0.0"
+    "@mapbox/vector-tile": "npm:^3.0.0"
+    "@maplibre/geojson-vt": "npm:^6.1.1"
+    "@maplibre/maplibre-gl-style-spec": "npm:^26.1.0"
+    "@maplibre/mlt": "npm:^1.1.12"
+    "@maplibre/vt-pbf": "npm:^4.3.2"
     "@types/geojson": "npm:^7946.0.16"
-    earcut: "npm:^3.0.2"
+    earcut: "npm:^3.2.3"
     gl-matrix: "npm:^3.4.4"
-    kdbush: "npm:^4.0.2"
+    kdbush: "npm:^4.1.0"
     murmurhash-js: "npm:^1.0.0"
-    pbf: "npm:^4.0.1"
+    pbf: "npm:^5.1.2"
     potpack: "npm:^2.1.0"
     quickselect: "npm:^3.0.0"
     tinyqueue: "npm:^3.0.0"
-  checksum: 10c0/4ebe63987d307a8133a8cce6b3a414c2ca1b9901b98b2867590d4ce517bdc82c46900610b7693d6eeffb792271596751cf0bf40e59ee7d5e5c779bef9296cf10
+  checksum: 10c0/81b368764becdd4c29d793303de4f360502160c5249596960d24d47eb74fc11868604ab8cd99ce7a33d7cc5ffd57513d98636fae1619c2e92e1cae7e97ab947d
   languageName: node
   linkType: hard
 
@@ -3269,7 +3239,7 @@ __metadata:
     globals: "npm:^17.4.0"
     highlight.js: "npm:^11.11.1"
     jsdom: "npm:^29.0.1"
-    maplibre-gl: "npm:^5.23.0"
+    maplibre-gl: "npm:^6.0.0"
     postcss: "npm:^8.5.8"
     prettier: "npm:^3.8.1"
     react: "npm:^19.2.4"
@@ -3591,14 +3561,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pbf@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "pbf@npm:4.0.1"
+"pbf@npm:^5.0.0, pbf@npm:^5.1.0, pbf@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "pbf@npm:5.1.2"
   dependencies:
     resolve-protobuf-schema: "npm:^2.1.0"
   bin:
     pbf: bin/pbf
-  checksum: 10c0/1a95cc3bdc61ee01d4728f4a57a9f1233732d183a8568818b714a747fd8b957d99b63e1c67f0f72dc5623657c42f88a1a7e44e1fbcd06e2fe2ef9a85a964832e
+  checksum: 10c0/e28e901d61a66c7afdeac881b3e2b0ad2c09df98bcd3bc3447c1a55d7bc866d71415bd7d8fcc8273f23828c0169cc60cb5f7c5beb4a5829e23506c8196460e83
   languageName: node
   linkType: hard
 
@@ -3858,13 +3828,6 @@ __metadata:
   bin:
     rolldown: ./bin/cli.mjs
   checksum: 10c0/93072aa9d95882f9fa5cd57fe7db6a48efd6f85a25a32137425052ecca02df653651eed0c33a865c33511681bd6a40691d5c88900b8e95ce1334f4f75ba826ff
-  languageName: node
-  linkType: hard
-
-"rw@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "rw@npm:1.3.3"
-  checksum: 10c0/b1e1ef37d1e79d9dc7050787866e30b6ddcb2625149276045c262c6b4d53075ddc35f387a856a8e76f0d0df59f4cd58fe24707e40797ebee66e542b840ed6a53
   languageName: node
   linkType: hard
 
@@ -4149,15 +4112,6 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
-  languageName: node
-  linkType: hard
-
-"supercluster@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "supercluster@npm:8.0.1"
-  dependencies:
-    kdbush: "npm:^4.0.2"
-  checksum: 10c0/79121e6dbff67b3036ea6651f3baddb942478830ba3ecbc27455715ab5bd269de8381dc04618c0c15963346ea2ed0f81cd5f767c2978a63e2841807c73445d57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Supersedes #542 with the migration it needs. maplibre-gl 6.0.0's breaking changes hit this codebase in three places:

- **ESM-only dist, no default export** — 11 files imported `maplibregl` as a default import; rewritten to namespace + named imports. This alone is why #542's CI fails.
- **Worker no longer inlined** — bundled apps must call `setWorkerUrl()`; added a bootstrap module (Vite `?worker&url` recipe) imported by both Map-constructing modules, kept inside the lazy maplibre chunk so the entry bundle is unchanged.
- **Internal `map.transform` removed** — the three custom WebGL layers read `transform.mercatorMatrix` for their 0..1-mercator vertex buffers; switched to the public, typed `options.defaultProjectionData.mainMatrix` (semantically identical under mercator per v5/v6 source comparison).

## Testing

- tsc, eslint, vitest (203/203), and production build all clean; dev server verified with the `?worker&url` path.
- Docker SPA image builds clean on node:25-alpine with `yarn install --immutable`; chunk hashes identical to the local build.
- Side-by-side headless-browser QA of this build vs the v5 build on a live mesh (2.8k nodes): cluster donuts, LoS tube, RF coverage/scan overlays, live packet arcs, NodeMap, spiderfy, traceroute flyover, terrain on/off lifecycle, and 3D buildings are pixel-equivalent (0.005–0.2% diff, live-data noise) with zero new console errors. The one intentional difference: with terrain enabled, custom-layer geometry now sits on the terrain surface instead of floating above it (v6's documented correction).
