### PR TITLE
Default to Mapbox Dark basemap and full coverage-overlay opacity

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -5,7 +5,7 @@ VITE_API_PROXY_TARGET=http://meshinfo:9000
 VITE_MAP_PROVIDER=osm
 # mapbox options, token required
 VITE_MAPBOX_TOKEN=
-VITE_MAPBOX_STYLE=mapbox/satellite-streets-v12
+VITE_MAPBOX_STYLE=mapbox/dark-v11
 
 # auto | nominatim | mapbox
 VITE_GEOCODER_PROVIDER=auto

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -184,7 +184,7 @@ export function Map() {
     return (
       stored ??
       env.MAPBOX_STYLE ??
-      "mapbox/satellite-streets-v12"
+      "mapbox/dark-v11"
     );
   });
 
@@ -285,7 +285,9 @@ export function Map() {
     () => urlLiveCoverageRef.current ?? readJson<boolean>(LS_KEYS.liveCoverage, false),
   );
   const [liveCoverageOpacity, setLiveCoverageOpacity] = useState<number>(
-    () => readJson<number>(LS_KEYS.liveCoverageOpacity, 0.6),
+    // Full opacity by default: at 0.6 the paint was hard to read over some
+    // basemap layers; the pill's slider still lets viewers dial it down.
+    () => readJson<number>(LS_KEYS.liveCoverageOpacity, 1),
   );
   const [liveCoverageHideNodes, setLiveCoverageHideNodes] = useState<boolean>(
     () => readJson<boolean>(LS_KEYS.liveCoverageHideNodes, true),

--- a/frontend/src/pages/nodes/NodeMap.tsx
+++ b/frontend/src/pages/nodes/NodeMap.tsx
@@ -180,7 +180,7 @@ export const NodeMap = ({ node }: { node: INode }) => {
     const mapboxStyle =
       readJson<string | null>(LS_KEYS.mapboxStyle, null) ??
       env.MAPBOX_STYLE ??
-      "mapbox/satellite-streets-v12";
+      "mapbox/dark-v11";
 
     const osmBasemap =
       readJson<OsmBasemap | null>(LS_KEYS.osmBasemap, null) ?? "carto_dark";


### PR DESCRIPTION
## Summary

Two small default changes. No behavior changes for anyone with saved
preferences — localStorage and env overrides still win.

### Mapbox Dark as the default basemap

The default Mapbox style was `mapbox/satellite-streets-v12`; it is now
`mapbox/dark-v11` in the main map, the node-detail mini-map, and the
`.env.sample` example.

- `isDarkBasemap` already treats any `dark` style as dark, so sky/terrain/
  3D-building shading adapts with no further changes.
- Instance operators can still override via `VITE_MAPBOX_STYLE`; viewers can
  still pick any style in the map settings panel.
- Token-less instances are unaffected (OSM Carto Dark remains their default).

### Live coverage overlay defaults to 100% opacity

The overlay previously defaulted to 60%, which made the coverage paint hard to
read over some basemap layers. New viewers now get full opacity; the coverage
pill's slider still lets anyone dial it down, and saved values are respected.

## Testing

- `tsc`, `eslint`, and the full test suite (211/211) pass
