### PR TITLE
Repair external node links and deeplink the live coverage overlay

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -403,10 +403,6 @@ lookup_url = "http://coverage-worker:9301"
 
 # External tools shown in the web UI sidebar
 [[mesh.tools]]
-name = "Armooo's MeshView"
-url = "https://meshview.armooo.net"
-
-[[mesh.tools]]
 name = "Liam's Meshtastic Map"
 url = "https://meshtastic.liamcottle.net"
 
@@ -416,7 +412,7 @@ url = "https://meshmap.net"
 
 [[mesh.tools]]
 name = "Bay Mesh Explorer"
-url = "https://app.bayme.sh"
+url = "https://meshview.bayme.sh"
 
 [[mesh.tools]]
 name = "HWT Path Profiler"
@@ -425,12 +421,8 @@ url = "https://heywhatsthat.com/profiler.html"
 # "Elsewhere" links shown on node detail pages
 # URLs support {node_id_hex} and {node_id_int} placeholders
 [[mesh.elsewhere_links]]
-name = "Armooo's MeshView"
-url = "https://meshview.armooo.net/packet_list/{node_id_int}"
-
-[[mesh.elsewhere_links]]
 name = "Bay Mesh Explorer"
-url = "https://app.bayme.sh/node/{node_id_hex}"
+url = "https://meshview.bayme.sh/node/{node_id_int}"
 
 [[mesh.elsewhere_links]]
 name = "Liam's Map"

--- a/frontend/src/components/navConfig.tsx
+++ b/frontend/src/components/navConfig.tsx
@@ -143,10 +143,9 @@ export const MESH_NAV: NavItemDef[] = [
 
 // Falls back here when config.mesh.tools is absent.
 export const DEFAULT_TOOLS: ExternalLinkDef[] = [
-  { name: "Armooo's MeshView", url: "https://meshview.armooo.net" },
   { name: "Liam's Meshtastic Map", url: "https://meshtastic.liamcottle.net" },
   { name: "MeshMap", url: "https://meshmap.net" },
-  { name: "Bay Mesh Explorer", url: "https://app.bayme.sh" },
+  { name: "Bay Mesh Explorer", url: "https://meshview.bayme.sh" },
   { name: "HWT Path Profiler", url: "https://heywhatsthat.com/profiler.html" },
 ];
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -77,6 +77,7 @@ import {
   ROLE_COLORS,
 } from "./map/lib/utils";
 import { CoverageLookupCard } from "./map/live/CoverageLookupCard";
+import { nextCoverageSearch, parseCoverageParam } from "./map/live/coverageUrlParam";
 import { LiveCoveragePill } from "./map/live/LiveCoveragePill";
 import { useCoverageLookup } from "./map/live/useCoverageLookup";
 import { useServerCoverageTiles } from "./map/live/useServerCoverageTiles";
@@ -273,7 +274,16 @@ export function Map() {
 
   // Live network-coverage layer: a server-baked raster tile pyramid (compute is
   // server-side; this only show/hides + sets opacity). Off (hidden) by default.
-  const [liveCoverage, setLiveCoverage] = useState<boolean>(() => readJson<boolean>(LS_KEYS.liveCoverage, false));
+  // A shared link's ?cov=1|0 overrides the saved preference for this session.
+  // Snapshot at first render — effects rewrite the real URL before a re-render
+  // could read it (same rationale as useUrlMapSync's snapshot).
+  const urlLiveCoverageRef = useRef<boolean | null | undefined>(undefined);
+  if (urlLiveCoverageRef.current === undefined) {
+    urlLiveCoverageRef.current = parseCoverageParam(window.location.search);
+  }
+  const [liveCoverage, setLiveCoverage] = useState<boolean>(
+    () => urlLiveCoverageRef.current ?? readJson<boolean>(LS_KEYS.liveCoverage, false),
+  );
   const [liveCoverageOpacity, setLiveCoverageOpacity] = useState<number>(
     () => readJson<number>(LS_KEYS.liveCoverageOpacity, 0.6),
   );
@@ -324,7 +334,26 @@ export function Map() {
   useEffect(() => writeJson(LS_KEYS.settingsPanelOpen, settingsPanelOpen), [settingsPanelOpen]);
   useEffect(() => writeJson(LS_KEYS.terrain3D, terrain3D), [terrain3D]);
   useEffect(() => writeJson(LS_KEYS.buildings3D, buildings3D), [buildings3D]);
-  useEffect(() => writeJson(LS_KEYS.liveCoverage, liveCoverage), [liveCoverage]);
+  useEffect(() => {
+    // The sharer's ?cov drives this session but must not overwrite the viewer's
+    // saved preference — persist only once the viewer changes the toggle.
+    if (urlLiveCoverageRef.current != null && liveCoverage === urlLiveCoverageRef.current) return;
+    urlLiveCoverageRef.current = null;
+    writeJson(LS_KEYS.liveCoverage, liveCoverage);
+  }, [liveCoverage]);
+  // Mirror the overlay toggle into ?cov= so the view is shareable. replaceState,
+  // not setSearchParams — a router navigation would re-render the whole Map
+  // route for a purely cosmetic URL update (same rationale as the lat/lng/z
+  // sync), and the no-write cases keep Safari's replaceState rate limit happy.
+  useEffect(() => {
+    const next = nextCoverageSearch(window.location.search, liveCoverage);
+    if (next === null) return;
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}?${next}${window.location.hash}`,
+    );
+  }, [liveCoverage]);
   useEffect(() => writeJson(LS_KEYS.liveCoverageOpacity, liveCoverageOpacity), [liveCoverageOpacity]);
   useEffect(() => writeJson(LS_KEYS.liveCoverageHideNodes, liveCoverageHideNodes), [liveCoverageHideNodes]);
   useEffect(() => writeJson(LS_KEYS.liveCoverageGroup, liveCoverageGroup), [liveCoverageGroup]);

--- a/frontend/src/pages/map/components/MapDetailsPanel.tsx
+++ b/frontend/src/pages/map/components/MapDetailsPanel.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useLiveEvent } from "../../../hooks/useLiveEvent";
 import { useGetNodePacketsQuery } from "../../../slices/apiSlice";
 import { HardwareModel, type NodeRole,roleTitles } from "../../../types";
+import { convertNodeIdFromHexToInt } from "../../../utils/convertNodeId";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../../utils/elsewhereLinks";
 import { normalizeNodeId8 } from "../../../utils/normalizeNodeId8";
 import { useBottomSheetGesture } from "../hooks/useBottomSheet";
@@ -368,7 +369,7 @@ export const MapDetailsPanel = memo(function MapDetailsPanel({
 
   const { node, liveNodes, displayName, channelLabel } = data;
 
-  const nodeIdInt = parseInt(node.id, 16);
+  const nodeIdInt = convertNodeIdFromHexToInt(node.id);
   const elsewhereLinks = getElsewhereLinks(data.elsewhereLinks);
 
   // node.id and liveNodes keys can disagree on the `!` prefix, and `hardware` may arrive as a string from the API

--- a/frontend/src/pages/map/live/coverageUrlParam.test.ts
+++ b/frontend/src/pages/map/live/coverageUrlParam.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { nextCoverageSearch, parseCoverageParam } from "./coverageUrlParam";
+
+describe("parseCoverageParam", () => {
+  it("returns null when the param is absent", () => {
+    expect(parseCoverageParam("")).toBeNull();
+    expect(parseCoverageParam("?lat=37.1&lng=-118.2&z=6")).toBeNull();
+  });
+
+  it("reads 1 and true (any case) as on", () => {
+    expect(parseCoverageParam("?cov=1")).toBe(true);
+    expect(parseCoverageParam("?cov=true")).toBe(true);
+    expect(parseCoverageParam("?cov=TRUE")).toBe(true);
+  });
+
+  it("reads 0, false, and unrecognized values as off", () => {
+    expect(parseCoverageParam("?cov=0")).toBe(false);
+    expect(parseCoverageParam("?cov=false")).toBe(false);
+    expect(parseCoverageParam("?cov=banana")).toBe(false);
+  });
+});
+
+describe("nextCoverageSearch", () => {
+  it("appends cov=1 when enabling, preserving other params", () => {
+    expect(nextCoverageSearch("?lat=37.1&z=6.04", true)).toBe("lat=37.1&z=6.04&cov=1");
+    expect(nextCoverageSearch("", true)).toBe("cov=1");
+  });
+
+  it("leaves pristine URLs alone while off", () => {
+    expect(nextCoverageSearch("?lat=37.1", false)).toBeNull();
+    expect(nextCoverageSearch("", false)).toBeNull();
+  });
+
+  it("flips an existing cov to 0 in place when disabling", () => {
+    expect(nextCoverageSearch("?cov=1&lat=37.1", false)).toBe("cov=0&lat=37.1");
+  });
+
+  it("no-ops when the URL already matches", () => {
+    expect(nextCoverageSearch("?cov=1", true)).toBeNull();
+    expect(nextCoverageSearch("?cov=0", false)).toBeNull();
+  });
+
+  it("normalizes true/false spellings to 1/0", () => {
+    expect(nextCoverageSearch("?cov=true", true)).toBe("cov=1");
+    expect(nextCoverageSearch("?cov=false", false)).toBe("cov=0");
+  });
+});

--- a/frontend/src/pages/map/live/coverageUrlParam.ts
+++ b/frontend/src/pages/map/live/coverageUrlParam.ts
@@ -1,0 +1,27 @@
+/** ?cov=1|0 deep link for the live-coverage overlay. Reads accept 1/0 and
+ * true/false; writes always emit "1"/"0". Pure string helpers so the URL
+ * semantics stay unit-testable apart from Map.tsx. */
+
+export const COVERAGE_URL_PARAM = "cov";
+
+/** Tri-state read: null when the URL doesn't mention the overlay. */
+export function parseCoverageParam(search: string): boolean | null {
+  const v = new URLSearchParams(search).get(COVERAGE_URL_PARAM);
+  if (v === null) return null;
+  return v === "1" || v.toLowerCase() === "true";
+}
+
+/** Next query string reflecting `enabled`, or null when no write is needed.
+ * Pristine URLs stay untouched while the overlay is off — cov only appears
+ * once the overlay has been on, so bare /map links never grow a cov=0. An
+ * explicit cov=0 matters when present: the viewer's saved preference may be
+ * "on", and a shared link must reproduce the sharer's view either way. */
+export function nextCoverageSearch(search: string, enabled: boolean): string | null {
+  const sp = new URLSearchParams(search);
+  const cur = sp.get(COVERAGE_URL_PARAM);
+  const want = enabled ? "1" : "0";
+  if (cur === want) return null;
+  if (cur === null && !enabled) return null;
+  sp.set(COVERAGE_URL_PARAM, want);
+  return sp.toString();
+}

--- a/frontend/src/utils/elsewhereLinks.ts
+++ b/frontend/src/utils/elsewhereLinks.ts
@@ -1,8 +1,7 @@
 import type { ElsewhereLink } from "../types/config";
 
 export const defaultElsewhereLinks: ElsewhereLink[] = [
-  { name: "Armooo's MeshView", url: "https://meshview.armooo.net/packet_list/{node_id_int}" },
-  { name: "Bay Mesh Explorer", url: "https://app.bayme.sh/node/{node_id_hex}" },
+  { name: "Bay Mesh Explorer", url: "https://meshview.bayme.sh/node/{node_id_int}" },
   { name: "Liam's Map", url: "https://meshtastic.liamcottle.net/?node_id={node_id_int}" },
   { name: "MeshMap", url: "https://meshmap.net/#{node_id_int}" },
 ];
@@ -17,6 +16,6 @@ export function resolveElsewhereUrl(
   nodeIdInt: number
 ): string {
   return urlTemplate
-    .replaceAll("{node_id_hex}", nodeIdHex)
+    .replaceAll("{node_id_hex}", nodeIdHex.replace(/^!/, ""))
     .replaceAll("{node_id_int}", String(nodeIdInt));
 }


### PR DESCRIPTION
### fix(ui): repair dead and stale external node links

All four default "Elsewhere" links on the node panel were broken in some way:

- **Armooo's MeshView** removed everywhere (sidebar tools, elsewhere defaults,
  `config.toml.sample`) — the instance is offline.
- **Bay Mesh Explorer** now points at the new instance at `meshview.bayme.sh`,
  which deeplinks by decimal node id: `https://meshview.bayme.sh/node/{node_id_int}`.
- **Liam's Map / MeshMap** templates were already correct but rendered as
  `?node_id=NaN` on the map panel: node ids arriving with a `!` prefix broke
  `parseInt(id, 16)`. The panel now uses `convertNodeIdFromHexToInt`, and
  `resolveElsewhereUrl` also strips `!` from `{node_id_hex}` substitutions for
  custom-configured templates.

Note for operators: instances that set `mesh.tools` / `mesh.elsewhere_links` in
their own `config.toml` override these defaults and need the same URL updates
(the Discord bot's "View Elsewhere" field reads the same config section).

### feat(map): deeplink the live coverage overlay via `?cov=` 

Toggling the coverage pill now mirrors into the map URL (`cov=1|0`) so a shared
link reproduces the sharer's overlay state alongside the existing `lat/lng/z`:

- The param overrides the viewer's saved preference for that session without
  overwriting it (same principle as the LOS share links).
- Pristine URLs are never stamped with `cov=0` — the param only appears once
  the overlay has been on; an explicit `cov=0` is kept so links shared by
  someone with the overlay off still override a viewer whose default is on.
- `cov=true/false` accepted on read, normalized to `1`/`0` on write.
- Written via `history.replaceState` like the pan/zoom sync — toggling never
  re-renders the map route. Composes with `?node=` and `?tool=` links.

Parse/write rules are pure helpers in `coverageUrlParam.ts` with unit tests.

## Testing

- 211/211 frontend tests pass (8 new for the `?cov=` param semantics)
- `tsc` and `eslint` clean
- Deployed on a live instance: verified the corrected links resolve, the `?cov=`
  param round-trips through share links, and it survives pan/zoom URL rewrites
