### PR TITLE
Traceroute overhaul: correct reply orientation, keep the richest data, expose the rest

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,7 +15,7 @@ directly for integrations. Responses are JSON unless noted.
 | GET | `/v1/nodes/{id}/telemetry` | Telemetry history. |
 | GET | `/v1/nodes/{id}/texts` | Chat messages from this node. |
 | GET | `/v1/nodes/{id}/packets` | Raw MQTT messages for this node, keyset-paginated. Query params: `limit` (1–200, default 50), `start`/`end` (unix-epoch seconds), `before` (cursor). Returns `{"packets": [...], "next_cursor": str \| null}`. |
-| GET | `/v1/nodes/{id}/traceroutes` | Traceroutes involving this node. |
+| GET | `/v1/nodes/{id}/traceroutes` | Traceroutes involving this node: as initiator, target, uplink gateway, or relay hop on either leg. Query params: `limit` (1–10000, default 1000). Returns `{"traceroutes": [...]}`. |
 
 ### Chat / Messages
 
@@ -32,14 +32,14 @@ directly for integrations. Responses are JSON unless noted.
 | Method | Path | Notes |
 |---|---|---|
 | GET | `/v1/telemetry` | All recent telemetry. |
-| GET | `/v1/traceroutes` | All recent traceroutes. |
+| GET | `/v1/traceroutes` | Recent traceroutes, newest first. Query params: `from`/`to` (node id; both = pair in either direction), `range` (`1h`/`24h`/`7d`), `limit` (1–10000, default 1000), `slim` (`1` keeps only the fields the SPA reads, adds `packet_id`/`created_at`/`route_back_ids`), `envelope` (`1` wraps the response as `{"traceroutes": [...], "next_cursor": str \| null}` for keyset pagination — pass `next_cursor` back as `before`). Without `envelope` the response is a bare array and cannot page. Payload semantics: `snr_towards`/`snr_back` are dB ×4 with `-128` = unknown; a row whose `snr_towards` length equals `route` length + 1 is a REPLY packet, whose travel path reads header `to` → route → header `from`. `packet_id` on replies carries the request's packet id. Rows may be upgraded in place for up to 1h after first insert as richer gateway copies arrive (`created_at` never changes). |
 | GET | `/v1/stats` | Mesh totals (counts, top nodes, modem preset, etc.). |
 
 ### Live events (SSE)
 
 | Method | Path | Notes |
 |---|---|---|
-| GET | `/v1/events` | Server-Sent Events stream of live updates, one multiplexed connection per client. Each frame's `event:` type is `node`, `chat`, `telemetry`, or `coverage`; `: ...` comment frames are keep-alive heartbeats. Served unbuffered through Caddy (`flush_interval -1`); the SPA reaches it as `/api/v1/events`. |
+| GET | `/v1/events` | Server-Sent Events stream of live updates, one multiplexed connection per client. Each frame's `event:` type is `node`, `chat`, `telemetry`, `coverage`, `packet`, or `traceroute`; `: ...` comment frames are keep-alive heartbeats. `packet` mirrors the archived message (keys like `rssi`/`snr` are omitted when unmeasured). `traceroute` mirrors a full `/v1/traceroutes` row (plus `route_back_ids`/`created_at`) and fires once per stored insert/upgrade, not per gateway copy; rows over ~4 KB degrade to a skinny `{from, to, route_ids, id}` frame — refetch on receipt. Served unbuffered through Caddy (`flush_interval -1`); the SPA reaches it as `/api/v1/events`. |
 
 ### Static map / Server
 

--- a/api/api.py
+++ b/api/api.py
@@ -282,17 +282,11 @@ class API:
                 limit = int(request.query_params.get("limit", 1000))
             except (TypeError, ValueError):
                 return JSONResponse({"error": "limit must be an integer"}, status_code=400)
-            # ?slim=1 keeps only the row fields the SPA reads and drops the
-            # rest (legacy `route`). Default stays byte-identical for
-            # third-party consumers: bare array, no cursor, legacy fields.
+            # ?slim=1 keeps only the row fields the SPA reads; default stays
+            # byte-identical for third-party consumers.
             slim = request.query_params.get("slim", "").lower() in ("1", "true", "yes")
-            # Keyset pagination is opt-in via ?envelope=1 ONLY: the response
-            # becomes {traceroutes, next_cursor}; pass next_cursor back as
-            # ?before= to walk older pages. Deliberately NOT implied by slim —
-            # already-open tabs run the previous bundle, which requests slim=1
-            # and expects a bare array; forcing the envelope onto slim would
-            # crash every open dashboard at deploy. Bare-array responses
-            # (default and slim-without-envelope) cannot carry a cursor.
+            # Pagination opt-in via ?envelope=1 ({traceroutes, next_cursor}); NOT
+            # implied by slim — already-open tabs request slim=1 and expect a bare array.
             envelope = request.query_params.get("envelope", "").lower() in ("1", "true", "yes")
             before = request.query_params.get("before")
             traceroutes_data = await self.data.pg_storage.query_all_traceroutes(

--- a/api/api.py
+++ b/api/api.py
@@ -239,7 +239,13 @@ class API:
         @app.get("/v1/nodes/{id}/traceroutes")
         async def node_traceroutes(request: Request, id: str) -> JSONResponse:
             node_id = self._coerce_node_id(id)
-            traceroutes = await self.data.pg_storage.query_node_traceroutes(node_id)
+            try:
+                limit = int(request.query_params.get("limit", 1000))
+            except (TypeError, ValueError):
+                return JSONResponse({"error": "limit must be an integer"}, status_code=400)
+            traceroutes = await self.data.pg_storage.query_node_traceroutes(
+                node_id, limit=max(1, min(limit, 10000))
+            )
             return JSONResponse(jsonable_encoder({ "traceroutes": traceroutes }))
 
         @app.get("/v1/chat")
@@ -277,15 +283,26 @@ class API:
             except (TypeError, ValueError):
                 return JSONResponse({"error": "limit must be an integer"}, status_code=400)
             # ?slim=1 keeps only the row fields the SPA reads and drops the
-            # rest (legacy `route`, duplicate payload arrays). Default stays
-            # byte-identical for third-party consumers.
+            # rest (legacy `route`). Default stays byte-identical for
+            # third-party consumers: bare array, no cursor, legacy fields.
             slim = request.query_params.get("slim", "").lower() in ("1", "true", "yes")
+            # Keyset pagination is opt-in via ?envelope=1 ONLY: the response
+            # becomes {traceroutes, next_cursor}; pass next_cursor back as
+            # ?before= to walk older pages. Deliberately NOT implied by slim —
+            # already-open tabs run the previous bundle, which requests slim=1
+            # and expects a bare array; forcing the envelope onto slim would
+            # crash every open dashboard at deploy. Bare-array responses
+            # (default and slim-without-envelope) cannot carry a cursor.
+            envelope = request.query_params.get("envelope", "").lower() in ("1", "true", "yes")
+            before = request.query_params.get("before")
             traceroutes_data = await self.data.pg_storage.query_all_traceroutes(
                 limit=max(1, min(limit, 10000)),
                 from_node_id=self._coerce_node_id(from_param) if from_param else None,
                 to_node_id=self._coerce_node_id(to_param) if to_param else None,
                 range_seconds=range_seconds,
                 slim=slim,
+                before=before if envelope else None,
+                with_cursor=envelope,
             )
             return JSONResponse(jsonable_encoder(traceroutes_data))
 

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -226,7 +226,7 @@ export const Graph = () => {
                               </span>
                               <span className="text-gray-500 shrink-0 ml-1">
                                 {e.kind === "neighbor" ? "RF" : "tr"}
-                                {e.snr != null && e.snr !== 0 && ` ${e.snr}dB`}
+                                {e.snr != null && ` ${e.snr}dB`}
                               </span>
                             </button>
                           );

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -234,22 +234,14 @@ export function Map() {
   // window that makes most pairs come back empty. Merged with the global cache
   // so routes crossing the pair as intermediate hops still count.
   const tracePairActive = activeTool === "traceroute" && !!toolFromId && !!toolToId;
-  // currentData (not data/isLoading): `data` retains the PREVIOUS pair's rows
-  // across an arg switch — which both leaked the old pair's 500 rows into
-  // traceData until the new fetch settled AND made isLoading useless as a
-  // fit gate (it's per-hook-lifetime, false forever after the first pair).
-  // currentData is undefined until THIS arg's fetch lands, and stays present
-  // through same-arg background refetches, so the gate below is true exactly
-  // while the selected pair's history is genuinely missing.
+  // currentData (not data): `data` retains the previous pair's rows across an
+  // arg switch; currentData is undefined until this pair's own fetch lands.
   const { currentData: pairTraceroutesRaw, isError: pairTraceroutesError } = useGetTraceroutesQuery(
     { from: toolFromId ?? "", to: toolToId ?? "", limit: 500 },
     { skip: !tracePairActive },
   );
   const pairTraceroutes = pairTraceroutesRaw ?? EMPTY_TRACEROUTES;
-  // isError escape: a failed pair fetch leaves currentData undefined forever
-  // (RTKQ doesn't auto-retry) — without it the fit gate and the panel's
-  // loading state would wedge; on error the tool degrades to the global
-  // window, exactly like the pre-currentData behavior.
+  // isError escape: a failed fetch never sets currentData; degrade to the global window.
   const pairTraceroutesLoading =
     tracePairActive && pairTraceroutesRaw === undefined && !pairTraceroutesError;
   const traceData = useMemo(() => {
@@ -831,11 +823,8 @@ export function Map() {
     if (traceFlyover.isFlying) {
       traceFlyover.cancelFlyover();
     } else if (traceSelectedPath) {
-      // Pin the flown path: with no explicit selection, traceSelectedPath is
-      // tracePaths[0] (newest), and a live row arriving mid-tour would
-      // silently re-point the panel + drawn primary at the new path while
-      // the camera keeps flying the old one. An explicit sig keeps them on
-      // the toured path for the duration (and after — the user chose it).
+      // Pin the toured path: without an explicit sig, a live row arriving
+      // mid-tour re-points the panel/primary while the camera flies the old path.
       setTraceSelectedSig(traceSelectedPath.hops.join(">"));
       traceFlyover.startFlyover(traceSelectedPath);
     }

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -234,12 +234,24 @@ export function Map() {
   // window that makes most pairs come back empty. Merged with the global cache
   // so routes crossing the pair as intermediate hops still count.
   const tracePairActive = activeTool === "traceroute" && !!toolFromId && !!toolToId;
-  // isLoading (not isFetching): true only on a pair's first fetch, so throttled
-  // background refetches neither flicker the panel nor re-gate the fitBounds.
-  const { data: pairTraceroutes = EMPTY_TRACEROUTES, isLoading: pairTraceroutesLoading } = useGetTraceroutesQuery(
+  // currentData (not data/isLoading): `data` retains the PREVIOUS pair's rows
+  // across an arg switch — which both leaked the old pair's 500 rows into
+  // traceData until the new fetch settled AND made isLoading useless as a
+  // fit gate (it's per-hook-lifetime, false forever after the first pair).
+  // currentData is undefined until THIS arg's fetch lands, and stays present
+  // through same-arg background refetches, so the gate below is true exactly
+  // while the selected pair's history is genuinely missing.
+  const { currentData: pairTraceroutesRaw, isError: pairTraceroutesError } = useGetTraceroutesQuery(
     { from: toolFromId ?? "", to: toolToId ?? "", limit: 500 },
     { skip: !tracePairActive },
   );
+  const pairTraceroutes = pairTraceroutesRaw ?? EMPTY_TRACEROUTES;
+  // isError escape: a failed pair fetch leaves currentData undefined forever
+  // (RTKQ doesn't auto-retry) — without it the fit gate and the panel's
+  // loading state would wedge; on error the tool degrades to the global
+  // window, exactly like the pre-currentData behavior.
+  const pairTraceroutesLoading =
+    tracePairActive && pairTraceroutesRaw === undefined && !pairTraceroutesError;
   const traceData = useMemo(() => {
     if (pairTraceroutes.length === 0) return rawTraceroutes;
     // globalThis: the component name shadows the Map constructor
@@ -790,6 +802,7 @@ export function Map() {
     setActiveTool, setToolStep, setToolFromId, setToolToId,
     losState, tracePendingPlayRef, traceSelectedPath, tracePosKey, styleEpoch,
     startFlyover: traceFlyover.startFlyover,
+    traceSelectedSig, setTraceSelectedSig,
   });
 
   // Observed paths + candidate rings on the map (owns endpoint/ghost markers)
@@ -815,8 +828,17 @@ export function Map() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const handleToggleFlyover = useCallback(() => {
-    if (traceFlyover.isFlying) traceFlyover.cancelFlyover();
-    else if (traceSelectedPath) traceFlyover.startFlyover(traceSelectedPath);
+    if (traceFlyover.isFlying) {
+      traceFlyover.cancelFlyover();
+    } else if (traceSelectedPath) {
+      // Pin the flown path: with no explicit selection, traceSelectedPath is
+      // tracePaths[0] (newest), and a live row arriving mid-tour would
+      // silently re-point the panel + drawn primary at the new path while
+      // the camera keeps flying the old one. An explicit sig keeps them on
+      // the toured path for the duration (and after — the user chose it).
+      setTraceSelectedSig(traceSelectedPath.hops.join(">"));
+      traceFlyover.startFlyover(traceSelectedPath);
+    }
     // start/cancel are identity-stable; only the data deps matter
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [traceFlyover.isFlying, traceSelectedPath]);

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -256,11 +256,16 @@ export const Traceroutes = () => {
   // Live polling (simple: on/off)
   const [liveEnabled, setLiveEnabled] = useState(true);
 
+  // Server-side range + explicit limit: the server's silent default cap made
+  // the page aggregate the newest 1000 packets while labeling it "all"; the
+  // cap still exists (pagination is cursor-based, not auto-walked) but is now
+  // surfaced via the truncation notice below.
+  const PAGE_LIMIT = 1000;
   const {
     data: traceroutesRaw,
     isFetching,
     refetch,
-  } = useGetTraceroutesQuery(undefined as any, {
+  } = useGetTraceroutesQuery({ range, limit: PAGE_LIMIT } as any, {
     pollingInterval: liveEnabled ? 5000 : 0,
     skipPollingIfUnfocused: true,
     refetchOnFocus: liveEnabled,
@@ -642,12 +647,17 @@ export const Traceroutes = () => {
 
   const totalEvents = exchangesSorted.length;
   const totalPackets = filteredEventsSorted.length;
+  // A full page means the server window is capped, not exhausted — say so
+  // instead of presenting the truncated window as the complete range.
+  const truncated = eventsAll.length >= PAGE_LIMIT;
 
   const totalLabel = `${totalPairs.toLocaleString()} pair${
     totalPairs === 1 ? "" : "s"
   } • ${totalEvents.toLocaleString()} traceroute${
     totalEvents === 1 ? "" : "s"
-  } (${totalPackets.toLocaleString()} packet${totalPackets === 1 ? "" : "s"})`;
+  } (${totalPackets.toLocaleString()} packet${totalPackets === 1 ? "" : "s"})${
+    truncated ? ` • newest ${PAGE_LIMIT.toLocaleString()} only` : ""
+  }`;
 
   const liveUiMode = liveEnabled ? ("live" as const) : ("off" as const);
   const livePillTitle = liveEnabled
@@ -728,12 +738,15 @@ export const Traceroutes = () => {
       "route_hops",
       "route_ids",
       "route_short",
+      "return_route_ids",
       "leg_snr_db",
       "snr",
       "rssi",
       "message_id",
       "header_from",
       "header_to",
+      "time_source",
+      "created_at",
     ] as const;
 
     const lines: string[] = [];
@@ -763,12 +776,17 @@ export const Traceroutes = () => {
         route_hops: rids.length,
         route_ids: rids.join(" "),
         route_short: routeShort,
+        return_route_ids: e.route_back_ids.join(" "),
         leg_snr_db: legSnr,
         snr: e.snr ?? "",
         rssi: e.rssi ?? "",
         message_id: e.id ?? "",
         header_from: e.header_from,
         header_to: e.header_to,
+        // The timestamp column falls back to ingest time for clock-less
+        // gateways; this column makes the substitution auditable.
+        time_source: e.timestamp_source ?? "",
+        created_at: e.created_at ? new Date(safeTsMs(e.created_at)).toISOString() : "",
       };
 
       lines.push(cols.map((c) => csvEscape(row[c])).join(","));

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -119,8 +119,7 @@ export const Traceroutes = () => {
     const legacySel = searchParams.get("sel") ?? "";
     const legacyRange = searchParams.get("range") ?? "";
 
-    // Directed pair keys from old share links (pair:B|A) canonicalize to the
-    // sorted undirected key so they keep resolving after the orientation fix.
+    // Old share links may carry directed pair keys (pair:B|A); canonicalize to the sorted key.
     const selPair = legacySel.startsWith("pair:") ? legacySel.slice(5) : "";
     const selPairParts = selPair.split("|");
     const selPairCanonical =
@@ -241,9 +240,8 @@ export const Traceroutes = () => {
   // URL state
   const range = clampRange(searchParams.get("range"));
   const urlQ = searchParams.get("q") || "";
-  // Canonicalize directed legacy pair keys at READ time — the URL-rewrite
-  // effect above is cosmetic and loses a race against the missing-key reset
-  // below, so the lookup key must already be canonical here.
+  // Canonicalize legacy directed pair keys at read time — the URL-rewrite
+  // effect above races the missing-key reset below.
   const selRawParam = searchParams.get("sel") || DEFAULT_SEL;
   const selectedKey = useMemo(() => {
     if (!selRawParam.startsWith("pair:")) return selRawParam;
@@ -256,9 +254,7 @@ export const Traceroutes = () => {
   // Live polling (simple: on/off)
   const [liveEnabled, setLiveEnabled] = useState(true);
 
-  // Server-side range + explicit limit: the server's silent default cap made
-  // the page aggregate the newest 1000 packets while labeling it "all"; the
-  // cap still exists (pagination is cursor-based, not auto-walked) but is now
+  // The server caps the window (cursor pagination, not auto-walked);
   // surfaced via the truncation notice below.
   const PAGE_LIMIT = 1000;
   const {
@@ -432,8 +428,7 @@ export const Traceroutes = () => {
     return arr;
   }, [filteredEvents]);
 
-  // One traceroute exchange can be captured as two packets (request + reply);
-  // runs/routes/pair stats count exchanges, packet totals stay visible beside.
+  // Stats count exchanges (request+reply packets collapsed); packet totals shown beside.
   const exchangesSorted: TracerouteEvent[] = useMemo(() => {
     return dedupeExchangeEvents(filteredEventsSorted);
   }, [filteredEventsSorted]);
@@ -444,9 +439,7 @@ export const Traceroutes = () => {
   }, [exchangesSorted]);
 
   // ---- Build pair summaries + events-by-pair
-  // Keyed on the undirected canonical pairKey so request/reply captures and
-  // A→B / B→A initiations of one pair share a single entry. Stats count
-  // EXCHANGES; raw packet counts ride along for visibility.
+  // Keyed on the undirected pairKey so A→B and B→A initiations share one entry.
   const { pairItems, eventsByPairKey, listItems } = useMemo(() => {
     const byPair = new Map<
       string,
@@ -615,9 +608,8 @@ export const Traceroutes = () => {
 
   useEffect(() => {
     if (!selectedItem) return;
-    // Don't judge a deep-linked pair against an empty/stale list: before the
-    // data lands, listItems holds only the overview item and the reset would
-    // wipe every share link's selection.
+    // Before data lands listItems holds only the overview item — resetting
+    // then would wipe deep-linked selections.
     if (!traceroutesRaw || !nodes) return;
     if (selectedKey && !listItems.find((it) => it.key === selectedKey)) {
       setParam("sel", DEFAULT_SEL, "replace");
@@ -647,8 +639,7 @@ export const Traceroutes = () => {
 
   const totalEvents = exchangesSorted.length;
   const totalPackets = filteredEventsSorted.length;
-  // A full page means the server window is capped, not exhausted — say so
-  // instead of presenting the truncated window as the complete range.
+  // A full page means the server window is capped, not exhausted.
   const truncated = eventsAll.length >= PAGE_LIMIT;
 
   const totalLabel = `${totalPairs.toLocaleString()} pair${
@@ -706,8 +697,7 @@ export const Traceroutes = () => {
       selection: selectedPairKey ? { pair: selectedPairKey } : { all: true },
       params: Object.fromEntries(searchParams.entries()),
       count: packetsSelected.length,
-      // One row per received packet; from/to/route_ids are travel-oriented,
-      // raw packet headers ride along as header_from/header_to.
+      // from/to/route_ids are travel-oriented; raw headers in header_from/header_to.
       rows: packetsSelected.map((e) => {
 
         const { __idx, ...rest } = e as any;
@@ -725,8 +715,7 @@ export const Traceroutes = () => {
   const doExportCsv = () => {
     if (!nodes) return;
 
-    // from/to/route are travel-oriented (initiator → target); header_from/
-    // header_to are the raw packet header (swapped on reply packets).
+    // from/to/route are travel-oriented; header_from/header_to are the raw packet header.
     const cols = [
       "timestamp",
       "direction",
@@ -783,8 +772,7 @@ export const Traceroutes = () => {
         message_id: e.id ?? "",
         header_from: e.header_from,
         header_to: e.header_to,
-        // The timestamp column falls back to ingest time for clock-less
-        // gateways; this column makes the substitution auditable.
+        // Makes the ingest-time fallback in the timestamp column auditable.
         time_source: e.timestamp_source ?? "",
         created_at: e.created_at ? new Date(safeTsMs(e.created_at)).toISOString() : "",
       };

--- a/frontend/src/pages/Traceroutes.tsx
+++ b/frontend/src/pages/Traceroutes.tsx
@@ -23,7 +23,9 @@ import {
 } from "./traceroutes/traceroutesTypes";
 import {
   coerceEvent,
+  dedupeExchangeEvents,
   groupTracerouteEvents,
+  hopChipLabel,
   type NodesById,
   routeHopsOf,
   routeIdsOf,
@@ -117,9 +119,17 @@ export const Traceroutes = () => {
     const legacySel = searchParams.get("sel") ?? "";
     const legacyRange = searchParams.get("range") ?? "";
 
+    // Directed pair keys from old share links (pair:B|A) canonicalize to the
+    // sorted undirected key so they keep resolving after the orientation fix.
+    const selPair = legacySel.startsWith("pair:") ? legacySel.slice(5) : "";
+    const selPairParts = selPair.split("|");
+    const selPairCanonical =
+      selPairParts.length === 2 && selPairParts[0] > selPairParts[1];
+
     const needsCleanup =
       !!legacyView ||
       legacyRange === "30d" ||
+      selPairCanonical ||
       [
         "newest",
         "oldest",
@@ -161,6 +171,12 @@ export const Traceroutes = () => {
         // old selection keys (evt:/route:) won’t exist anymore
         const s = p.get("sel") ?? "";
         if (s && s !== "all" && !s.startsWith("pair:")) p.delete("sel");
+        else if (s.startsWith("pair:")) {
+          const parts = s.slice(5).split("|");
+          if (parts.length === 2 && parts[0] > parts[1]) {
+            p.set("sel", `pair:${parts[1]}|${parts[0]}`);
+          }
+        }
 
         return p;
       },
@@ -225,7 +241,16 @@ export const Traceroutes = () => {
   // URL state
   const range = clampRange(searchParams.get("range"));
   const urlQ = searchParams.get("q") || "";
-  const selectedKey = searchParams.get("sel") || DEFAULT_SEL;
+  // Canonicalize directed legacy pair keys at READ time — the URL-rewrite
+  // effect above is cosmetic and loses a race against the missing-key reset
+  // below, so the lookup key must already be canonical here.
+  const selRawParam = searchParams.get("sel") || DEFAULT_SEL;
+  const selectedKey = useMemo(() => {
+    if (!selRawParam.startsWith("pair:")) return selRawParam;
+    const parts = selRawParam.slice(5).split("|");
+    if (parts.length === 2 && parts[0] > parts[1]) return `pair:${parts[1]}|${parts[0]}`;
+    return selRawParam;
+  }, [selRawParam]);
   const sort = clampSort(searchParams.get("sort") || DEFAULT_SORT);
 
   // Live polling (simple: on/off)
@@ -402,41 +427,53 @@ export const Traceroutes = () => {
     return arr;
   }, [filteredEvents]);
 
-  // Unique route sequences across all filtered events (for overview)
-  const uniqueRoutesTotal = useMemo(() => {
-    return groupTracerouteEvents(filteredEventsSorted).length;
+  // One traceroute exchange can be captured as two packets (request + reply);
+  // runs/routes/pair stats count exchanges, packet totals stay visible beside.
+  const exchangesSorted: TracerouteEvent[] = useMemo(() => {
+    return dedupeExchangeEvents(filteredEventsSorted);
   }, [filteredEventsSorted]);
 
+  // Unique route sequences across all filtered exchanges (for overview)
+  const uniqueRoutesTotal = useMemo(() => {
+    return groupTracerouteEvents(exchangesSorted).length;
+  }, [exchangesSorted]);
+
   // ---- Build pair summaries + events-by-pair
+  // Keyed on the undirected canonical pairKey so request/reply captures and
+  // A→B / B→A initiations of one pair share a single entry. Stats count
+  // EXCHANGES; raw packet counts ride along for visibility.
   const { pairItems, eventsByPairKey, listItems } = useMemo(() => {
     const byPair = new Map<
       string,
       {
         from: string;
         to: string;
+        bidirectional: boolean;
         count: number;
         firstTsMs: number;
         lastTsMs: number;
         uniqueRouteKeys: Set<string>;
         routeCounts: Map<
           string,
-          { routeIds: string[]; count: number; lastTsMs: number }
+          { routeIds: string[]; from: string; to: string; count: number; lastTsMs: number }
         >;
       }
     >();
 
     const eventsMap = new Map<string, TracerouteEvent[]>();
 
-    for (const e of filteredEventsSorted) {
-      const pairKey = `${e.from}|${e.to}`;
+    for (const e of exchangesSorted) {
+      const pairKey = e.pairKey;
       const ts = safeTsMs(e.timestamp);
       if (!eventsMap.has(pairKey)) eventsMap.set(pairKey, []);
       eventsMap.get(pairKey)!.push(e);
 
       if (!byPair.has(pairKey)) {
+        // Newest-first iteration: the first event fixes the displayed direction
         byPair.set(pairKey, {
           from: e.from,
           to: e.to,
+          bidirectional: false,
           count: 1,
           firstTsMs: ts,
           lastTsMs: ts,
@@ -448,27 +485,40 @@ export const Traceroutes = () => {
         s.count += 1;
         s.firstTsMs = Math.min(s.firstTsMs || ts, ts || s.firstTsMs);
         s.lastTsMs = Math.max(s.lastTsMs || ts, ts || s.lastTsMs);
+        if (e.from !== s.from) s.bidirectional = true;
       }
 
       const s = byPair.get(pairKey)!;
       const rids = routeIdsOf(e);
-      const rk = rids.join(",");
+      // Direction is part of a route's identity; ids are already normalized
+      const rk = `${e.from}>${rids.join(",")}>${e.to}`;
       s.uniqueRouteKeys.add(rk);
 
       const cur = s.routeCounts.get(rk);
       if (!cur) {
-        s.routeCounts.set(rk, { routeIds: rids, count: 1, lastTsMs: ts });
+        s.routeCounts.set(rk, { routeIds: rids, from: e.from, to: e.to, count: 1, lastTsMs: ts });
       } else {
         cur.count += 1;
         cur.lastTsMs = Math.max(cur.lastTsMs || ts, ts || cur.lastTsMs);
       }
     }
 
+    // Raw packet totals per pair (requests + replies before collapsing)
+    const packetsByPair = new Map<string, number>();
+    for (const e of filteredEventsSorted) {
+      packetsByPair.set(e.pairKey, (packetsByPair.get(e.pairKey) ?? 0) + 1);
+    }
+
     const pairs: TraceroutesListItem[] = Array.from(byPair.entries()).map(
       ([pairKey, s]) => {
         // compute a "top route" for the list preview
-        let best: { routeIds: string[]; count: number; lastTsMs: number } | null =
-          null;
+        let best: {
+          routeIds: string[];
+          from: string;
+          to: string;
+          count: number;
+          lastTsMs: number;
+        } | null = null;
 
         for (const v of s.routeCounts.values()) {
           if (
@@ -484,12 +534,16 @@ export const Traceroutes = () => {
           pairKey,
           from: s.from,
           to: s.to,
+          bidirectional: s.bidirectional,
           count: s.count,
+          packetCount: packetsByPair.get(pairKey) ?? s.count,
           firstTsMs: s.firstTsMs,
           lastTsMs: s.lastTsMs,
           uniqueRoutes: s.uniqueRouteKeys.size,
           topRouteIds: best?.routeIds ?? [],
           topRouteCount: best?.count ?? 0,
+          topRouteFrom: best?.from ?? s.from,
+          topRouteTo: best?.to ?? s.to,
         };
 
         return {
@@ -534,7 +588,8 @@ export const Traceroutes = () => {
       kind: "all",
       key: "all",
       totalPairs: sortedPairs.length,
-      totalEvents: filteredEventsSorted.length,
+      totalEvents: exchangesSorted.length,
+      totalPackets: filteredEventsSorted.length,
       lastTsMs: maxLast,
       uniqueRoutes: uniqueRoutesTotal,
     };
@@ -546,7 +601,7 @@ export const Traceroutes = () => {
       eventsByPairKey: eventsMap,
       listItems: items,
     };
-  }, [filteredEventsSorted, sort, uniqueRoutesTotal]);
+  }, [exchangesSorted, filteredEventsSorted, sort, uniqueRoutesTotal]);
 
   // ---- Selection
   const selectedItem = useMemo(() => {
@@ -555,6 +610,10 @@ export const Traceroutes = () => {
 
   useEffect(() => {
     if (!selectedItem) return;
+    // Don't judge a deep-linked pair against an empty/stale list: before the
+    // data lands, listItems holds only the overview item and the reset would
+    // wipe every share link's selection.
+    if (!traceroutesRaw || !nodes) return;
     if (selectedKey && !listItems.find((it) => it.key === selectedKey)) {
       setParam("sel", DEFAULT_SEL, "replace");
     }
@@ -565,9 +624,15 @@ export const Traceroutes = () => {
     selectedItem && selectedItem.kind === "pair" ? selectedItem.pairKey : null;
 
   const eventsSelected: TracerouteEvent[] = useMemo(() => {
-    if (!selectedPairKey) return filteredEventsSorted;
+    if (!selectedPairKey) return exchangesSorted;
     return eventsByPairKey.get(selectedPairKey) ?? [];
-  }, [selectedPairKey, filteredEventsSorted, eventsByPairKey]);
+  }, [selectedPairKey, exchangesSorted, eventsByPairKey]);
+
+  // Exports stay packet-level (raw data, one row per received packet)
+  const packetsSelected: TracerouteEvent[] = useMemo(() => {
+    if (!selectedPairKey) return filteredEventsSorted;
+    return filteredEventsSorted.filter((e) => e.pairKey === selectedPairKey);
+  }, [selectedPairKey, filteredEventsSorted]);
 
   // ---- Header derived values
   const totalPairs =
@@ -575,13 +640,14 @@ export const Traceroutes = () => {
       ? listItems[0].totalPairs
       : Math.max(0, listItems.length - 1);
 
-  const totalEvents = filteredEventsSorted.length;
+  const totalEvents = exchangesSorted.length;
+  const totalPackets = filteredEventsSorted.length;
 
   const totalLabel = `${totalPairs.toLocaleString()} pair${
     totalPairs === 1 ? "" : "s"
   } • ${totalEvents.toLocaleString()} traceroute${
     totalEvents === 1 ? "" : "s"
-  }`;
+  } (${totalPackets.toLocaleString()} packet${totalPackets === 1 ? "" : "s"})`;
 
   const liveUiMode = liveEnabled ? ("live" as const) : ("off" as const);
   const livePillTitle = liveEnabled
@@ -610,8 +676,8 @@ export const Traceroutes = () => {
     [setParam],
   );
 
-  // ---- Export (scope = selected pair or all)
-  const exportRowsCount = eventsSelected.length;
+  // ---- Export (scope = selected pair or all; packet-level rows)
+  const exportRowsCount = packetsSelected.length;
 
   const exportFilenameBase = useMemo(() => {
     if (selectedPairKey) {
@@ -629,9 +695,11 @@ export const Traceroutes = () => {
       exportedAt: new Date().toISOString(),
       selection: selectedPairKey ? { pair: selectedPairKey } : { all: true },
       params: Object.fromEntries(searchParams.entries()),
-      count: eventsSelected.length,
-      rows: eventsSelected.map((e) => {
-         
+      count: packetsSelected.length,
+      // One row per received packet; from/to/route_ids are travel-oriented,
+      // raw packet headers ride along as header_from/header_to.
+      rows: packetsSelected.map((e) => {
+
         const { __idx, ...rest } = e as any;
         return rest;
       }),
@@ -647,8 +715,11 @@ export const Traceroutes = () => {
   const doExportCsv = () => {
     if (!nodes) return;
 
+    // from/to/route are travel-oriented (initiator → target); header_from/
+    // header_to are the raw packet header (swapped on reply packets).
     const cols = [
       "timestamp",
+      "direction",
       "from_id",
       "from_short",
       "to_id",
@@ -657,21 +728,33 @@ export const Traceroutes = () => {
       "route_hops",
       "route_ids",
       "route_short",
+      "leg_snr_db",
+      "snr",
+      "rssi",
+      "message_id",
+      "header_from",
+      "header_to",
     ] as const;
 
     const lines: string[] = [];
     lines.push(cols.join(","));
 
-    for (const e of eventsSelected) {
+    for (const e of packetsSelected) {
       const fromShort = nodes[e.from]?.shortname ?? "UNK";
       const toShort = nodes[e.to]?.shortname ?? "UNK";
       const rids = routeIdsOf(e);
       const routeShort = rids
-        .map((id) => nodes[id]?.shortname ?? "UNK")
+        .map((id) => hopChipLabel(nodes, id))
         .join(" > ");
+      const legSnr = Array.isArray(e.payload?.snr_towards)
+        ? e.payload.snr_towards
+            .map((v) => (v === -128 ? "?" : String(v / 4)))
+            .join(" ")
+        : "";
 
       const row: Record<string, any> = {
         timestamp: e.timestamp ? new Date(safeTsMs(e.timestamp)).toISOString() : "",
+        direction: e.isReply ? "reply" : "request",
         from_id: e.from,
         from_short: fromShort,
         to_id: e.to,
@@ -680,6 +763,12 @@ export const Traceroutes = () => {
         route_hops: rids.length,
         route_ids: rids.join(" "),
         route_short: routeShort,
+        leg_snr_db: legSnr,
+        snr: e.snr ?? "",
+        rssi: e.rssi ?? "",
+        message_id: e.id ?? "",
+        header_from: e.header_from,
+        header_to: e.header_to,
       };
 
       lines.push(cols.map((c) => csvEscape(row[c])).join(","));
@@ -916,7 +1005,7 @@ export const Traceroutes = () => {
                   selectedItem={selectedItem ?? listItems[0]}
                   nodes={nodes}
                   range={range}
-                  eventsAll={filteredEventsSorted}
+                  eventsAll={exchangesSorted}
                   eventsSelected={eventsSelected}
                   pairItems={pairItems}
                   uniqueRoutesTotal={uniqueRoutesTotal}

--- a/frontend/src/pages/graph/AdjacencyHeatmap.tsx
+++ b/frontend/src/pages/graph/AdjacencyHeatmap.tsx
@@ -172,7 +172,7 @@ export const AdjacencyHeatmap: React.FC<Props> = ({ nodes, edges, nodeById: _nod
       const nodeB = matrixNodes[hoverCell.col];
       const edge = edgeMap.get(`${nodeA.id}~${nodeB.id}`);
       const text = edge
-        ? `${nodeA.label} \u2194 ${nodeB.label}: ${edge.kind}${edge.snr != null && edge.snr !== 0 ? ` (${edge.snr}dB)` : ""} w=${edge.w}`
+        ? `${nodeA.label} \u2194 ${nodeB.label}: ${edge.kind}${edge.snr != null ? ` (${edge.snr}dB)` : ""} w=${edge.w}`
         : `${nodeA.label} \u2194 ${nodeB.label}: no link`;
 
       ctx.font = "12px ui-sans-serif, system-ui, sans-serif";

--- a/frontend/src/pages/graph/graphEdges.test.ts
+++ b/frontend/src/pages/graph/graphEdges.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTracerouteEdges } from "./graphEdges";
+
+const VALID = new Set(["0000000a", "0000000d", "000000b1", "000000b2"]);
+
+function keysOf(traceroutes: any[]): string[] {
+  return buildTracerouteEdges(traceroutes, VALID)
+    .map((e) => `${e.a}~${e.b}`)
+    .sort();
+}
+
+describe("buildTracerouteEdges", () => {
+  it("emits true reply-row legs, not the phantom endpoint edges", () => {
+    // Reply for trace O→R1→R2→D: header from=D, to=O, request-ordered route
+    const reply = {
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { snr_towards: [4, 8, 12] },
+      timestamp: 100,
+    };
+    const keys = keysOf([reply]);
+    expect(keys).toEqual(["0000000a~000000b1", "0000000d~000000b2", "000000b1~000000b2"]);
+    expect(keys).not.toContain("0000000d~000000b1");
+    expect(keys).not.toContain("0000000a~000000b2");
+  });
+
+  it("halves edge weight for request+reply captures of one exchange", () => {
+    const request = {
+      from: "0000000a",
+      to: "0000000d",
+      route_ids: ["000000b1"],
+      payload: { snr_towards: [4] },
+      timestamp: 100,
+    };
+    const reply = {
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { snr_towards: [4, 8, 12] },
+      timestamp: 110,
+    };
+    const edges = buildTracerouteEdges([request, reply], VALID);
+    for (const e of edges) expect(e.w).toBe(1);
+  });
+
+  it("skips the speculative final leg of requests and unresolved/sentinel hops", () => {
+    const request = {
+      from: "0000000a",
+      to: "0000000d",
+      route_ids: ["000000b1"],
+      payload: { snr_towards: [4] },
+      timestamp: 100,
+    };
+    expect(keysOf([request])).toEqual(["0000000a~000000b1"]);
+
+    const sentinelReply = {
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["ffffffff"],
+      payload: { snr_towards: [4, 8] },
+      timestamp: 100,
+    };
+    expect(keysOf([sentinelReply])).toEqual([]);
+  });
+
+  it("emits the direct edge for a zero-hop reply", () => {
+    const zeroHopReply = {
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: [],
+      payload: { snr_towards: [5] },
+      timestamp: 100,
+    };
+    expect(keysOf([zeroHopReply])).toEqual(["0000000a~0000000d"]);
+  });
+});

--- a/frontend/src/pages/graph/graphEdges.test.ts
+++ b/frontend/src/pages/graph/graphEdges.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTracerouteEdges } from "./graphEdges";
+import { buildNeighborEdges, buildTracerouteEdges, mergeEdges } from "./graphEdges";
 
 const VALID = new Set(["0000000a", "0000000d", "000000b1", "000000b2"]);
 
@@ -74,5 +74,55 @@ describe("buildTracerouteEdges", () => {
       timestamp: 100,
     };
     expect(keysOf([zeroHopReply])).toEqual(["0000000a~0000000d"]);
+  });
+});
+
+describe("buildNeighborEdges", () => {
+  const mk = (neighbors: any[]) => ({
+    "0000000a": { neighborinfo: { neighbors } },
+  });
+
+  it("keeps missing SNR undefined instead of coercing to 0 dB", () => {
+    const edges = buildNeighborEdges(mk([{ node_id: "0000000b" }]));
+    expect(edges[0].snr).toBeUndefined();
+  });
+
+  it("max-aggregates over defined readings only", () => {
+    const edges = buildNeighborEdges({
+      "0000000a": { neighborinfo: { neighbors: [{ node_id: "0000000b", snr: -12.5 }] } },
+      "0000000b": { neighborinfo: { neighbors: [{ node_id: "0000000a" }] } },
+    });
+    // A reading-less report must not override the real -12.5 dB
+    expect(edges[0].snr).toBe(-12.5);
+  });
+
+  it("preserves a genuine 0 dB reading", () => {
+    const edges = buildNeighborEdges(mk([{ node_id: "0000000b", snr: 0 }]));
+    expect(edges[0].snr).toBe(0);
+  });
+});
+
+describe("mergeEdges", () => {
+  it("flags dual-evidence links with both kinds", () => {
+    const neighbor = [{ a: "0000000a", b: "0000000b", w: 2, kind: "neighbor" as const, snr: -5 }];
+    const trace = [{ a: "0000000a", b: "0000000b", w: 3, kind: "traceroute" as const }];
+    const merged = mergeEdges(neighbor, trace);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].hasNeighbor).toBe(true);
+    expect(merged[0].hasTraceroute).toBe(true);
+    expect(merged[0].w).toBe(5);
+  });
+
+  it("single-source edges carry only their own flag", () => {
+    const merged = mergeEdges(
+      [{ a: "0000000a", b: "0000000b", w: 1, kind: "neighbor" as const }],
+      [{ a: "0000000c", b: "0000000d", w: 1, kind: "traceroute" as const }],
+    );
+    const nb = merged.find((e) => e.a === "0000000a")!;
+    const tr = merged.find((e) => e.a === "0000000c")!;
+    expect(nb.hasNeighbor).toBe(true);
+    expect(nb.hasTraceroute).toBeUndefined();
+    expect(tr.hasTraceroute).toBe(true);
+    expect(tr.hasNeighbor).toBeUndefined();
   });
 });

--- a/frontend/src/pages/graph/graphEdges.ts
+++ b/frontend/src/pages/graph/graphEdges.ts
@@ -2,7 +2,7 @@ import { dedupeExchanges, isResolvedHop, orientTraceroute } from "../../utils/tr
 import { type GraphEdge,normNodeId } from "./graphUtils";
 
 export function buildNeighborEdges(nodesById: Record<string, any>): GraphEdge[] {
-  const wByKey = new Map<string, { w: number; snr: number }>();
+  const wByKey = new Map<string, { w: number; snr: number | undefined }>();
   for (const rawId of Object.keys(nodesById)) {
     const id = normNodeId(rawId);
     const node = nodesById[rawId];
@@ -17,9 +17,15 @@ export function buildNeighborEdges(nodesById: Record<string, any>): GraphEdge[] 
       const a = id < nbId ? id : nbId, b = id < nbId ? nbId : id;
       const key = `${a}~${b}`;
       const existing = wByKey.get(key);
-      const snr = typeof nb?.snr === "number" ? nb.snr : 0;
-      if (existing) { existing.w += 1; if (snr > existing.snr) existing.snr = snr; }
-      else wByKey.set(key, { w: 1, snr });
+      // Missing SNR stays undefined — coercing to 0 dB would out-rank real
+      // negative readings in the max.
+      const snr = typeof nb?.snr === "number" ? nb.snr : undefined;
+      if (existing) {
+        existing.w += 1;
+        if (snr != null && (existing.snr == null || snr > existing.snr)) existing.snr = snr;
+      } else {
+        wByKey.set(key, { w: 1, snr });
+      }
     }
   }
   const edges: GraphEdge[] = [];
@@ -32,10 +38,8 @@ export function buildNeighborEdges(nodesById: Record<string, any>): GraphEdge[] 
 
 export function buildTracerouteEdges(traceroutes: any[], validIds: Set<string>): GraphEdge[] {
   const wByKey = new Map<string, number>();
-  // orientTraceroute travel-orders reply rows (header swap ≠ path reversal —
-  // a raw [from,...route,to] walk fabricates both endpoint edges on replies);
-  // dedupeExchanges keeps a request+reply capture of one traceroute from
-  // double-weighting every edge.
+  // orientTraceroute travel-orders reply rows (header swap ≠ path reversal);
+  // dedupeExchanges keeps a request+reply capture from double-weighting edges.
   for (const tr of dedupeExchanges(traceroutes)) {
     const o = orientTraceroute(tr);
     if (!o) continue;
@@ -63,11 +67,16 @@ export function buildTracerouteEdges(traceroutes: any[], validIds: Set<string>):
 
 export function mergeEdges(neighborEdges: GraphEdge[], tracerouteEdges: GraphEdge[]): GraphEdge[] {
   const map = new Map<string, GraphEdge>();
-  for (const e of neighborEdges) map.set(`${e.a}~${e.b}`, { ...e });
+  for (const e of neighborEdges) map.set(`${e.a}~${e.b}`, { ...e, hasNeighbor: true });
   for (const e of tracerouteEdges) {
     const key = `${e.a}~${e.b}`;
     const ex = map.get(key);
-    if (ex) ex.w += e.w; else map.set(key, { ...e });
+    if (ex) {
+      ex.w += e.w;
+      ex.hasTraceroute = true;
+    } else {
+      map.set(key, { ...e, hasTraceroute: true });
+    }
   }
   return Array.from(map.values());
 }

--- a/frontend/src/pages/graph/graphEdges.ts
+++ b/frontend/src/pages/graph/graphEdges.ts
@@ -1,3 +1,4 @@
+import { dedupeExchanges, isResolvedHop, orientTraceroute } from "../../utils/traceroute";
 import { type GraphEdge,normNodeId } from "./graphUtils";
 
 export function buildNeighborEdges(nodesById: Record<string, any>): GraphEdge[] {
@@ -31,14 +32,23 @@ export function buildNeighborEdges(nodesById: Record<string, any>): GraphEdge[] 
 
 export function buildTracerouteEdges(traceroutes: any[], validIds: Set<string>): GraphEdge[] {
   const wByKey = new Map<string, number>();
-  for (const tr of traceroutes) {
-    const from = normNodeId(tr?.from), to = normNodeId(tr?.to);
-    // route_ids first: slim traceroute rows (?slim=1) drop the legacy route fields.
-    const route: string[] = (tr?.route_ids ?? tr?.route ?? tr?.payload?.route ?? []).map(normNodeId).filter(Boolean);
-    const path = [from, ...route, to].filter(Boolean);
+  // orientTraceroute travel-orders reply rows (header swap ≠ path reversal —
+  // a raw [from,...route,to] walk fabricates both endpoint edges on replies);
+  // dedupeExchanges keeps a request+reply capture of one traceroute from
+  // double-weighting every edge.
+  for (const tr of dedupeExchanges(traceroutes)) {
+    const o = orientTraceroute(tr);
+    if (!o) continue;
+    const path = o.orderedPath;
+    const lastLegIdx = path.length - 2;
     for (let i = 0; i < path.length - 1; i++) {
+      // A mid-flight request never observed its final (…→target) leg.
+      if (o.provisional && i === lastLegIdx) continue;
       const a = path[i], b = path[i + 1];
       if (!a || !b || a === b) continue;
+      // Placeholder/sentinel hops break the chain; skip the legs touching
+      // them rather than splicing a fake edge across the gap.
+      if (!isResolvedHop(a) || !isResolvedHop(b)) continue;
       const ka = a < b ? a : b, kb = a < b ? b : a;
       wByKey.set(`${ka}~${kb}`, (wByKey.get(`${ka}~${kb}`) ?? 0) + 1);
     }

--- a/frontend/src/pages/graph/graphUtils.ts
+++ b/frontend/src/pages/graph/graphUtils.ts
@@ -41,7 +41,11 @@ export type GraphEdge = {
   b: string;
   w: number;
   kind: EdgeKind;
+  /** undefined = no reading (0 dB is a real value). */
   snr?: number;
+  // Evidence flags survive merging so kind filters keep dual-source links.
+  hasNeighbor?: boolean;
+  hasTraceroute?: boolean;
 };
 
 export const ROLE_LABELS: Record<string, string> = {

--- a/frontend/src/pages/graph/useGraphData.ts
+++ b/frontend/src/pages/graph/useGraphData.ts
@@ -76,7 +76,11 @@ export function useGraphData(
     let allEdges = mergeEdges(neighborEdges, tracerouteEdges);
 
     if (filter !== "all") {
-      allEdges = allEdges.filter((e) => e.kind === filter);
+      // Evidence flags, not kind: a merged link has both and must survive
+      // either single-kind filter.
+      allEdges = allEdges.filter((e) =>
+        filter === "neighbor" ? e.hasNeighbor : e.hasTraceroute,
+      );
     }
 
     // Compute degrees

--- a/frontend/src/pages/map/components/MapDetailsPanel.tsx
+++ b/frontend/src/pages/map/components/MapDetailsPanel.tsx
@@ -6,6 +6,7 @@ import { HardwareModel, type NodeRole,roleTitles } from "../../../types";
 import { convertNodeIdFromHexToInt } from "../../../utils/convertNodeId";
 import { getElsewhereLinks, resolveElsewhereUrl } from "../../../utils/elsewhereLinks";
 import { normalizeNodeId8 } from "../../../utils/normalizeNodeId8";
+import { dedupeExchanges, isResolvedHop, orientTraceroute } from "../../../utils/traceroute";
 import { useBottomSheetGesture } from "../hooks/useBottomSheet";
 import { normNodeId } from "../lib/linkFeatures";
 import type { IMapNode, NodeDetailsData } from "../lib/types";
@@ -329,20 +330,21 @@ export const MapDetailsPanel = memo(function MapDetailsPanel({
     if (!data) return [];
     const normId = normNodeId(data.node.id);
     const trLinkCounts = new Map<string, number>();
-    for (const tr of data.traceroutes ?? []) {
-      const from = normNodeId(tr.from);
-      const to = normNodeId(tr.to);
-      const hops = (tr.route_ids ?? tr.route ?? []).map((r: string) => normNodeId(r));
-      const path = [from, ...hops, to].filter(Boolean);
+    // Travel-ordered walk (reply headers are swapped), request+reply of one
+    // exchange counted once, speculative/unresolved legs excluded.
+    for (const tr of dedupeExchanges(data.traceroutes ?? [])) {
+      const o = orientTraceroute(tr);
+      if (!o) continue;
+      const path = o.orderedPath;
       const idx = path.indexOf(normId);
       if (idx === -1) continue;
-      if (idx > 0) {
+      if (idx > 0 && !(o.provisional && idx === path.length - 1)) {
         const prev = path[idx - 1];
-        trLinkCounts.set(prev, (trLinkCounts.get(prev) ?? 0) + 1);
+        if (isResolvedHop(prev)) trLinkCounts.set(prev, (trLinkCounts.get(prev) ?? 0) + 1);
       }
-      if (idx < path.length - 1) {
+      if (idx < path.length - 1 && !(o.provisional && idx + 1 === path.length - 1)) {
         const next = path[idx + 1];
-        trLinkCounts.set(next, (trLinkCounts.get(next) ?? 0) + 1);
+        if (isResolvedHop(next)) trLinkCounts.set(next, (trLinkCounts.get(next) ?? 0) + 1);
       }
     }
     return [...trLinkCounts.entries()].sort((a, b) => b[1] - a[1]);

--- a/frontend/src/pages/map/components/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/components/MapTraceroutePanel.tsx
@@ -104,6 +104,10 @@ function MapTraceroutePanelInner({
   const isLatest = selected != null && selected === paths[0];
   // Dossier rows only apply to the path they were computed for
   const legRows = analysis && selected && analysis.sig === selected.hops.join(">") ? analysis.legs : null;
+  // Verdicts exist only when the grading pass produced this analysis —
+  // ungraded dossiers (terrain off, token missing, grade in flight) mark
+  // every leg "gap" and badging that would be pure noise.
+  const legsGraded = legRows != null && !!analysis?.graded;
 
   const [minimized, setMinimized] = useState(false);
   const sheet = useBottomSheetGesture({
@@ -324,7 +328,19 @@ function MapTraceroutePanelInner({
                 </div>
                 <div className="text-gray-200">
                   {selected.hopCount} {selected.hopCount === 1 ? "hop" : "hops"}
-                  {totalKm != null && totalKm > 0 && <span className="text-gray-500 ml-2">{totalKm.toFixed(1)} km</span>}
+                  {totalKm != null && totalKm > 0 && (
+                    <span
+                      className="text-gray-500 ml-2"
+                      title={
+                        legRows?.some((l) => l.distanceKm == null)
+                          ? "Legs touching unpositioned hops are not included"
+                          : undefined
+                      }
+                    >
+                      {legRows?.some((l) => l.distanceKm == null) ? "≥ " : ""}
+                      {totalKm.toFixed(1)} km
+                    </span>
+                  )}
                   {runsList.length > 1 ? (
                     <span className="text-gray-500 ml-2">
                       {selected.count}/{runsList.length} runs · {Math.round((selected.count / runsList.length) * 100)}%
@@ -355,7 +371,7 @@ function MapTraceroutePanelInner({
                     )}
                   </div>
                 )}
-                {terrain3D && isComputing && !legRows && (
+                {terrain3D && isComputing && !legsGraded && (
                   <div className="mt-1.5 text-[10px] text-cyan-300/80 animate-pulse">
                     Grading route against terrain…
                   </div>
@@ -384,7 +400,7 @@ function MapTraceroutePanelInner({
                             {leg.distanceKm != null && (
                               <span className="text-gray-400">{leg.distanceKm.toFixed(1)} km</span>
                             )}
-                            <VerdictBadge v={leg.verdict} />
+                            {legsGraded && <VerdictBadge v={leg.verdict} />}
                             {leg.verdict === "blocked" && leg.worstObstructionM > 0 && (
                               <span className="text-red-300/90">+{Math.round(leg.worstObstructionM)} m</span>
                             )}

--- a/frontend/src/pages/map/components/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/components/MapTraceroutePanel.tsx
@@ -471,15 +471,15 @@ function MapTraceroutePanelInner({
                           onSelectPath(run.sig);
                         }}
                         onMouseEnter={() => onHighlight?.(toCoords(run.hops))}
-                        title={`${observedAgo(run.timestamp) ?? "age unknown"} · ${run.hopCount} ${run.hopCount === 1 ? "hop" : "hops"}${changed ? " · route changed" : ""}`}
-                        aria-label={`Run ${i + 1} of ${displayRuns.length}, ${run.hopCount} hops${changed ? ", route changed" : ""}`}
+                        title={`${observedAgo(run.timestamp) ?? "age unknown"} · ${run.hopCount} ${run.hopCount === 1 ? "hop" : "hops"}${changed ? " · route changed" : ""}${run.provisional ? " · request, awaiting reply" : ""}`}
+                        aria-label={`Run ${i + 1} of ${displayRuns.length}, ${run.hopCount} hops${changed ? ", route changed" : ""}${run.provisional ? ", request awaiting reply" : ""}`}
                         className={`flex-1 min-w-0.75 rounded-[1px] transition-colors ${
                           isSel
                             ? "bg-cyan-400/90"
                             : changed
                               ? "bg-amber-400/60 hover:bg-amber-300/80"
                               : "bg-white/15 hover:bg-white/35"
-                        }`}
+                        }${run.provisional ? " opacity-50 outline outline-1 outline-dashed outline-white/40 -outline-offset-1" : ""}`}
                       />
                     );
                   })}

--- a/frontend/src/pages/map/components/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/components/MapTraceroutePanel.tsx
@@ -485,8 +485,8 @@ function MapTraceroutePanelInner({
                           onSelectPath(run.sig);
                         }}
                         onMouseEnter={() => onHighlight?.(toCoords(run.hops))}
-                        title={`${observedAgo(run.timestamp) ?? "age unknown"} · ${run.hopCount} ${run.hopCount === 1 ? "hop" : "hops"}${changed ? " · route changed" : ""}${run.provisional ? " · request, awaiting reply" : ""}`}
-                        aria-label={`Run ${i + 1} of ${displayRuns.length}, ${run.hopCount} hops${changed ? ", route changed" : ""}${run.provisional ? ", request awaiting reply" : ""}`}
+                        title={`${observedAgo(run.timestamp) ?? "age unknown"} · ${run.hopCount} ${run.hopCount === 1 ? "hop" : "hops"}${changed ? " · route changed" : ""}${run.provisional ? " · no reply" : ""}`}
+                        aria-label={`Run ${i + 1} of ${displayRuns.length}, ${run.hopCount} hops${changed ? ", route changed" : ""}${run.provisional ? ", no reply" : ""}`}
                         className={`flex-1 min-w-0.75 rounded-[1px] transition-colors ${
                           isSel
                             ? "bg-cyan-400/90"

--- a/frontend/src/pages/map/components/MapTraceroutePanel.tsx
+++ b/frontend/src/pages/map/components/MapTraceroutePanel.tsx
@@ -104,9 +104,7 @@ function MapTraceroutePanelInner({
   const isLatest = selected != null && selected === paths[0];
   // Dossier rows only apply to the path they were computed for
   const legRows = analysis && selected && analysis.sig === selected.hops.join(">") ? analysis.legs : null;
-  // Verdicts exist only when the grading pass produced this analysis —
-  // ungraded dossiers (terrain off, token missing, grade in flight) mark
-  // every leg "gap" and badging that would be pure noise.
+  // Ungraded dossiers mark every leg "gap" — badge verdicts only when grading ran.
   const legsGraded = legRows != null && !!analysis?.graded;
 
   const [minimized, setMinimized] = useState(false);

--- a/frontend/src/pages/map/hooks/useToolUrlSync.ts
+++ b/frontend/src/pages/map/hooks/useToolUrlSync.ts
@@ -1,7 +1,7 @@
-/** Shareable tool deep links: keeps ?tool=los|traceroute&from&to(&fh&th&fq / &play)
- *  in sync with the active analysis, restores once from the URL on mount, and
- *  fires a play=1 tour when the restored path is ready. LOS and traceroute share
- *  one URL snapshot — the tools are mutually exclusive. */
+/** Shareable tool deep links: keeps ?tool=los|traceroute&from&to(&fh&th&fq /
+ *  &sel&play) in sync with the active analysis, restores once from the URL on
+ *  mount, and fires a play=1 tour when the restored path is ready. LOS and
+ *  traceroute share one URL snapshot — the tools are mutually exclusive. */
 import { useEffect, useRef } from "react";
 
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
@@ -44,13 +44,18 @@ export type ToolUrlSyncParams = {
   tracePosKey: string;
   styleEpoch: number;
   startFlyover: (path: AnalyzedPath) => boolean;
+  /** Explicitly selected path signature (alternate / history run) — carried
+   *  in the URL so a shared link reproduces the route being looked at, not
+   *  just the pair (which silently showed the recipient the newest path). */
+  traceSelectedSig: string | null;
+  setTraceSelectedSig: (sig: string | null) => void;
 };
 
 export function useToolUrlSync({
   activeTool, toolStep, toolFromId, toolToId,
   setActiveTool, setToolStep, setToolFromId, setToolToId,
   losState, tracePendingPlayRef, traceSelectedPath, tracePosKey, styleEpoch,
-  startFlyover,
+  startFlyover, traceSelectedSig, setTraceSelectedSig,
 }: ToolUrlSyncParams): void {
   // Snapshot the URL at first render: the write effect rewrites the real URL
   // synchronously (loader-less router), so the restore effect must never read
@@ -143,13 +148,17 @@ export function useToolUrlSync({
         sp.set("tool", "traceroute");
         sp.set("from", toolFromId);
         sp.set("to", toolToId);
+        // The explicitly selected alternate/run — without it, "Copy link"
+        // while inspecting an alternate handed the recipient the newest path.
+        if (traceSelectedSig) sp.set("sel", traceSelectedSig);
+        else sp.delete("sel");
         // play=1 is a one-shot request from a shared link — never persist it
         sp.delete("play");
       } else {
-        for (const k of ["tool", "from", "to", "play"]) sp.delete(k);
+        for (const k of ["tool", "from", "to", "sel", "play"]) sp.delete(k);
       }
     });
-  }, [activeTool, toolStep, toolFromId, toolToId]);
+  }, [activeTool, toolStep, toolFromId, toolToId, traceSelectedSig]);
 
   // Restore a shared traceroute analysis from the URL snapshot (once, on mount)
   useEffect(() => {
@@ -165,12 +174,18 @@ export function useToolUrlSync({
       // Invalid share link: the write effect never re-runs (no state changed),
       // so strip the stale params here or they linger in the URL forever.
       writeToolParams((spx) => {
-        for (const k of ["tool", "from", "to", "play"]) spx.delete(k);
+        for (const k of ["tool", "from", "to", "sel", "play"]) spx.delete(k);
       });
       return;
     }
     setToolFromId(f);
     setToolToId(t);
+    // Restore the shared alternate/run selection. The sig is only ever
+    // compared against locally computed path signatures (find-by-equality;
+    // an unknown sig falls back to the newest path), so a bounded length is
+    // the only sanitation it needs.
+    const sel = sp.get("sel");
+    if (sel && sel.length <= 512) setTraceSelectedSig(sel);
     setActiveTool("traceroute");
     setToolStep("result");
     if (sp.get("play") === "1") tracePendingPlayRef.current = true;
@@ -188,8 +203,21 @@ export function useToolUrlSync({
       return;
     }
     if (!traceSelectedPath) return; // traceroutes still loading — retry on next change
-    if (startFlyover(traceSelectedPath)) tracePendingPlayRef.current = false;
+    // A restored &sel alternate usually arrives with the pair-scoped history
+    // (after the global window): starting the tour on the newest-path
+    // fallback would fly — and then PIN — the wrong route. Wait for the
+    // sel'd path; the effect retries as data/positions land. If the sig has
+    // aged out of history entirely, the tour simply doesn't autostart (the
+    // recipient still sees the pair and can press Play) — better than
+    // silently touring a different route than the one that was shared.
+    if (traceSelectedSig && traceSelectedPath.hops.join(">") !== traceSelectedSig) return;
+    if (startFlyover(traceSelectedPath)) {
+      // Pin the toured path so a live row arriving mid-tour can't re-point
+      // the panel/primary at a newer path while the camera flies this one.
+      setTraceSelectedSig(traceSelectedPath.hops.join(">"));
+      tracePendingPlayRef.current = false;
+    }
     // tracePosKey: retries as hop positions stream in after a cold deep-link load
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTool, toolStep, traceSelectedPath, tracePosKey, styleEpoch]);
+  }, [activeTool, toolStep, traceSelectedPath, traceSelectedSig, tracePosKey, styleEpoch]);
 }

--- a/frontend/src/pages/map/hooks/useToolUrlSync.ts
+++ b/frontend/src/pages/map/hooks/useToolUrlSync.ts
@@ -44,9 +44,8 @@ export type ToolUrlSyncParams = {
   tracePosKey: string;
   styleEpoch: number;
   startFlyover: (path: AnalyzedPath) => boolean;
-  /** Explicitly selected path signature (alternate / history run) — carried
-   *  in the URL so a shared link reproduces the route being looked at, not
-   *  just the pair (which silently showed the recipient the newest path). */
+  /** Explicitly selected path signature (alternate/history run) — carried in
+   *  the URL so a shared link reproduces the exact route, not just the pair. */
   traceSelectedSig: string | null;
   setTraceSelectedSig: (sig: string | null) => void;
 };
@@ -148,8 +147,7 @@ export function useToolUrlSync({
         sp.set("tool", "traceroute");
         sp.set("from", toolFromId);
         sp.set("to", toolToId);
-        // The explicitly selected alternate/run — without it, "Copy link"
-        // while inspecting an alternate handed the recipient the newest path.
+        // Without &sel, a copied link hands the recipient the newest path.
         if (traceSelectedSig) sp.set("sel", traceSelectedSig);
         else sp.delete("sel");
         // play=1 is a one-shot request from a shared link — never persist it
@@ -180,10 +178,8 @@ export function useToolUrlSync({
     }
     setToolFromId(f);
     setToolToId(t);
-    // Restore the shared alternate/run selection. The sig is only ever
-    // compared against locally computed path signatures (find-by-equality;
-    // an unknown sig falls back to the newest path), so a bounded length is
-    // the only sanitation it needs.
+    // The sig is only compared by equality against locally computed path
+    // signatures, so a bounded length is the only sanitation it needs.
     const sel = sp.get("sel");
     if (sel && sel.length <= 512) setTraceSelectedSig(sel);
     setActiveTool("traceroute");
@@ -203,13 +199,8 @@ export function useToolUrlSync({
       return;
     }
     if (!traceSelectedPath) return; // traceroutes still loading — retry on next change
-    // A restored &sel alternate usually arrives with the pair-scoped history
-    // (after the global window): starting the tour on the newest-path
-    // fallback would fly — and then PIN — the wrong route. Wait for the
-    // sel'd path; the effect retries as data/positions land. If the sig has
-    // aged out of history entirely, the tour simply doesn't autostart (the
-    // recipient still sees the pair and can press Play) — better than
-    // silently touring a different route than the one that was shared.
+    // Wait for the sel'd path before touring (the effect retries as data
+    // lands); if the sig aged out of history the tour just doesn't autostart.
     if (traceSelectedSig && traceSelectedPath.hops.join(">") !== traceSelectedSig) return;
     if (startFlyover(traceSelectedPath)) {
       // Pin the toured path so a live row arriving mid-tour can't re-point

--- a/frontend/src/pages/map/hooks/useTraceCompute.ts
+++ b/frontend/src/pages/map/hooks/useTraceCompute.ts
@@ -46,7 +46,9 @@ export interface TraceLeg {
   index: number;
   fromId: string;
   toId: string;
-  /** null when either end lacks a position (verdict "gap"). */
+  /** null when either end lacks a position. NOT interchangeable with
+   *  verdict "gap": ungraded analyses mark every leg "gap" while still
+   *  carrying real haversine distances for positioned pairs. */
   distanceKm: number | null;
   verdict: TraceLegVerdict;
   /** Worst first-Fresnel clearance along the leg as a ratio of F₁ (≥0.6 = clear enough). */
@@ -70,6 +72,10 @@ export interface TraceDirect {
 export interface TraceAnalysis {
   /** Path signature this analysis belongs to (hops.join(">")). */
   sig: string;
+  /** True only when the terrain grading pass produced this analysis; false
+   *  for ungraded dossiers (no terrain / no token / too few positions), whose
+   *  legs all carry verdict "gap" regardless of real obstruction state. */
+  graded: boolean;
   legs: TraceLeg[];
   direct: TraceDirect | null;
   /** Hops in the path with no known position. */
@@ -134,14 +140,6 @@ export function useTraceCompute(params: TraceComputeParams) {
       setIsComputingTrace(false);
       return;
     }
-    if (!terrain3D) {
-      // Panel shows the enable-terrain hint; the 2D path stays useful.
-      setTraceAnalysis(null);
-      setTraceError(null);
-      setTraceWarning(null);
-      setIsComputingTrace(false);
-      return;
-    }
     // A different path was selected — drop the previous path's artifacts now,
     // not when the new grade lands (the push effect renders whatever is set).
     setTraceAnalysis((prev) => (prev && prev.sig !== pathKey ? null : prev));
@@ -165,24 +163,46 @@ export function useTraceCompute(params: TraceComputeParams) {
       .filter((x): x is { pos: [number, number]; i: number } => x.pos != null);
     const ghostHops = hops.length - positioned.length;
 
-    if (positioned.length < 2) {
-      setTraceAnalysis({
-        sig: pathKey,
-        legs: hops.slice(0, -1).map((id, i) => ({
-          index: i, fromId: id, toId: hops[i + 1], distanceKm: null, verdict: "gap" as const,
+    // Ungraded dossier: per-leg haversine distances from positions alone.
+    // Packet-measured per-leg SNR and distances need neither terrain nor a
+    // Mapbox token, so the panel gets rows even when grading can't run —
+    // verdicts stay "gap" (ungraded) and the tube/obstruction artifacts null.
+    const ungradedAnalysis = (): TraceAnalysis => ({
+      sig: pathKey,
+      graded: false,
+      legs: hops.slice(0, -1).map((id, i) => {
+        const a = positions[i];
+        const b = positions[i + 1];
+        return {
+          index: i, fromId: id, toId: hops[i + 1],
+          distanceKm: a && b ? haversineKm(a, b) : null,
+          verdict: "gap" as const,
           minClearanceRatio: null, worstObstructionM: 0, diffractionLossDb: 0,
-        })),
-        direct: null, ghostHops, tubeData: null, obstructions: [], directCoords: null,
-      });
+        };
+      }),
+      direct: null, ghostHops, tubeData: null, obstructions: [], directCoords: null,
+    });
+
+    if (positioned.length < 2) {
+      setTraceAnalysis(ungradedAnalysis());
       setTraceError(null);
       setTraceWarning("Too few hops have known positions to grade this route.");
       setIsComputingTrace(false);
       return;
     }
 
+    if (!terrain3D) {
+      // Panel shows the enable-terrain hint; distances + measured SNR stay.
+      setTraceAnalysis(ungradedAnalysis());
+      setTraceError(null);
+      setTraceWarning(null);
+      setIsComputingTrace(false);
+      return;
+    }
+
     const token = env.MAPBOX_TOKEN;
     if (!token) {
-      setTraceAnalysis(null);
+      setTraceAnalysis(ungradedAnalysis());
       setTraceError("Terrain elevation source unavailable (Mapbox token not configured).");
       setTraceWarning(null);
       setIsComputingTrace(false);
@@ -416,7 +436,7 @@ export function useTraceCompute(params: TraceComputeParams) {
         for (const o of topObs) o.severity = Math.min(1, o.violationM / worstV);
 
         const geometric: TraceAnalysis = {
-          sig: pathKey, legs, direct, ghostHops,
+          sig: pathKey, graded: true, legs, direct, ghostHops,
           tubeData: tubePoints.length >= 2 ? { points: tubePoints } : null,
           obstructions: topObs,
           directCoords,

--- a/frontend/src/pages/map/hooks/useTraceCompute.ts
+++ b/frontend/src/pages/map/hooks/useTraceCompute.ts
@@ -46,9 +46,8 @@ export interface TraceLeg {
   index: number;
   fromId: string;
   toId: string;
-  /** null when either end lacks a position. NOT interchangeable with
-   *  verdict "gap": ungraded analyses mark every leg "gap" while still
-   *  carrying real haversine distances for positioned pairs. */
+  /** null when either end lacks a position — not implied by verdict "gap":
+   *  ungraded analyses mark every leg "gap" yet still carry real distances. */
   distanceKm: number | null;
   verdict: TraceLegVerdict;
   /** Worst first-Fresnel clearance along the leg as a ratio of F₁ (≥0.6 = clear enough). */
@@ -72,9 +71,8 @@ export interface TraceDirect {
 export interface TraceAnalysis {
   /** Path signature this analysis belongs to (hops.join(">")). */
   sig: string;
-  /** True only when the terrain grading pass produced this analysis; false
-   *  for ungraded dossiers (no terrain / no token / too few positions), whose
-   *  legs all carry verdict "gap" regardless of real obstruction state. */
+  /** False for ungraded dossiers (no terrain/token/positions): their legs all
+   *  read verdict "gap" regardless of real obstruction state. */
   graded: boolean;
   legs: TraceLeg[];
   direct: TraceDirect | null;
@@ -163,10 +161,8 @@ export function useTraceCompute(params: TraceComputeParams) {
       .filter((x): x is { pos: [number, number]; i: number } => x.pos != null);
     const ghostHops = hops.length - positioned.length;
 
-    // Ungraded dossier: per-leg haversine distances from positions alone.
-    // Packet-measured per-leg SNR and distances need neither terrain nor a
-    // Mapbox token, so the panel gets rows even when grading can't run —
-    // verdicts stay "gap" (ungraded) and the tube/obstruction artifacts null.
+    // Ungraded dossier: distances/measured SNR need neither terrain nor a
+    // token; verdicts stay "gap" and the tube/obstruction artifacts null.
     const ungradedAnalysis = (): TraceAnalysis => ({
       sig: pathKey,
       graded: false,

--- a/frontend/src/pages/map/hooks/useTraceDraw.ts
+++ b/frontend/src/pages/map/hooks/useTraceDraw.ts
@@ -75,6 +75,39 @@ export function useTraceDraw({
     const features: GeoJSON.Feature[] = [];
     clearGhostMarkers();
 
+    // Ghost marker: shortname chip over a dashed '?' ring, so you can tell
+    // WHICH node's placement is estimated, not just that one is.
+    const addGhostMarker = (hopId: string, lngLat: [number, number], offset: [number, number]) => {
+      const ghostNode = nodesRef.current[hopId] ?? nodesRef.current[`!${hopId}`];
+      const label =
+        ghostNode?.shortname?.trim() ||
+        (hopId.startsWith("?") ? hopId.slice(1, 11) : hopId.slice(0, 8));
+      const el = document.createElement("div");
+      el.setAttribute("aria-hidden", "true");
+      el.title = `${label} — position unknown, placement estimated`;
+      el.style.cssText =
+        "display:flex;flex-direction:column;align-items:center;gap:2px;pointer-events:auto;";
+      const chip = document.createElement("div");
+      chip.textContent = label;
+      // max-width + ellipsis: stacked edge-ghost chips sit on a fixed pitch,
+      // and an unclamped long label would paint over its neighbors.
+      chip.style.cssText =
+        "padding:1px 6px;border-radius:9999px;background:rgba(17,24,39,0.88);" +
+        "border:1px dashed rgba(156,163,175,0.6);color:#d1d5db;font-size:10px;" +
+        "font-weight:600;white-space:nowrap;max-width:52px;overflow:hidden;" +
+        "text-overflow:ellipsis;";
+      const ring = document.createElement("div");
+      ring.textContent = "?";
+      ring.style.cssText =
+        "width:18px;height:18px;border-radius:50%;border:2px dashed #9ca3af;" +
+        "background:rgba(17,24,39,0.85);color:#d1d5db;font-size:11px;" +
+        "line-height:14px;text-align:center;font-weight:600;";
+      el.append(chip, ring);
+      traceGhostMarkersRef.current.push(
+        new maplibregl.Marker({ element: el, offset }).setLngLat(lngLat).addTo(mb),
+      );
+    };
+
     // Selected path: one feature per drawn segment so legs spanning ghost hops
     // render dashed, with '?' markers spread across each gap run.
     if (primary) {
@@ -110,41 +143,31 @@ export function useTraceDraw({
           geometry: { type: "LineString", coordinates: [[aLng, A.pos[1]], [bLng, B.pos[1]]] },
         });
         if (isGap) {
-          // Ghost markers evenly spread along the estimated connector:
-          // shortname chip over a dashed '?' ring, so you can tell WHICH
-          // node's placement is estimated, not just that one is.
+          // Ghost markers evenly spread along the estimated connector.
           for (let g = A.i + 1; g < B.i; g++) {
             const t = (g - A.i) / (B.i - A.i);
             const lng = normalizeLng(aLng + (bLng - aLng) * t);
             const lat = A.pos[1] + (B.pos[1] - A.pos[1]) * t;
-            const hopId = primary.hops[g];
-            const ghostNode = nodesRef.current[hopId] ?? nodesRef.current[`!${hopId}`];
-            const label =
-              ghostNode?.shortname?.trim() ||
-              (hopId.startsWith("?") ? hopId.slice(1, 11) : hopId.slice(0, 8));
-            const el = document.createElement("div");
-            el.setAttribute("aria-hidden", "true");
-            el.title = `${label} — position unknown, placement estimated`;
-            el.style.cssText =
-              "display:flex;flex-direction:column;align-items:center;gap:2px;pointer-events:auto;";
-            const chip = document.createElement("div");
-            chip.textContent = label;
-            chip.style.cssText =
-              "padding:1px 6px;border-radius:9999px;background:rgba(17,24,39,0.88);" +
-              "border:1px dashed rgba(156,163,175,0.6);color:#d1d5db;font-size:10px;" +
-              "font-weight:600;white-space:nowrap;";
-            const ring = document.createElement("div");
-            ring.textContent = "?";
-            ring.style.cssText =
-              "width:18px;height:18px;border-radius:50%;border:2px dashed #9ca3af;" +
-              "background:rgba(17,24,39,0.85);color:#d1d5db;font-size:11px;" +
-              "line-height:14px;text-align:center;font-weight:600;";
-            el.append(chip, ring);
-            traceGhostMarkersRef.current.push(
-              // Offset keeps the '?' ring (not the stack's center) on the point
-              new maplibregl.Marker({ element: el, offset: [0, -10] }).setLngLat([lng, lat]).addTo(mb),
-            );
+            // Offset keeps the '?' ring (not the stack's center) on the point
+            addGhostMarker(primary.hops[g], [lng, lat], [0, -10]);
           }
+        }
+      }
+
+      // Leading/trailing ghosts: hops before the first (or after the last)
+      // positioned hop have no gap run to interpolate into, and used to be
+      // completely invisible — stack their chips beside the nearest
+      // positioned hop instead so the path's true extent is visible.
+      if (positioned.length > 0) {
+        // Far-to-near add order: markers added later paint on top, and the
+        // hop nearest the positioned anchor should win an overlap.
+        const first = positioned[0];
+        for (let g = 0; g < first.i; g++) {
+          addGhostMarker(primary.hops[g], first.pos, [-(first.i - g) * 60, -10]);
+        }
+        const last = positioned[positioned.length - 1];
+        for (let g = primary.hops.length - 1; g > last.i; g--) {
+          addGhostMarker(primary.hops[g], last.pos, [(g - last.i) * 60, -10]);
         }
       }
     }
@@ -157,54 +180,77 @@ export function useTraceDraw({
       .filter((p) => p.hops.join(">") !== primarySig)
       .slice(0, 5)
       .forEach((p, rank) => {
-        const coords: [number, number][] = [];
+        // Split the strand at unpositioned hops: silently splicing the nodes
+        // on either side of a gap into one segment draws an RF link that was
+        // never observed — the same fabrication the primary path avoids with
+        // its dashed gap segments.
+        const runs: [number, number][][] = [];
+        let cur: [number, number][] = [];
         for (const hop of p.hops) {
           const pos = posOf(hop);
-          if (!pos) continue; // hop with unknown position — skip (honest gap)
-          const prev = coords[coords.length - 1];
+          if (!pos) {
+            if (cur.length >= 2) runs.push(cur);
+            cur = [];
+            continue;
+          }
+          const prev = cur[cur.length - 1];
           // Chain-unwrap so seam-crossing legs draw the short way
-          coords.push(prev ? [unwrapLngTo(prev[0], pos[0]), pos[1]] : pos);
+          cur.push(prev ? [unwrapLngTo(prev[0], pos[0]), pos[1]] : pos);
         }
-        if (coords.length < 2) return;
-        features.push({
-          type: "Feature",
-          properties: {
-            primary: false,
-            gap: false,
-            sort: -rank,
-            opacity: Math.min(0.55, 0.55 * recencyOpacityFromAgeMs(now - tsToMs(p.timestamp))),
-            // Capped below the primary's 4 so a dominant alternate can't outweigh it
-            width: Math.min(3.4, 1.4 + 3.2 * Math.min(1, p.count / totalCount)),
-          },
-          geometry: { type: "LineString", coordinates: coords },
-        });
+        if (cur.length >= 2) runs.push(cur);
+        for (const coords of runs) {
+          features.push({
+            type: "Feature",
+            properties: {
+              primary: false,
+              gap: false,
+              sort: -rank,
+              opacity: Math.min(0.55, 0.55 * recencyOpacityFromAgeMs(now - tsToMs(p.timestamp))),
+              // Capped below the primary's 4 so a dominant alternate can't outweigh it
+              width: Math.min(3.4, 1.4 + 3.2 * Math.min(1, p.count / totalCount)),
+            },
+            geometry: { type: "LineString", coordinates: coords },
+          });
+        }
       });
     src.setData({ type: "FeatureCollection", features });
 
+    // Endpoint markers placed INDEPENDENTLY: one unpositioned endpoint used
+    // to bail out of both, hiding the endpoint we do know about.
     const fromPos = posOf(toolFromId);
     const toPos = posOf(toolToId);
-    if (!fromPos || !toPos) {
-      clearTraceMarkers();
-      return;
+    if (fromPos) {
+      if (traceFromMarkerRef.current) traceFromMarkerRef.current.setLngLat(fromPos);
+      else traceFromMarkerRef.current = new maplibregl.Marker({ color: "#06b6d4", scale: 0.75 }).setLngLat(fromPos).addTo(mb);
+    } else {
+      traceFromMarkerRef.current?.remove();
+      traceFromMarkerRef.current = null;
     }
-    if (traceFromMarkerRef.current) traceFromMarkerRef.current.setLngLat(fromPos);
-    else traceFromMarkerRef.current = new maplibregl.Marker({ color: "#06b6d4", scale: 0.75 }).setLngLat(fromPos).addTo(mb);
-    if (traceToMarkerRef.current) traceToMarkerRef.current.setLngLat(toPos);
-    else traceToMarkerRef.current = new maplibregl.Marker({ color: "#d946ef", scale: 0.75 }).setLngLat(toPos).addTo(mb);
+    if (toPos) {
+      if (traceToMarkerRef.current) traceToMarkerRef.current.setLngLat(toPos);
+      else traceToMarkerRef.current = new maplibregl.Marker({ color: "#d946ef", scale: 0.75 }).setLngLat(toPos).addTo(mb);
+    } else {
+      traceToMarkerRef.current?.remove();
+      traceToMarkerRef.current = null;
+    }
 
     // Fit once per pair, not on every data refresh — but not before the
     // pair-scoped history lands, or the fit would exclude the actual routes.
     const fitKey = `${toolFromId}-${toolToId}`;
     if (!pairTraceroutesLoading && traceFitKeyRef.current !== fitKey) {
-      traceFitKeyRef.current = fitKey;
       const bounds = new maplibregl.LngLatBounds();
-      bounds.extend(fromPos);
+      if (fromPos) bounds.extend(fromPos);
       // Unwrap so an antimeridian-crossing pair frames the short way
-      bounds.extend([unwrapLngTo(fromPos[0], toPos[0]), toPos[1]]);
+      if (toPos) bounds.extend(fromPos ? [unwrapLngTo(fromPos[0], toPos[0]), toPos[1]] : toPos);
       for (const f of features) {
         for (const c of (f.geometry as GeoJSON.LineString).coordinates) bounds.extend(c as [number, number]);
       }
-      mb.fitBounds(bounds, { padding: 120, duration: 600, maxZoom: 12 });
+      if (!bounds.isEmpty()) {
+        // Consume the one-shot key only on a real fit: an empty first pass
+        // (positions still loading on a cold deep link) must keep retrying.
+        traceFitKeyRef.current = fitKey;
+        mb.fitBounds(bounds, { padding: 120, duration: 600, maxZoom: 12 });
+      }
     }
     // styleEpoch: setStyle recreates the path-analysis source empty — redraw after style.load
   }, [activeTool, toolStep, toolFromId, toolToId, tracePaths, traceSelectedPath, pairTraceroutesLoading, styleEpoch, mbMapRef, nodesRef]);

--- a/frontend/src/pages/map/hooks/useTraceDraw.ts
+++ b/frontend/src/pages/map/hooks/useTraceDraw.ts
@@ -89,8 +89,7 @@ export function useTraceDraw({
         "display:flex;flex-direction:column;align-items:center;gap:2px;pointer-events:auto;";
       const chip = document.createElement("div");
       chip.textContent = label;
-      // max-width + ellipsis: stacked edge-ghost chips sit on a fixed pitch,
-      // and an unclamped long label would paint over its neighbors.
+      // max-width + ellipsis: stacked chips sit on a fixed pitch; a long label would overlap neighbors.
       chip.style.cssText =
         "padding:1px 6px;border-radius:9999px;background:rgba(17,24,39,0.88);" +
         "border:1px dashed rgba(156,163,175,0.6);color:#d1d5db;font-size:10px;" +
@@ -123,10 +122,8 @@ export function useTraceDraw({
         const bLng = unwrapLngTo(aLng, B.pos[0]);
         prevLng = bLng;
         const isGap = B.i - A.i > 1;
-        // Request-only path: the unobserved leg (index from pathAnalysis —
-        // last leg when displayed forward, leg 0 when the a→b pick reversed
-        // travel order) draws dashed and faded, not solid. This segment spans
-        // hop-legs A.i..B.i-1.
+        // A request-only path's unobserved leg draws dashed/faded.
+        // This segment spans hop-legs A.i..B.i-1.
         const provisionalLeg =
           primary.provisionalLegIndex != null &&
           A.i <= primary.provisionalLegIndex &&
@@ -154,13 +151,10 @@ export function useTraceDraw({
         }
       }
 
-      // Leading/trailing ghosts: hops before the first (or after the last)
-      // positioned hop have no gap run to interpolate into, and used to be
-      // completely invisible — stack their chips beside the nearest
-      // positioned hop instead so the path's true extent is visible.
+      // Hops outside the positioned span have no gap run to interpolate into;
+      // stack their chips beside the nearest positioned hop.
       if (positioned.length > 0) {
-        // Far-to-near add order: markers added later paint on top, and the
-        // hop nearest the positioned anchor should win an overlap.
+        // Far-to-near add order: the hop nearest the anchor paints on top of an overlap.
         const first = positioned[0];
         for (let g = 0; g < first.i; g++) {
           addGhostMarker(primary.hops[g], first.pos, [-(first.i - g) * 60, -10]);
@@ -180,10 +174,8 @@ export function useTraceDraw({
       .filter((p) => p.hops.join(">") !== primarySig)
       .slice(0, 5)
       .forEach((p, rank) => {
-        // Split the strand at unpositioned hops: silently splicing the nodes
-        // on either side of a gap into one segment draws an RF link that was
-        // never observed — the same fabrication the primary path avoids with
-        // its dashed gap segments.
+        // Split the strand at unpositioned hops — splicing across a gap would
+        // draw an RF link that was never observed.
         const runs: [number, number][][] = [];
         let cur: [number, number][] = [];
         for (const hop of p.hops) {
@@ -215,8 +207,7 @@ export function useTraceDraw({
       });
     src.setData({ type: "FeatureCollection", features });
 
-    // Endpoint markers placed INDEPENDENTLY: one unpositioned endpoint used
-    // to bail out of both, hiding the endpoint we do know about.
+    // Endpoint markers are placed independently: one unknown endpoint must not hide the other.
     const fromPos = posOf(toolFromId);
     const toPos = posOf(toolToId);
     if (fromPos) {

--- a/frontend/src/pages/map/hooks/useTraceDraw.ts
+++ b/frontend/src/pages/map/hooks/useTraceDraw.ts
@@ -90,9 +90,23 @@ export function useTraceDraw({
         const bLng = unwrapLngTo(aLng, B.pos[0]);
         prevLng = bLng;
         const isGap = B.i - A.i > 1;
+        // Request-only path: the unobserved leg (index from pathAnalysis —
+        // last leg when displayed forward, leg 0 when the a→b pick reversed
+        // travel order) draws dashed and faded, not solid. This segment spans
+        // hop-legs A.i..B.i-1.
+        const provisionalLeg =
+          primary.provisionalLegIndex != null &&
+          A.i <= primary.provisionalLegIndex &&
+          primary.provisionalLegIndex < B.i;
         features.push({
           type: "Feature",
-          properties: { primary: true, gap: isGap, sort: 1000, opacity: 0.95, width: 4 },
+          properties: {
+            primary: true,
+            gap: isGap || provisionalLeg,
+            sort: 1000,
+            opacity: provisionalLeg ? 0.5 : 0.95,
+            width: provisionalLeg ? 3 : 4,
+          },
           geometry: { type: "LineString", coordinates: [[aLng, A.pos[1]], [bLng, B.pos[1]]] },
         });
         if (isGap) {

--- a/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
+++ b/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
@@ -17,7 +17,11 @@ import { store } from "../../../store";
 import type { ITraceroutesResponse } from "../../../types";
 import { normalizeNodeId8 } from "../../../utils/normalizeNodeId8";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
-import { orientTraceroute } from "../../../utils/traceroute";
+import {
+  hasFullTraceroutePayload,
+  orientTraceroute,
+  tracerouteRichness,
+} from "../../../utils/traceroute";
 import type { ActivityLayer } from "../layers/activityLayer";
 import type { ClusterDonutLayer } from "../layers/clusterDonutLayer";
 import { samePoint } from "../lib/geo";
@@ -181,11 +185,26 @@ export function useTraceLiveEvents({
       const row = t as unknown as ITraceroutesResponse;
       const key = `${row.id}:${row.from}`; // Map.tsx's merge key
       const upsert = (max: number) => (draft: ITraceroutesResponse[]) => {
-        // Key collision = another gateway's copy of a row we already hold.
-        // Keep the FIRST copy, matching the DB's ON CONFLICT DO NOTHING — a
-        // later refetch would return the first-written copy, and replacing it
-        // here would let per-gateway rssi/snr diverge from REST.
-        if (draft.some((tr) => `${tr.id}:${tr.from}` === key)) return;
+        // Key collision = another copy of a row we already hold. Mirror the
+        // DB's richer-wins upsert: a held SLIM row (refetch snapshot; its
+        // payload strips route_back/snr_back, so richness is incomparable)
+        // is replaced by any full incoming row — a full row carries
+        // everything slim does plus the payload arrays, and a rare poorer
+        // outage-copy self-heals on the next refetch. Between two FULL rows
+        // the richness compare is exact: replace only strictly richer
+        // ('upgraded' broadcasts), keep the held row otherwise (no churn on
+        // identical fan-out copies, no regression on reordered delivery).
+        const held = draft.findIndex((tr) => `${tr.id}:${tr.from}` === key);
+        if (held !== -1) {
+          const heldRow = draft[held];
+          if (
+            !hasFullTraceroutePayload(heldRow) ||
+            tracerouteRichness(row) > tracerouteRichness(heldRow)
+          ) {
+            draft[held] = row;
+          }
+          return;
+        }
         // Cache is newest-first (ORDER BY created_at DESC); a live row is
         // almost always the newest, so this loop exits at index 0.
         let i = 0;

--- a/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
+++ b/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
@@ -17,6 +17,7 @@ import { store } from "../../../store";
 import type { ITraceroutesResponse } from "../../../types";
 import { normalizeNodeId8 } from "../../../utils/normalizeNodeId8";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
+import { orientTraceroute } from "../../../utils/traceroute";
 import type { ActivityLayer } from "../layers/activityLayer";
 import type { ClusterDonutLayer } from "../layers/clusterDonutLayer";
 import { samePoint } from "../lib/geo";
@@ -92,9 +93,10 @@ export function useTraceLiveEvents({
   // behind a 300 s full-row backstop timer).
   const traceRefetchDueAtRef = useRef(0);
 
-  // Resolve a traceroute's hops to positions and draw one sequential comet along
-  // [from, ...route, to], snapping each hop to its cluster and skipping hops with
-  // no known position.
+  // Resolve a traceroute's hops to positions and draw one sequential comet in
+  // TRAVEL order (orientTraceroute swaps reply-row headers back; skinny events
+  // without payload fall back to header order), snapping each hop to its
+  // cluster and skipping hops with no known position.
   const animateTraceroute = useCallback((t: TraceEv) => {
     const layer = activityLayerRef.current;
     if (!layer) return;
@@ -118,7 +120,8 @@ export function useTraceLiveEvents({
       return best ?? pos;
     };
     const pts: [number, number][] = [];
-    for (const raw of [t.from, ...(t.route_ids ?? []), t.to]) {
+    const walk = orientTraceroute(t)?.orderedPath ?? [t.from, ...(t.route_ids ?? []), t.to];
+    for (const raw of walk) {
       const id = normalizeNodeId8(raw);
       const pos = id ? liveNodes[id]?.map_position : undefined;
       if (!pos) continue; // hop with unknown position — skip (honest gap)

--- a/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
+++ b/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
@@ -186,14 +186,15 @@ export function useTraceLiveEvents({
       const key = `${row.id}:${row.from}`; // Map.tsx's merge key
       const upsert = (max: number) => (draft: ITraceroutesResponse[]) => {
         // Key collision = another copy of a row we already hold. Mirror the
-        // DB's richer-wins upsert: a held SLIM row (refetch snapshot; its
-        // payload strips route_back/snr_back, so richness is incomparable)
-        // is replaced by any full incoming row — a full row carries
-        // everything slim does plus the payload arrays, and a rare poorer
-        // outage-copy self-heals on the next refetch. Between two FULL rows
-        // the richness compare is exact: replace only strictly richer
-        // ('upgraded' broadcasts), keep the held row otherwise (no churn on
-        // identical fan-out copies, no regression on reordered delivery).
+        // DB's richer-wins upsert: a held SLIM row (refetch snapshot — lacks
+        // payload.route; older backends also stripped the back arrays, so
+        // richness against it isn't trustworthy) is replaced by any full
+        // incoming row — a full row carries everything slim does plus the
+        // payload arrays, and a rare poorer outage-copy self-heals on the
+        // next refetch. Between two FULL rows the richness compare is exact:
+        // replace only strictly richer ('upgraded' broadcasts), keep the held
+        // row otherwise (no churn on identical fan-out copies, no regression
+        // on reordered delivery).
         const held = draft.findIndex((tr) => `${tr.id}:${tr.from}` === key);
         if (held !== -1) {
           const heldRow = draft[held];

--- a/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
+++ b/frontend/src/pages/map/hooks/useTraceLiveEvents.ts
@@ -97,10 +97,8 @@ export function useTraceLiveEvents({
   // behind a 300 s full-row backstop timer).
   const traceRefetchDueAtRef = useRef(0);
 
-  // Resolve a traceroute's hops to positions and draw one sequential comet in
-  // TRAVEL order (orientTraceroute swaps reply-row headers back; skinny events
-  // without payload fall back to header order), snapping each hop to its
-  // cluster and skipping hops with no known position.
+  // Draw one sequential comet along the hops in travel order (skinny events
+  // without payload fall back to header order), snapping each hop to its cluster.
   const animateTraceroute = useCallback((t: TraceEv) => {
     const layer = activityLayerRef.current;
     if (!layer) return;
@@ -185,16 +183,8 @@ export function useTraceLiveEvents({
       const row = t as unknown as ITraceroutesResponse;
       const key = `${row.id}:${row.from}`; // Map.tsx's merge key
       const upsert = (max: number) => (draft: ITraceroutesResponse[]) => {
-        // Key collision = another copy of a row we already hold. Mirror the
-        // DB's richer-wins upsert: a held SLIM row (refetch snapshot — lacks
-        // payload.route; older backends also stripped the back arrays, so
-        // richness against it isn't trustworthy) is replaced by any full
-        // incoming row — a full row carries everything slim does plus the
-        // payload arrays, and a rare poorer outage-copy self-heals on the
-        // next refetch. Between two FULL rows the richness compare is exact:
-        // replace only strictly richer ('upgraded' broadcasts), keep the held
-        // row otherwise (no churn on identical fan-out copies, no regression
-        // on reordered delivery).
+        // Mirror the DB's richer-wins upsert: any full row replaces a held
+        // slim row; between two full rows replace only strictly richer.
         const held = draft.findIndex((tr) => `${tr.id}:${tr.from}` === key);
         if (held !== -1) {
           const heldRow = draft[held];

--- a/frontend/src/pages/map/lib/helpers.ts
+++ b/frontend/src/pages/map/lib/helpers.ts
@@ -1,6 +1,7 @@
 import type { Map as MlMap } from "maplibre-gl";
 
 import type { ITraceroutesResponse } from "../../../types";
+import { isResolvedHop, orientTraceroute } from "../../../utils/traceroute";
 import { AGGRESSION_STOPS, DEFAULT_AGGRESSION_IDX } from "../rf/coverageAnalysis";
 import { normalizeLng } from "./geo";
 import { normNodeId } from "./linkFeatures";
@@ -163,19 +164,23 @@ export function computeMaxRange(
 
   for (const id of heardBy) connectedIds.add(id);
 
-  // Traceroute peers (adjacent hops)
+  // Traceroute peers (adjacent hops, travel-ordered — a raw header walk
+  // attributes both endpoint legs to the wrong nodes on reply rows)
   const normId = normNodeId(nodeId);
   for (const tr of traceroutes) {
-    const from = normNodeId(tr?.from);
-    const to = normNodeId(tr?.to);
-    const route: string[] = (tr?.route_ids ?? tr?.route ?? [])
-      .map(normNodeId)
-      .filter(Boolean);
-    const path = [from, ...route, to].filter(Boolean);
+    const o = orientTraceroute(tr);
+    if (!o) continue;
+    const path = o.orderedPath;
     const idx = path.indexOf(normId);
     if (idx === -1) continue;
-    if (idx > 0 && path[idx - 1]) connectedIds.add(path[idx - 1]);
-    if (idx < path.length - 1 && path[idx + 1]) connectedIds.add(path[idx + 1]);
+    const prev = idx > 0 ? path[idx - 1] : null;
+    // The final (…→target) leg of a mid-flight request was never observed.
+    const nextIsProvisional = o.provisional && idx + 1 === path.length - 1;
+    const next = idx < path.length - 1 && !nextIsProvisional ? path[idx + 1] : null;
+    if (prev && isResolvedHop(prev) && !(o.provisional && idx === path.length - 1)) {
+      connectedIds.add(prev);
+    }
+    if (next && isResolvedHop(next)) connectedIds.add(next);
   }
 
   let maxDist = 0;

--- a/frontend/src/pages/map/lib/linkFeatures.test.ts
+++ b/frontend/src/pages/map/lib/linkFeatures.test.ts
@@ -69,7 +69,7 @@ describe("buildTracerouteLinkFeatureCollection", () => {
     });
     const keys = edgeKeys([reply]);
     expect(keys).toEqual(["0000000a|000000b1", "0000000d|000000b2", "000000b1|000000b2"]);
-    // The pre-fix phantom edges D–R1 and R2–O must not exist
+    // Phantom endpoint edges D–R1 and R2–O must not exist
     expect(keys).not.toContain("0000000d|000000b1");
     expect(keys).not.toContain("0000000a|000000b2");
   });
@@ -81,8 +81,7 @@ describe("buildTracerouteLinkFeatureCollection", () => {
       route_ids: ["000000b1", "Some Longname"],
       payload: { route: [], snr_towards: [4, 8, 12] },
     });
-    // Real legs: O–R1 (drawable), R1–?, ?–D (both skipped). No O–D shortcut,
-    // and crucially no R1–D splice across the unknown hop.
+    // Only O–R1 is drawable; no O–D shortcut, no R1–D splice across the unknown hop.
     expect(edgeKeys([reply])).toEqual(["0000000a|000000b1"]);
   });
 

--- a/frontend/src/pages/map/lib/linkFeatures.test.ts
+++ b/frontend/src/pages/map/lib/linkFeatures.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { ITraceroutesResponse } from "../../../types";
+import { buildTracerouteLinkFeatureCollection, normalizedTraceroutePath } from "./linkFeatures";
+
+function row(overrides: Partial<ITraceroutesResponse>): ITraceroutesResponse {
+  return {
+    channel: 0,
+    from: "0000000a",
+    to: "0000000d",
+    id: 1,
+    payload: { route: [] },
+    route: [],
+    route_ids: [],
+    rssi: -80,
+    snr: -5,
+    timestamp: 1000,
+    type: "traceroute",
+    ...overrides,
+  } as ITraceroutesResponse;
+}
+
+const liveNodes: Record<string, any> = Object.fromEntries(
+  ["0000000a", "0000000d", "000000b1", "000000b2"].map((id, i) => [
+    id,
+    { id, map_position: [i, i], last_seen: undefined },
+  ]),
+);
+
+function edgeKeys(traceroutes: ITraceroutesResponse[]): string[] {
+  const fc = buildTracerouteLinkFeatureCollection(traceroutes, liveNodes);
+  return fc.features.map((f) => `${f.properties?.aId}|${f.properties?.bId}`).sort();
+}
+
+describe("normalizedTraceroutePath", () => {
+  it("travel-orders reply rows (header swap, not reversal)", () => {
+    const reply = row({
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+    });
+    expect(normalizedTraceroutePath(reply)).toEqual([
+      "0000000a",
+      "000000b1",
+      "000000b2",
+      "0000000d",
+    ]);
+  });
+
+  it("keeps unresolvable hops as placeholders", () => {
+    const reply = row({
+      route_ids: ["000000b1", "Some Longname"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+    });
+    const path = normalizedTraceroutePath(row({ ...reply }));
+    expect(path).toHaveLength(4);
+  });
+});
+
+describe("buildTracerouteLinkFeatureCollection", () => {
+  it("draws real reply-row legs, never the phantom endpoint edges", () => {
+    // Reply for trace O→R1→R2→D: header from=D, to=O, request-ordered route
+    const reply = row({
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+    });
+    const keys = edgeKeys([reply]);
+    expect(keys).toEqual(["0000000a|000000b1", "0000000d|000000b2", "000000b1|000000b2"]);
+    // The pre-fix phantom edges D–R1 and R2–O must not exist
+    expect(keys).not.toContain("0000000d|000000b1");
+    expect(keys).not.toContain("0000000a|000000b2");
+  });
+
+  it("skips legs touching an unpositionable placeholder instead of splicing across it", () => {
+    const reply = row({
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "Some Longname"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+    });
+    // Real legs: O–R1 (drawable), R1–?, ?–D (both skipped). No O–D shortcut,
+    // and crucially no R1–D splice across the unknown hop.
+    expect(edgeKeys([reply])).toEqual(["0000000a|000000b1"]);
+  });
+
+  it("excludes the speculative final leg of a mid-flight request", () => {
+    const request = row({
+      route_ids: ["000000b1"],
+      payload: { route: [], snr_towards: [4] },
+    });
+    expect(edgeKeys([request])).toEqual(["0000000a|000000b1"]);
+  });
+
+  it("draws the direct leg of a zero-hop reply but not of a zero-hop request", () => {
+    const zeroHopReply = row({
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: [],
+      payload: { route: [], snr_towards: [5] },
+    });
+    const zeroHopRequest = row({ route_ids: [], payload: { route: [] } });
+    expect(edgeKeys([zeroHopReply])).toEqual(["0000000a|0000000d"]);
+    expect(edgeKeys([zeroHopRequest])).toEqual([]);
+  });
+});

--- a/frontend/src/pages/map/lib/linkFeatures.ts
+++ b/frontend/src/pages/map/lib/linkFeatures.ts
@@ -7,6 +7,7 @@ import type {
 
 import type { ITraceroutesResponse } from "../../../types";
 import { normNodeId } from "../../../utils/normalizeNodeId8";
+import { isResolvedHop, orientTraceroute } from "../../../utils/traceroute";
 import { unwrapLngTo } from "./geo";
 import type { IMapNeighbor, IMapNode, NodeLike } from "./types";
 
@@ -39,23 +40,14 @@ function quantizeLastHeardMs(ms: number | null): number | null {
   return ms == null ? null : Math.floor(ms / 60_000) * 60_000;
 }
 
-// Traceroute rows are immutable once fetched; normalizing hop ids costs a regex
-// per hop, so cache the normalized path per row across the many passes that
-// need it (link building, candidate rings, per-node filters).
-const normalizedPathCache = new WeakMap<ITraceroutesResponse, string[]>();
-
-/** Full normalized hop path [from, ...route, to] for a traceroute row, cached. */
+/** Full normalized TRAVEL-ordered hop path for a traceroute row (reply rows
+ *  have their header endpoints swapped back into initiator → … → target
+ *  order). Unresolvable hops are kept as `?<raw>` placeholders — splicing
+ *  them out would fabricate a shortcut edge across the gap — so edge builders
+ *  must skip legs touching them, not this function. Cached per row inside
+ *  orientTraceroute. */
 export function normalizedTraceroutePath(tr: ITraceroutesResponse): string[] {
-  const cached = normalizedPathCache.get(tr);
-  if (cached) return cached;
-  const from = normNodeId(tr?.from);
-  const to = normNodeId(tr?.to);
-  const route: string[] = ((tr?.route_ids ?? tr?.route ?? tr?.payload?.route ?? []) as (string | number)[])
-    .map(normNodeId)
-    .filter(Boolean);
-  const path = [from, ...route, to].filter(Boolean);
-  normalizedPathCache.set(tr, path);
-  return path;
+  return orientTraceroute(tr)?.orderedPath ?? [];
 }
 
 /** Most recent edge activity (ms). Prefers per-direction `lastRxTime`; falls
@@ -235,11 +227,20 @@ export function buildTracerouteLinkFeatureCollection(
   const seen = new Set<string>();
 
   for (const tr of traceroutes) {
-    const path = normalizedTraceroutePath(tr);
+    const o = orientTraceroute(tr);
+    if (!o) continue;
+    const path = o.orderedPath;
+    const lastLegIdx = path.length - 2;
 
     for (let i = 0; i < path.length - 1; i++) {
+      // A mid-flight request never observed its final (…→target) leg — drawing
+      // it would fabricate an RF link the mesh may not have.
+      if (o.provisional && i === lastLegIdx) continue;
       const a = path[i], b = path[i + 1];
       if (!a || !b || a === b) continue;
+      // Placeholder/sentinel hops can't be positioned; skipping the LEG (not
+      // the hop) keeps us from splicing a phantom edge across the gap.
+      if (!isResolvedHop(a) || !isResolvedHop(b)) continue;
 
       const ka = a < b ? a : b;
       const kb = a < b ? b : a;

--- a/frontend/src/pages/map/lib/linkFeatures.ts
+++ b/frontend/src/pages/map/lib/linkFeatures.ts
@@ -40,12 +40,9 @@ function quantizeLastHeardMs(ms: number | null): number | null {
   return ms == null ? null : Math.floor(ms / 60_000) * 60_000;
 }
 
-/** Full normalized TRAVEL-ordered hop path for a traceroute row (reply rows
- *  have their header endpoints swapped back into initiator → … → target
- *  order). Unresolvable hops are kept as `?<raw>` placeholders — splicing
- *  them out would fabricate a shortcut edge across the gap — so edge builders
- *  must skip legs touching them, not this function. Cached per row inside
- *  orientTraceroute. */
+/** Full normalized travel-ordered hop path for a traceroute row (cached in
+ *  orientTraceroute). Unresolvable hops stay as `?<raw>` placeholders — edge
+ *  builders must skip legs touching them, not splice across the gap. */
 export function normalizedTraceroutePath(tr: ITraceroutesResponse): string[] {
   return orientTraceroute(tr)?.orderedPath ?? [];
 }
@@ -233,8 +230,7 @@ export function buildTracerouteLinkFeatureCollection(
     const lastLegIdx = path.length - 2;
 
     for (let i = 0; i < path.length - 1; i++) {
-      // A mid-flight request never observed its final (…→target) leg — drawing
-      // it would fabricate an RF link the mesh may not have.
+      // A mid-flight request never observed its final (…→target) leg — don't draw it.
       if (o.provisional && i === lastLegIdx) continue;
       const a = path[i], b = path[i + 1];
       if (!a || !b || a === b) continue;

--- a/frontend/src/pages/map/lib/pathAnalysis.test.ts
+++ b/frontend/src/pages/map/lib/pathAnalysis.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ITraceroutesResponse } from "../../../types";
-import { computeTraceEdgeStats, decodeSnr, findPathsBetween } from "./pathAnalysis";
+import { computeTraceEdgeStats, decodeSnr, findPathsBetween, findRunsBetween } from "./pathAnalysis";
 
 /** Minimal traceroute row; O=0000000a requester, D=0000000d destination. */
 function row(overrides: Partial<ITraceroutesResponse>): ITraceroutesResponse {
@@ -81,6 +81,28 @@ describe("findPathsBetween", () => {
     expect(paths[0].legSnrDb).toEqual([1, 2, 3]);
   });
 
+  it("suppresses the truncated request when its reply is present", () => {
+    const request = row({
+      id: 1,
+      route_ids: ["000000b1"],
+      payload: { route: [], snr_towards: [4] },
+      timestamp: 100,
+    });
+    const reply = row({
+      id: 2,
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+      timestamp: 110,
+    });
+    const paths = findPathsBetween("0000000a", "0000000d", [request, reply]);
+    // One path, the full one — no phantom shorter sig from the mid-flight capture
+    expect(paths).toHaveLength(1);
+    expect(paths[0].hops).toHaveLength(4);
+    expect(paths[0].provisional).toBe(false);
+  });
+
   it("ranks newest first with hop count as tiebreak, counting repeats", () => {
     const stale1hop = row({ id: 1, route_ids: [], timestamp: 100 });
     const fresh2hopA = row({ id: 2, route_ids: ["000000b1"], timestamp: 900 });
@@ -95,11 +117,33 @@ describe("findPathsBetween", () => {
 
 describe("computeTraceEdgeStats", () => {
   it("counts undirected edge traversals once per run", () => {
+    // Reply rows (full snr_towards) so every leg is observed, not speculative.
     const runs = [
-      row({ id: 1, route_ids: ["000000b1"], timestamp: 100 }),
-      // Reverse direction — same undirected edges
-      row({ id: 2, from: "0000000d", to: "0000000a", route_ids: ["000000b1"], timestamp: 200 }),
-      row({ id: 3, route_ids: [], timestamp: 300 }),
+      // O-initiated trace via R1, captured as the reply (header swapped)
+      row({
+        id: 1,
+        from: "0000000d",
+        to: "0000000a",
+        route_ids: ["000000b1"],
+        payload: { route: [], snr_towards: [4, 8] },
+        timestamp: 100,
+      }),
+      // D-initiated trace via R1 — same undirected edges
+      row({
+        id: 2,
+        route_ids: ["000000b1"],
+        payload: { route: [], snr_towards: [4, 8] },
+        timestamp: 200,
+      }),
+      // Zero-hop reply: the direct O–D link was genuinely observed
+      row({
+        id: 3,
+        from: "0000000d",
+        to: "0000000a",
+        route_ids: [],
+        payload: { route: [], snr_towards: [5] },
+        timestamp: 300,
+      }),
     ];
     const stats = computeTraceEdgeStats(runs);
     const byKey = new Map(stats.map((e) => [`${e.aId}|${e.bId}`, e]));
@@ -107,6 +151,49 @@ describe("computeTraceEdgeStats", () => {
     expect(byKey.get("0000000d|000000b1")?.count).toBe(2);
     expect(byKey.get("0000000a|0000000d")?.count).toBe(1);
     expect(byKey.get("0000000a|000000b1")?.lastTimestamp).toBe(200);
+  });
+
+  it("excludes the speculative final leg of mid-flight request rows", () => {
+    // Request heard near the initiator: only O→R1 was actually observed;
+    // R1→D is implied by the header. Zero-hop requests contribute nothing.
+    const stats = computeTraceEdgeStats([
+      row({ id: 1, route_ids: ["000000b1"], payload: { route: [], snr_towards: [4] }, timestamp: 100 }),
+      row({ id: 2, route_ids: [], payload: { route: [] }, timestamp: 200 }),
+    ]);
+    const keys = stats.map((e) => `${e.aId}|${e.bId}`);
+    expect(keys).toEqual(["0000000a|000000b1"]);
+  });
+
+  it("collapses a request+reply exchange to a single run", () => {
+    const request = row({
+      id: 1,
+      route_ids: ["000000b1"],
+      payload: { route: [], snr_towards: [4] },
+      timestamp: 100,
+    });
+    const reply = row({
+      id: 2,
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+      timestamp: 110,
+    });
+    const stats = computeTraceEdgeStats([request, reply]);
+    const byKey = new Map(stats.map((e) => [`${e.aId}|${e.bId}`, e]));
+    expect(byKey.get("0000000a|000000b1")?.count).toBe(1);
+    expect(byKey.get("000000b1|000000b2")?.count).toBe(1);
+    expect(byKey.get("0000000d|000000b2")?.count).toBe(1);
+  });
+
+  it("emits no edges touching the 0xffffffff unknown-hop sentinel", () => {
+    const reply = row({
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["ffffffff"],
+      payload: { route: [], snr_towards: [4, 8] },
+    });
+    expect(computeTraceEdgeStats([reply])).toEqual([]);
   });
 
   it("orients reply rows before counting edges (header swap ≠ reversal)", () => {
@@ -128,5 +215,60 @@ describe("computeTraceEdgeStats", () => {
       row({ id: 9, route_ids: ["Some Longname"] as string[], timestamp: 50 }),
     ]);
     expect(stats).toEqual([]);
+  });
+});
+
+describe("findRunsBetween", () => {
+  it("collapses request+reply of one exchange and flags request-only runs", () => {
+    const request = row({
+      id: 1,
+      route_ids: ["000000b1"],
+      payload: { route: [], snr_towards: [4] },
+      timestamp: 100,
+    });
+    const reply = row({
+      id: 2,
+      from: "0000000d",
+      to: "0000000a",
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [], snr_towards: [4, 8, 12] },
+      timestamp: 110,
+    });
+    const runs = findRunsBetween("0000000a", "0000000d", [request, reply]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].provisional).toBe(false);
+    expect(runs[0].hops).toEqual(["0000000a", "000000b1", "000000b2", "0000000d"]);
+
+    const requestOnly = findRunsBetween("0000000a", "0000000d", [request]);
+    expect(requestOnly).toHaveLength(1);
+    expect(requestOnly[0].provisional).toBe(true);
+  });
+
+  it("keeps repeated same-role runs (two requests are two attempts)", () => {
+    const req1 = row({ id: 1, route_ids: ["000000b1"], timestamp: 100 });
+    const req2 = row({ id: 2, route_ids: ["000000b1"], timestamp: 150 });
+    expect(findRunsBetween("0000000a", "0000000d", [req1, req2])).toHaveLength(2);
+  });
+
+  it("places the unobserved leg by display orientation, not always last", () => {
+    // Request A→D via R1: observed leg A–R1, speculative leg R1–D
+    const request = row({
+      route_ids: ["000000b1"],
+      payload: { route: [], snr_towards: [4] },
+    });
+    // Displayed forward (a=A): speculative leg is the LAST leg
+    const fwd = findRunsBetween("0000000a", "0000000d", [request])[0];
+    expect(fwd.hops).toEqual(["0000000a", "000000b1", "0000000d"]);
+    expect(fwd.provisionalLegIndex).toBe(1);
+    // Displayed reversed (a=D): the same speculative leg is now leg 0 —
+    // dashing the last leg here would invert the honesty cue
+    const rev = findRunsBetween("0000000d", "0000000a", [request])[0];
+    expect(rev.hops).toEqual(["0000000d", "000000b1", "0000000a"]);
+    expect(rev.provisionalLegIndex).toBe(0);
+    // Sub-path that stops short of the target contains no speculative leg
+    const sub = findRunsBetween("0000000a", "000000b1", [request])[0];
+    expect(sub.hops).toEqual(["0000000a", "000000b1"]);
+    expect(sub.provisionalLegIndex).toBeNull();
+    expect(sub.provisional).toBe(true); // exchange status still request-only
   });
 });

--- a/frontend/src/pages/map/lib/pathAnalysis.test.ts
+++ b/frontend/src/pages/map/lib/pathAnalysis.test.ts
@@ -260,8 +260,7 @@ describe("findRunsBetween", () => {
     const fwd = findRunsBetween("0000000a", "0000000d", [request])[0];
     expect(fwd.hops).toEqual(["0000000a", "000000b1", "0000000d"]);
     expect(fwd.provisionalLegIndex).toBe(1);
-    // Displayed reversed (a=D): the same speculative leg is now leg 0 —
-    // dashing the last leg here would invert the honesty cue
+    // Displayed reversed (a=D): the same speculative leg is now leg 0
     const rev = findRunsBetween("0000000d", "0000000a", [request])[0];
     expect(rev.hops).toEqual(["0000000d", "000000b1", "0000000a"]);
     expect(rev.provisionalLegIndex).toBe(0);

--- a/frontend/src/pages/map/lib/pathAnalysis.ts
+++ b/frontend/src/pages/map/lib/pathAnalysis.ts
@@ -1,5 +1,14 @@
 import type { ITraceroutesResponse } from "../../../types";
+import {
+  dedupeExchanges,
+  isResolvedHop,
+  orientTraceroute,
+} from "../../../utils/traceroute";
 import { normNodeId } from "./linkFeatures";
+
+// Orientation/decoding primitives moved to utils/traceroute (shared with the
+// Traceroutes page and graph); re-exported so existing map imports keep working.
+export { decodeSnr, tsToMs } from "../../../utils/traceroute";
 
 export interface AnalyzedPath {
   /** Normalized IDs: [from, ...intermediates, to]. Unresolvable hops are kept
@@ -17,6 +26,14 @@ export interface AnalyzedPath {
   legSnrDb?: (number | null)[];
   /** True when the SNR was measured opposite to the displayed a→b orientation. */
   legSnrReversed?: boolean;
+  /** True when ONLY mid-flight request packets observed this sequence: the
+   *  row's final (…→target) leg is implied by the header, not observed. */
+  provisional: boolean;
+  /** DISPLAYED index of the unobserved leg (legSnrDb/hop coordinates: leg i is
+   *  hops[i]→hops[i+1]), or null when no displayed leg is speculative. NOT
+   *  always the last leg — a reversed a→b extraction puts it at index 0, and a
+   *  sub-path that stops short of the row's target contains it not at all. */
+  provisionalLegIndex: number | null;
 }
 
 /** One observed traceroute run between the pair, oriented a → b. */
@@ -25,14 +42,10 @@ export interface TraceRun {
   hops: string[];
   hopCount: number;
   timestamp: number;
-}
-
-const SNR_UNKNOWN_SENTINEL = -128;
-
-/** Decode a firmware ×4-scaled SNR value; -128 sentinel → null (unknown). */
-export function decodeSnr(raw: number | null | undefined): number | null {
-  if (raw == null || !Number.isFinite(raw) || raw === SNR_UNKNOWN_SENTINEL) return null;
-  return raw / 4;
+  /** Request-only observation — awaiting reply (exchange status). */
+  provisional: boolean;
+  /** See AnalyzedPath.provisionalLegIndex. */
+  provisionalLegIndex: number | null;
 }
 
 interface ExtractedPath {
@@ -43,40 +56,19 @@ interface ExtractedPath {
   rssi?: number;
   legSnrDb?: (number | null)[];
   forward: boolean;
-}
-
-/** Travel-ordered full path for one row. Reply rows (the only ones carrying
- *  the full per-leg SNR: the destination appends its own reading, so
- *  snr_towards = route + 1) keep the REQUEST's route order but swap the header
- *  endpoints — the towards path is to → route → from, matching the official
- *  client. EVERY consumer of a row's hop sequence must route through here: a
- *  header swap is NOT a path reversal, so an ad-hoc [from,...route,to] walk
- *  attributes endpoint-adjacent legs to the wrong nodes on reply rows. */
-function orientRow(
-  tr: ITraceroutesResponse,
-  tFrom: string,
-  tTo: string,
-  route: string[],
-): { fullPath: string[]; isReply: boolean } {
-  const snrTow = tr?.payload?.snr_towards;
-  const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
-  return { fullPath: isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo], isReply };
+  provisional: boolean;
+  provisionalLegIndex: number | null;
 }
 
 /** Extract the a→b sub-path of one traceroute row, or null if it doesn't
  *  contain both nodes. Shared by the dedup (paths) and chronological (runs)
- *  views so orientation semantics can never drift apart. */
+ *  views so orientation semantics can never drift apart. Travel ordering,
+ *  reply detection, and per-leg SNR alignment all come from orientTraceroute
+ *  — the single mandatory entry point for walking a row's hops. */
 function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): ExtractedPath | null {
-  const tFrom = normNodeId(tr?.from);
-  const tTo = normNodeId(tr?.to);
-  if (!tFrom || !tTo) return null;
-  // Keep unresolvable hops as placeholders instead of dropping them — a drop
-  // would shrink the hop count and shift per-leg SNR alignment.
-  const route: string[] = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
-    .map((r) => normNodeId(r) || `?${String(r)}`);
-
-  const snrTow = tr?.payload?.snr_towards;
-  const { fullPath, isReply } = orientRow(tr, tFrom, tTo, route);
+  const o = orientTraceroute(tr);
+  if (!o) return null;
+  const fullPath = o.orderedPath;
 
   const idxA = fullPath.indexOf(a);
   const idxB = fullPath.indexOf(b);
@@ -88,12 +80,21 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
   // Orient a → b
   const hops = forward ? sub : sub.slice().reverse();
 
-  // snr_towards has one entry per leg of the request-oriented full path;
-  // slice the legs covering [lo, hi] and flip them when we flipped the hops.
+  // legSnrDb[i] covers the fullPath[i]→fullPath[i+1] leg; slice the legs
+  // covering [lo, hi] and flip them when we flipped the hops.
   let legSnrDb: (number | null)[] | undefined;
-  if (isReply && Array.isArray(snrTow)) {
-    const legs = snrTow.slice(lo, hi).map(decodeSnr);
+  if (o.legSnrDb) {
+    const legs = o.legSnrDb.slice(lo, hi);
     legSnrDb = forward ? legs : legs.slice().reverse();
+  }
+
+  // The row's unobserved leg is the LAST leg of fullPath. It appears in this
+  // sub-path only when the slice reaches the row's target (hi === last index);
+  // in displayed coordinates it is then the last leg when forward, leg 0 when
+  // reversed.
+  let provisionalLegIndex: number | null = null;
+  if (o.provisional && hi === fullPath.length - 1) {
+    provisionalLegIndex = forward ? hops.length - 2 : 0;
   }
 
   return {
@@ -104,12 +105,15 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
     rssi: tr.rssi,
     legSnrDb,
     forward,
+    provisional: o.provisional,
+    provisionalLegIndex,
   };
 }
 
 /** Unique traceroute paths between two nodes (either direction), newest first.
  *  Freshness outranks hop count: a stale one-hop fluke must not beat the route
- *  the mesh is actually using now. */
+ *  the mesh is actually using now. Request+reply rows of one exchange are
+ *  collapsed to the reply before analysis. */
 export function findPathsBetween(
   fromId: string,
   toId: string,
@@ -121,13 +125,16 @@ export function findPathsBetween(
 
   const bySig = new Map<string, AnalyzedPath>();
 
-  for (const tr of traceroutes) {
+  for (const tr of dedupeExchanges(traceroutes)) {
     const ex = extractPathFromRow(a, b, tr);
     if (!ex) continue;
 
     const existing = bySig.get(ex.sig);
     if (existing) {
       existing.count += 1;
+      // Any confirmed (reply) observation clears the provisional flag.
+      existing.provisional = existing.provisional && ex.provisional;
+      if (!existing.provisional) existing.provisionalLegIndex = null;
       if (ex.timestamp > existing.timestamp) {
         existing.timestamp = ex.timestamp;
         existing.snr = ex.snr;
@@ -152,6 +159,8 @@ export function findPathsBetween(
       count: 1,
       legSnrDb: ex.legSnrDb,
       legSnrReversed: ex.legSnrDb ? !ex.forward : undefined,
+      provisional: ex.provisional,
+      provisionalLegIndex: ex.provisionalLegIndex,
     });
   }
 
@@ -161,7 +170,9 @@ export function findPathsBetween(
 }
 
 /** Every observed run between the pair, oldest first — the time-machine view.
- *  No dedup: repeated signatures are the point (stability over time). */
+ *  No dedup of repeated signatures (stability over time is the point), but
+ *  request+reply packets of ONE exchange collapse to the reply so a single
+ *  traceroute never counts as two runs or fakes a route-change tick. */
 export function findRunsBetween(
   fromId: string,
   toId: string,
@@ -172,7 +183,7 @@ export function findRunsBetween(
   if (!a || !b || a === b) return [];
 
   const runs: TraceRun[] = [];
-  for (const tr of traceroutes) {
+  for (const tr of dedupeExchanges(traceroutes)) {
     const ex = extractPathFromRow(a, b, tr);
     if (!ex) continue;
     runs.push({
@@ -180,6 +191,8 @@ export function findRunsBetween(
       hops: ex.hops,
       hopCount: ex.hops.length - 1,
       timestamp: ex.timestamp,
+      provisional: ex.provisional,
+      provisionalLegIndex: ex.provisionalLegIndex,
     });
   }
   runs.sort((x, y) => x.timestamp - y.timestamp);
@@ -196,29 +209,26 @@ export interface TraceEdgeStat {
   lastTimestamp: number;
 }
 
-/** Resolved node ids normalize to bare lowercase hex; longnames and `?<raw>`
- *  placeholders don't, and their edges can't be positioned or clicked. */
-const RESOLVED_ID = /^[0-9a-f]{1,8}$/;
-
 /** Count how often each adjacent hop pair appears across runs — the mesh's
- *  busiest links. Edges touching an unresolved hop are skipped, and reply
- *  rows are travel-ordered via orientRow (endpoint-adjacent edges would
- *  otherwise be attributed to the wrong nodes). */
+ *  busiest links. Edges touching an unresolved hop or the 0xffffffff sentinel
+ *  are skipped, rows are travel-ordered via orientTraceroute, request+reply
+ *  pairs collapse to one run, and the speculative final leg of a mid-flight
+ *  request (never actually observed) is excluded — otherwise every request
+ *  heard near the initiator fabricates a direct initiator–target corridor. */
 export function computeTraceEdgeStats(traceroutes: ITraceroutesResponse[]): TraceEdgeStat[] {
   const byKey = new Map<string, TraceEdgeStat>();
-  for (const tr of traceroutes) {
-    const tFrom = normNodeId(tr?.from);
-    const tTo = normNodeId(tr?.to);
-    if (!tFrom || !tTo) continue;
-    const route = ((tr?.route_ids ?? tr?.route ?? []) as (string | number)[])
-      .map((r) => normNodeId(r) || `?${String(r)}`);
-    const { fullPath } = orientRow(tr, tFrom, tTo, route);
+  for (const tr of dedupeExchanges(traceroutes)) {
+    const o = orientTraceroute(tr);
+    if (!o) continue;
+    const fullPath = o.orderedPath;
     const ts = tr.timestamp ?? 0;
+    const lastLegIdx = fullPath.length - 2;
     const seenInRun = new Set<string>();
     for (let i = 0; i + 1 < fullPath.length; i++) {
+      if (o.provisional && i === lastLegIdx) continue;
       const a = fullPath[i];
       const b = fullPath[i + 1];
-      if (a === b || !RESOLVED_ID.test(a) || !RESOLVED_ID.test(b)) continue;
+      if (a === b || !isResolvedHop(a) || !isResolvedHop(b)) continue;
       const [ka, kb] = a < b ? [a, b] : [b, a];
       const key = `${ka}|${kb}`;
       if (seenInRun.has(key)) continue;
@@ -233,9 +243,4 @@ export function computeTraceEdgeStats(traceroutes: ITraceroutesResponse[]): Trac
     }
   }
   return [...byKey.values()];
-}
-
-/** Epoch that may be seconds or milliseconds → milliseconds. */
-export function tsToMs(ts: number): number {
-  return ts > 1e12 ? ts : ts * 1000;
 }

--- a/frontend/src/pages/map/lib/pathAnalysis.ts
+++ b/frontend/src/pages/map/lib/pathAnalysis.ts
@@ -6,8 +6,7 @@ import {
 } from "../../../utils/traceroute";
 import { normNodeId } from "./linkFeatures";
 
-// Orientation/decoding primitives moved to utils/traceroute (shared with the
-// Traceroutes page and graph); re-exported so existing map imports keep working.
+// Re-exported from utils/traceroute so existing map imports keep working.
 export { decodeSnr, tsToMs } from "../../../utils/traceroute";
 
 export interface AnalyzedPath {
@@ -26,13 +25,11 @@ export interface AnalyzedPath {
   legSnrDb?: (number | null)[];
   /** True when the SNR was measured opposite to the displayed a→b orientation. */
   legSnrReversed?: boolean;
-  /** True when ONLY mid-flight request packets observed this sequence: the
-   *  row's final (…→target) leg is implied by the header, not observed. */
+  /** Only request packets observed this sequence; the final (…→target) leg
+   *  is implied by the header, not observed. */
   provisional: boolean;
-  /** DISPLAYED index of the unobserved leg (legSnrDb/hop coordinates: leg i is
-   *  hops[i]→hops[i+1]), or null when no displayed leg is speculative. NOT
-   *  always the last leg — a reversed a→b extraction puts it at index 0, and a
-   *  sub-path that stops short of the row's target contains it not at all. */
+  /** Displayed index of the unobserved leg (leg i = hops[i]→hops[i+1]), or
+   *  null. NOT always last: a reversed a→b extraction puts it at index 0. */
   provisionalLegIndex: number | null;
 }
 
@@ -61,10 +58,8 @@ interface ExtractedPath {
 }
 
 /** Extract the a→b sub-path of one traceroute row, or null if it doesn't
- *  contain both nodes. Shared by the dedup (paths) and chronological (runs)
- *  views so orientation semantics can never drift apart. Travel ordering,
- *  reply detection, and per-leg SNR alignment all come from orientTraceroute
- *  — the single mandatory entry point for walking a row's hops. */
+ *  contain both nodes. Hop ordering and reply detection come from
+ *  orientTraceroute — the mandatory entry point for walking a row's hops. */
 function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): ExtractedPath | null {
   const o = orientTraceroute(tr);
   if (!o) return null;
@@ -88,10 +83,8 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
     legSnrDb = forward ? legs : legs.slice().reverse();
   }
 
-  // The row's unobserved leg is the LAST leg of fullPath. It appears in this
-  // sub-path only when the slice reaches the row's target (hi === last index);
-  // in displayed coordinates it is then the last leg when forward, leg 0 when
-  // reversed.
+  // The unobserved leg is fullPath's last; it lands in this sub-path only when
+  // the slice reaches the target — last leg when forward, leg 0 when reversed.
   let provisionalLegIndex: number | null = null;
   if (o.provisional && hi === fullPath.length - 1) {
     provisionalLegIndex = forward ? hops.length - 2 : 0;
@@ -101,8 +94,8 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
     hops,
     sig: hops.join(">"),
     timestamp: tr.timestamp ?? 0,
-    snr: tr.snr,
-    rssi: tr.rssi,
+    snr: tr.snr ?? undefined,
+    rssi: tr.rssi ?? undefined,
     legSnrDb,
     forward,
     provisional: o.provisional,
@@ -111,9 +104,8 @@ function extractPathFromRow(a: string, b: string, tr: ITraceroutesResponse): Ext
 }
 
 /** Unique traceroute paths between two nodes (either direction), newest first.
- *  Freshness outranks hop count: a stale one-hop fluke must not beat the route
- *  the mesh is actually using now. Request+reply rows of one exchange are
- *  collapsed to the reply before analysis. */
+ *  Freshness outranks hop count; request+reply rows of one exchange collapse
+ *  to the reply before analysis. */
 export function findPathsBetween(
   fromId: string,
   toId: string,
@@ -170,9 +162,8 @@ export function findPathsBetween(
 }
 
 /** Every observed run between the pair, oldest first — the time-machine view.
- *  No dedup of repeated signatures (stability over time is the point), but
- *  request+reply packets of ONE exchange collapse to the reply so a single
- *  traceroute never counts as two runs or fakes a route-change tick. */
+ *  No dedup of repeated signatures, but request+reply packets of one exchange
+ *  collapse to the reply so a single traceroute never counts as two runs. */
 export function findRunsBetween(
   fromId: string,
   toId: string,
@@ -210,11 +201,8 @@ export interface TraceEdgeStat {
 }
 
 /** Count how often each adjacent hop pair appears across runs — the mesh's
- *  busiest links. Edges touching an unresolved hop or the 0xffffffff sentinel
- *  are skipped, rows are travel-ordered via orientTraceroute, request+reply
- *  pairs collapse to one run, and the speculative final leg of a mid-flight
- *  request (never actually observed) is excluded — otherwise every request
- *  heard near the initiator fabricates a direct initiator–target corridor. */
+ *  busiest links. Skips unresolved/sentinel hops and a mid-flight request's
+ *  speculative final leg; request+reply exchanges collapse to one run. */
 export function computeTraceEdgeStats(traceroutes: ITraceroutesResponse[]): TraceEdgeStat[] {
   const byKey = new Map<string, TraceEdgeStat>();
   for (const tr of dedupeExchanges(traceroutes)) {

--- a/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
+++ b/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
@@ -12,6 +12,7 @@ import {
   hopChipLabel,
   isHopLinkable,
   type NodesById,
+  returnRouteIdsOf,
   routeIdsOf,
   safeTsMs,
   type TracerouteEvent,
@@ -534,6 +535,21 @@ export function TracerouteDetailsPanel({
                       <div className="mt-2">
                         <RouteChips nodes={nodes} routeIds={rids} />
                       </div>
+
+                      {(() => {
+                        // Return leg travels target → … → initiator; only
+                        // reply rows that recorded it have one to show.
+                        const back = returnRouteIdsOf(e);
+                        if (!back.length) return null;
+                        return (
+                          <div className="mt-2">
+                            <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">
+                              Return path ({(nodes[e.to]?.shortname || "UNK") + " → " + (nodes[e.from]?.shortname || "UNK")})
+                            </div>
+                            <RouteChips nodes={nodes} routeIds={back} />
+                          </div>
+                        );
+                      })()}
 
                       {selectedItem.kind !== "pair" ? (
                         <div className="mt-2 text-[11px] text-gray-500 tabular-nums">

--- a/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
+++ b/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
@@ -9,6 +9,8 @@ import {
 } from "./traceroutesTypes";
 import {
   groupTracerouteEvents,
+  hopChipLabel,
+  isHopLinkable,
   type NodesById,
   routeIdsOf,
   safeTsMs,
@@ -71,11 +73,17 @@ function RouteChips({
   return (
     <div className="flex flex-wrap items-center gap-2">
       {routeIds.map((id, i) => {
-        const label = nodes[id]?.shortname || "UNK";
+        const label = hopChipLabel(nodes, id);
         return (
           <span key={`${id}-${i}`} className="inline-flex items-center gap-2">
             <span className="inline-flex items-center rounded-full border border-gray-300/60 dark:border-gray-700 px-3 py-1 text-xs text-gray-700 dark:text-gray-200 bg-white/60 dark:bg-gray-950/40">
-              <NodeInline id={id} label={label} />
+              {isHopLinkable(id) ? (
+                <NodeInline id={id} label={label} />
+              ) : (
+                <span className="text-gray-500 italic" title={id}>
+                  {label}
+                </span>
+              )}
             </span>
             {i < routeIds.length - 1 ? (
               <span className="text-gray-300 dark:text-gray-700">›</span>
@@ -87,8 +95,19 @@ function RouteChips({
   );
 }
 
+function ProvisionalBadge() {
+  return (
+    <span
+      className="inline-flex items-center rounded-full border border-amber-400/50 bg-amber-50/60 dark:bg-amber-900/20 px-2 py-0.5 text-[10px] text-amber-700 dark:text-amber-300"
+      title="Mid-flight request packet — the final hop is implied by the header and the reply was not observed"
+    >
+      awaiting reply
+    </span>
+  );
+}
+
 function buildRouteText(nodes: NodesById, routeIds: string[]) {
-  return routeIds.map((id) => nodes[id]?.shortname || "UNK").join(" > ");
+  return routeIds.map((id) => hopChipLabel(nodes, id)).join(" > ");
 }
 
 function pairLabel(nodes: NodesById, from: string, to: string) {
@@ -141,9 +160,13 @@ export function TracerouteDetailsPanel({
         ? Math.max(...scopeEvents.map((e) => safeTsMs(e.timestamp)))
         : 0;
 
+      const packetsNote =
+        selectedItem.totalPackets > selectedItem.totalEvents
+          ? ` (${selectedItem.totalPackets.toLocaleString()} packets)`
+          : "";
       return {
         title: "Traceroutes overview",
-        subtitle: `Range: ${range} • ${eventsAll.length.toLocaleString()} runs • ${pairItems.length.toLocaleString()} pairs • ${uniqueRoutesTotal.toLocaleString()} unique routes`,
+        subtitle: `Range: ${range} • ${selectedItem.totalEvents.toLocaleString()} runs${packetsNote} • ${pairItems.length.toLocaleString()} pairs • ${uniqueRoutesTotal.toLocaleString()} unique routes`,
         lastTsMs: last,
         from: null as string | null,
         to: null as string | null,
@@ -153,7 +176,10 @@ export function TracerouteDetailsPanel({
     const from = selectedItem.from;
     const to = selectedItem.to;
     const title = pairLabel(nodes, from, to);
-    const subtitle = `${selectedItem.summary.count.toLocaleString()} runs • ${selectedItem.summary.uniqueRoutes.toLocaleString()} unique routes • Range: ${range}`;
+    const s = selectedItem.summary;
+    const pairPacketsNote =
+      s.packetCount > s.count ? ` (${s.packetCount.toLocaleString()} packets)` : "";
+    const subtitle = `${s.count.toLocaleString()} runs${pairPacketsNote} • ${s.uniqueRoutes.toLocaleString()} unique routes • Range: ${range}`;
 
     return {
       title,
@@ -162,7 +188,7 @@ export function TracerouteDetailsPanel({
       from,
       to,
     };
-  }, [selectedItem, nodes, range, eventsAll.length, pairItems.length, uniqueRoutesTotal, scopeEvents]);
+  }, [selectedItem, nodes, range, pairItems.length, uniqueRoutesTotal, scopeEvents]);
 
   const lastEvent = useMemo(() => {
     if (!scopeEvents.length) return null;
@@ -381,7 +407,8 @@ export function TracerouteDetailsPanel({
                           <div className="flex items-start justify-between gap-3">
                             <div className="min-w-0">
                               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-                                {g.count.toLocaleString()}× • {g.route_ids.length} hops
+                                {g.count.toLocaleString()}× • {g.route_ids.length} hops{" "}
+                                {g.provisional ? <ProvisionalBadge /> : null}
                               </div>
                               <div className="text-xs text-gray-500 mt-1">
                                 Last: {g.lastTsMs ? formatTimestamp(g.lastTsMs) : "—"}
@@ -496,8 +523,11 @@ export function TracerouteDetailsPanel({
                             </>
                           )}
                         </div>
-                        <div className="text-[11px] text-gray-500 tabular-nums">
-                          hops={rids.length}
+                        <div className="flex items-center gap-2">
+                          {e.provisional ? <ProvisionalBadge /> : null}
+                          <div className="text-[11px] text-gray-500 tabular-nums">
+                            hops={rids.length}
+                          </div>
                         </div>
                       </div>
 

--- a/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
+++ b/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
@@ -96,13 +96,27 @@ function RouteChips({
   );
 }
 
-function ProvisionalBadge() {
+// Replies land within seconds; past this age the exchange is settled.
+const REPLY_PENDING_MS = 5 * 60_000;
+
+function ProvisionalBadge({ tsMs }: { tsMs?: number }) {
+  const pending = tsMs != null && Date.now() - tsMs < REPLY_PENDING_MS;
+  if (pending) {
+    return (
+      <span
+        className="inline-flex items-center rounded-full border border-amber-400/50 bg-amber-50/60 dark:bg-amber-900/20 px-2 py-0.5 text-[10px] text-amber-700 dark:text-amber-300"
+        title="Request seen mid-flight — the reply may still arrive"
+      >
+        awaiting reply
+      </span>
+    );
+  }
   return (
     <span
-      className="inline-flex items-center rounded-full border border-amber-400/50 bg-amber-50/60 dark:bg-amber-900/20 px-2 py-0.5 text-[10px] text-amber-700 dark:text-amber-300"
-      title="Mid-flight request packet — the final hop is implied by the header and the reply was not observed"
+      className="inline-flex items-center rounded-full border border-gray-400/40 bg-gray-100/50 dark:bg-gray-800/40 px-2 py-0.5 text-[10px] text-gray-500 dark:text-gray-400"
+      title="The target never answered this traceroute — only the request was observed"
     >
-      awaiting reply
+      no reply
     </span>
   );
 }
@@ -409,7 +423,7 @@ export function TracerouteDetailsPanel({
                             <div className="min-w-0">
                               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
                                 {g.count.toLocaleString()}× • {g.route_ids.length} hops{" "}
-                                {g.provisional ? <ProvisionalBadge /> : null}
+                                {g.provisional ? <ProvisionalBadge tsMs={g.lastTsMs} /> : null}
                               </div>
                               <div className="text-xs text-gray-500 mt-1">
                                 Last: {g.lastTsMs ? formatTimestamp(g.lastTsMs) : "—"}
@@ -525,7 +539,7 @@ export function TracerouteDetailsPanel({
                           )}
                         </div>
                         <div className="flex items-center gap-2">
-                          {e.provisional ? <ProvisionalBadge /> : null}
+                          {e.provisional ? <ProvisionalBadge tsMs={safeTsMs(e.timestamp)} /> : null}
                           <div className="text-[11px] text-gray-500 tabular-nums">
                             hops={rids.length}
                           </div>

--- a/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
+++ b/frontend/src/pages/traceroutes/TracerouteDetailsPanel.tsx
@@ -537,8 +537,7 @@ export function TracerouteDetailsPanel({
                       </div>
 
                       {(() => {
-                        // Return leg travels target → … → initiator; only
-                        // reply rows that recorded it have one to show.
+                        // Return leg travels target → … → initiator.
                         const back = returnRouteIdsOf(e);
                         if (!back.length) return null;
                         return (

--- a/frontend/src/pages/traceroutes/TraceroutesList.tsx
+++ b/frontend/src/pages/traceroutes/TraceroutesList.tsx
@@ -4,7 +4,7 @@ import { Virtuoso } from "react-virtuoso";
 
 import { formatTimestamp } from "../../utils/formatTimestamp";
 import { type TraceroutesListItem } from "./traceroutesTypes";
-import { type NodesById } from "./traceroutesUtils";
+import { hopChipLabel, isHopLinkable, type NodesById } from "./traceroutesUtils";
 
 type GetNode = (id: string) => NodesById[string] | undefined;
 
@@ -51,11 +51,17 @@ function RouteInline({
     <div className="flex items-center gap-2 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
       {routeIds.map((id, i) => {
         const n = getNode(id);
-        const label = n?.shortname || "UNK";
+        const label = n?.shortname || hopChipLabel({}, id);
         return (
           <span key={`${id}-${i}`} className="inline-flex items-center gap-2">
             <span className="inline-flex items-center rounded-full border border-gray-300/60 dark:border-gray-700 px-2 py-0.5 text-xs text-gray-700 dark:text-gray-200 bg-white/60 dark:bg-gray-950/40">
-              <NodeLink id={id} label={label} />
+              {isHopLinkable(id) ? (
+                <NodeLink id={id} label={label} />
+              ) : (
+                <span className="text-gray-500 italic" title={id}>
+                  {label}
+                </span>
+              )}
             </span>
             {i < routeIds.length - 1 ? (
               <span className="text-gray-300 dark:text-gray-700">›</span>
@@ -102,7 +108,8 @@ const TracerouteRow = memo(function TracerouteRow({
               </div>
               <div className="text-xs text-gray-500 mt-1">
                 {item.totalPairs.toLocaleString()} pairs •{" "}
-                {item.totalEvents.toLocaleString()} runs •{" "}
+                {item.totalEvents.toLocaleString()} runs (
+                {item.totalPackets.toLocaleString()} pkts) •{" "}
                 {item.uniqueRoutes.toLocaleString()} unique routes
               </div>
             </div>
@@ -142,7 +149,16 @@ const TracerouteRow = memo(function TracerouteRow({
           <div className="min-w-0">
             <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
               <NodeLink id={item.from} label={fromLabel} />
-              <span className="mx-2 text-gray-400">→</span>
+              <span
+                className="mx-2 text-gray-400"
+                title={
+                  item.summary.bidirectional
+                    ? "Both nodes have initiated traceroutes"
+                    : "Initiator → target"
+                }
+              >
+                {item.summary.bidirectional ? "⇄" : "→"}
+              </span>
               <NodeLink id={item.to} label={toLabel} />
             </div>
 
@@ -155,6 +171,9 @@ const TracerouteRow = memo(function TracerouteRow({
               Runs:{" "}
               <span className="text-gray-700 dark:text-gray-200">
                 {item.summary.count.toLocaleString()}
+                {item.summary.packetCount > item.summary.count
+                  ? ` (${item.summary.packetCount.toLocaleString()} pkts)`
+                  : ""}
               </span>
               {" • "}
               Unique routes:{" "}
@@ -168,6 +187,13 @@ const TracerouteRow = memo(function TracerouteRow({
                 <>
                   <div className="text-[11px] text-gray-500 mb-1">
                     Most common route ({item.summary.topRouteCount.toLocaleString()}×)
+                    {item.summary.bidirectional ? (
+                      <span className="ml-1 text-gray-400">
+                        {getNode(item.summary.topRouteFrom)?.shortname || "UNK"}
+                        {" → "}
+                        {getNode(item.summary.topRouteTo)?.shortname || "UNK"}
+                      </span>
+                    ) : null}
                   </div>
                   <RouteInline getNode={getNode} routeIds={item.summary.topRouteIds} />
                 </>
@@ -182,7 +208,7 @@ const TracerouteRow = memo(function TracerouteRow({
               Pair
             </div>
             <div className="text-[11px] text-gray-400 tabular-nums mt-1">
-              {item.from} → {item.to}
+              {item.from} {item.summary.bidirectional ? "⇄" : "→"} {item.to}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/traceroutes/traceroutesTypes.ts
+++ b/frontend/src/pages/traceroutes/traceroutesTypes.ts
@@ -17,9 +17,8 @@ export type TraceroutePairSummary = {
   lastTsMs: number;
   uniqueRoutes: number;
 
-  // preview for list row; topRouteFrom/topRouteTo carry the top route's OWN
-  // direction — on a bidirectional (⇄) pair it can oppose the summary's
-  // newest-run from/to, and unlabeled chips would read backwards.
+  // Preview for list row; topRouteFrom/topRouteTo carry the top route's own
+  // direction, which can oppose the newest-run from/to on a ⇄ pair.
   topRouteIds: string[];
   topRouteCount: number;
   topRouteFrom: string;

--- a/frontend/src/pages/traceroutes/traceroutesTypes.ts
+++ b/frontend/src/pages/traceroutes/traceroutesTypes.ts
@@ -1,17 +1,29 @@
 export type RangeKey = "all" | "1h" | "24h" | "7d";
 
 export type TraceroutePairSummary = {
-  pairKey: string; // `${from}|${to}`
+  /** Canonical undirected pair key: sorted `${min}|${max}`. */
+  pairKey: string;
+  /** Newest run's initiator (travel orientation). */
   from: string;
+  /** Newest run's target. */
   to: string;
+  /** Both endpoints have initiated traceroutes in this scope. */
+  bidirectional: boolean;
+  /** Exchanges (request+reply packets of one traceroute collapsed). */
   count: number;
+  /** Raw packets observed (requests + replies, before collapsing). */
+  packetCount: number;
   firstTsMs: number;
   lastTsMs: number;
   uniqueRoutes: number;
 
-  // preview for list row
+  // preview for list row; topRouteFrom/topRouteTo carry the top route's OWN
+  // direction — on a bidirectional (⇄) pair it can oppose the summary's
+  // newest-run from/to, and unlabeled chips would read backwards.
   topRouteIds: string[];
   topRouteCount: number;
+  topRouteFrom: string;
+  topRouteTo: string;
 };
 
 export type TraceroutesListItem =
@@ -19,14 +31,17 @@ export type TraceroutesListItem =
       kind: "all";
       key: "all";
       totalPairs: number;
+      /** Exchanges in scope (see TraceroutePairSummary.count). */
       totalEvents: number;
+      /** Raw packets in scope. */
+      totalPackets: number;
       lastTsMs: number;
       uniqueRoutes: number; // unique hop-sequences across all pairs
     }
   | {
       kind: "pair";
       key: `pair:${string}`;
-      pairKey: string; // `${from}|${to}`
+      pairKey: string; // canonical undirected sorted key
       from: string;
       to: string;
       summary: TraceroutePairSummary;

--- a/frontend/src/pages/traceroutes/traceroutesUtils.ts
+++ b/frontend/src/pages/traceroutes/traceroutesUtils.ts
@@ -11,28 +11,21 @@ export type NodesById = Record<
   { shortname?: string; longname?: string; id?: string }
 >;
 
-/** A traceroute row normalized into TRAVEL orientation at the coercion
- *  boundary: `from` is always the initiator (requester), `to` the traced
- *  target, and `route_ids` the travel-ordered intermediate hops — regardless
- *  of whether the underlying packet was the request or the reply (whose
- *  header endpoints arrive swapped). Raw header values are preserved in
- *  header_from/header_to for exports. */
+/** Row normalized into TRAVEL orientation: from = initiator, to = target, route_ids =
+ *  travel-ordered hops, even on reply rows; raw headers kept in header_from/header_to. */
 export type TracerouteEvent = {
   __idx: number; // stable key helper
   timestamp: any;
-  /** Where `timestamp` came from: the packet itself, or the server ingest
-   *  time substituted for clock-less gateways (timestamp 0). */
+  /** "ingest" = server ingest time substituted for a clock-less gateway's timestamp 0. */
   timestamp_source: "packet" | "ingest" | null;
   /** Initiator (requester) — travel orientation, not the packet header. */
   from: string;
   /** Target (traced node) — travel orientation, not the packet header. */
   to: string;
   hops_away: number | null;
-  /** Travel-ordered intermediate hops, normalized to 8-hex where resolvable;
-   *  unresolvable entries kept as-is / `?<raw>` placeholders. */
+  /** Travel-ordered intermediate hops, 8-hex where resolvable; else `?<raw>` placeholders. */
   route_ids: string[];
-  /** Return-path hops in return-travel order (target → … → initiator),
-   *  server-resolved; empty for requests and pre-column rows. */
+  /** Return-path hops in return-travel order; empty for requests and pre-column rows. */
   route_back_ids: string[];
   route?: any;
   id?: number | string;
@@ -42,7 +35,6 @@ export type TracerouteEvent = {
   created_at?: number | null;
   snr?: number | null;
   rssi?: number | null;
-  /** RouteDiscovery payload (snr_towards etc.) as served by the API. */
   payload?: {
     route?: (string | number)[];
     snr_towards?: number[];
@@ -51,8 +43,7 @@ export type TracerouteEvent = {
   };
   /** Reply packet (complete route; snr_towards = route + 1). */
   isReply: boolean;
-  /** Mid-flight request: the final leg is implied by the header, and the
-   *  exchange's reply was not (yet) observed. */
+  /** Mid-flight request: final leg implied, reply not (yet) observed. */
   provisional: boolean;
   /** Undirected canonical pair key (sorted `${min}|${max}`). */
   pairKey: string;
@@ -105,9 +96,8 @@ export function routeHopsOf(e: Pick<TracerouteEvent, "route_ids" | "route">): nu
   return 0;
 }
 
-/** Display label for a hop chip; UNK only for resolvable-but-unnamed ids.
- *  Placeholders/longnames/the 0xffffffff sentinel get honest labels and must
- *  not be rendered as node links (guard with isHopLinkable). */
+/** Hop chip label; UNK only for resolvable-but-unnamed ids. Non-resolvable
+ *  labels must not render as node links (guard with isHopLinkable). */
 export function hopChipLabel(nodes: NodesById, id: string): string {
   const named = nodes[id]?.shortname;
   if (named) return named;
@@ -122,10 +112,8 @@ export function isHopLinkable(id: string): boolean {
   return isResolvedHop(id);
 }
 
-/** Return-path intermediate hops in return-travel order (target → … →
- *  initiator). Prefers the server-resolved route_back_ids; falls back to
- *  normalizing the raw payload.route_back for rows predating the column.
- *  Empty for requests and replies whose return leg wasn't recorded. */
+/** Return-path hops in return-travel order; falls back to normalizing raw
+ *  payload.route_back for rows predating the route_back_ids column. */
 export function returnRouteIdsOf(e: TracerouteEvent): string[] {
   if (e.route_back_ids.length > 0) return e.route_back_ids;
   const raw = e.payload?.route_back;
@@ -139,8 +127,7 @@ export function coerceEvent(raw: any, idx: number): TracerouteEvent {
   const headerTo = raw?.to ?? "";
   return {
     __idx: idx,
-    // Packet timestamp, falling back to server ingest time for rows from
-    // clock-less gateways (timestamp 0 used to sort them to 1970).
+    // Fall back to ingest time for clock-less gateways (timestamp 0 would sort to 1970).
     timestamp: raw?.timestamp || raw?.created_at,
     timestamp_source: raw?.timestamp ? "packet" : raw?.created_at ? "ingest" : null,
     from: o ? o.initiator : headerFrom,
@@ -165,8 +152,7 @@ export function coerceEvent(raw: any, idx: number): TracerouteEvent {
   };
 }
 
-/** Collapse request+reply rows of one exchange to the reply (events are
- *  already travel-oriented, so the ExchangeView is a direct projection). */
+/** Collapse request+reply of one exchange to the reply; events are already travel-oriented. */
 export function dedupeExchangeEvents(events: TracerouteEvent[]): TracerouteEvent[] {
   const mask = exchangeKeepMask(
     events.map((e) =>

--- a/frontend/src/pages/traceroutes/traceroutesUtils.ts
+++ b/frontend/src/pages/traceroutes/traceroutesUtils.ts
@@ -1,3 +1,4 @@
+import { normNodeId } from "../../utils/normalizeNodeId8";
 import {
   canonicalPairKey,
   exchangeKeepMask,
@@ -19,6 +20,9 @@ export type NodesById = Record<
 export type TracerouteEvent = {
   __idx: number; // stable key helper
   timestamp: any;
+  /** Where `timestamp` came from: the packet itself, or the server ingest
+   *  time substituted for clock-less gateways (timestamp 0). */
+  timestamp_source: "packet" | "ingest" | null;
   /** Initiator (requester) — travel orientation, not the packet header. */
   from: string;
   /** Target (traced node) — travel orientation, not the packet header. */
@@ -27,8 +31,15 @@ export type TracerouteEvent = {
   /** Travel-ordered intermediate hops, normalized to 8-hex where resolvable;
    *  unresolvable entries kept as-is / `?<raw>` placeholders. */
   route_ids: string[];
+  /** Return-path hops in return-travel order (target → … → initiator),
+   *  server-resolved; empty for requests and pre-column rows. */
+  route_back_ids: string[];
   route?: any;
   id?: number | string;
+  /** Reply rows: the request's packet id (exact exchange pairing). */
+  packet_id?: number | string | null;
+  /** Server ingest time (epoch s) — dates rows whose packet timestamp is 0. */
+  created_at?: number | null;
   snr?: number | null;
   rssi?: number | null;
   /** RouteDiscovery payload (snr_towards etc.) as served by the API. */
@@ -111,13 +122,27 @@ export function isHopLinkable(id: string): boolean {
   return isResolvedHop(id);
 }
 
+/** Return-path intermediate hops in return-travel order (target → … →
+ *  initiator). Prefers the server-resolved route_back_ids; falls back to
+ *  normalizing the raw payload.route_back for rows predating the column.
+ *  Empty for requests and replies whose return leg wasn't recorded. */
+export function returnRouteIdsOf(e: TracerouteEvent): string[] {
+  if (e.route_back_ids.length > 0) return e.route_back_ids;
+  const raw = e.payload?.route_back;
+  if (!Array.isArray(raw)) return [];
+  return raw.map((r) => normNodeId(r) || `?${String(r)}`);
+}
+
 export function coerceEvent(raw: any, idx: number): TracerouteEvent {
   const o = orientTraceroute(raw);
   const headerFrom = raw?.from ?? "";
   const headerTo = raw?.to ?? "";
   return {
     __idx: idx,
-    timestamp: raw?.timestamp,
+    // Packet timestamp, falling back to server ingest time for rows from
+    // clock-less gateways (timestamp 0 used to sort them to 1970).
+    timestamp: raw?.timestamp || raw?.created_at,
+    timestamp_source: raw?.timestamp ? "packet" : raw?.created_at ? "ingest" : null,
     from: o ? o.initiator : headerFrom,
     to: o ? o.target : headerTo,
     hops_away: raw?.hops_away ?? null,
@@ -125,7 +150,10 @@ export function coerceEvent(raw: any, idx: number): TracerouteEvent {
       ? o.orderedPath.slice(1, -1)
       : ((raw?.route_ids ?? []) as any[]).map((r) => String(r)),
     route: raw?.route,
+    route_back_ids: ((raw?.route_back_ids ?? []) as any[]).map((r) => String(r)),
     id: raw?.id,
+    packet_id: raw?.packet_id ?? null,
+    created_at: raw?.created_at ?? null,
     snr: raw?.snr ?? null,
     rssi: raw?.rssi ?? null,
     payload: raw?.payload,
@@ -149,6 +177,8 @@ export function dedupeExchangeEvents(events: TracerouteEvent[]): TracerouteEvent
             isReply: e.isReply,
             orderedPath: [e.from, ...e.route_ids, e.to],
             ms: safeTsMs(e.timestamp),
+            id: e.id,
+            replyTo: e.packet_id,
           }
         : null,
     ),

--- a/frontend/src/pages/traceroutes/traceroutesUtils.ts
+++ b/frontend/src/pages/traceroutes/traceroutesUtils.ts
@@ -1,27 +1,66 @@
+import {
+  canonicalPairKey,
+  exchangeKeepMask,
+  isResolvedHop,
+  orientTraceroute,
+} from "../../utils/traceroute";
+
 export type NodesById = Record<
   string,
   { shortname?: string; longname?: string; id?: string }
 >;
 
+/** A traceroute row normalized into TRAVEL orientation at the coercion
+ *  boundary: `from` is always the initiator (requester), `to` the traced
+ *  target, and `route_ids` the travel-ordered intermediate hops — regardless
+ *  of whether the underlying packet was the request or the reply (whose
+ *  header endpoints arrive swapped). Raw header values are preserved in
+ *  header_from/header_to for exports. */
 export type TracerouteEvent = {
   __idx: number; // stable key helper
   timestamp: any;
+  /** Initiator (requester) — travel orientation, not the packet header. */
   from: string;
+  /** Target (traced node) — travel orientation, not the packet header. */
   to: string;
-  hops_away: number;
-  route_ids?: string[];
+  hops_away: number | null;
+  /** Travel-ordered intermediate hops, normalized to 8-hex where resolvable;
+   *  unresolvable entries kept as-is / `?<raw>` placeholders. */
+  route_ids: string[];
   route?: any;
+  id?: number | string;
+  snr?: number | null;
+  rssi?: number | null;
+  /** RouteDiscovery payload (snr_towards etc.) as served by the API. */
+  payload?: {
+    route?: (string | number)[];
+    snr_towards?: number[];
+    route_back?: (string | number)[];
+    snr_back?: number[];
+  };
+  /** Reply packet (complete route; snr_towards = route + 1). */
+  isReply: boolean;
+  /** Mid-flight request: the final leg is implied by the header, and the
+   *  exchange's reply was not (yet) observed. */
+  provisional: boolean;
+  /** Undirected canonical pair key (sorted `${min}|${max}`). */
+  pairKey: string;
+  /** Raw packet-header endpoints as received (swapped on reply rows). */
+  header_from: string;
+  header_to: string;
 };
 
 export type TracerouteGroup = {
-  key: string; // from|to|routeIdsCsv
+  key: string; // `${from}|${to}|${routeIdsCsv}` — travel-oriented values
   from: string;
   to: string;
   route_ids: string[];
-  hops_away: number;
+  hops_away: number | null;
   count: number;
   firstTsMs: number;
   lastTsMs: number;
+  /** True when every observation of this route was a mid-flight request. */
+  provisional: boolean;
 };
 
 export type TraceroutesListItem =
@@ -55,16 +94,66 @@ export function routeHopsOf(e: Pick<TracerouteEvent, "route_ids" | "route">): nu
   return 0;
 }
 
+/** Display label for a hop chip; UNK only for resolvable-but-unnamed ids.
+ *  Placeholders/longnames/the 0xffffffff sentinel get honest labels and must
+ *  not be rendered as node links (guard with isHopLinkable). */
+export function hopChipLabel(nodes: NodesById, id: string): string {
+  const named = nodes[id]?.shortname;
+  if (named) return named;
+  if (id === "ffffffff") return "unknown";
+  if (id.startsWith("?")) return "unknown";
+  if (!isResolvedHop(id)) return id; // longname text is more honest than UNK
+  return "UNK";
+}
+
+/** Only resolvable hop ids may render as /nodes/<id> links. */
+export function isHopLinkable(id: string): boolean {
+  return isResolvedHop(id);
+}
+
 export function coerceEvent(raw: any, idx: number): TracerouteEvent {
+  const o = orientTraceroute(raw);
+  const headerFrom = raw?.from ?? "";
+  const headerTo = raw?.to ?? "";
   return {
     __idx: idx,
     timestamp: raw?.timestamp,
-    from: raw?.from,
-    to: raw?.to,
-    hops_away: raw?.hops_away ?? 0,
-    route_ids: raw?.route_ids ?? [],
-    route: raw?.route ?? [],
+    from: o ? o.initiator : headerFrom,
+    to: o ? o.target : headerTo,
+    hops_away: raw?.hops_away ?? null,
+    route_ids: o
+      ? o.orderedPath.slice(1, -1)
+      : ((raw?.route_ids ?? []) as any[]).map((r) => String(r)),
+    route: raw?.route,
+    id: raw?.id,
+    snr: raw?.snr ?? null,
+    rssi: raw?.rssi ?? null,
+    payload: raw?.payload,
+    isReply: o?.isReply ?? false,
+    provisional: o?.provisional ?? true,
+    pairKey: o ? o.pairKey : canonicalPairKey(headerFrom, headerTo),
+    header_from: headerFrom,
+    header_to: headerTo,
   };
+}
+
+/** Collapse request+reply rows of one exchange to the reply (events are
+ *  already travel-oriented, so the ExchangeView is a direct projection). */
+export function dedupeExchangeEvents(events: TracerouteEvent[]): TracerouteEvent[] {
+  const mask = exchangeKeepMask(
+    events.map((e) =>
+      e.from && e.to
+        ? {
+            initiator: e.from,
+            target: e.to,
+            isReply: e.isReply,
+            orderedPath: [e.from, ...e.route_ids, e.to],
+            ms: safeTsMs(e.timestamp),
+          }
+        : null,
+    ),
+  );
+  return events.filter((_, i) => mask[i]);
 }
 
 export function groupTracerouteEvents(events: TracerouteEvent[]): TracerouteGroup[] {
@@ -82,15 +171,18 @@ export function groupTracerouteEvents(events: TracerouteEvent[]): TracerouteGrou
         from: e.from,
         to: e.to,
         route_ids: rids,
-        hops_away: e.hops_away ?? 0,
+        hops_away: e.hops_away ?? null,
         count: 1,
         firstTsMs: ts,
         lastTsMs: ts,
+        provisional: e.provisional,
       });
     } else {
       existing.count += 1;
       existing.firstTsMs = Math.min(existing.firstTsMs, ts || existing.firstTsMs);
       existing.lastTsMs = Math.max(existing.lastTsMs, ts || existing.lastTsMs);
+      // Any confirmed (reply) observation clears the provisional flag.
+      existing.provisional = existing.provisional && e.provisional;
       // Keep a simple representative hops_away (it should be stable anyway)
       if (typeof e.hops_away === "number") existing.hops_away = e.hops_away;
     }

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -145,8 +145,11 @@ export const apiSlice = createApi({
         if (params && params.range && params.range !== "all") sp.set("range", params.range);
         if (params && params.limit) sp.set("limit", String(params.limit));
         // slim=1: server drops the legacy `route` field and unused payload keys,
-        // keeping id/from/to/route_ids/timestamp/snr/rssi + payload.snr_towards
-        // that the map's path analysis reads (ignored by older backends).
+        // keeping id/from/to/route_ids/timestamp/snr/rssi + payload.snr_towards.
+        // payload.snr_towards is load-bearing for EVERY consumer now, not just
+        // map path analysis: utils/traceroute.ts orientTraceroute derives reply
+        // orientation from it (Traceroutes page, graph edges, link layer, live
+        // comet). Ignored by older backends.
         sp.set("slim", "1");
         return `traceroutes?${sp.toString()}`;
       },

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -144,18 +144,10 @@ export const apiSlice = createApi({
         if (params && params.to) sp.set("to", params.to);
         if (params && params.range && params.range !== "all") sp.set("range", params.range);
         if (params && params.limit) sp.set("limit", String(params.limit));
-        // slim=1: server drops the legacy `route` field, keeping
-        // id/packet_id/from/to/route_ids/route_back_ids/timestamp/created_at/
-        // snr/rssi + payload snr_towards/route_back/snr_back.
-        // payload.snr_towards is load-bearing for EVERY consumer, not just
-        // map path analysis: utils/traceroute.ts orientTraceroute derives reply
-        // orientation from it (Traceroutes page, graph edges, link layer, live
-        // comet). Ignored by older backends.
+        // slim=1: drops payload.route + legacy `route` (ignored by older backends);
+        // payload.snr_towards must survive — orientTraceroute derives reply orientation from it.
         sp.set("slim", "1");
-        // envelope=1 requests the {traceroutes, next_cursor} pagination wrap
-        // (this bundle unwraps it below). Older backends ignore the param and
-        // return the bare array; newer backends only wrap when asked, so
-        // stale bundles that don't send it keep working across deploys.
+        // envelope=1: opt-in {traceroutes, next_cursor} wrap; older backends return the bare array.
         sp.set("envelope", "1");
         return `traceroutes?${sp.toString()}`;
       },

--- a/frontend/src/slices/apiSlice.ts
+++ b/frontend/src/slices/apiSlice.ts
@@ -144,15 +144,23 @@ export const apiSlice = createApi({
         if (params && params.to) sp.set("to", params.to);
         if (params && params.range && params.range !== "all") sp.set("range", params.range);
         if (params && params.limit) sp.set("limit", String(params.limit));
-        // slim=1: server drops the legacy `route` field and unused payload keys,
-        // keeping id/from/to/route_ids/timestamp/snr/rssi + payload.snr_towards.
-        // payload.snr_towards is load-bearing for EVERY consumer now, not just
+        // slim=1: server drops the legacy `route` field, keeping
+        // id/packet_id/from/to/route_ids/route_back_ids/timestamp/created_at/
+        // snr/rssi + payload snr_towards/route_back/snr_back.
+        // payload.snr_towards is load-bearing for EVERY consumer, not just
         // map path analysis: utils/traceroute.ts orientTraceroute derives reply
         // orientation from it (Traceroutes page, graph edges, link layer, live
         // comet). Ignored by older backends.
         sp.set("slim", "1");
+        // envelope=1 requests the {traceroutes, next_cursor} pagination wrap
+        // (this bundle unwraps it below). Older backends ignore the param and
+        // return the bare array; newer backends only wrap when asked, so
+        // stale bundles that don't send it keep working across deploys.
+        sp.set("envelope", "1");
         return `traceroutes?${sp.toString()}`;
       },
+      transformResponse: (resp: any): ITraceroutesResponse[] =>
+        Array.isArray(resp) ? resp : (resp?.traceroutes ?? []),
       providesTags: [{ type: "Traceroutes", id: "LIST" }],
     }),
     getNodePackets: builder.query<

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,6 +47,13 @@ export interface ITraceroutesResponse {
   from: string;
   hop_start?: number;
   id: number;
+  /** Reply rows: the request's packet id (exact exchange pairing); null on
+   *  requests and rows written before the backend captured it. */
+  packet_id?: number | null;
+  /** Server ingest time, epoch seconds (slim rows + SSE events). */
+  created_at?: number | null;
+  /** Server-resolved return-path hops, return-travel order. */
+  route_back_ids?: (string | number)[];
   /** Full RouteDiscovery. SNR arrays are firmware-scaled ×4 with -128 = unknown.
    *  Rows carrying the full snr_towards (length = route + 1) are REPLY packets:
    *  their towards path reads header `to` → route → header `from` (the route

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,33 +47,28 @@ export interface ITraceroutesResponse {
   from: string;
   hop_start?: number;
   id: number;
-  /** Reply rows: the request's packet id (exact exchange pairing); null on
-   *  requests and rows written before the backend captured it. */
+  /** Reply rows: the request's packet id (exact exchange pairing). */
   packet_id?: number | null;
   /** Server ingest time, epoch seconds (slim rows + SSE events). */
   created_at?: number | null;
-  /** Server-resolved return-path hops, return-travel order. */
+  /** Resolved return-path hops, return-travel order. */
   route_back_ids?: (string | number)[];
-  /** Full RouteDiscovery. SNR arrays are firmware-scaled ×4 with -128 = unknown.
-   *  Rows carrying the full snr_towards (length = route + 1) are REPLY packets:
-   *  their towards path reads header `to` → route → header `from` (the route
-   *  stays request-oriented while the reply header swaps the endpoints).
-   *  NEVER walk [from, ...route, to] by hand — utils/traceroute.ts
-   *  orientTraceroute is the single mandatory entry point for a row's hop
-   *  sequence (it also normalizes hops and flags mid-flight requests). */
+  /** RouteDiscovery. SNR arrays ×4-scaled, -128 = unknown; snr_towards length = route + 1
+   *  marks a REPLY — walk via orientTraceroute only. Slim rows omit payload.route. */
   payload: {
-    route: (string | number)[];
+    route?: (string | number)[];
     route_back?: (string | number)[];
     snr_towards?: number[];
     snr_back?: number[];
   };
-  route: string[];
+  route?: string[];
   route_ids?: string[];
-  rssi: number;
+  /** null/absent = no RF measurement (self-gatewayed or bridged copies). */
+  rssi?: number | null;
   rx_rssi?: number;
   rx_snr?: number;
   rx_time?: number;
-  snr: number;
+  snr?: number | null;
   timestamp: number;
   to: string;
   topic?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,7 +50,10 @@ export interface ITraceroutesResponse {
   /** Full RouteDiscovery. SNR arrays are firmware-scaled ×4 with -128 = unknown.
    *  Rows carrying the full snr_towards (length = route + 1) are REPLY packets:
    *  their towards path reads header `to` → route → header `from` (the route
-   *  stays request-oriented while the reply header swaps the endpoints). */
+   *  stays request-oriented while the reply header swaps the endpoints).
+   *  NEVER walk [from, ...route, to] by hand — utils/traceroute.ts
+   *  orientTraceroute is the single mandatory entry point for a row's hop
+   *  sequence (it also normalizes hops and flags mid-flight requests). */
   payload: {
     route: (string | number)[];
     route_back?: (string | number)[];

--- a/frontend/src/utils/normalizeNodeId8.test.ts
+++ b/frontend/src/utils/normalizeNodeId8.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeNodeId8 } from "./normalizeNodeId8";
+import { normalizeNodeId8, normNodeId } from "./normalizeNodeId8";
+
+describe("normNodeId", () => {
+  it("pads numeric ids to 8 hex chars (matches backend keys)", () => {
+    expect(normNodeId(0x0165ec15)).toBe("0165ec15");
+    expect(normNodeId(255)).toBe("000000ff");
+  });
+
+  it("treats ≤8-digit all-decimal strings as hex verbatim", () => {
+    // 8-hex backend ids can be all digits; decimal ids arrive as numbers or
+    // >8-digit strings, so at ≤8 chars hex must win.
+    expect(normNodeId("23456789")).toBe("23456789");
+    expect(normNodeId("1234567")).toBe("1234567");
+  });
+
+  it("decimal-parses >8-digit numeric strings, padded", () => {
+    expect(normNodeId("1128082076")).toBe((1128082076).toString(16));
+    expect(normNodeId("305441741")).toBe("1234abcd");
+  });
+
+  it("passes longnames through lowercased and unpadded", () => {
+    expect(normNodeId("Base Camp")).toBe("base camp");
+    expect(normNodeId("cafe")).toBe("cafe");
+  });
+});
 
 describe("normalizeNodeId8", () => {
   it("left-pads short hex to the canonical 8 chars", () => {

--- a/frontend/src/utils/normalizeNodeId8.test.ts
+++ b/frontend/src/utils/normalizeNodeId8.test.ts
@@ -9,8 +9,7 @@ describe("normNodeId", () => {
   });
 
   it("treats ≤8-digit all-decimal strings as hex verbatim", () => {
-    // 8-hex backend ids can be all digits; decimal ids arrive as numbers or
-    // >8-digit strings, so at ≤8 chars hex must win.
+    // Decimal ids only arrive as numbers or >8-digit strings, so at ≤8 chars hex wins.
     expect(normNodeId("23456789")).toBe("23456789");
     expect(normNodeId("1234567")).toBe("1234567");
   });

--- a/frontend/src/utils/normalizeNodeId8.ts
+++ b/frontend/src/utils/normalizeNodeId8.ts
@@ -1,14 +1,22 @@
-/** Normalize a node ID (int or hex string) to lowercase hex. */
+/** Normalize a node ID (int or hex string) to lowercase hex.
+ *  Numeric ids (and >8-digit decimal strings, which can't be 8-hex ids) are
+ *  zero-padded to 8 chars so they match backend normalize_node_id output and
+ *  the getNodes cache keys; ≤8-char all-digit strings are treated as hex
+ *  verbatim — backend ids are always 8-hex, and decimal ids only arrive as
+ *  JSON numbers or longer-than-8-digit strings. Non-hex strings (longnames)
+ *  pass through lowercased and unpadded — padding would fabricate an id. */
 export function normNodeId(raw: unknown): string {
   if (raw == null) return "";
   if (typeof raw === "number") {
     if (!Number.isFinite(raw) || raw <= 0) return "";
-    return (raw >>> 0).toString(16).toLowerCase();
+    return (raw >>> 0).toString(16).toLowerCase().padStart(8, "0");
   }
   let s = String(raw).trim();
-  if (/^\d+$/.test(s) && s.length > 6) {
+  if (/^\d+$/.test(s) && s.length > 8) {
     const n = parseInt(s, 10);
-    if (Number.isFinite(n) && n > 0) return (n >>> 0).toString(16).toLowerCase();
+    if (Number.isFinite(n) && n > 0) {
+      return (n >>> 0).toString(16).toLowerCase().padStart(8, "0");
+    }
   }
   if (s.startsWith("!")) s = s.slice(1);
   if (s.startsWith("0x") || s.startsWith("0X")) s = s.slice(2);

--- a/frontend/src/utils/normalizeNodeId8.ts
+++ b/frontend/src/utils/normalizeNodeId8.ts
@@ -1,10 +1,6 @@
-/** Normalize a node ID (int or hex string) to lowercase hex.
- *  Numeric ids (and >8-digit decimal strings, which can't be 8-hex ids) are
- *  zero-padded to 8 chars so they match backend normalize_node_id output and
- *  the getNodes cache keys; ≤8-char all-digit strings are treated as hex
- *  verbatim — backend ids are always 8-hex, and decimal ids only arrive as
- *  JSON numbers or longer-than-8-digit strings. Non-hex strings (longnames)
- *  pass through lowercased and unpadded — padding would fabricate an id. */
+/** Normalize a node ID (int or hex string) to lowercase hex. Numeric ids and >8-digit
+ *  decimal strings zero-pad to 8 chars (matches backend keys); ≤8-char all-digit strings
+ *  are hex verbatim; non-hex strings (longnames) pass through lowercased, unpadded. */
 export function normNodeId(raw: unknown): string {
   if (raw == null) return "";
   if (typeof raw === "number") {

--- a/frontend/src/utils/traceroute.test.ts
+++ b/frontend/src/utils/traceroute.test.ts
@@ -11,8 +11,7 @@ import {
   type TracerouteRowLike,
 } from "./traceroute";
 
-/** Trace A → R1 → R2 → D captured as the REQUEST packet mid-flight (route
- *  accumulated up to R1; snr_towards has one entry per observed leg). */
+/** REQUEST row caught mid-flight: route accumulated up to R1, one snr_towards per observed leg. */
 const requestRow = (over: Partial<TracerouteRowLike> = {}): TracerouteRowLike => ({
   from: "000000aa",
   to: "000000dd",
@@ -23,8 +22,7 @@ const requestRow = (over: Partial<TracerouteRowLike> = {}): TracerouteRowLike =>
   ...over,
 });
 
-/** The matching REPLY packet: header endpoints swapped, route request-ordered
- *  and complete, snr_towards = route + 1 (destination appended its reading). */
+/** Matching REPLY: header endpoints swapped, route request-ordered, snr_towards = route + 1. */
 const replyRow = (over: Partial<TracerouteRowLike> = {}): TracerouteRowLike => ({
   from: "000000dd",
   to: "000000aa",
@@ -208,16 +206,14 @@ describe("dedupeExchanges", () => {
   });
 
   it("pairs exactly via packet_id, ignoring window and path", () => {
-    // Request stored 10 minutes before the reply (heuristic window is 60s)
-    // via a DIFFERENT first hop (heuristic prefix rule would also fail)
+    // Outside the 60s window and via a different first hop — packet_id pairing must still win.
     const req = requestRow({ id: 424242, timestamp: 400, route_ids: ["000000c9"], payload: { route: [0xc9], snr_towards: [4] } });
     const rep = replyRow({ timestamp: 1010, packet_id: 424242 });
     expect(dedupeExchanges([req, rep])).toEqual([rep]);
   });
 
   it("exact-keyed replies never heuristically merge a different request", () => {
-    // The reply names its request (never stored/heard); the same-pair request
-    // within the window belongs to another attempt and must survive.
+    // The named request was never heard; the in-window same-pair request is another attempt.
     const otherReq = requestRow({ id: 111, timestamp: 1000 });
     const rep = replyRow({ timestamp: 1010, packet_id: 999999 });
     expect(dedupeExchanges([otherReq, rep])).toEqual([otherReq, rep]);

--- a/frontend/src/utils/traceroute.test.ts
+++ b/frontend/src/utils/traceroute.test.ts
@@ -4,8 +4,10 @@ import {
   canonicalPairKey,
   decodeSnr,
   dedupeExchanges,
+  hasFullTraceroutePayload,
   isResolvedHop,
   orientTraceroute,
+  tracerouteRichness,
   type TracerouteRowLike,
 } from "./traceroute";
 
@@ -117,6 +119,47 @@ describe("decodeSnr", () => {
     expect(decodeSnr(0)).toBe(0);
     expect(decodeSnr(-128)).toBeNull();
     expect(decodeSnr(undefined)).toBeNull();
+  });
+});
+
+describe("tracerouteRichness", () => {
+  it("sums the four RouteDiscovery arrays (mirrors the DB upsert metric)", () => {
+    const poor: TracerouteRowLike = {
+      payload: { route: [1, 2], snr_towards: [4, 8, 12], route_back: [], snr_back: [] },
+    };
+    const rich: TracerouteRowLike = {
+      payload: { route: [1, 2], snr_towards: [4, 8, 12], route_back: [3], snr_back: [9] },
+    };
+    expect(tracerouteRichness(poor)).toBe(5);
+    expect(tracerouteRichness(rich)).toBe(7);
+  });
+
+  it("falls back to route_ids for slim rows so they don't under-count", () => {
+    // Slim REST row: payload stripped to snr_towards, route carried as route_ids
+    const slim: TracerouteRowLike = {
+      route_ids: ["000000b1", "000000b2"],
+      payload: { snr_towards: [4, 8, 12] },
+    };
+    // The identical packet as a full SSE row, no back-leg data yet
+    const fullSameData: TracerouteRowLike = {
+      route_ids: ["000000b1", "000000b2"],
+      payload: { route: [1, 2], snr_towards: [4, 8, 12], route_back: [], snr_back: [] },
+    };
+    expect(tracerouteRichness(slim)).toBe(5);
+    // Equal — a same-data full row must NOT read as richer than its slim twin
+    expect(tracerouteRichness(fullSameData)).toBe(tracerouteRichness(slim));
+  });
+
+  it("handles missing/malformed payloads as zero", () => {
+    expect(tracerouteRichness({})).toBe(0);
+    expect(tracerouteRichness({ payload: { route: "bogus" as unknown as [] } })).toBe(0);
+  });
+
+  it("hasFullTraceroutePayload separates slim rows from full rows", () => {
+    expect(hasFullTraceroutePayload({ payload: { route: [1], snr_towards: [4, 8] } })).toBe(true);
+    // Slim REST row: payload stripped to snr_towards only
+    expect(hasFullTraceroutePayload({ route_ids: ["000000b1"], payload: { snr_towards: [4, 8] } })).toBe(false);
+    expect(hasFullTraceroutePayload({})).toBe(false);
   });
 });
 

--- a/frontend/src/utils/traceroute.test.ts
+++ b/frontend/src/utils/traceroute.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalPairKey,
+  decodeSnr,
+  dedupeExchanges,
+  isResolvedHop,
+  orientTraceroute,
+  type TracerouteRowLike,
+} from "./traceroute";
+
+/** Trace A → R1 → R2 → D captured as the REQUEST packet mid-flight (route
+ *  accumulated up to R1; snr_towards has one entry per observed leg). */
+const requestRow = (over: Partial<TracerouteRowLike> = {}): TracerouteRowLike => ({
+  from: "000000aa",
+  to: "000000dd",
+  route_ids: ["000000b1"],
+  payload: { route: [0xb1], snr_towards: [-29] },
+  timestamp: 1000,
+  id: 1,
+  ...over,
+});
+
+/** The matching REPLY packet: header endpoints swapped, route request-ordered
+ *  and complete, snr_towards = route + 1 (destination appended its reading). */
+const replyRow = (over: Partial<TracerouteRowLike> = {}): TracerouteRowLike => ({
+  from: "000000dd",
+  to: "000000aa",
+  route_ids: ["000000b1", "000000b2"],
+  payload: { route: [0xb1, 0xb2], snr_towards: [-29, 8, 12] },
+  timestamp: 1010,
+  id: 2,
+  ...over,
+});
+
+describe("orientTraceroute", () => {
+  it("walks request rows header from → route → to", () => {
+    const o = orientTraceroute(requestRow())!;
+    expect(o.orderedPath).toEqual(["000000aa", "000000b1", "000000dd"]);
+    expect(o.initiator).toBe("000000aa");
+    expect(o.target).toBe("000000dd");
+    expect(o.isReply).toBe(false);
+    expect(o.provisional).toBe(true);
+  });
+
+  it("swaps reply-row headers without reversing the route", () => {
+    const o = orientTraceroute(replyRow())!;
+    expect(o.orderedPath).toEqual(["000000aa", "000000b1", "000000b2", "000000dd"]);
+    expect(o.initiator).toBe("000000aa");
+    expect(o.target).toBe("000000dd");
+    expect(o.isReply).toBe(true);
+    expect(o.provisional).toBe(false);
+  });
+
+  it("decodes reply per-leg SNR aligned to orderedPath legs", () => {
+    const o = orientTraceroute(replyRow())!;
+    expect(o.legSnrDb).toEqual([-7.25, 2, 3]);
+  });
+
+  it("keeps request partial SNR for observed legs, null for the final leg", () => {
+    const o = orientTraceroute(requestRow())!;
+    expect(o.legSnrDb).toEqual([-7.25, null]);
+  });
+
+  it("treats an snr_towards length mismatch as an unusable request", () => {
+    const o = orientTraceroute(requestRow({ payload: { route: [0xb1], snr_towards: [1, 2, 3, 4] } }))!;
+    expect(o.isReply).toBe(false);
+    expect(o.legSnrDb).toBeUndefined();
+  });
+
+  it("keeps unresolvable hops as ?-placeholders so alignment holds", () => {
+    const o = orientTraceroute(replyRow({ route_ids: ["000000b1", "Some Longname"] }))!;
+    expect(o.orderedPath).toEqual(["000000aa", "000000b1", "some longname", "000000dd"]);
+    expect(o.legSnrDb).toHaveLength(3);
+  });
+
+  it("pads raw-int hops to canonical 8-hex", () => {
+    const o = orientTraceroute(requestRow({ route_ids: [0x0165ec15] }))!;
+    expect(o.orderedPath[1]).toBe("0165ec15");
+  });
+
+  it("returns null when an endpoint is missing", () => {
+    expect(orientTraceroute({ from: "000000aa", route_ids: [] })).toBeNull();
+    expect(orientTraceroute(null)).toBeNull();
+  });
+
+  it("handles the skinny SSE shape (no payload) as a request walk", () => {
+    const o = orientTraceroute({ from: "000000dd", to: "000000aa", route_ids: ["000000b1"], id: 9 })!;
+    expect(o.orderedPath).toEqual(["000000dd", "000000b1", "000000aa"]);
+    expect(o.provisional).toBe(true);
+  });
+});
+
+describe("isResolvedHop", () => {
+  it("accepts bare hex ids and rejects sentinels/placeholders/longnames", () => {
+    expect(isResolvedHop("67ea9400")).toBe(true);
+    expect(isResolvedHop("ffffffff")).toBe(false); // broadcast / unknown-hop sentinel
+    expect(isResolvedHop("?2864434397")).toBe(false);
+    expect(isResolvedHop("some longname")).toBe(false);
+    // Hex-lookalike longname ("Cafe" → "cafe"): resolvable ids are exactly 8 hex
+    expect(isResolvedHop("cafe")).toBe(false);
+    expect(isResolvedHop("")).toBe(false);
+  });
+});
+
+describe("canonicalPairKey", () => {
+  it("is symmetric and normalizes both endpoints", () => {
+    expect(canonicalPairKey("000000dd", "000000aa")).toBe("000000aa|000000dd");
+    expect(canonicalPairKey("000000aa", "000000dd")).toBe("000000aa|000000dd");
+    expect(canonicalPairKey(0xdd, "!000000aa")).toBe("000000aa|000000dd");
+  });
+});
+
+describe("decodeSnr", () => {
+  it("divides by 4 and nulls the -128 sentinel", () => {
+    expect(decodeSnr(-29)).toBe(-7.25);
+    expect(decodeSnr(0)).toBe(0);
+    expect(decodeSnr(-128)).toBeNull();
+    expect(decodeSnr(undefined)).toBeNull();
+  });
+});
+
+describe("dedupeExchanges", () => {
+  it("drops the truncated request when its reply is present", () => {
+    const req = requestRow();
+    const rep = replyRow();
+    expect(dedupeExchanges([req, rep])).toEqual([rep]);
+  });
+
+  it("keeps an unmatched request (reply lost to RF)", () => {
+    const req = requestRow();
+    expect(dedupeExchanges([req])).toEqual([req]);
+  });
+
+  it("keeps a request outside the 60s window", () => {
+    const req = requestRow({ timestamp: 900 }); // 110s before the reply
+    const rep = replyRow({ timestamp: 1010 });
+    expect(dedupeExchanges([req, rep])).toEqual([req, rep]);
+  });
+
+  it("never merges two same-role rows: repeated requests are repeated attempts", () => {
+    const req1 = requestRow({ timestamp: 1000, id: 1 });
+    const req2 = requestRow({ timestamp: 1050, id: 2 });
+    expect(dedupeExchanges([req1, req2])).toEqual([req1, req2]);
+  });
+
+  it("a reply consumes only its closest preceding request", () => {
+    const req1 = requestRow({ timestamp: 990, id: 1 });
+    const req2 = requestRow({ timestamp: 1000, id: 2 });
+    const rep = replyRow({ timestamp: 1010 });
+    expect(dedupeExchanges([req1, req2, rep])).toEqual([req1, rep]);
+  });
+
+  it("requires the request path to prefix the reply path", () => {
+    // Same pair but the request went via a different first hop — not this exchange.
+    const req = requestRow({ route_ids: ["000000c9"], payload: { route: [0xc9], snr_towards: [4] } });
+    const rep = replyRow();
+    expect(dedupeExchanges([req, rep])).toEqual([req, rep]);
+  });
+
+  it("passes unorientable rows through untouched", () => {
+    const bad = { route_ids: ["000000b1"] } as TracerouteRowLike;
+    const rep = replyRow();
+    expect(dedupeExchanges([bad, rep])).toEqual([bad, rep]);
+  });
+
+  it("collapses a zero-hop exchange to the reply", () => {
+    const req: TracerouteRowLike = {
+      from: "000000aa",
+      to: "000000dd",
+      route_ids: [],
+      payload: { route: [], snr_towards: [] },
+      timestamp: 1000,
+    };
+    const rep: TracerouteRowLike = {
+      from: "000000dd",
+      to: "000000aa",
+      route_ids: [],
+      payload: { route: [], snr_towards: [5] },
+      timestamp: 1005,
+    };
+    expect(dedupeExchanges([req, rep])).toEqual([rep]);
+  });
+});

--- a/frontend/src/utils/traceroute.test.ts
+++ b/frontend/src/utils/traceroute.test.ts
@@ -207,6 +207,22 @@ describe("dedupeExchanges", () => {
     expect(dedupeExchanges([bad, rep])).toEqual([bad, rep]);
   });
 
+  it("pairs exactly via packet_id, ignoring window and path", () => {
+    // Request stored 10 minutes before the reply (heuristic window is 60s)
+    // via a DIFFERENT first hop (heuristic prefix rule would also fail)
+    const req = requestRow({ id: 424242, timestamp: 400, route_ids: ["000000c9"], payload: { route: [0xc9], snr_towards: [4] } });
+    const rep = replyRow({ timestamp: 1010, packet_id: 424242 });
+    expect(dedupeExchanges([req, rep])).toEqual([rep]);
+  });
+
+  it("exact-keyed replies never heuristically merge a different request", () => {
+    // The reply names its request (never stored/heard); the same-pair request
+    // within the window belongs to another attempt and must survive.
+    const otherReq = requestRow({ id: 111, timestamp: 1000 });
+    const rep = replyRow({ timestamp: 1010, packet_id: 999999 });
+    expect(dedupeExchanges([otherReq, rep])).toEqual([otherReq, rep]);
+  });
+
   it("collapses a zero-hop exchange to the reply", () => {
     const req: TracerouteRowLike = {
       from: "000000aa",

--- a/frontend/src/utils/traceroute.ts
+++ b/frontend/src/utils/traceroute.ts
@@ -149,6 +149,37 @@ function computeOriented(tr: TracerouteRowLike): OrientedTraceroute | null {
   };
 }
 
+/** Accumulated-data metric for competing copies of ONE packet — mirrors the
+ *  backend's richer-wins upsert (sum of the four RouteDiscovery array
+ *  lengths), with a deviation: the route component falls back to route_ids
+ *  when payload.route is absent (slim REST rows strip the payload down to
+ *  snr_towards). The metric is EXACT only between two full-payload rows;
+ *  a slim REPLY row still under-counts (its route_back/snr_back are
+ *  stripped), so callers must not richness-compare a slim row against a full
+ *  one — see hasFullTraceroutePayload. Only meaningful between rows sharing
+ *  a packet identity (id + header endpoints). */
+export function tracerouteRichness(tr: TracerouteRowLike): number {
+  const p = tr.payload;
+  const routeLen = Array.isArray(p?.route)
+    ? p.route.length
+    : Array.isArray(tr.route_ids)
+      ? tr.route_ids.length
+      : 0;
+  return (
+    routeLen +
+    (Array.isArray(p?.snr_towards) ? p.snr_towards.length : 0) +
+    (Array.isArray(p?.route_back) ? p.route_back.length : 0) +
+    (Array.isArray(p?.snr_back) ? p.snr_back.length : 0)
+  );
+}
+
+/** True when the row carries the full RouteDiscovery payload (SSE rows, non-
+ *  slim REST rows). Slim rows strip payload.route/route_back/snr_back, making
+ *  their richness incomparable against full rows. */
+export function hasFullTraceroutePayload(tr: TracerouteRowLike): boolean {
+  return Array.isArray(tr.payload?.route);
+}
+
 /** One traceroute exchange writes up to two rows: the request packet (caught
  *  mid-flight, truncated route) and the reply packet (complete route).
  *  Counting both inflates runs/edge stats ~2× on well-heard pairs. */

--- a/frontend/src/utils/traceroute.ts
+++ b/frontend/src/utils/traceroute.ts
@@ -29,6 +29,10 @@ export type TracerouteRowLike = {
   };
   timestamp?: number;
   id?: number | string;
+  /** Reply rows: the REQUEST's packet id (backend Data.request_id, stored in
+   *  the packet_id column) — enables exact request/reply exchange pairing.
+   *  Null/absent on request rows and rows written before it was captured. */
+  packet_id?: number | string | null;
 };
 
 export interface OrientedTraceroute {
@@ -174,8 +178,10 @@ export function tracerouteRichness(tr: TracerouteRowLike): number {
 }
 
 /** True when the row carries the full RouteDiscovery payload (SSE rows, non-
- *  slim REST rows). Slim rows strip payload.route/route_back/snr_back, making
- *  their richness incomparable against full rows. */
+ *  slim REST rows). Current-backend slim rows strip only payload.route (the
+ *  back arrays now survive), older-backend slim rows stripped the back arrays
+ *  too — either way payload.route is the reliable discriminator, and held
+ *  rows lacking it are replaced by any full copy rather than richness-raced. */
 export function hasFullTraceroutePayload(tr: TracerouteRowLike): boolean {
   return Array.isArray(tr.payload?.route);
 }
@@ -196,24 +202,35 @@ export interface ExchangeView {
   orderedPath: string[];
   /** Timestamp in milliseconds. */
   ms: number;
+  /** The row's own packet id, when known. */
+  id?: number | string | null;
+  /** Reply rows: the request's packet id (exact pairing key), when known. */
+  replyTo?: number | string | null;
 }
 
 /** Core exchange pairing: returns a keep-mask over `items` (false = this row
  *  is the request half of a matched exchange and should collapse into its
- *  reply). Pairs exactly ONE request with ONE reply: same initiator/target,
- *  request within EXCHANGE_WINDOW_MS before the reply, and the request's
- *  observed hops (its orderedPath minus the speculative final target hop) a
- *  prefix of the reply's orderedPath. Never merges two same-role rows — two
- *  requests are two attempts. null items (unorientable rows) are always kept.
- *  Heuristic by necessity: request_id is not persisted for historical rows;
- *  once the backend exposes it (fix-plan Batch 4) exact pairing takes over
- *  with this as fallback. */
+ *  reply). Pairs exactly ONE request with ONE reply.
+ *
+ *  EXACT pairing: a reply carrying `replyTo` (the request's packet id, from
+ *  the backend's packet_id capture) matches only the request whose own id
+ *  equals it — no window, no path comparison, and no heuristic fallback for
+ *  that reply (its request either exists or was never heard).
+ *
+ *  HEURISTIC fallback (historical rows without replyTo): same
+ *  initiator/target, request within EXCHANGE_WINDOW_MS before the reply, and
+ *  the request's observed hops (its orderedPath minus the speculative final
+ *  target hop) a prefix of the reply's orderedPath.
+ *
+ *  Never merges two same-role rows — two requests are two attempts. null
+ *  items (unorientable rows) are always kept. */
 export function exchangeKeepMask(items: (ExchangeView | null)[]): boolean[] {
   interface Entry {
     v: ExchangeView;
     matched: boolean;
   }
   const requests = new Map<string, Entry[]>(); // keyed initiator→target (directed)
+  const requestsById = new Map<string, Entry>();
   const entries: (Entry | null)[] = items.map((v) => {
     if (!v) return null;
     const e: Entry = { v, matched: false };
@@ -222,12 +239,27 @@ export function exchangeKeepMask(items: (ExchangeView | null)[]): boolean[] {
       const list = requests.get(key);
       if (list) list.push(e);
       else requests.set(key, [e]);
+      if (v.id != null) requestsById.set(String(v.id), e);
     }
     return e;
   });
 
   for (const e of entries) {
     if (!e || !e.v.isReply) continue;
+
+    if (e.v.replyTo != null) {
+      const exact = requestsById.get(String(e.v.replyTo));
+      if (
+        exact &&
+        !exact.matched &&
+        exact.v.initiator === e.v.initiator &&
+        exact.v.target === e.v.target
+      ) {
+        exact.matched = true;
+      }
+      continue; // exact-keyed replies never fall back to the heuristic
+    }
+
     const candidates = requests.get(`${e.v.initiator}>${e.v.target}`);
     if (!candidates) continue;
     let best: Entry | null = null;
@@ -260,6 +292,8 @@ export function dedupeExchanges<T extends TracerouteRowLike>(rows: T[]): T[] {
         isReply: o.isReply,
         orderedPath: o.orderedPath,
         ms: tsToMs(row.timestamp ?? 0),
+        id: row.id,
+        replyTo: row.packet_id,
       };
     }),
   );

--- a/frontend/src/utils/traceroute.ts
+++ b/frontend/src/utils/traceroute.ts
@@ -1,0 +1,236 @@
+/** Shared traceroute-row semantics: the single mandatory entry point for
+ *  walking a traceroute's hop sequence.
+ *
+ *  Meshtastic RouteDiscovery accumulates hop-by-hop: `route` is the list of
+ *  intermediate hops toward the destination, `snr_towards` the per-leg SNR
+ *  (firmware-scaled ×4, -128 = unknown). The destination appends one extra
+ *  SNR reading when building its REPLY, so a row with
+ *  snr_towards.length === route.length + 1 is a reply packet: its header
+ *  endpoints are swapped (from = traced node, to = requester) while the route
+ *  stays request-ordered. The travel-ordered path is therefore
+ *  to → route → from — a header swap, NOT a path reversal, so an ad-hoc
+ *  [from, ...route, to] walk attributes both endpoint-adjacent legs to the
+ *  wrong nodes on reply rows. Never walk rows by hand; use orientTraceroute.
+ */
+import { normNodeId } from "./normalizeNodeId8";
+
+/** Structural row shape so slim REST rows, full SSE events, and page-coerced
+ *  events all fit without casts. */
+export type TracerouteRowLike = {
+  from?: string | number;
+  to?: string | number;
+  route_ids?: (string | number)[];
+  route?: unknown;
+  payload?: {
+    route?: (string | number)[];
+    snr_towards?: number[];
+    route_back?: (string | number)[];
+    snr_back?: number[];
+  };
+  timestamp?: number;
+  id?: number | string;
+};
+
+export interface OrientedTraceroute {
+  /** Travel order [initiator, ...hops, target]; unresolvable hops kept as
+   *  `?<raw>` placeholders so hop counts and per-leg SNR stay aligned. */
+  orderedPath: string[];
+  /** Requester (header `from` on request rows, header `to` on reply rows). */
+  initiator: string;
+  /** Traced node. */
+  target: string;
+  isReply: boolean;
+  /** Request seen mid-flight: the final orderedPath leg (…→target) is implied
+   *  by the header, not observed. Aggregations must skip that leg. */
+  provisional: boolean;
+  /** Undirected canonical pair key: sorted `${min}|${max}`. */
+  pairKey: string;
+  /** Decoded per-leg SNR in dB aligned to orderedPath legs (legSnrDb[i] is the
+   *  orderedPath[i]→orderedPath[i+1] leg; null = unknown). Present on reply
+   *  rows (all legs) and on requests carrying a partial snr_towards (all but
+   *  the final leg); absent when the row has no usable snr_towards. */
+  legSnrDb?: (number | null)[];
+}
+
+/** 0xFFFFFFFF: firmware's unknown-hop / broadcast sentinel. */
+export const BROADCAST_ID = "ffffffff";
+
+const SNR_UNKNOWN_SENTINEL = -128;
+
+/** Decode a firmware ×4-scaled SNR value; -128 sentinel → null (unknown). */
+export function decodeSnr(raw: number | null | undefined): number | null {
+  if (raw == null || !Number.isFinite(raw) || raw === SNR_UNKNOWN_SENTINEL) return null;
+  return raw / 4;
+}
+
+/** Epoch that may be seconds or milliseconds → milliseconds. */
+export function tsToMs(ts: number): number {
+  return ts > 1e12 ? ts : ts * 1000;
+}
+
+/** Resolved node ids normalize to exactly 8 lowercase hex chars (numbers and
+ *  long decimal strings are padded; backend ids are always 8-hex); longnames,
+ *  `?<raw>` placeholders — and hex-lookalike longnames like "cafe", which a
+ *  looser length would admit — don't. The broadcast sentinel is a real hex id
+ *  but never a routable node. Edges touching any of these can't be
+ *  positioned, clicked, or counted as observed links. */
+export function isResolvedHop(hop: string): boolean {
+  return /^[0-9a-f]{8}$/.test(hop) && hop !== BROADCAST_ID;
+}
+
+/** Undirected canonical pair key, independent of who initiated. */
+export function canonicalPairKey(a: string | number, b: string | number): string {
+  const na = normNodeId(a);
+  const nb = normNodeId(b);
+  return na < nb ? `${na}|${nb}` : `${nb}|${na}`;
+}
+
+const orientCache = new WeakMap<object, OrientedTraceroute | null>();
+
+function rawRoute(tr: TracerouteRowLike): (string | number)[] {
+  if (Array.isArray(tr.route_ids) && tr.route_ids.length > 0) return tr.route_ids;
+  if (Array.isArray(tr.route) && tr.route.length > 0) return tr.route as (string | number)[];
+  if (Array.isArray(tr.payload?.route)) return tr.payload.route;
+  return [];
+}
+
+/** Orient one traceroute row into travel order. Returns null when either
+ *  header endpoint is missing/invalid. Cached per row object (rows are
+ *  replaced wholesale on refetch, so identity keying is safe). */
+export function orientTraceroute(tr: TracerouteRowLike | null | undefined): OrientedTraceroute | null {
+  if (!tr || typeof tr !== "object") return null;
+  const cached = orientCache.get(tr);
+  if (cached !== undefined) return cached;
+
+  const result = computeOriented(tr);
+  orientCache.set(tr, result);
+  return result;
+}
+
+function computeOriented(tr: TracerouteRowLike): OrientedTraceroute | null {
+  const tFrom = normNodeId(tr.from);
+  const tTo = normNodeId(tr.to);
+  if (!tFrom || !tTo) return null;
+
+  const raw = rawRoute(tr);
+  // Keep unresolvable hops as placeholders instead of dropping them — a drop
+  // would shrink the hop count and shift per-leg SNR alignment.
+  const route = raw.map((r) => normNodeId(r) || `?${String(r)}`);
+
+  const snrTow = tr.payload?.snr_towards;
+  const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
+
+  // The towards journey is initiator → route → target in BOTH cases;
+  // snr_towards[i] is the orderedPath[i]→orderedPath[i+1] leg either way.
+  const orderedPath = isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo];
+  const initiator = orderedPath[0];
+  const target = orderedPath[orderedPath.length - 1];
+
+  let legSnrDb: (number | null)[] | undefined;
+  if (Array.isArray(snrTow)) {
+    if (isReply) {
+      legSnrDb = snrTow.map(decodeSnr);
+    } else if (snrTow.length === route.length && route.length > 0) {
+      // Mid-flight request: SNR was measured for every observed leg; only the
+      // final (…→target) leg is unobserved. Anything else is a length
+      // mismatch we can't align safely.
+      legSnrDb = [...snrTow.map(decodeSnr), null];
+    }
+  }
+
+  return {
+    orderedPath,
+    initiator,
+    target,
+    isReply,
+    provisional: !isReply,
+    pairKey: initiator < target ? `${initiator}|${target}` : `${target}|${initiator}`,
+    legSnrDb,
+  };
+}
+
+/** One traceroute exchange writes up to two rows: the request packet (caught
+ *  mid-flight, truncated route) and the reply packet (complete route).
+ *  Counting both inflates runs/edge stats ~2× on well-heard pairs. */
+export const EXCHANGE_WINDOW_MS = 60_000;
+
+/** Minimal oriented view of a row for exchange matching — lets callers that
+ *  already hold oriented data (e.g. page-coerced events) reuse the pairing
+ *  algorithm without re-orienting. */
+export interface ExchangeView {
+  initiator: string;
+  target: string;
+  isReply: boolean;
+  /** Travel order [initiator, ...hops, target]. */
+  orderedPath: string[];
+  /** Timestamp in milliseconds. */
+  ms: number;
+}
+
+/** Core exchange pairing: returns a keep-mask over `items` (false = this row
+ *  is the request half of a matched exchange and should collapse into its
+ *  reply). Pairs exactly ONE request with ONE reply: same initiator/target,
+ *  request within EXCHANGE_WINDOW_MS before the reply, and the request's
+ *  observed hops (its orderedPath minus the speculative final target hop) a
+ *  prefix of the reply's orderedPath. Never merges two same-role rows — two
+ *  requests are two attempts. null items (unorientable rows) are always kept.
+ *  Heuristic by necessity: request_id is not persisted for historical rows;
+ *  once the backend exposes it (fix-plan Batch 4) exact pairing takes over
+ *  with this as fallback. */
+export function exchangeKeepMask(items: (ExchangeView | null)[]): boolean[] {
+  interface Entry {
+    v: ExchangeView;
+    matched: boolean;
+  }
+  const requests = new Map<string, Entry[]>(); // keyed initiator→target (directed)
+  const entries: (Entry | null)[] = items.map((v) => {
+    if (!v) return null;
+    const e: Entry = { v, matched: false };
+    if (!v.isReply) {
+      const key = `${v.initiator}>${v.target}`;
+      const list = requests.get(key);
+      if (list) list.push(e);
+      else requests.set(key, [e]);
+    }
+    return e;
+  });
+
+  for (const e of entries) {
+    if (!e || !e.v.isReply) continue;
+    const candidates = requests.get(`${e.v.initiator}>${e.v.target}`);
+    if (!candidates) continue;
+    let best: Entry | null = null;
+    for (const req of candidates) {
+      if (req.matched) continue;
+      const dt = e.v.ms - req.v.ms;
+      if (dt < 0 || dt > EXCHANGE_WINDOW_MS) continue;
+      const observed = req.v.orderedPath.slice(0, -1);
+      if (observed.length >= e.v.orderedPath.length) continue;
+      if (!observed.every((hop, i) => e.v.orderedPath[i] === hop)) continue;
+      if (!best || req.v.ms > best.v.ms) best = req; // closest request before the reply
+    }
+    if (best) best.matched = true;
+  }
+
+  return entries.map((e) => e == null || !e.matched);
+}
+
+/** Collapse request+reply of one exchange to the reply row (see
+ *  exchangeKeepMask for the pairing rules). Unmatched requests are kept — the
+ *  exchange's reply was lost to RF and the mid-flight capture is all we have. */
+export function dedupeExchanges<T extends TracerouteRowLike>(rows: T[]): T[] {
+  const mask = exchangeKeepMask(
+    rows.map((row) => {
+      const o = orientTraceroute(row);
+      if (!o) return null;
+      return {
+        initiator: o.initiator,
+        target: o.target,
+        isReply: o.isReply,
+        orderedPath: o.orderedPath,
+        ms: tsToMs(row.timestamp ?? 0),
+      };
+    }),
+  );
+  return rows.filter((_, i) => mask[i]);
+}

--- a/frontend/src/utils/traceroute.ts
+++ b/frontend/src/utils/traceroute.ts
@@ -1,21 +1,9 @@
-/** Shared traceroute-row semantics: the single mandatory entry point for
- *  walking a traceroute's hop sequence.
- *
- *  Meshtastic RouteDiscovery accumulates hop-by-hop: `route` is the list of
- *  intermediate hops toward the destination, `snr_towards` the per-leg SNR
- *  (firmware-scaled ×4, -128 = unknown). The destination appends one extra
- *  SNR reading when building its REPLY, so a row with
- *  snr_towards.length === route.length + 1 is a reply packet: its header
- *  endpoints are swapped (from = traced node, to = requester) while the route
- *  stays request-ordered. The travel-ordered path is therefore
- *  to → route → from — a header swap, NOT a path reversal, so an ad-hoc
- *  [from, ...route, to] walk attributes both endpoint-adjacent legs to the
- *  wrong nodes on reply rows. Never walk rows by hand; use orientTraceroute.
- */
+/** Shared traceroute-row semantics. snr_towards.length === route.length + 1 marks a
+ *  reply: its header endpoints are swapped, so travel order is to → route → from.
+ *  Always walk rows via orientTraceroute, never by hand. */
 import { normNodeId } from "./normalizeNodeId8";
 
-/** Structural row shape so slim REST rows, full SSE events, and page-coerced
- *  events all fit without casts. */
+/** Structural row shape covering slim REST rows, full SSE events, and page-coerced events. */
 export type TracerouteRowLike = {
   from?: string | number;
   to?: string | number;
@@ -29,30 +17,24 @@ export type TracerouteRowLike = {
   };
   timestamp?: number;
   id?: number | string;
-  /** Reply rows: the REQUEST's packet id (backend Data.request_id, stored in
-   *  the packet_id column) — enables exact request/reply exchange pairing.
-   *  Null/absent on request rows and rows written before it was captured. */
+  /** Reply rows: the REQUEST's packet id (backend Data.request_id); null/absent on requests. */
   packet_id?: number | string | null;
 };
 
 export interface OrientedTraceroute {
-  /** Travel order [initiator, ...hops, target]; unresolvable hops kept as
-   *  `?<raw>` placeholders so hop counts and per-leg SNR stay aligned. */
+  /** Travel order [initiator, ...hops, target]; unresolvable hops kept as `?<raw>` placeholders. */
   orderedPath: string[];
   /** Requester (header `from` on request rows, header `to` on reply rows). */
   initiator: string;
   /** Traced node. */
   target: string;
   isReply: boolean;
-  /** Request seen mid-flight: the final orderedPath leg (…→target) is implied
-   *  by the header, not observed. Aggregations must skip that leg. */
+  /** Mid-flight request: the final (…→target) leg is implied, not observed — skip it in aggregations. */
   provisional: boolean;
   /** Undirected canonical pair key: sorted `${min}|${max}`. */
   pairKey: string;
-  /** Decoded per-leg SNR in dB aligned to orderedPath legs (legSnrDb[i] is the
-   *  orderedPath[i]→orderedPath[i+1] leg; null = unknown). Present on reply
-   *  rows (all legs) and on requests carrying a partial snr_towards (all but
-   *  the final leg); absent when the row has no usable snr_towards. */
+  /** Per-leg SNR in dB; legSnrDb[i] is the orderedPath[i]→orderedPath[i+1] leg,
+   *  null = unknown, absent when the row has no usable snr_towards. */
   legSnrDb?: (number | null)[];
 }
 
@@ -72,12 +54,8 @@ export function tsToMs(ts: number): number {
   return ts > 1e12 ? ts : ts * 1000;
 }
 
-/** Resolved node ids normalize to exactly 8 lowercase hex chars (numbers and
- *  long decimal strings are padded; backend ids are always 8-hex); longnames,
- *  `?<raw>` placeholders — and hex-lookalike longnames like "cafe", which a
- *  looser length would admit — don't. The broadcast sentinel is a real hex id
- *  but never a routable node. Edges touching any of these can't be
- *  positioned, clicked, or counted as observed links. */
+/** Exactly 8 lowercase hex chars and not the broadcast sentinel — longnames
+ *  (even hex-lookalikes like "cafe") and `?<raw>` placeholders fail. */
 export function isResolvedHop(hop: string): boolean {
   return /^[0-9a-f]{8}$/.test(hop) && hop !== BROADCAST_ID;
 }
@@ -98,9 +76,7 @@ function rawRoute(tr: TracerouteRowLike): (string | number)[] {
   return [];
 }
 
-/** Orient one traceroute row into travel order. Returns null when either
- *  header endpoint is missing/invalid. Cached per row object (rows are
- *  replaced wholesale on refetch, so identity keying is safe). */
+/** Orient a row into travel order; null when a header endpoint is missing. Cached per row object. */
 export function orientTraceroute(tr: TracerouteRowLike | null | undefined): OrientedTraceroute | null {
   if (!tr || typeof tr !== "object") return null;
   const cached = orientCache.get(tr);
@@ -117,15 +93,13 @@ function computeOriented(tr: TracerouteRowLike): OrientedTraceroute | null {
   if (!tFrom || !tTo) return null;
 
   const raw = rawRoute(tr);
-  // Keep unresolvable hops as placeholders instead of dropping them — a drop
-  // would shrink the hop count and shift per-leg SNR alignment.
+  // Keep unresolvable hops as placeholders — dropping them would shift per-leg SNR alignment.
   const route = raw.map((r) => normNodeId(r) || `?${String(r)}`);
 
   const snrTow = tr.payload?.snr_towards;
   const isReply = Array.isArray(snrTow) && snrTow.length === route.length + 1;
 
-  // The towards journey is initiator → route → target in BOTH cases;
-  // snr_towards[i] is the orderedPath[i]→orderedPath[i+1] leg either way.
+  // snr_towards[i] is the orderedPath[i]→orderedPath[i+1] leg in both cases.
   const orderedPath = isReply ? [tTo, ...route, tFrom] : [tFrom, ...route, tTo];
   const initiator = orderedPath[0];
   const target = orderedPath[orderedPath.length - 1];
@@ -135,9 +109,7 @@ function computeOriented(tr: TracerouteRowLike): OrientedTraceroute | null {
     if (isReply) {
       legSnrDb = snrTow.map(decodeSnr);
     } else if (snrTow.length === route.length && route.length > 0) {
-      // Mid-flight request: SNR was measured for every observed leg; only the
-      // final (…→target) leg is unobserved. Anything else is a length
-      // mismatch we can't align safely.
+      // Mid-flight request: only the final (…→target) leg is unobserved; other lengths can't align.
       legSnrDb = [...snrTow.map(decodeSnr), null];
     }
   }
@@ -153,15 +125,8 @@ function computeOriented(tr: TracerouteRowLike): OrientedTraceroute | null {
   };
 }
 
-/** Accumulated-data metric for competing copies of ONE packet — mirrors the
- *  backend's richer-wins upsert (sum of the four RouteDiscovery array
- *  lengths), with a deviation: the route component falls back to route_ids
- *  when payload.route is absent (slim REST rows strip the payload down to
- *  snr_towards). The metric is EXACT only between two full-payload rows;
- *  a slim REPLY row still under-counts (its route_back/snr_back are
- *  stripped), so callers must not richness-compare a slim row against a full
- *  one — see hasFullTraceroutePayload. Only meaningful between rows sharing
- *  a packet identity (id + header endpoints). */
+/** Richer-wins metric (sum of RouteDiscovery array lengths) for competing copies of one
+ *  packet. Slim rows under-count — never richness-compare a slim row against a full one. */
 export function tracerouteRichness(tr: TracerouteRowLike): number {
   const p = tr.payload;
   const routeLen = Array.isArray(p?.route)
@@ -177,23 +142,16 @@ export function tracerouteRichness(tr: TracerouteRowLike): number {
   );
 }
 
-/** True when the row carries the full RouteDiscovery payload (SSE rows, non-
- *  slim REST rows). Current-backend slim rows strip only payload.route (the
- *  back arrays now survive), older-backend slim rows stripped the back arrays
- *  too — either way payload.route is the reliable discriminator, and held
- *  rows lacking it are replaced by any full copy rather than richness-raced. */
+/** payload.route is the slim/full discriminator: slim REST rows always strip it.
+ *  Rows lacking it are replaced by any full copy rather than richness-raced. */
 export function hasFullTraceroutePayload(tr: TracerouteRowLike): boolean {
   return Array.isArray(tr.payload?.route);
 }
 
-/** One traceroute exchange writes up to two rows: the request packet (caught
- *  mid-flight, truncated route) and the reply packet (complete route).
- *  Counting both inflates runs/edge stats ~2× on well-heard pairs. */
+/** Heuristic pairing window: one exchange writes up to two rows (mid-flight request + reply). */
 export const EXCHANGE_WINDOW_MS = 60_000;
 
-/** Minimal oriented view of a row for exchange matching — lets callers that
- *  already hold oriented data (e.g. page-coerced events) reuse the pairing
- *  algorithm without re-orienting. */
+/** Minimal oriented view of a row for exchange matching. */
 export interface ExchangeView {
   initiator: string;
   target: string;
@@ -208,22 +166,9 @@ export interface ExchangeView {
   replyTo?: number | string | null;
 }
 
-/** Core exchange pairing: returns a keep-mask over `items` (false = this row
- *  is the request half of a matched exchange and should collapse into its
- *  reply). Pairs exactly ONE request with ONE reply.
- *
- *  EXACT pairing: a reply carrying `replyTo` (the request's packet id, from
- *  the backend's packet_id capture) matches only the request whose own id
- *  equals it — no window, no path comparison, and no heuristic fallback for
- *  that reply (its request either exists or was never heard).
- *
- *  HEURISTIC fallback (historical rows without replyTo): same
- *  initiator/target, request within EXCHANGE_WINDOW_MS before the reply, and
- *  the request's observed hops (its orderedPath minus the speculative final
- *  target hop) a prefix of the reply's orderedPath.
- *
- *  Never merges two same-role rows — two requests are two attempts. null
- *  items (unorientable rows) are always kept. */
+/** Keep-mask over items (false = request half of a matched exchange). Replies with
+ *  replyTo pair exactly by request id (no heuristic fallback); others use same
+ *  endpoints + EXCHANGE_WINDOW_MS + observed-hops-prefix. null items are kept. */
 export function exchangeKeepMask(items: (ExchangeView | null)[]): boolean[] {
   interface Entry {
     v: ExchangeView;
@@ -278,9 +223,7 @@ export function exchangeKeepMask(items: (ExchangeView | null)[]): boolean[] {
   return entries.map((e) => e == null || !e.matched);
 }
 
-/** Collapse request+reply of one exchange to the reply row (see
- *  exchangeKeepMask for the pairing rules). Unmatched requests are kept — the
- *  exchange's reply was lost to RF and the mid-flight capture is all we have. */
+/** Collapse each matched request+reply to the reply row; unmatched requests are kept. */
 export function dedupeExchanges<T extends TracerouteRowLike>(rows: T[]): T[] {
   const mask = exchangeKeepMask(
     rows.map((row) => {

--- a/mqtt.py
+++ b/mqtt.py
@@ -133,17 +133,9 @@ class MQTT:
                             logger.debug("Decryption failed: %s", e)
                             continue
 
-                # rx_rssi/rx_snr are proto3 no-presence fields: a 0/0.0 pair
-                # means "no RF measurement" (typical when the gateway uplinks
-                # its own packet), not a perfect reading. rssi==0 dBm is
-                # physically implausible; snr alone can legitimately be 0.0 dB,
-                # so drop snr only when rssi is also zero (snr-only legacy
-                # gateways keep their reading). Omit the keys entirely rather
-                # than storing None: a no-reading COPY then diffs to an empty
-                # dedup extras patch (None would patch every one). When the
-                # no-reading copy is itself the CANONICAL, later real readings
-                # still cost a small set-patch each — inherent, reconstruction
-                # stays lossless.
+                # A 0/0.0 rssi/snr pair means "no RF measurement" (proto3 no-presence);
+                # snr alone can legitimately be 0.0 dB. Omit keys (not None) so a
+                # no-reading copy diffs to an empty dedup extras patch.
                 if mp.rx_rssi != 0:
                     outs['rssi'] = mp.rx_rssi
                 if mp.rx_rssi != 0 or mp.rx_snr != 0.0:
@@ -159,8 +151,7 @@ class MQTT:
                 outs['topic'] = msg.topic.value
                 outs["qos"] = getattr(msg, "qos", None)
                 outs["retain"] = getattr(msg, "retain", None)
-                # Channel index straight from the packet: MessageToJson omits
-                # the zero value, silently hiding the primary channel (0).
+                # MessageToJson omits channel 0 (primary); read it off mp.
                 outs.setdefault('channel', mp.channel)
 
                 # Fallback: extract gateway from topic suffix if gateway_id was empty
@@ -169,13 +160,8 @@ class MQTT:
                     if topic_parts and topic_parts[-1].startswith('!'):
                         outs['sender'] = topic_parts[-1].replace('!', '')
 
-                # hops_away from the protobuf header, read directly off mp:
-                # proto3 zero-omission hides hop_limit==0 (a packet that used
-                # ALL its hops — exactly the rows that used to lose their hop
-                # count) and hop_start==0 from MessageToJson's dict.
-                # hop_start==0 means pre-2.3 firmware that never reported it →
-                # genuinely unknown, leave hops_away absent (stored as NULL).
-                # Clamped at 0: hop_limit > hop_start is a firmware anomaly.
+                # Read off mp: MessageToJson hides hop_limit==0. hop_start==0 =
+                # pre-2.3 firmware, hops unknown → leave absent (NULL).
                 if mp.hop_start > 0:
                     outs["hop_start"] = mp.hop_start
                     outs["hop_limit"] = mp.hop_limit
@@ -264,10 +250,8 @@ class MQTT:
                         out = json.loads(MessageToJson(route_msg, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True, always_print_fields_with_no_presence=True))
                         outs["type"] = "traceroute"
                         outs["payload"] = out
-                        # Reply packets carry the REQUEST's packet id in
-                        # Data.request_id (proto3: 0 = unset, i.e. a request).
-                        # Stored in the packet_id column so request/reply rows
-                        # of one exchange pair exactly instead of by heuristic.
+                        # Replies carry the request's packet id in Data.request_id
+                        # (0 = unset, i.e. this is a request).
                         outs["packet_id"] = mp.decoded.request_id or None
                         logger.debug("Decoded protobuf message: traceroute: %s", outs)
                     except UnicodeDecodeError as e:
@@ -348,13 +332,8 @@ class MQTT:
                 logger.debug("Processed message: %s", outs)
                 await self.handle_log(outs)
 
-        # The JSON decoder is EXCLUSIVE with the protobuf decoder, by design:
-        # the topic namespaces are disjoint (/2/e/ + /2/map/ vs /2/json), but
-        # the PACKETS are not — a gateway with JSON output publishes the same
-        # mesh packet to both, so running both decoders would double-fire
-        # every SSE event and record a duplicate packet_receptions row per
-        # such gateway. With protobuf enabled, /2/json copies are skipped;
-        # enable the JSON decoder alone for meshes that only publish JSON.
+        # Exclusive with protobuf: gateways publish the same packet to both
+        # namespaces; running both decoders double-fires events.
         if (
             self.config['broker']['decoders']['json']['enabled']
             and not self.config['broker']['decoders']['protobuf']['enabled']
@@ -702,15 +681,9 @@ class MQTT:
 
 
     async def _resolve_route_entries(self, route):
-        """Resolve RouteDiscovery hop entries to canonical node ids.
-
-        Known nodes resolve to their stored id. Unknown protobuf ints store
-        the canonical 8-hex form so consumers can group/resolve them once the
-        node is seen (normalize_node_id rejects out-of-uint32 garbage, falling
-        back to the raw echo). Strings stay verbatim — JSON-path entries are
-        longnames, and a hex-looking "cafe" must not be minted into an id;
-        bools are excluded so a hostile `true` can't become node 00000001.
-        """
+        """Resolve RouteDiscovery hop entries to canonical node ids. Unknown ints
+        fall back to 8-hex; strings stay verbatim (never minted into ids); bools
+        are excluded so `true` can't become node 00000001."""
         resolved = []
         for r in route:
             if isinstance(r, str):
@@ -743,8 +716,6 @@ class MQTT:
 
         msg['route'] = route
         msg['route_ids'] = await self._resolve_route_entries(route)
-        # Reply rows accumulate the return path too; resolve it the same way
-        # so the return leg is displayable without re-resolving client-side.
         route_back = payload.get('route_back') if isinstance(payload, dict) else None
         msg['route_back_ids'] = (
             await self._resolve_route_entries(route_back)
@@ -760,13 +731,8 @@ class MQTT:
         # BIGINT column) so clients can upsert it into their cached list
         # instead of refetching. `sender` is normalized the same way the DB
         # write is, so the event matches a later REST fetch of the row.
-        # Gated on the richer-wins upsert outcome so the live feed mirrors
-        # storage: 'inserted' and 'upgraded' broadcast (clients replace their
-        # cached copy with the richer row); 'duplicate' stays silent — that
-        # covers poorer/equal copies AND the ~1-in-2^32 stale id collision,
-        # where a genuinely new packet is dropped like DO NOTHING always did;
-        # None (write skipped or buffered on a DB outage) still broadcasts so
-        # the live view survives the outage.
+        # 'duplicate' stays silent; None (write buffered on DB outage) still
+        # broadcasts so the live view survives the outage.
         if outcome != "duplicate" and self.data.broadcaster.subscriber_count:
             try:
                 # The broker payload is publisher-controlled: forward only the
@@ -798,10 +764,8 @@ class MQTT:
                         "route": msg.get("route", []),
                         "route_ids": msg["route_ids"],
                         "route_back_ids": msg.get("route_back_ids", []),
-                        # write_traceroute surfaces the row's REAL created_at
-                        # (first-heard, which upgrades preserve); the now()
-                        # fallback covers the outage path where the row hasn't
-                        # landed yet and NOW() is what it will get on insert.
+                        # First-heard created_at from write_traceroute; now() covers
+                        # the outage path where the row hasn't landed yet.
                         "created_at": msg.get("created_at") or int(time.time()),
                         "payload": payload,
                     }

--- a/mqtt.py
+++ b/mqtt.py
@@ -733,7 +733,7 @@ class MQTT:
             else:
                 msg['route_ids'].append(r)
 
-        await self.data.pg_storage.write_traceroute(id, msg)
+        outcome = await self.data.pg_storage.write_traceroute(id, msg)
 
         # Live push: resolved multi-hop path for the map's traceroute tracer.
         # The event mirrors a full non-slim /v1/traceroutes row (same field
@@ -741,7 +741,14 @@ class MQTT:
         # BIGINT column) so clients can upsert it into their cached list
         # instead of refetching. `sender` is normalized the same way the DB
         # write is, so the event matches a later REST fetch of the row.
-        if self.data.broadcaster.subscriber_count:
+        # Gated on the richer-wins upsert outcome so the live feed mirrors
+        # storage: 'inserted' and 'upgraded' broadcast (clients replace their
+        # cached copy with the richer row); 'duplicate' stays silent — that
+        # covers poorer/equal copies AND the ~1-in-2^32 stale id collision,
+        # where a genuinely new packet is dropped like DO NOTHING always did;
+        # None (write skipped or buffered on a DB outage) still broadcasts so
+        # the live view survives the outage.
+        if outcome != "duplicate" and self.data.broadcaster.subscriber_count:
             try:
                 # The broker payload is publisher-controlled: forward only the
                 # keys the REST row actually mirrors, never the dict verbatim,

--- a/mqtt.py
+++ b/mqtt.py
@@ -133,8 +133,21 @@ class MQTT:
                             logger.debug("Decryption failed: %s", e)
                             continue
 
-                outs['rssi'] = mp.rx_rssi
-                outs['snr'] = mp.rx_snr
+                # rx_rssi/rx_snr are proto3 no-presence fields: a 0/0.0 pair
+                # means "no RF measurement" (typical when the gateway uplinks
+                # its own packet), not a perfect reading. rssi==0 dBm is
+                # physically implausible; snr alone can legitimately be 0.0 dB,
+                # so drop snr only when rssi is also zero (snr-only legacy
+                # gateways keep their reading). Omit the keys entirely rather
+                # than storing None: a no-reading COPY then diffs to an empty
+                # dedup extras patch (None would patch every one). When the
+                # no-reading copy is itself the CANONICAL, later real readings
+                # still cost a small set-patch each — inherent, reconstruction
+                # stays lossless.
+                if mp.rx_rssi != 0:
+                    outs['rssi'] = mp.rx_rssi
+                if mp.rx_rssi != 0 or mp.rx_snr != 0.0:
+                    outs['snr'] = mp.rx_snr
                 # Clamp rx_time to current time if node clock is ahead
                 rx_time = mp.rx_time
                 now_epoch = int(time.time())
@@ -146,6 +159,9 @@ class MQTT:
                 outs['topic'] = msg.topic.value
                 outs["qos"] = getattr(msg, "qos", None)
                 outs["retain"] = getattr(msg, "retain", None)
+                # Channel index straight from the packet: MessageToJson omits
+                # the zero value, silently hiding the primary channel (0).
+                outs.setdefault('channel', mp.channel)
 
                 # Fallback: extract gateway from topic suffix if gateway_id was empty
                 if not outs.get('sender'):
@@ -153,14 +169,17 @@ class MQTT:
                     if topic_parts and topic_parts[-1].startswith('!'):
                         outs['sender'] = topic_parts[-1].replace('!', '')
 
-                # Calculate hops_away from hop_start and hop_limit
-                hop_start = outs.get("hop_start")
-                hop_limit = outs.get("hop_limit")
-                if hop_start is not None and hop_limit is not None:
-                    try:
-                        outs["hops_away"] = int(hop_start) - int(hop_limit)
-                    except (ValueError, TypeError):
-                        pass
+                # hops_away from the protobuf header, read directly off mp:
+                # proto3 zero-omission hides hop_limit==0 (a packet that used
+                # ALL its hops — exactly the rows that used to lose their hop
+                # count) and hop_start==0 from MessageToJson's dict.
+                # hop_start==0 means pre-2.3 firmware that never reported it →
+                # genuinely unknown, leave hops_away absent (stored as NULL).
+                # Clamped at 0: hop_limit > hop_start is a firmware anomaly.
+                if mp.hop_start > 0:
+                    outs["hop_start"] = mp.hop_start
+                    outs["hop_limit"] = mp.hop_limit
+                    outs["hops_away"] = max(mp.hop_start - mp.hop_limit, 0)
 
                 if mp.decoded.portnum == portnums_pb2.TEXT_MESSAGE_APP:
                     payload_bytes = bytes(mp.decoded.payload)
@@ -324,7 +343,17 @@ class MQTT:
                 logger.debug("Processed message: %s", outs)
                 await self.handle_log(outs)
 
-        elif self.config['broker']['decoders']['json']['enabled']:
+        # The JSON decoder is EXCLUSIVE with the protobuf decoder, by design:
+        # the topic namespaces are disjoint (/2/e/ + /2/map/ vs /2/json), but
+        # the PACKETS are not — a gateway with JSON output publishes the same
+        # mesh packet to both, so running both decoders would double-fire
+        # every SSE event and record a duplicate packet_receptions row per
+        # such gateway. With protobuf enabled, /2/json copies are skipped;
+        # enable the JSON decoder alone for meshes that only publish JSON.
+        if (
+            self.config['broker']['decoders']['json']['enabled']
+            and not self.config['broker']['decoders']['protobuf']['enabled']
+        ):
             if '/2/json' in msg.topic.value:
                 logger.debug("Received a JSON message: %s %s", msg.topic, msg.payload)
                 try:
@@ -684,7 +713,7 @@ class MQTT:
             if isinstance(r, str):
                 # JSON publisher path: route entries arrive as longnames.
                 node = await self.data.pg_storage.find_node_by_longname(r)
-            elif isinstance(r, int):
+            elif isinstance(r, int) and not isinstance(r, bool):
                 # Protobuf path: route entries are uint32 node ids.
                 node = await self.data.pg_storage.get_node_cached(utils.convert_node_id_from_int_to_hex(r))
             else:
@@ -692,6 +721,15 @@ class MQTT:
 
             if node:
                 msg['route_ids'].append(node['id'])
+            elif isinstance(r, int) and not isinstance(r, bool):
+                # Unknown protobuf hop: store the canonical 8-hex id, not the
+                # raw int, so consumers can group/resolve it once the node is
+                # seen (normalize_node_id also rejects out-of-uint32 garbage,
+                # falling back to the raw echo). The else branch stays
+                # verbatim on purpose — JSON-path strings are longnames (a
+                # hex-looking "cafe" must not be minted into an id), and bools
+                # are excluded so a hostile `true` can't become node 00000001.
+                msg['route_ids'].append(normalize_node_id(r) or r)
             else:
                 msg['route_ids'].append(r)
 

--- a/mqtt.py
+++ b/mqtt.py
@@ -264,6 +264,11 @@ class MQTT:
                         out = json.loads(MessageToJson(route_msg, preserving_proto_field_name=True, ensure_ascii=False, indent=2, sort_keys=True, use_integers_for_enums=True, always_print_fields_with_no_presence=True))
                         outs["type"] = "traceroute"
                         outs["payload"] = out
+                        # Reply packets carry the REQUEST's packet id in
+                        # Data.request_id (proto3: 0 = unset, i.e. a request).
+                        # Stored in the packet_id column so request/reply rows
+                        # of one exchange pair exactly instead of by heuristic.
+                        outs["packet_id"] = mp.decoded.request_id or None
                         logger.debug("Decoded protobuf message: traceroute: %s", outs)
                     except UnicodeDecodeError as e:
                         logger.debug("Unicode decoding error: text: %s", e)
@@ -696,6 +701,35 @@ class MQTT:
             self._record_discord_drop('text')
 
 
+    async def _resolve_route_entries(self, route):
+        """Resolve RouteDiscovery hop entries to canonical node ids.
+
+        Known nodes resolve to their stored id. Unknown protobuf ints store
+        the canonical 8-hex form so consumers can group/resolve them once the
+        node is seen (normalize_node_id rejects out-of-uint32 garbage, falling
+        back to the raw echo). Strings stay verbatim — JSON-path entries are
+        longnames, and a hex-looking "cafe" must not be minted into an id;
+        bools are excluded so a hostile `true` can't become node 00000001.
+        """
+        resolved = []
+        for r in route:
+            if isinstance(r, str):
+                # JSON publisher path: route entries arrive as longnames.
+                node = await self.data.pg_storage.find_node_by_longname(r)
+            elif isinstance(r, int) and not isinstance(r, bool):
+                # Protobuf path: route entries are uint32 node ids.
+                node = await self.data.pg_storage.get_node_cached(utils.convert_node_id_from_int_to_hex(r))
+            else:
+                node = None
+
+            if node:
+                resolved.append(node['id'])
+            elif isinstance(r, int) and not isinstance(r, bool):
+                resolved.append(normalize_node_id(r) or r)
+            else:
+                resolved.append(r)
+        return resolved
+
     async def handle_traceroute(self, msg):
         id = self._normalize_msg_addrs(msg)
         if id is None:
@@ -708,30 +742,15 @@ class MQTT:
             return
 
         msg['route'] = route
-        msg['route_ids'] = []
-        for r in route:
-            if isinstance(r, str):
-                # JSON publisher path: route entries arrive as longnames.
-                node = await self.data.pg_storage.find_node_by_longname(r)
-            elif isinstance(r, int) and not isinstance(r, bool):
-                # Protobuf path: route entries are uint32 node ids.
-                node = await self.data.pg_storage.get_node_cached(utils.convert_node_id_from_int_to_hex(r))
-            else:
-                node = None
-
-            if node:
-                msg['route_ids'].append(node['id'])
-            elif isinstance(r, int) and not isinstance(r, bool):
-                # Unknown protobuf hop: store the canonical 8-hex id, not the
-                # raw int, so consumers can group/resolve it once the node is
-                # seen (normalize_node_id also rejects out-of-uint32 garbage,
-                # falling back to the raw echo). The else branch stays
-                # verbatim on purpose — JSON-path strings are longnames (a
-                # hex-looking "cafe" must not be minted into an id), and bools
-                # are excluded so a hostile `true` can't become node 00000001.
-                msg['route_ids'].append(normalize_node_id(r) or r)
-            else:
-                msg['route_ids'].append(r)
+        msg['route_ids'] = await self._resolve_route_entries(route)
+        # Reply rows accumulate the return path too; resolve it the same way
+        # so the return leg is displayable without re-resolving client-side.
+        route_back = payload.get('route_back') if isinstance(payload, dict) else None
+        msg['route_back_ids'] = (
+            await self._resolve_route_entries(route_back)
+            if isinstance(route_back, list)
+            else []
+        )
 
         outcome = await self.data.pg_storage.write_traceroute(id, msg)
 
@@ -778,6 +797,12 @@ class MQTT:
                         "timestamp": msg.get("timestamp"),
                         "route": msg.get("route", []),
                         "route_ids": msg["route_ids"],
+                        "route_back_ids": msg.get("route_back_ids", []),
+                        # write_traceroute surfaces the row's REAL created_at
+                        # (first-heard, which upgrades preserve); the now()
+                        # fallback covers the outage path where the row hasn't
+                        # landed yet and NOW() is what it will get on insert.
+                        "created_at": msg.get("created_at") or int(time.time()),
                         "payload": payload,
                     }
                 )

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -181,17 +181,12 @@ CREATE INDEX IF NOT EXISTS idx_traceroutes_from_node_id ON traceroutes(from_node
 CREATE INDEX IF NOT EXISTS idx_traceroutes_to_node_id ON traceroutes(to_node_id);
 CREATE INDEX IF NOT EXISTS idx_traceroutes_created_at ON traceroutes(created_at DESC);
 
--- Resolved return-path hop ids (reply rows only; NULL on rows written before
--- the column existed — consumers must treat absence as "not resolved", the
--- verbatim RouteDiscovery route_back still lives in payload).
--- NOTE: fresh-install copies. Existing databases get these from the
--- migrations block in ensure_schema (storage/db/postgres.py), which runs
--- with a long timeout — this file executes as one short-timeout transaction,
--- where a full-table index build could roll everything back.
+-- Resolved return-path hop ids (reply rows only; NULL = not resolved).
+-- Fresh-install copies: existing databases get these from the ensure_schema
+-- migrations block, which runs with a long timeout.
 ALTER TABLE traceroutes ADD COLUMN IF NOT EXISTS route_back_ids JSONB;
 CREATE INDEX IF NOT EXISTS idx_traceroutes_sender_node_id ON traceroutes(sender_node_id);
--- Containment lookups for "traceroutes involving node X as a relay"
--- (route_ids @> jsonb_build_array(id)); jsonb_path_ops is @>-only and small.
+-- Containment lookups for "traceroutes involving node X as a relay".
 CREATE INDEX IF NOT EXISTS idx_traceroutes_route_ids_gin
     ON traceroutes USING gin (route_ids jsonb_path_ops);
 CREATE INDEX IF NOT EXISTS idx_traceroutes_route_back_ids_gin

--- a/postgres/sql/schema.sql
+++ b/postgres/sql/schema.sql
@@ -181,6 +181,22 @@ CREATE INDEX IF NOT EXISTS idx_traceroutes_from_node_id ON traceroutes(from_node
 CREATE INDEX IF NOT EXISTS idx_traceroutes_to_node_id ON traceroutes(to_node_id);
 CREATE INDEX IF NOT EXISTS idx_traceroutes_created_at ON traceroutes(created_at DESC);
 
+-- Resolved return-path hop ids (reply rows only; NULL on rows written before
+-- the column existed — consumers must treat absence as "not resolved", the
+-- verbatim RouteDiscovery route_back still lives in payload).
+-- NOTE: fresh-install copies. Existing databases get these from the
+-- migrations block in ensure_schema (storage/db/postgres.py), which runs
+-- with a long timeout — this file executes as one short-timeout transaction,
+-- where a full-table index build could roll everything back.
+ALTER TABLE traceroutes ADD COLUMN IF NOT EXISTS route_back_ids JSONB;
+CREATE INDEX IF NOT EXISTS idx_traceroutes_sender_node_id ON traceroutes(sender_node_id);
+-- Containment lookups for "traceroutes involving node X as a relay"
+-- (route_ids @> jsonb_build_array(id)); jsonb_path_ops is @>-only and small.
+CREATE INDEX IF NOT EXISTS idx_traceroutes_route_ids_gin
+    ON traceroutes USING gin (route_ids jsonb_path_ops);
+CREATE INDEX IF NOT EXISTS idx_traceroutes_route_back_ids_gin
+    ON traceroutes USING gin (route_back_ids jsonb_path_ops);
+
 -- MQTT messages: the raw packet archive. Partitioned by month on created_at
 -- so it stays manageable as it grows. This block only fires on a fresh install
 -- (the table does not yet exist); existing non-partitioned installs are

--- a/scripts/backfill_traceroute_route_ids.py
+++ b/scripts/backfill_traceroute_route_ids.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: normalize raw-int entries inside traceroutes.route_ids
+JSONB to canonical 8-char lowercase hex strings.
+
+Before the ingest fix, a traceroute hop through a node this instance had never
+seen was stored as the raw uint32 node number (protobuf path); afterwards it is
+stored as padded hex. Historical int entries never re-resolve in the SPA's
+node lookups and fragment route grouping (the same physical route keys as
+"…,2864434397,…" in old rows and "…,aabbccdd,…" in new ones). This rewrites
+only the int entries; resolved hex strings, longnames, and out-of-uint32
+garbage are left byte-identical. The parallel legacy `route` column and the
+payload JSONB (verbatim RouteDiscovery) are deliberately untouched.
+
+Idempotent: rows without numeric entries are skipped by the WHERE clause, so a
+re-run after completion updates nothing. Batched by primary key with a pause
+between batches to stay polite on a small box; safe to interrupt and re-run
+(each batch commits independently).
+
+Usage:
+    python3 scripts/backfill_traceroute_route_ids.py --dry-run
+    python3 scripts/backfill_traceroute_route_ids.py
+    python3 scripts/backfill_traceroute_route_ids.py --dsn postgresql://...
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import asyncpg
+
+
+def _dsn_from_config(path: Path) -> str:
+    """Build a DSN from config.toml's [storage.postgres] section."""
+    import tomllib
+
+    with open(path, "rb") as f:
+        pg = tomllib.load(f).get("storage", {}).get("postgres", {})
+    return (
+        f"postgresql://{pg.get('username', 'postgres')}:{pg.get('password', 'password')}"
+        f"@{pg.get('host', 'postgres')}:{pg.get('port', 5432)}/{pg.get('database', 'meshinfo')}"
+    )
+
+
+# Rewrites one row's route_ids array, preserving element order. Only integral
+# numbers within uint32 become hex; everything else passes through untouched.
+NORMALIZE_SQL = """
+UPDATE traceroutes
+SET route_ids = (
+    SELECT jsonb_agg(
+        CASE
+            WHEN jsonb_typeof(elem) = 'number'
+                 AND (elem::text) ~ '^[0-9]+$'
+                 AND (elem::text)::numeric <= 4294967295
+            THEN to_jsonb(lpad(to_hex(((elem::text))::bigint), 8, '0'))
+            ELSE elem
+        END
+        ORDER BY ord
+    )
+    FROM jsonb_array_elements(route_ids) WITH ORDINALITY AS t(elem, ord)
+)
+WHERE id = ANY($1::bigint[])
+"""
+
+# Rows the updater will actually touch. The dry-run queries MUST use this
+# same predicate: counting merely-numeric rows would include out-of-uint32
+# raw echoes the ingest deliberately keeps, so a completed run would never
+# show a zero residue.
+AFFECTED_PREDICATE = """
+jsonb_typeof(route_ids) = 'array'
+  AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(route_ids) e
+      WHERE jsonb_typeof(e) = 'number'
+        AND (e::text) ~ '^[0-9]+$'
+        AND (e::text)::numeric <= 4294967295
+  )
+"""
+
+FIND_BATCH_SQL = f"""
+SELECT id
+FROM traceroutes
+WHERE id > $1
+  AND {AFFECTED_PREDICATE}
+ORDER BY id
+LIMIT $2
+"""
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--dsn", help="postgres DSN (default: from --config)")
+    ap.add_argument(
+        "--config",
+        default=str(Path(__file__).resolve().parents[1] / "config.toml"),
+    )
+    ap.add_argument("--batch-size", type=int, default=500)
+    ap.add_argument(
+        "--sleep", type=float, default=0.25, help="pause between batches (seconds)"
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="count affected rows and show a sample, change nothing",
+    )
+    args = ap.parse_args()
+
+    dsn = args.dsn or _dsn_from_config(Path(args.config))
+    conn = await asyncpg.connect(dsn)
+    try:
+        if args.dry_run:
+            total = await conn.fetchval(
+                f"SELECT count(*) FROM traceroutes WHERE {AFFECTED_PREDICATE}"
+            )
+            sample = await conn.fetch(
+                f"""
+                SELECT id, route_ids FROM traceroutes
+                WHERE {AFFECTED_PREDICATE}
+                ORDER BY id LIMIT 5
+                """
+            )
+            print(f"rows the backfill will update: {total}")
+            for r in sample:
+                print(f"  id={r['id']}: {r['route_ids']}")
+            return 0
+
+        updated = 0
+        last_id = 0
+        started = time.monotonic()
+        while True:
+            ids = [
+                r["id"]
+                for r in await conn.fetch(FIND_BATCH_SQL, last_id, args.batch_size)
+            ]
+            if not ids:
+                break
+            await conn.execute(NORMALIZE_SQL, ids)
+            updated += len(ids)
+            last_id = ids[-1]
+            print(f"updated {updated} rows (through id {last_id})", flush=True)
+            await asyncio.sleep(args.sleep)
+
+        print(f"done: {updated} rows normalized in {time.monotonic() - started:.1f}s")
+        return 0
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/backfill_traceroute_route_ids.py
+++ b/scripts/backfill_traceroute_route_ids.py
@@ -1,26 +1,7 @@
 #!/usr/bin/env python3
-"""
-One-time backfill: normalize raw-int entries inside traceroutes.route_ids
-JSONB to canonical 8-char lowercase hex strings.
-
-Before the ingest fix, a traceroute hop through a node this instance had never
-seen was stored as the raw uint32 node number (protobuf path); afterwards it is
-stored as padded hex. Historical int entries never re-resolve in the SPA's
-node lookups and fragment route grouping (the same physical route keys as
-"…,2864434397,…" in old rows and "…,aabbccdd,…" in new ones). This rewrites
-only the int entries; resolved hex strings, longnames, and out-of-uint32
-garbage are left byte-identical. The parallel legacy `route` column and the
-payload JSONB (verbatim RouteDiscovery) are deliberately untouched.
-
-Idempotent: rows without numeric entries are skipped by the WHERE clause, so a
-re-run after completion updates nothing. Batched by primary key with a pause
-between batches to stay polite on a small box; safe to interrupt and re-run
-(each batch commits independently).
-
-Usage:
-    python3 scripts/backfill_traceroute_route_ids.py --dry-run
-    python3 scripts/backfill_traceroute_route_ids.py
-    python3 scripts/backfill_traceroute_route_ids.py --dsn postgresql://...
+"""One-time, idempotent backfill: normalize raw-int entries in
+traceroutes.route_ids to canonical 8-hex strings. Strings and out-of-uint32
+garbage stay byte-identical; safe to interrupt and re-run (batched commits).
 """
 from __future__ import annotations
 
@@ -45,8 +26,7 @@ def _dsn_from_config(path: Path) -> str:
     )
 
 
-# Rewrites one row's route_ids array, preserving element order. Only integral
-# numbers within uint32 become hex; everything else passes through untouched.
+# Preserves element order; only integral numbers within uint32 become hex.
 NORMALIZE_SQL = """
 UPDATE traceroutes
 SET route_ids = (
@@ -65,10 +45,8 @@ SET route_ids = (
 WHERE id = ANY($1::bigint[])
 """
 
-# Rows the updater will actually touch. The dry-run queries MUST use this
-# same predicate: counting merely-numeric rows would include out-of-uint32
-# raw echoes the ingest deliberately keeps, so a completed run would never
-# show a zero residue.
+# Dry-run MUST use this same predicate: out-of-uint32 raw echoes are kept
+# on purpose, so a looser count would never reach zero.
 AFFECTED_PREDICATE = """
 jsonb_typeof(route_ids) = 'array'
   AND EXISTS (

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -68,6 +68,103 @@ def _finite_or_none(value: Any) -> Any:
 # against this so a typo'd kind fails in tests, not silently during recovery.
 _RETRY_KINDS = frozenset({"mqtt_message", "telemetry", "chat_message", "traceroute"})
 
+# Richer-wins traceroute upsert: upgrades are confined to rows younger than
+# this window so a genuinely NEW traceroute reusing a 32-bit packet id weeks
+# later can never overwrite history (outside the window the statement degrades
+# to the old DO NOTHING semantics — the pre-existing id-reuse drop, not a
+# regression). One hour also covers write-retry drain latency after an outage
+# (the buffer holds roughly half an hour of traffic).
+TRACEROUTE_UPGRADE_WINDOW_S = 3600
+
+
+# Meshtastic hop_limit tops out at 7, so genuine RouteDiscovery arrays never
+# exceed ~8 entries; counting is capped there so a hostile publisher padding
+# arrays gains bounded score, not an arbitrary overwrite budget.
+_TRACEROUTE_ARRAY_CAP = 10
+
+
+def _traceroute_richness_sql(payload_expr: str) -> str:
+    """SQL summing the four RouteDiscovery array lengths of a payload jsonb.
+
+    Richness is monotone along the relay chain — every hop appends to
+    route/route_back/snr_* — so the richest single copy is a superset of every
+    poorer copy and whole-row replacement never needs field-level merging.
+    jsonb_typeof guards make it total for malformed/JSON-publisher payloads;
+    per-array LEAST caps bound what publisher-crafted padding can score.
+    """
+    return " + ".join(
+        f"CASE WHEN jsonb_typeof({payload_expr}->'{key}') = 'array'"
+        f" THEN LEAST(jsonb_array_length({payload_expr}->'{key}'), {_TRACEROUTE_ARRAY_CAP})"
+        " ELSE 0 END"
+        for key in ("route", "route_back", "snr_towards", "snr_back")
+    )
+
+
+def _traceroute_prefix_guard_sql(key: str) -> str:
+    """SQL requiring the stored payload's array to be a PREFIX of the incoming
+    copy's — the monotonicity invariant made enforceable: genuine richer copies
+    only ever APPEND hops, so an upgrade may extend recorded data but never
+    rewrite it. Blocks a hostile publisher from replacing genuine hops with
+    forged ones inside the upgrade window (they can at most append plausible
+    junk — no more power than winning the original first-uplink race gave
+    them). Skipped when the stored value isn't an array (absent key /
+    legacy / malformed — IS DISTINCT FROM keeps the NULL of an absent key
+    from vetoing the whole guard)."""
+    return f"""(
+        jsonb_typeof(traceroutes.payload->'{key}') IS DISTINCT FROM 'array'
+        OR traceroutes.payload->'{key}' = (
+            SELECT COALESCE(jsonb_agg(e ORDER BY ord), '[]'::jsonb)
+            FROM jsonb_array_elements(EXCLUDED.payload->'{key}')
+                 WITH ORDINALITY AS t(e, ord)
+            WHERE ord <= jsonb_array_length(traceroutes.payload->'{key}')
+        )
+    )"""
+
+
+# Guarded richer-wins upsert. Copy-scoped columns move TOGETHER on an upgrade
+# (payload + the reception fields sender/rssi/snr/hops_away): mixing
+# first-copy reception data with a later copy's payload would create a row no
+# gateway ever heard. Exceptions: created_at and the PK stay put (created_at
+# is first-heard and anchors the recency guard, list ordering, pagination),
+# and a valid stored timestamp/rx_time is never regressed by a clock-less
+# gateway's copy (rx_time=0 on nodes without a time source) — the SSE event
+# for such an upgrade carries the incoming copy's zero timestamp and diverges
+# from REST on that one field until the next refetch, an accepted cost.
+# RETURNING (xmax = 0) discriminates insert (true) from update (false); no row
+# means the guard refused the copy: poorer/equal, prefix-violating, or a
+# STALE id collision (row older than the window — such packets are genuinely
+# new but indistinguishable from history rewrites, so they are dropped, as
+# the old DO NOTHING always did). $15 = upgrade window (s).
+TRACEROUTE_UPSERT_SQL = f"""
+    INSERT INTO traceroutes (
+        from_node_id, to_node_id, sender_node_id, message_id, channel,
+        packet_id, hops_away, rssi, snr, timestamp, rx_time,
+        route, route_ids, payload
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14::jsonb)
+    ON CONFLICT (from_node_id, message_id) DO UPDATE SET
+        to_node_id     = EXCLUDED.to_node_id,
+        sender_node_id = EXCLUDED.sender_node_id,
+        channel        = EXCLUDED.channel,
+        packet_id      = EXCLUDED.packet_id,
+        hops_away      = EXCLUDED.hops_away,
+        rssi           = EXCLUDED.rssi,
+        snr            = EXCLUDED.snr,
+        timestamp      = CASE
+            WHEN EXCLUDED.timestamp IS NULL OR EXCLUDED.timestamp = 0
+            THEN traceroutes.timestamp ELSE EXCLUDED.timestamp END,
+        rx_time        = COALESCE(EXCLUDED.rx_time, traceroutes.rx_time),
+        route          = EXCLUDED.route,
+        route_ids      = EXCLUDED.route_ids,
+        payload        = EXCLUDED.payload
+    WHERE traceroutes.created_at > now() - make_interval(secs => $15)
+      AND ({_traceroute_richness_sql("EXCLUDED.payload")})
+        > ({_traceroute_richness_sql("traceroutes.payload")})
+      AND {_traceroute_prefix_guard_sql("route")}
+      AND {_traceroute_prefix_guard_sql("route_back")}
+    RETURNING (xmax = 0) AS inserted
+"""
+
 # True while the current *task* is the retry drain replaying a buffered write —
 # a ContextVar, not an instance flag, because live ingest writes interleave
 # with replays on the same loop and must not inherit the replay behavior.
@@ -1182,16 +1279,27 @@ class PostgresStorage:
         except Exception as e:
             self._handle_write_failure("chat message", "chat_message", (node_id, chat_msg), e)
 
-    async def write_traceroute(self, node_id: str, traceroute_msg: Dict[str, Any]) -> None:
+    async def write_traceroute(self, node_id: str, traceroute_msg: Dict[str, Any]) -> Optional[str]:
         """
-        Write traceroute to PostgreSQL.
+        Write traceroute to PostgreSQL via the richer-wins upsert: the stored
+        row is always the richest single heard copy of a packet (whole-copy
+        replacement, reception fields included; created_at stays first-heard).
 
         Args:
             node_id: from-node id (any supported form; will be normalized)
             traceroute_msg: Traceroute message dictionary
+
+        Returns:
+            'inserted' | 'upgraded' | 'duplicate', or None when the write was
+            skipped or failed (buffered for retry on outage-shaped errors).
+            'duplicate' covers every guard refusal: poorer/equal copies,
+            prefix-violating (forged) copies, AND stale 32-bit id collisions
+            with a row older than the upgrade window — that last packet is
+            genuinely new but dropped, exactly as ON CONFLICT DO NOTHING
+            always dropped it (probability ~ per-node rows / 2^32).
         """
         if not self._ready("write_traceroute"):
-            return
+            return None
 
         if not isinstance(node_id, str) or not node_id:
             raise ValueError("write_traceroute: node_id must be a non-empty string")
@@ -1204,7 +1312,7 @@ class PostgresStorage:
                 from_id = await self._ensure_node_stub(conn, node_id)
                 if not from_id:
                     logger.warning(f"write_traceroute: could not normalize node_id={node_id!r}, skipping")
-                    return
+                    return None
 
                 msg_from = traceroute_msg.get("from")
                 if msg_from is not None:
@@ -1239,23 +1347,15 @@ class PostgresStorage:
                 msg_id = traceroute_msg.get("id")
                 if msg_id is None:
                     logger.warning("write_traceroute: missing traceroute_msg['id']; skipping insert")
-                    return
+                    return None
                 try:
                     msg_id = int(msg_id)
                 except (TypeError, ValueError):
                     logger.warning("write_traceroute: invalid traceroute_msg['id']=%r; skipping insert", msg_id)
-                    return
+                    return None
 
-                await conn.execute(
-                    """
-                    INSERT INTO traceroutes (
-                        from_node_id, to_node_id, sender_node_id, message_id, channel,
-                        packet_id, hops_away, rssi, snr, timestamp, rx_time,
-                        route, route_ids, payload
-                    )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14::jsonb)
-                    ON CONFLICT (from_node_id, message_id) DO NOTHING
-                    """,
+                row = await conn.fetchrow(
+                    TRACEROUTE_UPSERT_SQL,
                     from_id,
                     to_id,
                     sender_id,
@@ -1270,10 +1370,15 @@ class PostgresStorage:
                     route_json,
                     route_ids_json,
                     payload_json,
+                    float(TRACEROUTE_UPGRADE_WINDOW_S),
                 )
+                if row is None:
+                    return "duplicate"
+                return "inserted" if row["inserted"] else "upgraded"
 
         except Exception as e:
             self._handle_write_failure("traceroute", "traceroute", (node_id, traceroute_msg), e)
+            return None
 
     def _coerce_mqtt_payload_text(self, value: Any) -> Optional[str]:
         """

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -134,14 +134,14 @@ def _traceroute_prefix_guard_sql(key: str) -> str:
 # means the guard refused the copy: poorer/equal, prefix-violating, or a
 # STALE id collision (row older than the window — such packets are genuinely
 # new but indistinguishable from history rewrites, so they are dropped, as
-# the old DO NOTHING always did). $15 = upgrade window (s).
+# the old DO NOTHING always did). $16 = upgrade window (s).
 TRACEROUTE_UPSERT_SQL = f"""
     INSERT INTO traceroutes (
         from_node_id, to_node_id, sender_node_id, message_id, channel,
         packet_id, hops_away, rssi, snr, timestamp, rx_time,
-        route, route_ids, payload
+        route, route_ids, payload, route_back_ids
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14::jsonb)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14::jsonb, $15::jsonb)
     ON CONFLICT (from_node_id, message_id) DO UPDATE SET
         to_node_id     = EXCLUDED.to_node_id,
         sender_node_id = EXCLUDED.sender_node_id,
@@ -156,13 +156,14 @@ TRACEROUTE_UPSERT_SQL = f"""
         rx_time        = COALESCE(EXCLUDED.rx_time, traceroutes.rx_time),
         route          = EXCLUDED.route,
         route_ids      = EXCLUDED.route_ids,
-        payload        = EXCLUDED.payload
-    WHERE traceroutes.created_at > now() - make_interval(secs => $15)
+        payload        = EXCLUDED.payload,
+        route_back_ids = EXCLUDED.route_back_ids
+    WHERE traceroutes.created_at > now() - make_interval(secs => $16)
       AND ({_traceroute_richness_sql("EXCLUDED.payload")})
         > ({_traceroute_richness_sql("traceroutes.payload")})
       AND {_traceroute_prefix_guard_sql("route")}
       AND {_traceroute_prefix_guard_sql("route_back")}
-    RETURNING (xmax = 0) AS inserted
+    RETURNING (xmax = 0) AS inserted, created_at
 """
 
 # True while the current *task* is the retry drain replaying a buffered write —
@@ -529,6 +530,24 @@ class PostgresStorage:
                     CREATE INDEX IF NOT EXISTS idx_mqtt_messages_packet
                         ON mqtt_messages(from_node_id, packet_id, created_at DESC)
                         WHERE packet_id IS NOT NULL;
+                """, timeout=600)
+                # Traceroute return-path column + involvement indexes. The
+                # ALTER is instant; the index builds scan the whole table on
+                # first run, hence the explicit timeout (schema.sql also
+                # carries copies for fresh installs, but its single implicit
+                # transaction runs under the pool's 10s command_timeout — a
+                # timeout there would roll the ALTER back with it, so the
+                # migrations block is the authoritative path for upgrades).
+                await conn.execute("""
+                    ALTER TABLE traceroutes ADD COLUMN IF NOT EXISTS route_back_ids JSONB;
+                """)
+                await conn.execute("""
+                    CREATE INDEX IF NOT EXISTS idx_traceroutes_sender_node_id
+                        ON traceroutes(sender_node_id);
+                    CREATE INDEX IF NOT EXISTS idx_traceroutes_route_ids_gin
+                        ON traceroutes USING gin (route_ids jsonb_path_ops);
+                    CREATE INDEX IF NOT EXISTS idx_traceroutes_route_back_ids_gin
+                        ON traceroutes USING gin (route_back_ids jsonb_path_ops);
                 """, timeout=600)
         except Exception as e:
             logger.error(f"Failed to run migrations: {e}")
@@ -1341,6 +1360,7 @@ class PostgresStorage:
                 payload_json = json.dumps(traceroute_msg.get("payload", {}), default=_json_default)
                 route_json = json.dumps(traceroute_msg.get("route", []), default=_json_default)
                 route_ids_json = json.dumps(traceroute_msg.get("route_ids", []), default=_json_default)
+                route_back_ids_json = json.dumps(traceroute_msg.get("route_back_ids", []), default=_json_default)
 
                 rx_time = self._ts_to_dt(traceroute_msg.get("timestamp"))
 
@@ -1370,10 +1390,16 @@ class PostgresStorage:
                     route_json,
                     route_ids_json,
                     payload_json,
+                    route_back_ids_json,
                     float(TRACEROUTE_UPGRADE_WINDOW_S),
                 )
                 if row is None:
                     return "duplicate"
+                # The row's REAL created_at (first-heard — upgrades keep it),
+                # surfaced on the msg so the SSE event matches a later REST
+                # fetch instead of stamping upgrade-time.
+                if row["created_at"] is not None:
+                    traceroute_msg["created_at"] = int(row["created_at"].timestamp())
                 return "inserted" if row["inserted"] else "upgraded"
 
         except Exception as e:
@@ -2316,8 +2342,10 @@ class PostgresStorage:
             logger.error(f"Failed to query texts from PostgreSQL: {e}")
             return []
 
-    async def query_node_traceroutes(self, node_id: str) -> List[Dict[str, Any]]:
-        """Query traceroutes for a specific node."""
+    async def query_node_traceroutes(self, node_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
+        """Query traceroutes INVOLVING a node: as initiator, target, uplink
+        gateway, or relay hop on either leg (containment over the resolved
+        hop arrays, GIN-indexed)."""
         if not self.enabled or not self.pool:
             return []
 
@@ -2327,10 +2355,14 @@ class PostgresStorage:
                     """
                     SELECT * FROM traceroutes
                     WHERE from_node_id = $1 OR to_node_id = $1
+                       OR sender_node_id = $1
+                       OR route_ids @> jsonb_build_array($1::text)
+                       OR route_back_ids @> jsonb_build_array($1::text)
                     ORDER BY created_at DESC
-                    LIMIT 1000
+                    LIMIT $2
                     """,
                     node_id,
+                    limit,
                 )
 
                 traceroutes = []
@@ -2349,6 +2381,7 @@ class PostgresStorage:
                             "timestamp": row["timestamp"],
                             "route": self._jsonb(row["route"], []),
                             "route_ids": self._jsonb(row["route_ids"], []),
+                            "route_back_ids": self._jsonb(row["route_back_ids"], []),
                             "payload": self._jsonb(row["payload"], {}),
                         }
                     )
@@ -2566,21 +2599,30 @@ class PostgresStorage:
         to_node_id: Optional[str] = None,
         range_seconds: Optional[int] = None,
         slim: bool = False,
-    ) -> List[Dict[str, Any]]:
+        before: Optional[str] = None,
+        with_cursor: bool = False,
+    ) -> Any:
         """Query traceroutes, newest first, optionally filtered.
 
         With both endpoints given, the pair matches in either direction
         (consumers orient the path client-side). A single endpoint filters
         just that column. `range_seconds` windows on created_at.
 
-        With `slim`, each row keeps only what the SPA reads (from, to, id,
-        hops_away, rssi, snr, timestamp, route_ids, payload.snr_towards) —
-        the full rows triple-carry the path via `route`, `route_ids` AND the
-        payload's route/route_back arrays. Default False keeps the full
-        shape for third-party consumers.
+        With `slim`, each row keeps what the SPA reads: from, to, id,
+        packet_id (the reply's request_id — exact exchange pairing),
+        hops_away, rssi, snr, timestamp, created_at (epoch; dates rows whose
+        packet timestamp is 0), route_ids, route_back_ids, and the payload's
+        snr_towards/route_back/snr_back. Default False keeps the legacy full
+        shape byte-identical for third-party consumers.
+
+        Keyset pagination: `before` is an opaque cursor (from a previous
+        page's next_cursor) over (created_at, id) — stable because upgrades
+        never touch created_at. With `with_cursor` the return value is
+        {"traceroutes": rows, "next_cursor": str | None} instead of a bare
+        list; next_cursor is present only when the page filled `limit`.
         """
         if not self.enabled or not self.pool:
-            return []
+            return {"traceroutes": [], "next_cursor": None} if with_cursor else []
 
         where = []
         params: List[Any] = []
@@ -2599,6 +2641,12 @@ class PostgresStorage:
         if range_seconds:
             params.append(range_seconds)
             where.append(f"created_at >= NOW() - make_interval(secs => ${len(params)})")
+        cursor = _decode_cursor(before) if before else None
+        if cursor:
+            params += [cursor[0], cursor[1]]
+            where.append(
+                f"(created_at, id) < (${len(params) - 1}, ${len(params)})"
+            )
         where_sql = f"WHERE {' AND '.join(where)}" if where else ""
         params.append(limit)
 
@@ -2608,7 +2656,7 @@ class PostgresStorage:
                     f"""
                     SELECT * FROM traceroutes
                     {where_sql}
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, id DESC
                     LIMIT ${len(params)}
                     """,
                     *params,
@@ -2617,23 +2665,30 @@ class PostgresStorage:
                 traceroutes = []
                 for row in rows:
                     if slim:
-                        # payload still has to be parsed: snr_towards lives in
-                        # it (per-leg SNR + reply-orientation detection). Only
-                        # that key survives — route/route_back/snr_back don't.
+                        # payload still has to be parsed: snr_towards drives
+                        # reply-orientation detection + per-leg SNR, and the
+                        # back arrays carry the return leg. The legacy `route`
+                        # stays dropped (route_ids duplicates it resolved).
                         payload = self._jsonb(row["payload"], {})
                         slim_payload = {}
-                        if isinstance(payload, dict) and "snr_towards" in payload:
-                            slim_payload["snr_towards"] = payload["snr_towards"]
+                        if isinstance(payload, dict):
+                            for key in ("snr_towards", "route_back", "snr_back"):
+                                if key in payload:
+                                    slim_payload[key] = payload[key]
+                        created = row["created_at"]
                         traceroutes.append(
                             {
                                 "from": row["from_node_id"],
                                 "to": row["to_node_id"],
                                 "id": row["message_id"],
+                                "packet_id": row["packet_id"],
                                 "hops_away": row["hops_away"],
                                 "rssi": row["rssi"],
                                 "snr": row["snr"],
                                 "timestamp": row["timestamp"],
+                                "created_at": int(created.timestamp()) if created else None,
                                 "route_ids": self._jsonb(row["route_ids"], []),
+                                "route_back_ids": self._jsonb(row["route_back_ids"], []),
                                 "payload": slim_payload,
                             }
                         )
@@ -2656,11 +2711,17 @@ class PostgresStorage:
                         }
                     )
 
-                return traceroutes
+                if not with_cursor:
+                    return traceroutes
+                next_cursor = None
+                if len(rows) >= limit and rows:
+                    last = rows[-1]
+                    next_cursor = _encode_cursor(last["created_at"], last["id"])
+                return {"traceroutes": traceroutes, "next_cursor": next_cursor}
 
         except Exception as e:
             logger.error(f"Failed to query traceroutes from PostgreSQL: {e}")
-            return []
+            return {"traceroutes": [], "next_cursor": None} if with_cursor else []
 
     async def query_stats(self) -> Dict[str, Any]:
         """Query statistics from PostgreSQL."""

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -68,30 +68,20 @@ def _finite_or_none(value: Any) -> Any:
 # against this so a typo'd kind fails in tests, not silently during recovery.
 _RETRY_KINDS = frozenset({"mqtt_message", "telemetry", "chat_message", "traceroute"})
 
-# Richer-wins traceroute upsert: upgrades are confined to rows younger than
-# this window so a genuinely NEW traceroute reusing a 32-bit packet id weeks
-# later can never overwrite history (outside the window the statement degrades
-# to the old DO NOTHING semantics — the pre-existing id-reuse drop, not a
-# regression). One hour also covers write-retry drain latency after an outage
-# (the buffer holds roughly half an hour of traffic).
+# Upgrades only touch rows younger than this, so a new traceroute reusing a
+# 32-bit packet id later can never overwrite history (degrades to DO NOTHING).
 TRACEROUTE_UPGRADE_WINDOW_S = 3600
 
 
-# Meshtastic hop_limit tops out at 7, so genuine RouteDiscovery arrays never
-# exceed ~8 entries; counting is capped there so a hostile publisher padding
-# arrays gains bounded score, not an arbitrary overwrite budget.
+# Genuine RouteDiscovery arrays never exceed ~8 entries (hop_limit <= 7);
+# the cap bounds what a hostile publisher's padding can score.
 _TRACEROUTE_ARRAY_CAP = 10
 
 
 def _traceroute_richness_sql(payload_expr: str) -> str:
     """SQL summing the four RouteDiscovery array lengths of a payload jsonb.
-
-    Richness is monotone along the relay chain — every hop appends to
-    route/route_back/snr_* — so the richest single copy is a superset of every
-    poorer copy and whole-row replacement never needs field-level merging.
-    jsonb_typeof guards make it total for malformed/JSON-publisher payloads;
-    per-array LEAST caps bound what publisher-crafted padding can score.
-    """
+    Richness is monotone along the relay chain, so the richest copy is a
+    superset of every poorer one — whole-row replacement needs no merging."""
     return " + ".join(
         f"CASE WHEN jsonb_typeof({payload_expr}->'{key}') = 'array'"
         f" THEN LEAST(jsonb_array_length({payload_expr}->'{key}'), {_TRACEROUTE_ARRAY_CAP})"
@@ -101,15 +91,9 @@ def _traceroute_richness_sql(payload_expr: str) -> str:
 
 
 def _traceroute_prefix_guard_sql(key: str) -> str:
-    """SQL requiring the stored payload's array to be a PREFIX of the incoming
-    copy's — the monotonicity invariant made enforceable: genuine richer copies
-    only ever APPEND hops, so an upgrade may extend recorded data but never
-    rewrite it. Blocks a hostile publisher from replacing genuine hops with
-    forged ones inside the upgrade window (they can at most append plausible
-    junk — no more power than winning the original first-uplink race gave
-    them). Skipped when the stored value isn't an array (absent key /
-    legacy / malformed — IS DISTINCT FROM keeps the NULL of an absent key
-    from vetoing the whole guard)."""
+    """SQL requiring the stored array to be a prefix of the incoming copy's:
+    genuine richer copies only append hops, so upgrades may extend but never
+    rewrite recorded data. Skipped when the stored value isn't an array."""
     return f"""(
         jsonb_typeof(traceroutes.payload->'{key}') IS DISTINCT FROM 'array'
         OR traceroutes.payload->'{key}' = (
@@ -121,20 +105,10 @@ def _traceroute_prefix_guard_sql(key: str) -> str:
     )"""
 
 
-# Guarded richer-wins upsert. Copy-scoped columns move TOGETHER on an upgrade
-# (payload + the reception fields sender/rssi/snr/hops_away): mixing
-# first-copy reception data with a later copy's payload would create a row no
-# gateway ever heard. Exceptions: created_at and the PK stay put (created_at
-# is first-heard and anchors the recency guard, list ordering, pagination),
-# and a valid stored timestamp/rx_time is never regressed by a clock-less
-# gateway's copy (rx_time=0 on nodes without a time source) — the SSE event
-# for such an upgrade carries the incoming copy's zero timestamp and diverges
-# from REST on that one field until the next refetch, an accepted cost.
-# RETURNING (xmax = 0) discriminates insert (true) from update (false); no row
-# means the guard refused the copy: poorer/equal, prefix-violating, or a
-# STALE id collision (row older than the window — such packets are genuinely
-# new but indistinguishable from history rewrites, so they are dropped, as
-# the old DO NOTHING always did). $16 = upgrade window (s).
+# Guarded richer-wins upsert: copy-scoped columns move together on an upgrade,
+# but created_at stays first-heard and a valid timestamp/rx_time is never
+# regressed by a clock-less gateway's copy (rx_time=0). RETURNING (xmax = 0)
+# discriminates insert from update; no row = guard refused. $16 = window (s).
 TRACEROUTE_UPSERT_SQL = f"""
     INSERT INTO traceroutes (
         from_node_id, to_node_id, sender_node_id, message_id, channel,
@@ -531,13 +505,9 @@ class PostgresStorage:
                         ON mqtt_messages(from_node_id, packet_id, created_at DESC)
                         WHERE packet_id IS NOT NULL;
                 """, timeout=600)
-                # Traceroute return-path column + involvement indexes. The
-                # ALTER is instant; the index builds scan the whole table on
-                # first run, hence the explicit timeout (schema.sql also
-                # carries copies for fresh installs, but its single implicit
-                # transaction runs under the pool's 10s command_timeout — a
-                # timeout there would roll the ALTER back with it, so the
-                # migrations block is the authoritative path for upgrades).
+                # First-run index builds scan the whole table, hence the
+                # explicit timeout; this block, not schema.sql, is the
+                # authoritative path for upgrades.
                 await conn.execute("""
                     ALTER TABLE traceroutes ADD COLUMN IF NOT EXISTS route_back_ids JSONB;
                 """)
@@ -1299,24 +1269,8 @@ class PostgresStorage:
             self._handle_write_failure("chat message", "chat_message", (node_id, chat_msg), e)
 
     async def write_traceroute(self, node_id: str, traceroute_msg: Dict[str, Any]) -> Optional[str]:
-        """
-        Write traceroute to PostgreSQL via the richer-wins upsert: the stored
-        row is always the richest single heard copy of a packet (whole-copy
-        replacement, reception fields included; created_at stays first-heard).
-
-        Args:
-            node_id: from-node id (any supported form; will be normalized)
-            traceroute_msg: Traceroute message dictionary
-
-        Returns:
-            'inserted' | 'upgraded' | 'duplicate', or None when the write was
-            skipped or failed (buffered for retry on outage-shaped errors).
-            'duplicate' covers every guard refusal: poorer/equal copies,
-            prefix-violating (forged) copies, AND stale 32-bit id collisions
-            with a row older than the upgrade window — that last packet is
-            genuinely new but dropped, exactly as ON CONFLICT DO NOTHING
-            always dropped it (probability ~ per-node rows / 2^32).
-        """
+        """Richer-wins traceroute upsert. Returns 'inserted' | 'upgraded' |
+        'duplicate' (any guard refusal), or None when skipped/failed."""
         if not self._ready("write_traceroute"):
             return None
 
@@ -1395,9 +1349,7 @@ class PostgresStorage:
                 )
                 if row is None:
                     return "duplicate"
-                # The row's REAL created_at (first-heard — upgrades keep it),
-                # surfaced on the msg so the SSE event matches a later REST
-                # fetch instead of stamping upgrade-time.
+                # Surface first-heard created_at so the SSE event matches REST.
                 if row["created_at"] is not None:
                     traceroute_msg["created_at"] = int(row["created_at"].timestamp())
                 return "inserted" if row["inserted"] else "upgraded"
@@ -2343,9 +2295,8 @@ class PostgresStorage:
             return []
 
     async def query_node_traceroutes(self, node_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
-        """Query traceroutes INVOLVING a node: as initiator, target, uplink
-        gateway, or relay hop on either leg (containment over the resolved
-        hop arrays, GIN-indexed)."""
+        """Query traceroutes involving a node: initiator, target, gateway,
+        or relay hop on either leg."""
         if not self.enabled or not self.pool:
             return []
 
@@ -2608,18 +2559,12 @@ class PostgresStorage:
         (consumers orient the path client-side). A single endpoint filters
         just that column. `range_seconds` windows on created_at.
 
-        With `slim`, each row keeps what the SPA reads: from, to, id,
-        packet_id (the reply's request_id — exact exchange pairing),
-        hops_away, rssi, snr, timestamp, created_at (epoch; dates rows whose
-        packet timestamp is 0), route_ids, route_back_ids, and the payload's
-        snr_towards/route_back/snr_back. Default False keeps the legacy full
-        shape byte-identical for third-party consumers.
+        With `slim`, each row keeps only what the SPA reads; default False
+        keeps the legacy full shape for third-party consumers.
 
-        Keyset pagination: `before` is an opaque cursor (from a previous
-        page's next_cursor) over (created_at, id) — stable because upgrades
-        never touch created_at. With `with_cursor` the return value is
-        {"traceroutes": rows, "next_cursor": str | None} instead of a bare
-        list; next_cursor is present only when the page filled `limit`.
+        `before` is an opaque keyset cursor over (created_at, id) — stable
+        because upgrades never touch created_at. With `with_cursor` the return
+        is {"traceroutes": rows, "next_cursor": str | None} instead of a list.
         """
         if not self.enabled or not self.pool:
             return {"traceroutes": [], "next_cursor": None} if with_cursor else []
@@ -2665,10 +2610,7 @@ class PostgresStorage:
                 traceroutes = []
                 for row in rows:
                     if slim:
-                        # payload still has to be parsed: snr_towards drives
-                        # reply-orientation detection + per-leg SNR, and the
-                        # back arrays carry the return leg. The legacy `route`
-                        # stays dropped (route_ids duplicates it resolved).
+                        # Legacy `route` stays dropped (route_ids duplicates it resolved).
                         payload = self._jsonb(row["payload"], {})
                         slim_payload = {}
                         if isinstance(payload, dict):

--- a/storage/db/write_retry.py
+++ b/storage/db/write_retry.py
@@ -21,9 +21,11 @@ concurrently can never be mistaken for replay failures.
 Known, accepted semantics:
 - At-least-once: an ambiguous failure (connection dies after the server
   committed but before the client read the result) replays a write that
-  already landed. telemetry/chat/traceroute inserts are idempotent
-  (ON CONFLICT DO NOTHING); a replayed mqtt_message can in rare cases add a
-  duplicate reception/row — weighed against certain loss, we take it.
+  already landed. telemetry/chat inserts are idempotent (ON CONFLICT DO
+  NOTHING); traceroutes use a richer-wins upsert whose strict `>` richness
+  guard makes an exact replay a no-op (equally idempotent). A replayed
+  mqtt_message can in rare cases add a duplicate reception/row — weighed
+  against certain loss, we take it.
 - Replayed rows get created_at = replay time (they sort/partition by when
   they were actually stored).
 - Live SSE broadcasts for replayed writes are not re-emitted; the archive

--- a/storage/db/write_retry.py
+++ b/storage/db/write_retry.py
@@ -22,10 +22,9 @@ Known, accepted semantics:
 - At-least-once: an ambiguous failure (connection dies after the server
   committed but before the client read the result) replays a write that
   already landed. telemetry/chat inserts are idempotent (ON CONFLICT DO
-  NOTHING); traceroutes use a richer-wins upsert whose strict `>` richness
-  guard makes an exact replay a no-op (equally idempotent). A replayed
-  mqtt_message can in rare cases add a duplicate reception/row — weighed
-  against certain loss, we take it.
+  NOTHING); the traceroute upsert's strict `>` richness guard makes an exact
+  replay a no-op. A replayed mqtt_message can in rare cases add a duplicate
+  reception/row — weighed against certain loss, we take it.
 - Replayed rows get created_at = replay time (they sort/partition by when
   they were actually stored).
 - Live SSE broadcasts for replayed writes are not re-emitted; the archive

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -46,8 +46,30 @@ class FakePgStorage:
     async def write_telemetry(self, node_id: str, msg) -> None:
         self.telemetry_writes.append((node_id, dict(msg)))
 
-    async def write_traceroute(self, node_id: str, msg) -> None:
+    async def write_traceroute(self, node_id: str, msg) -> str:
+        # Richer-wins emulation mirroring the real upsert's outcome contract
+        # ('inserted' | 'upgraded' | 'duplicate') so handler broadcast-gating
+        # tests exercise every branch. Keyed on (node_id, msg id); id-less
+        # messages always insert (the real writer skips them, but existing
+        # handler tests assert the write reaches the store).
+        def richness(m):
+            p = m.get("payload") or {}
+            return sum(
+                len(p[k])
+                for k in ("route", "route_back", "snr_towards", "snr_back")
+                if isinstance(p.get(k), list)
+            )
+
+        msg_id = msg.get("id")
+        if msg_id is not None:
+            for i, (nid, prev) in enumerate(self.traceroute_writes):
+                if nid == node_id and prev.get("id") == msg_id:
+                    if richness(msg) > richness(prev):
+                        self.traceroute_writes[i] = (node_id, dict(msg))
+                        return "upgraded"
+                    return "duplicate"
         self.traceroute_writes.append((node_id, dict(msg)))
+        return "inserted"
 
     async def find_node_by_longname(self, name: str):
         for nid, n in self._nodes.items():

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -9,6 +9,7 @@ import mode.
 
 import asyncio
 
+from meshtastic import mesh_pb2, mqtt_pb2
 from broadcaster import Broadcaster
 
 
@@ -72,3 +73,53 @@ class FakeDataStore:
 def run(coro):
     """Drive an async function without pytest-asyncio (not in requirements-dev)."""
     return asyncio.run(coro)
+
+
+class _FakeTopic:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class FakeMqttMessage:
+    """Minimal aiomqtt message stand-in for driving process_mqtt_msg."""
+
+    def __init__(self, topic: str, payload: bytes, qos: int = 0, retain: bool = False):
+        self.topic = _FakeTopic(topic)
+        self.payload = payload
+        self.qos = qos
+        self.retain = retain
+
+
+def build_envelope(
+    from_=0x67EA9400,
+    to=0xABCD1234,
+    packet_id=123456,
+    portnum=1,  # TEXT_MESSAGE_APP
+    payload=b"hi",
+    hop_start=0,
+    hop_limit=0,
+    rx_rssi=0,
+    rx_snr=0.0,
+    rx_time=1753500000,
+    channel=0,
+    gateway_id="!abcd1234",
+    topic="msh/US/2/e/LongFast/!abcd1234",
+) -> FakeMqttMessage:
+    """Serialize a real ServiceEnvelope wrapping an unencrypted MeshPacket —
+    the exact wire shape process_mqtt_msg decodes, so proto3 zero-omission
+    behavior (hop_limit==0, rx_rssi==0, channel==0) is exercised for real."""
+    mp = mesh_pb2.MeshPacket(
+        **{"from": from_},
+        to=to,
+        id=packet_id,
+        hop_start=hop_start,
+        hop_limit=hop_limit,
+        rx_rssi=rx_rssi,
+        rx_snr=rx_snr,
+        rx_time=rx_time,
+        channel=channel,
+    )
+    mp.decoded.portnum = portnum
+    mp.decoded.payload = payload
+    se = mqtt_pb2.ServiceEnvelope(packet=mp, gateway_id=gateway_id, channel_id="LongFast")
+    return FakeMqttMessage(topic, se.SerializeToString())

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -47,11 +47,8 @@ class FakePgStorage:
         self.telemetry_writes.append((node_id, dict(msg)))
 
     async def write_traceroute(self, node_id: str, msg) -> str:
-        # Richer-wins emulation mirroring the real upsert's outcome contract
-        # ('inserted' | 'upgraded' | 'duplicate') so handler broadcast-gating
-        # tests exercise every branch. Keyed on (node_id, msg id); id-less
-        # messages always insert (the real writer skips them, but existing
-        # handler tests assert the write reaches the store).
+        # Mirrors the real upsert's outcome contract ('inserted' | 'upgraded'
+        # | 'duplicate'); id-less messages always insert.
         def richness(m):
             p = m.get("payload") or {}
             return sum(
@@ -65,8 +62,7 @@ class FakePgStorage:
             for i, (nid, prev) in enumerate(self.traceroute_writes):
                 if nid == node_id and prev.get("id") == msg_id:
                     if richness(msg) > richness(prev):
-                        # Upgrades keep the original row's created_at (mirrors
-                        # RETURNING created_at surfacing it onto the msg).
+                        # Upgrades keep the original row's created_at.
                         msg["created_at"] = prev.get("created_at")
                         self.traceroute_writes[i] = (node_id, dict(msg))
                         return "upgraded"
@@ -132,9 +128,8 @@ def build_envelope(
     topic="msh/US/2/e/LongFast/!abcd1234",
     request_id=0,
 ) -> FakeMqttMessage:
-    """Serialize a real ServiceEnvelope wrapping an unencrypted MeshPacket —
-    the exact wire shape process_mqtt_msg decodes, so proto3 zero-omission
-    behavior (hop_limit==0, rx_rssi==0, channel==0) is exercised for real."""
+    """Serialize a real ServiceEnvelope wrapping an unencrypted MeshPacket, so
+    proto3 zero-omission (hop_limit==0, rx_rssi==0, channel==0) is exercised."""
     mp = mesh_pb2.MeshPacket(
         **{"from": from_},
         to=to,

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -65,9 +65,13 @@ class FakePgStorage:
             for i, (nid, prev) in enumerate(self.traceroute_writes):
                 if nid == node_id and prev.get("id") == msg_id:
                     if richness(msg) > richness(prev):
+                        # Upgrades keep the original row's created_at (mirrors
+                        # RETURNING created_at surfacing it onto the msg).
+                        msg["created_at"] = prev.get("created_at")
                         self.traceroute_writes[i] = (node_id, dict(msg))
                         return "upgraded"
                     return "duplicate"
+        msg["created_at"] = 1753600000
         self.traceroute_writes.append((node_id, dict(msg)))
         return "inserted"
 
@@ -126,6 +130,7 @@ def build_envelope(
     channel=0,
     gateway_id="!abcd1234",
     topic="msh/US/2/e/LongFast/!abcd1234",
+    request_id=0,
 ) -> FakeMqttMessage:
     """Serialize a real ServiceEnvelope wrapping an unencrypted MeshPacket —
     the exact wire shape process_mqtt_msg decodes, so proto3 zero-omission
@@ -143,5 +148,6 @@ def build_envelope(
     )
     mp.decoded.portnum = portnum
     mp.decoded.payload = payload
+    mp.decoded.request_id = request_id
     se = mqtt_pb2.ServiceEnvelope(packet=mp, gateway_id=gateway_id, channel_id="LongFast")
     return FakeMqttMessage(topic, se.SerializeToString())

--- a/tests/test_mqtt_decrypt.py
+++ b/tests/test_mqtt_decrypt.py
@@ -106,7 +106,16 @@ def make_mqtt_pb(keys):
     return MQTT(config, data), data
 
 
-def _build_encrypted_envelope(key_bytes, text, from_=0x67EA9401, pkt_id=424242):
+def _build_encrypted_envelope(
+    key_bytes,
+    text,
+    from_=0x67EA9401,
+    pkt_id=424242,
+    rx_rssi=-92,
+    rx_snr=5.5,
+    hop_start=3,
+    hop_limit=1,
+):
     """Serialize a ServiceEnvelope whose MeshPacket carries an AES-CTR
     encrypted TEXT_MESSAGE_APP payload, mirroring what a Meshtastic gateway
     uplinks. Nonce layout must match mqtt.py: packet_id LE64 ‖ from LE64.
@@ -126,10 +135,10 @@ def _build_encrypted_envelope(key_bytes, text, from_=0x67EA9401, pkt_id=424242):
     mp.id = pkt_id
     mp.channel = 8
     mp.rx_time = 1700000000
-    mp.rx_rssi = -92
-    mp.rx_snr = 5.5
-    mp.hop_start = 3
-    mp.hop_limit = 1
+    mp.rx_rssi = rx_rssi
+    mp.rx_snr = rx_snr
+    mp.hop_start = hop_start
+    mp.hop_limit = hop_limit
     mp.encrypted = ciphertext
 
     se = mqtt_pb2.ServiceEnvelope()
@@ -194,6 +203,28 @@ class TestProcessEncryptedPacket:
         assert from_id == GOLDEN_FROM_HEX
         assert chat["text"] == GOLDEN_TEXT
         assert chat["channel"] == "8"
+
+    def test_encrypted_packet_zero_header_fields_handled(self):
+        """Zero-valued header fields must survive the decrypt branch's dict
+        re-serialization: hops_away is read off mp directly (hop_limit==0 —
+        an exhausted-hops packet — vanishes from MessageToJson output), and a
+        zero rssi/snr pair stays absent instead of fabricating a reading."""
+        mqtt, data = make_mqtt_pb([DEFAULT_KEY_B64])
+        env = _build_encrypted_envelope(
+            base64.b64decode(DEFAULT_KEY_B64),
+            "zero header fields",
+            rx_rssi=0,
+            rx_snr=0.0,
+            hop_start=3,
+            hop_limit=0,
+        )
+        run(mqtt.process_mqtt_msg(None, FakeMsg(GOLDEN_TOPIC, env)))
+
+        stored = data.pg_storage.mqtt_writes[0]
+        assert stored["hops_away"] == 3
+        assert stored["hop_limit"] == 0
+        assert "rssi" not in stored
+        assert "snr" not in stored
 
     def test_second_key_in_list_decrypts(self):
         """The key loop must survive a failing key and go on to the right one."""

--- a/tests/test_mqtt_decrypt.py
+++ b/tests/test_mqtt_decrypt.py
@@ -205,10 +205,7 @@ class TestProcessEncryptedPacket:
         assert chat["channel"] == "8"
 
     def test_encrypted_packet_zero_header_fields_handled(self):
-        """Zero-valued header fields must survive the decrypt branch's dict
-        re-serialization: hops_away is read off mp directly (hop_limit==0 —
-        an exhausted-hops packet — vanishes from MessageToJson output), and a
-        zero rssi/snr pair stays absent instead of fabricating a reading."""
+        """hop_limit==0 still yields hops_away; a 0/0.0 rssi/snr pair stays absent."""
         mqtt, data = make_mqtt_pb([DEFAULT_KEY_B64])
         env = _build_encrypted_envelope(
             base64.b64decode(DEFAULT_KEY_B64),

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -515,6 +515,67 @@ class TestHandleTraceroute:
         _, event = q.get_nowait()
         assert event["route_ids"] == ["deadbeef"]
 
+    def test_duplicate_copy_broadcasts_no_second_event(self):
+        """A confirmed poorer/equal gateway copy must stay silent — the live
+        feed mirrors the richer-wins storage outcome."""
+        mqtt, data = make_mqtt()
+        q = data.broadcaster.subscribe()
+        msg = {
+            "from": 0x67EA9400,
+            "to": 0xABCD1234,
+            "id": 555,
+            "payload": {"route": [1], "snr_towards": [4]},
+        }
+        run(mqtt.handle_traceroute(dict(msg)))
+        run(mqtt.handle_traceroute(dict(msg)))  # identical second copy
+        assert q.qsize() == 1
+        assert len(data.pg_storage.traceroute_writes) == 1
+
+    def test_richer_copy_broadcasts_upgraded_event(self):
+        mqtt, data = make_mqtt()
+        q = data.broadcaster.subscribe()
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "to": 0xABCD1234,
+            "id": 556,
+            "payload": {"route": [1, 2], "snr_towards": [4, 8, 12], "route_back": []},
+        }))
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "to": 0xABCD1234,
+            "id": 556,
+            "payload": {
+                "route": [1, 2],
+                "snr_towards": [4, 8, 12],
+                "route_back": [3, 4],
+                "snr_back": [9, 10],
+            },
+        }))
+        assert q.qsize() == 2
+        q.get_nowait()
+        _, upgraded = q.get_nowait()
+        assert upgraded["payload"]["route_back"] == [3, 4]
+        _, written = data.pg_storage.traceroute_writes[0]
+        assert written["payload"]["route_back"] == [3, 4]
+
+    def test_outage_none_outcome_still_broadcasts(self):
+        """DB down (write buffered, outcome None): the live feed must not go
+        dark for the whole outage."""
+        mqtt, data = make_mqtt()
+
+        async def down(node_id, msg):
+            return None
+
+        data.pg_storage.write_traceroute = down
+        q = data.broadcaster.subscribe()
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "to": 0xABCD1234,
+            "id": 557,
+            "payload": {"route": [1]},
+        }))
+        assert q.qsize() == 1
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # process_mqtt_msg — envelope decode; pins the proto3 zero-omission fixes

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -429,6 +429,9 @@ class TestHandleTraceroute:
             "payload": payload,
         }))
         _, event = q.get_nowait()
+        # created_at is the handler's now() approximation of the DB default
+        created_at = event.pop("created_at")
+        assert isinstance(created_at, int) and created_at > 1753500000
         assert event == {
             "from": "67ea9400",
             "to": "abcd1234",
@@ -443,6 +446,7 @@ class TestHandleTraceroute:
             "timestamp": 1753500000,
             "route": [0x67EA9400],
             "route_ids": ["67ea9400"],
+            "route_back_ids": [],
             "payload": payload,
         }
 
@@ -492,6 +496,25 @@ class TestHandleTraceroute:
         }))
         _, written = data.pg_storage.traceroute_writes[0]
         assert written["route_ids"] == [2**40]
+
+    def test_route_back_resolved_like_forward_route(self):
+        mqtt, data = make_mqtt(nodes={
+            "67ea9400": {"id": "67ea9400", "longname": "A"},
+        })
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "to": 0xABCD1234,
+            "id": 900,
+            "payload": {
+                "route": [0x67EA9400],
+                "snr_towards": [4, 8],
+                "route_back": [0xDEADBEEF, 0x67EA9400],
+                "snr_back": [3, 5],
+            },
+        }))
+        _, written = data.pg_storage.traceroute_writes[0]
+        # Known node resolves, unknown int becomes canonical hex
+        assert written["route_back_ids"] == ["deadbeef", "67ea9400"]
 
     def test_bool_hop_not_minted_into_node_id(self):
         """bool subclasses int: a hostile JSON `true` route entry must echo
@@ -647,6 +670,32 @@ class TestProcessEnvelope:
         _, written = data.pg_storage.traceroute_writes[0]
         assert written["payload"]["route"] == []
         assert written["payload"]["snr_towards"] == [-128]
+
+    def test_traceroute_reply_request_id_captured_as_packet_id(self):
+        """Data.request_id (the request's packet id, set on replies) must land
+        in the stored row's packet_id for exact exchange pairing."""
+        rd = mesh_pb2.RouteDiscovery(route=[], snr_towards=[8])
+        msg = build_envelope(
+            portnum=portnums_pb2.TRACEROUTE_APP,
+            payload=rd.SerializeToString(),
+            request_id=424242,
+        )
+        mqtt, data = make_mqtt()
+        run(mqtt.process_mqtt_msg(None, msg))
+        _, written = data.pg_storage.traceroute_writes[0]
+        assert written["packet_id"] == 424242
+
+    def test_traceroute_request_has_null_packet_id(self):
+        rd = mesh_pb2.RouteDiscovery(route=[], snr_towards=[])
+        msg = build_envelope(
+            portnum=portnums_pb2.TRACEROUTE_APP,
+            payload=rd.SerializeToString(),
+            request_id=0,  # proto3 unset — a request packet
+        )
+        mqtt, data = make_mqtt()
+        run(mqtt.process_mqtt_msg(None, msg))
+        _, written = data.pg_storage.traceroute_writes[0]
+        assert written["packet_id"] is None
 
     def test_json_decoder_processes_when_protobuf_disabled(self):
         mqtt, data = make_mqtt(json_decoder=True, protobuf_decoder=False)

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -4,12 +4,16 @@ prevent a malformed packet from crashing the handler and killing the MQTT
 loop (which would drop other in-flight messages including corrective NODEINFOs).
 """
 
+import json
+
+from meshtastic import mesh_pb2, portnums_pb2
+
 from mqtt import MQTT, normalize_node_id  # noqa: F401  (re-exported via from utils)
 
-from _helpers import FakeDataStore, run
+from _helpers import FakeDataStore, FakeMqttMessage, build_envelope, run
 
 
-def make_mqtt(nodes=None):
+def make_mqtt(nodes=None, json_decoder=False, protobuf_decoder=True):
     """Build an MQTT instance wired up with fakes — no broker, no DB."""
     config = {
         "broker": {
@@ -18,6 +22,13 @@ def make_mqtt(nodes=None):
             "client_id": "test",
             "username": "",
             "password": "",
+            # process_mqtt_msg reads both decoder gates unconditionally.
+            # channels.encryption is only read in the encrypted branch, which
+            # these tests never enter — deliberately absent.
+            "decoders": {
+                "protobuf": {"enabled": protobuf_decoder},
+                "json": {"enabled": json_decoder},
+            },
         },
         "server": {
             "timezone": "UTC",
@@ -457,6 +468,162 @@ class TestHandleTraceroute:
         mqtt, data = make_mqtt()
         run(mqtt.handle_traceroute({"payload": {"route": [1, 2]}}))
         assert data.pg_storage.traceroute_writes == []
+
+    def test_unknown_int_hop_stored_as_canonical_hex(self):
+        """A hop through a node this instance has never seen must store the
+        canonical 8-hex id, not the raw int — raw ints never re-resolve after
+        the node appears and fragment route grouping."""
+        mqtt, data = make_mqtt(nodes={
+            "67ea9400": {"id": "67ea9400", "longname": "A"},
+        })
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "payload": {"route": [0x67EA9400, 0xDEADBEEF, 0x0165EC15]},
+        }))
+        _, written = data.pg_storage.traceroute_writes[0]
+        # Known node resolves; unknown ints become padded 8-hex
+        assert written["route_ids"] == ["67ea9400", "deadbeef", "0165ec15"]
+
+    def test_out_of_uint32_int_hop_kept_raw(self):
+        mqtt, data = make_mqtt()
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "payload": {"route": [2**40]},
+        }))
+        _, written = data.pg_storage.traceroute_writes[0]
+        assert written["route_ids"] == [2**40]
+
+    def test_bool_hop_not_minted_into_node_id(self):
+        """bool subclasses int: a hostile JSON `true` route entry must echo
+        verbatim, never become node 00000001."""
+        mqtt, data = make_mqtt()
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "payload": {"route": [True]},
+        }))
+        _, written = data.pg_storage.traceroute_writes[0]
+        assert written["route_ids"] == [True]
+
+    def test_sse_event_carries_hex_fallback(self):
+        mqtt, data = make_mqtt()
+        q = data.broadcaster.subscribe()
+        run(mqtt.handle_traceroute({
+            "from": 0x67EA9400,
+            "to": 0xABCD1234,
+            "payload": {"route": [0xDEADBEEF]},
+        }))
+        _, event = q.get_nowait()
+        assert event["route_ids"] == ["deadbeef"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# process_mqtt_msg — envelope decode; pins the proto3 zero-omission fixes
+# (hop_limit==0, rx_rssi==0, channel==0 all vanish from MessageToJson output)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestProcessEnvelope:
+    def _archived(self, msg, nodes=None):
+        mqtt, data = make_mqtt(nodes=nodes)
+        run(mqtt.process_mqtt_msg(None, msg))
+        assert len(data.pg_storage.mqtt_writes) == 1
+        return data.pg_storage.mqtt_writes[0], data
+
+    def test_exhausted_hops_get_real_hops_away(self):
+        """hop_start=3, hop_limit=0: the packet used ALL its hops — exactly
+        the max-distance rows that used to store hops_away NULL because
+        MessageToJson omits the zero-valued hop_limit."""
+        archived, _ = self._archived(build_envelope(hop_start=3, hop_limit=0))
+        assert archived["hops_away"] == 3
+        assert archived["hop_start"] == 3
+        assert archived["hop_limit"] == 0
+
+    def test_pre23_firmware_leaves_hops_away_unknown(self):
+        # hop_start==0: firmware that never reports it — unknown, not 0
+        archived, _ = self._archived(build_envelope(hop_start=0, hop_limit=3))
+        assert "hops_away" not in archived
+
+    def test_hops_away_clamped_at_zero(self):
+        # hop_limit > hop_start is a firmware anomaly; store 0, not negative
+        archived, _ = self._archived(build_envelope(hop_start=2, hop_limit=5))
+        assert archived["hops_away"] == 0
+
+    def test_self_gateway_zero_pair_omits_rssi_and_snr(self):
+        archived, _ = self._archived(build_envelope(rx_rssi=0, rx_snr=0.0))
+        assert "rssi" not in archived
+        assert "snr" not in archived
+
+    def test_real_reception_kept_verbatim(self):
+        archived, _ = self._archived(build_envelope(rx_rssi=-95, rx_snr=-7.25))
+        assert archived["rssi"] == -95
+        assert archived["snr"] == -7.25
+
+    def test_snr_only_legacy_gateway_keeps_snr(self):
+        archived, _ = self._archived(build_envelope(rx_rssi=0, rx_snr=5.5))
+        assert "rssi" not in archived
+        assert archived["snr"] == 5.5
+
+    def test_primary_channel_zero_archived(self):
+        archived, _ = self._archived(build_envelope(channel=0))
+        assert archived["channel"] == 0
+
+    def test_nonzero_channel_unchanged(self):
+        archived, _ = self._archived(build_envelope(channel=2))
+        assert archived["channel"] == 2
+
+    def test_zero_hop_traceroute_not_dropped(self):
+        """RouteDiscovery with an empty route (direct neighbor) must reach
+        write_traceroute — the payload's route arrives as [] thanks to the
+        decode's always_print_fields_with_no_presence, not absent."""
+        rd = mesh_pb2.RouteDiscovery(route=[], snr_towards=[-128])
+        msg = build_envelope(
+            portnum=portnums_pb2.TRACEROUTE_APP,
+            payload=rd.SerializeToString(),
+        )
+        mqtt, data = make_mqtt()
+        run(mqtt.process_mqtt_msg(None, msg))
+        assert len(data.pg_storage.traceroute_writes) == 1
+        _, written = data.pg_storage.traceroute_writes[0]
+        assert written["payload"]["route"] == []
+        assert written["payload"]["snr_towards"] == [-128]
+
+    def test_json_decoder_processes_when_protobuf_disabled(self):
+        mqtt, data = make_mqtt(json_decoder=True, protobuf_decoder=False)
+        payload = json.dumps({"type": "text", "from": 123}).encode("utf-8")
+        msg = FakeMqttMessage("msh/US/2/json/LongFast/!abcd1234", payload)
+        run(mqtt.process_mqtt_msg(None, msg))
+        assert len(data.pg_storage.mqtt_writes) == 1
+        assert data.pg_storage.mqtt_writes[0]["topic"] == "msh/US/2/json/LongFast/!abcd1234"
+
+    def test_json_decoder_exclusive_with_protobuf(self):
+        """Both decoders enabled: /2/json copies are SKIPPED by design — a
+        gateway with JSON output publishes the same packet to both
+        namespaces, and processing both would double-fire every SSE event
+        and duplicate packet_receptions rows."""
+        mqtt, data = make_mqtt(json_decoder=True, protobuf_decoder=True)
+        payload = json.dumps({"type": "text", "from": 123}).encode("utf-8")
+        msg = FakeMqttMessage("msh/US/2/json/LongFast/!abcd1234", payload)
+        run(mqtt.process_mqtt_msg(None, msg))
+        assert data.pg_storage.mqtt_writes == []
+
+    def test_packet_sse_event_omits_unmeasured_keys(self):
+        """The live 'packet' event forwards the archived dict: a self-gateway
+        zero pair must arrive without rssi/snr keys (absent, not null), and
+        an exhausted-hops packet must carry its computed hops_away."""
+        mqtt, data = make_mqtt()
+        q = data.broadcaster.subscribe()
+        run(mqtt.process_mqtt_msg(
+            None, build_envelope(rx_rssi=0, rx_snr=0.0, hop_start=3, hop_limit=0)
+        ))
+        # A text envelope also emits a 'chat' event; find the 'packet' one.
+        events = {}
+        while not q.empty():
+            event_type, event = q.get_nowait()
+            events[event_type] = event
+        packet = events["packet"]
+        assert "rssi" not in packet
+        assert "snr" not in packet
+        assert packet["hops_away"] == 3
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -22,9 +22,8 @@ def make_mqtt(nodes=None, json_decoder=False, protobuf_decoder=True):
             "client_id": "test",
             "username": "",
             "password": "",
-            # process_mqtt_msg reads both decoder gates unconditionally.
-            # channels.encryption is only read in the encrypted branch, which
-            # these tests never enter — deliberately absent.
+            # channels.encryption is only read in the encrypted branch,
+            # which these tests never enter — deliberately absent.
             "decoders": {
                 "protobuf": {"enabled": protobuf_decoder},
                 "json": {"enabled": json_decoder},
@@ -474,9 +473,7 @@ class TestHandleTraceroute:
         assert data.pg_storage.traceroute_writes == []
 
     def test_unknown_int_hop_stored_as_canonical_hex(self):
-        """A hop through a node this instance has never seen must store the
-        canonical 8-hex id, not the raw int — raw ints never re-resolve after
-        the node appears and fragment route grouping."""
+        """Raw ints never re-resolve and fragment route grouping."""
         mqtt, data = make_mqtt(nodes={
             "67ea9400": {"id": "67ea9400", "longname": "A"},
         })
@@ -517,8 +514,7 @@ class TestHandleTraceroute:
         assert written["route_back_ids"] == ["deadbeef", "67ea9400"]
 
     def test_bool_hop_not_minted_into_node_id(self):
-        """bool subclasses int: a hostile JSON `true` route entry must echo
-        verbatim, never become node 00000001."""
+        """bool subclasses int: `true` must echo verbatim, never become node 00000001."""
         mqtt, data = make_mqtt()
         run(mqtt.handle_traceroute({
             "from": 0x67EA9400,
@@ -539,8 +535,7 @@ class TestHandleTraceroute:
         assert event["route_ids"] == ["deadbeef"]
 
     def test_duplicate_copy_broadcasts_no_second_event(self):
-        """A confirmed poorer/equal gateway copy must stay silent — the live
-        feed mirrors the richer-wins storage outcome."""
+        """A poorer/equal gateway copy stays silent — live feed mirrors storage."""
         mqtt, data = make_mqtt()
         q = data.broadcaster.subscribe()
         msg = {
@@ -582,8 +577,7 @@ class TestHandleTraceroute:
         assert written["payload"]["route_back"] == [3, 4]
 
     def test_outage_none_outcome_still_broadcasts(self):
-        """DB down (write buffered, outcome None): the live feed must not go
-        dark for the whole outage."""
+        """DB down (outcome None): the live feed must not go dark."""
         mqtt, data = make_mqtt()
 
         async def down(node_id, msg):
@@ -602,7 +596,6 @@ class TestHandleTraceroute:
 
 # ─────────────────────────────────────────────────────────────────────────────
 # process_mqtt_msg — envelope decode; pins the proto3 zero-omission fixes
-# (hop_limit==0, rx_rssi==0, channel==0 all vanish from MessageToJson output)
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -614,9 +607,7 @@ class TestProcessEnvelope:
         return data.pg_storage.mqtt_writes[0], data
 
     def test_exhausted_hops_get_real_hops_away(self):
-        """hop_start=3, hop_limit=0: the packet used ALL its hops — exactly
-        the max-distance rows that used to store hops_away NULL because
-        MessageToJson omits the zero-valued hop_limit."""
+        """hop_limit==0 (all hops used) vanishes from MessageToJson; hops_away must still compute."""
         archived, _ = self._archived(build_envelope(hop_start=3, hop_limit=0))
         assert archived["hops_away"] == 3
         assert archived["hop_start"] == 3
@@ -656,9 +647,8 @@ class TestProcessEnvelope:
         assert archived["channel"] == 2
 
     def test_zero_hop_traceroute_not_dropped(self):
-        """RouteDiscovery with an empty route (direct neighbor) must reach
-        write_traceroute — the payload's route arrives as [] thanks to the
-        decode's always_print_fields_with_no_presence, not absent."""
+        """Empty route (direct neighbor) still reaches write_traceroute;
+        the decode yields route=[], not absent."""
         rd = mesh_pb2.RouteDiscovery(route=[], snr_towards=[-128])
         msg = build_envelope(
             portnum=portnums_pb2.TRACEROUTE_APP,
@@ -672,8 +662,6 @@ class TestProcessEnvelope:
         assert written["payload"]["snr_towards"] == [-128]
 
     def test_traceroute_reply_request_id_captured_as_packet_id(self):
-        """Data.request_id (the request's packet id, set on replies) must land
-        in the stored row's packet_id for exact exchange pairing."""
         rd = mesh_pb2.RouteDiscovery(route=[], snr_towards=[8])
         msg = build_envelope(
             portnum=portnums_pb2.TRACEROUTE_APP,
@@ -706,10 +694,8 @@ class TestProcessEnvelope:
         assert data.pg_storage.mqtt_writes[0]["topic"] == "msh/US/2/json/LongFast/!abcd1234"
 
     def test_json_decoder_exclusive_with_protobuf(self):
-        """Both decoders enabled: /2/json copies are SKIPPED by design — a
-        gateway with JSON output publishes the same packet to both
-        namespaces, and processing both would double-fire every SSE event
-        and duplicate packet_receptions rows."""
+        """Both enabled: /2/json copies are skipped — gateways publish the
+        same packet to both namespaces."""
         mqtt, data = make_mqtt(json_decoder=True, protobuf_decoder=True)
         payload = json.dumps({"type": "text", "from": 123}).encode("utf-8")
         msg = FakeMqttMessage("msh/US/2/json/LongFast/!abcd1234", payload)
@@ -717,9 +703,7 @@ class TestProcessEnvelope:
         assert data.pg_storage.mqtt_writes == []
 
     def test_packet_sse_event_omits_unmeasured_keys(self):
-        """The live 'packet' event forwards the archived dict: a self-gateway
-        zero pair must arrive without rssi/snr keys (absent, not null), and
-        an exhausted-hops packet must carry its computed hops_away."""
+        """A zero rssi/snr pair arrives absent (not null) on the live 'packet' event."""
         mqtt, data = make_mqtt()
         q = data.broadcaster.subscribe()
         run(mqtt.process_mqtt_msg(

--- a/tests/test_traceroute_upsert.py
+++ b/tests/test_traceroute_upsert.py
@@ -1,0 +1,301 @@
+"""
+Real-database tests for the traceroute richer-wins upsert (TRACEROUTE_UPSERT_SQL).
+
+Opt-in: they need a THROWAWAY postgres reachable via TRACEROUTE_PG_DSN and are
+skipped otherwise, keeping the default suite runnable anywhere. Never point the
+DSN at a live database — the setup truncates the traceroutes table. Recipe:
+
+    docker run --rm -d --name tr-upsert-pg -e POSTGRES_PASSWORD=x \
+        -e POSTGRES_DB=meshinfo -p 127.0.0.1:5433:5432 postgres:18
+    docker exec -i tr-upsert-pg psql -U postgres -d meshinfo \
+        < postgres/sql/schema.sql
+    TRACEROUTE_PG_DSN=postgresql://postgres:x@127.0.0.1:5433/meshinfo \
+        python -m pytest tests/test_traceroute_upsert.py -q
+    docker rm -f tr-upsert-pg
+
+The tests drive the exact SQL constant the app executes, so guard behavior
+(recency window, strict richness, concurrency arbitration) is pinned against a
+real server, not a fake.
+"""
+
+import asyncio
+import json
+import os
+
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from storage.db.postgres import TRACEROUTE_UPGRADE_WINDOW_S, TRACEROUTE_UPSERT_SQL
+
+DSN = os.environ.get("TRACEROUTE_PG_DSN")
+
+pytestmark = pytest.mark.skipif(
+    not DSN, reason="TRACEROUTE_PG_DSN not set (throwaway postgres required)"
+)
+
+FROM_ID = "67ea9400"
+TO_ID = "abcd1234"
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# Live-DSN tripwire: a fresh schema-loaded throwaway starts EMPTY, so a
+# populated traceroutes table means the DSN points somewhere real — refuse
+# before the TRUNCATE below can destroy it. Checked once per session (our own
+# tests populate the table afterwards).
+_dsn_checked = False
+
+
+async def _conn():
+    global _dsn_checked
+    conn = await asyncpg.connect(DSN)
+    if not _dsn_checked:
+        existing = await conn.fetchval("SELECT count(*) FROM traceroutes")
+        if existing:
+            await conn.close()
+            pytest.fail(
+                f"TRACEROUTE_PG_DSN points at a database with {existing} traceroutes "
+                "rows — refusing to TRUNCATE. Use a fresh throwaway postgres."
+            )
+        _dsn_checked = True
+    # FK stubs + a clean slate per test.
+    await conn.execute(
+        "INSERT INTO nodes (id) VALUES ($1), ($2) ON CONFLICT (id) DO NOTHING",
+        FROM_ID,
+        TO_ID,
+    )
+    await conn.execute("TRUNCATE traceroutes")
+    return conn
+
+
+async def _upsert(conn, message_id, payload, rssi=None, snr=None, sender=None):
+    """Execute the production statement; returns 'inserted'/'upgraded'/'duplicate'."""
+    row = await conn.fetchrow(
+        TRACEROUTE_UPSERT_SQL,
+        FROM_ID,
+        TO_ID,
+        sender,
+        message_id,
+        None,  # channel
+        None,  # packet_id
+        None,  # hops_away
+        rssi,
+        snr,
+        1753500000,  # timestamp
+        None,  # rx_time
+        json.dumps(payload.get("route", [])),
+        json.dumps([]),
+        json.dumps(payload),
+        float(TRACEROUTE_UPGRADE_WINDOW_S),
+    )
+    if row is None:
+        return "duplicate"
+    return "inserted" if row["inserted"] else "upgraded"
+
+
+POOR = {"route": [1, 2], "snr_towards": [4, 8, 12], "route_back": [], "snr_back": []}
+RICH = {
+    "route": [1, 2],
+    "snr_towards": [4, 8, 12],
+    "route_back": [3, 4],
+    "snr_back": [9, 10],
+}
+
+
+class TestRicherWinsUpsert:
+    def test_richer_copy_upgrades_whole_row(self):
+        async def body():
+            conn = await _conn()
+            try:
+                assert await _upsert(conn, 1, POOR, rssi=-90, snr=-5.0) == "inserted"
+                created0 = await conn.fetchval("SELECT created_at FROM traceroutes")
+                assert await _upsert(conn, 1, RICH, rssi=-110, snr=-12.0) == "upgraded"
+                rows = await conn.fetch("SELECT * FROM traceroutes")
+                assert len(rows) == 1
+                row = rows[0]
+                # Whole-copy replacement: payload AND reception fields together
+                assert json.loads(row["payload"])["route_back"] == [3, 4]
+                assert row["rssi"] == -110 and row["snr"] == -12.0
+                # created_at anchors first-heard
+                assert row["created_at"] == created0
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_poorer_equal_and_replay_are_noops(self):
+        async def body():
+            conn = await _conn()
+            try:
+                assert await _upsert(conn, 2, RICH, rssi=-110) == "inserted"
+                # Poorer copy refused
+                assert await _upsert(conn, 2, POOR, rssi=-90) == "duplicate"
+                # Byte-identical replay (write-retry at-least-once) is a no-op
+                assert await _upsert(conn, 2, RICH, rssi=-110) == "duplicate"
+                row = await conn.fetchrow("SELECT * FROM traceroutes")
+                assert json.loads(row["payload"])["route_back"] == [3, 4]
+                assert row["rssi"] == -110
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_reply_snr_beats_equal_route_length(self):
+        async def body():
+            conn = await _conn()
+            try:
+                request = {"route": [1, 2], "snr_towards": [4, 8]}
+                reply = {"route": [1, 2], "snr_towards": [4, 8, 12]}
+                assert await _upsert(conn, 3, request) == "inserted"
+                # Same route length; the destination's appended SNR is richer
+                assert await _upsert(conn, 3, reply) == "upgraded"
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_malformed_payloads_evaluate_as_zero(self):
+        async def body():
+            conn = await _conn()
+            try:
+                assert await _upsert(conn, 4, {}) == "inserted"
+                assert await _upsert(conn, 4, {"route": "bogus"}) == "duplicate"
+                assert await _upsert(conn, 4, {"route": [1]}) == "upgraded"
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_prefix_guard_refuses_rewritten_hops(self):
+        """A 'richer' copy that REWRITES recorded hops instead of extending
+        them is forged — genuine copies only append (monotonicity)."""
+
+        async def body():
+            conn = await _conn()
+            try:
+                genuine = {"route": [1, 2], "snr_towards": [4, 8, 12], "route_back": [3]}
+                assert await _upsert(conn, 6, genuine) == "inserted"
+                # Forged: higher richness but different recorded hops
+                forged = {
+                    "route": [9, 9],
+                    "snr_towards": [1, 1, 1],
+                    "route_back": [0, 0, 0, 0],
+                }
+                assert await _upsert(conn, 6, forged) == "duplicate"
+                # Forged route_back that doesn't extend the genuine one
+                forged_back = dict(genuine, route_back=[7, 7, 7])
+                assert await _upsert(conn, 6, forged_back) == "duplicate"
+                # Genuine extension: same prefix, more accumulated hops
+                extended = dict(genuine, route_back=[3, 4], snr_back=[9, 10])
+                assert await _upsert(conn, 6, extended) == "upgraded"
+                row = await conn.fetchrow("SELECT payload FROM traceroutes")
+                assert json.loads(row["payload"])["route_back"] == [3, 4]
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_padding_gains_are_capped(self):
+        """Publisher-padded arrays score at most the per-array cap, so junk
+        padding can't manufacture unlimited richness."""
+
+        async def body():
+            conn = await _conn()
+            try:
+                genuine = {"route": [1, 2], "snr_towards": [4, 8, 12]}
+                assert await _upsert(conn, 7, genuine) == "inserted"
+                # Extends the (empty) route_back prefix but pads far past any
+                # real mesh: counts as at most the cap, still > stored here —
+                # the cap bounds the SCORE; the prefix guard bounds the DAMAGE
+                # (recorded hops survive verbatim).
+                padded = dict(genuine, route_back=[0] * 50)
+                assert await _upsert(conn, 7, padded) == "upgraded"
+                row = await conn.fetchrow("SELECT payload FROM traceroutes")
+                assert json.loads(row["payload"])["route"] == [1, 2]
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_upgrade_never_regresses_a_valid_timestamp(self):
+        """A clock-less gateway's richer copy (timestamp 0) must not wipe the
+        stored valid timestamp — dedupe windows and sort order depend on it."""
+
+        async def body():
+            conn = await _conn()
+            try:
+                row0 = await conn.fetchrow(
+                    TRACEROUTE_UPSERT_SQL,
+                    FROM_ID, TO_ID, None, 8, None, None, None, None, None,
+                    1753500000, None,
+                    json.dumps(POOR["route"]), json.dumps([]), json.dumps(POOR),
+                    float(TRACEROUTE_UPGRADE_WINDOW_S),
+                )
+                assert row0["inserted"]
+                # Richer copy with timestamp=0 (no time source on the gateway)
+                row1 = await conn.fetchrow(
+                    TRACEROUTE_UPSERT_SQL,
+                    FROM_ID, TO_ID, None, 8, None, None, None, None, None,
+                    0, None,
+                    json.dumps(RICH["route"]), json.dumps([]), json.dumps(RICH),
+                    float(TRACEROUTE_UPGRADE_WINDOW_S),
+                )
+                assert row1 is not None and not row1["inserted"]  # upgraded
+                stored = await conn.fetchrow("SELECT timestamp, payload FROM traceroutes")
+                assert stored["timestamp"] == 1753500000  # preserved
+                assert json.loads(stored["payload"])["route_back"] == [3, 4]
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_recency_guard_blocks_stale_id_reuse(self):
+        async def body():
+            conn = await _conn()
+            try:
+                assert await _upsert(conn, 5, POOR) == "inserted"
+                await conn.execute(
+                    "UPDATE traceroutes SET created_at = now() - interval '2 hours'"
+                )
+                # Outside the window even a richer copy must not rewrite history
+                assert await _upsert(conn, 5, RICH) == "duplicate"
+                row = await conn.fetchrow("SELECT payload FROM traceroutes")
+                assert json.loads(row["payload"])["route_back"] == []
+            finally:
+                await conn.close()
+
+        run(body())
+
+    def test_concurrent_copies_converge_on_richest(self):
+        async def body():
+            setup = await _conn()
+            await setup.close()
+            c1 = await asyncpg.connect(DSN)
+            c2 = await asyncpg.connect(DSN)
+            try:
+                for i in range(50):
+                    mid = 1000 + i
+                    # Alternate submission order; actual arrival order is
+                    # nondeterministic, the assertion covers whichever
+                    # interleaving the server saw.
+                    a = lambda: _upsert(c1, mid, POOR, rssi=-90)
+                    b = lambda: _upsert(c2, mid, RICH, rssi=-110)
+                    if i % 2:
+                        a, b = b, a
+                    await asyncio.gather(a(), b())
+                rows = await c1.fetch(
+                    "SELECT message_id, payload FROM traceroutes WHERE message_id >= 1000"
+                )
+                assert len(rows) == 50
+                for row in rows:
+                    assert json.loads(row["payload"])["route_back"] == [3, 4], (
+                        f"message {row['message_id']} kept the poorer copy"
+                    )
+            finally:
+                await c1.close()
+                await c2.close()
+
+        run(body())

--- a/tests/test_traceroute_upsert.py
+++ b/tests/test_traceroute_upsert.py
@@ -1,9 +1,7 @@
-"""
-Real-database tests for the traceroute richer-wins upsert (TRACEROUTE_UPSERT_SQL).
+"""Real-database tests for the traceroute richer-wins upsert.
 
-Opt-in: they need a THROWAWAY postgres reachable via TRACEROUTE_PG_DSN and are
-skipped otherwise, keeping the default suite runnable anywhere. Never point the
-DSN at a live database — the setup truncates the traceroutes table. Recipe:
+Opt-in via TRACEROUTE_PG_DSN (skipped otherwise). NEVER point the DSN at a
+live database — the setup TRUNCATEs traceroutes. Throwaway recipe:
 
     docker run --rm -d --name tr-upsert-pg -e POSTGRES_PASSWORD=x \
         -e POSTGRES_DB=meshinfo -p 127.0.0.1:5433:5432 postgres:18
@@ -12,10 +10,6 @@ DSN at a live database — the setup truncates the traceroutes table. Recipe:
     TRACEROUTE_PG_DSN=postgresql://postgres:x@127.0.0.1:5433/meshinfo \
         python -m pytest tests/test_traceroute_upsert.py -q
     docker rm -f tr-upsert-pg
-
-The tests drive the exact SQL constant the app executes, so guard behavior
-(recency window, strict richness, concurrency arbitration) is pinned against a
-real server, not a fake.
 """
 
 import asyncio
@@ -47,10 +41,8 @@ def run(coro):
     return asyncio.run(coro)
 
 
-# Live-DSN tripwire: a fresh schema-loaded throwaway starts EMPTY, so a
-# populated traceroutes table means the DSN points somewhere real — refuse
-# before the TRUNCATE below can destroy it. Checked once per session (our own
-# tests populate the table afterwards).
+# Live-DSN tripwire: a populated traceroutes table means the DSN points at
+# something real — refuse before the TRUNCATE. Checked once per session.
 _dsn_checked = False
 
 
@@ -176,8 +168,7 @@ class TestRicherWinsUpsert:
         run(body())
 
     def test_prefix_guard_refuses_rewritten_hops(self):
-        """A 'richer' copy that REWRITES recorded hops instead of extending
-        them is forged — genuine copies only append (monotonicity)."""
+        """Genuine copies only append; a copy that rewrites recorded hops is forged."""
 
         async def body():
             conn = await _conn()
@@ -205,18 +196,14 @@ class TestRicherWinsUpsert:
         run(body())
 
     def test_padding_gains_are_capped(self):
-        """Publisher-padded arrays score at most the per-array cap, so junk
-        padding can't manufacture unlimited richness."""
+        """Publisher-padded arrays score at most the per-array cap."""
 
         async def body():
             conn = await _conn()
             try:
                 genuine = {"route": [1, 2], "snr_towards": [4, 8, 12]}
                 assert await _upsert(conn, 7, genuine) == "inserted"
-                # Extends the (empty) route_back prefix but pads far past any
-                # real mesh: counts as at most the cap, still > stored here —
-                # the cap bounds the SCORE; the prefix guard bounds the DAMAGE
-                # (recorded hops survive verbatim).
+                # The cap bounds the score; the prefix guard bounds the damage.
                 padded = dict(genuine, route_back=[0] * 50)
                 assert await _upsert(conn, 7, padded) == "upgraded"
                 row = await conn.fetchrow("SELECT payload FROM traceroutes")
@@ -227,8 +214,7 @@ class TestRicherWinsUpsert:
         run(body())
 
     def test_upgrade_never_regresses_a_valid_timestamp(self):
-        """A clock-less gateway's richer copy (timestamp 0) must not wipe the
-        stored valid timestamp — dedupe windows and sort order depend on it."""
+        """A clock-less gateway's richer copy (timestamp 0) must not wipe a valid timestamp."""
 
         async def body():
             conn = await _conn()
@@ -286,9 +272,7 @@ class TestRicherWinsUpsert:
             try:
                 for i in range(50):
                     mid = 1000 + i
-                    # Alternate submission order; actual arrival order is
-                    # nondeterministic, the assertion covers whichever
-                    # interleaving the server saw.
+                    # Alternate submission order; arrival order is nondeterministic.
                     a = lambda: _upsert(c1, mid, POOR, rssi=-90)
                     b = lambda: _upsert(c2, mid, RICH, rssi=-110)
                     if i % 2:
@@ -336,9 +320,8 @@ SEED_SQL = """
 
 
 class TestKeysetPaginationAndShapes:
-    """Drives the real query functions (not just the SQL constants) so the
-    param-assembly around cursors, containment, and slim projection is pinned
-    against a live server."""
+    """Drives the real query functions (cursor param assembly, containment,
+    slim projection) against a live server."""
 
     async def _seeded_storage(self):
         conn = await _conn()  # tripwire + node stubs + clean slate

--- a/tests/test_traceroute_upsert.py
+++ b/tests/test_traceroute_upsert.py
@@ -21,12 +21,17 @@ real server, not a fake.
 import asyncio
 import json
 import os
+from urllib.parse import urlparse
 
 import pytest
 
 asyncpg = pytest.importorskip("asyncpg")
 
-from storage.db.postgres import TRACEROUTE_UPGRADE_WINDOW_S, TRACEROUTE_UPSERT_SQL
+from storage.db.postgres import (
+    PostgresStorage,
+    TRACEROUTE_UPGRADE_WINDOW_S,
+    TRACEROUTE_UPSERT_SQL,
+)
 
 DSN = os.environ.get("TRACEROUTE_PG_DSN")
 
@@ -71,7 +76,7 @@ async def _conn():
     return conn
 
 
-async def _upsert(conn, message_id, payload, rssi=None, snr=None, sender=None):
+async def _upsert(conn, message_id, payload, rssi=None, snr=None, sender=None, packet_id=None):
     """Execute the production statement; returns 'inserted'/'upgraded'/'duplicate'."""
     row = await conn.fetchrow(
         TRACEROUTE_UPSERT_SQL,
@@ -80,7 +85,7 @@ async def _upsert(conn, message_id, payload, rssi=None, snr=None, sender=None):
         sender,
         message_id,
         None,  # channel
-        None,  # packet_id
+        packet_id,
         None,  # hops_away
         rssi,
         snr,
@@ -89,6 +94,7 @@ async def _upsert(conn, message_id, payload, rssi=None, snr=None, sender=None):
         json.dumps(payload.get("route", [])),
         json.dumps([]),
         json.dumps(payload),
+        json.dumps([]),  # route_back_ids
         float(TRACEROUTE_UPGRADE_WINDOW_S),
     )
     if row is None:
@@ -232,6 +238,7 @@ class TestRicherWinsUpsert:
                     FROM_ID, TO_ID, None, 8, None, None, None, None, None,
                     1753500000, None,
                     json.dumps(POOR["route"]), json.dumps([]), json.dumps(POOR),
+                    json.dumps([]),
                     float(TRACEROUTE_UPGRADE_WINDOW_S),
                 )
                 assert row0["inserted"]
@@ -241,6 +248,7 @@ class TestRicherWinsUpsert:
                     FROM_ID, TO_ID, None, 8, None, None, None, None, None,
                     0, None,
                     json.dumps(RICH["route"]), json.dumps([]), json.dumps(RICH),
+                    json.dumps([]),
                     float(TRACEROUTE_UPGRADE_WINDOW_S),
                 )
                 assert row1 is not None and not row1["inserted"]  # upgraded
@@ -297,5 +305,128 @@ class TestRicherWinsUpsert:
             finally:
                 await c1.close()
                 await c2.close()
+
+        run(body())
+
+
+def _storage_config():
+    u = urlparse(DSN)
+    return {
+        "storage": {
+            "postgres": {
+                "enabled": True,
+                "host": u.hostname,
+                "port": u.port or 5432,
+                "database": (u.path or "/meshinfo").lstrip("/"),
+                "username": u.username or "postgres",
+                "password": u.password or "",
+            }
+        },
+        "server": {"timezone": "UTC"},
+    }
+
+
+SEED_SQL = """
+    INSERT INTO traceroutes (
+        from_node_id, to_node_id, message_id, timestamp,
+        route_ids, route_back_ids, payload, created_at
+    )
+    VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, to_timestamp($8))
+"""
+
+
+class TestKeysetPaginationAndShapes:
+    """Drives the real query functions (not just the SQL constants) so the
+    param-assembly around cursors, containment, and slim projection is pinned
+    against a live server."""
+
+    async def _seeded_storage(self):
+        conn = await _conn()  # tripwire + node stubs + clean slate
+        # 7 rows; created_at PAIRS share a second so the id tiebreak matters.
+        for i in range(7):
+            await conn.execute(
+                SEED_SQL,
+                FROM_ID,
+                TO_ID,
+                1000 + i,
+                1753500000 + i,
+                json.dumps(["cccccccc"] if i == 2 else []),
+                json.dumps(["cccccccc"] if i == 5 else []),
+                json.dumps({"route": [], "snr_towards": [4]}),
+                1753500000 + (i // 2),
+            )
+        await conn.close()
+        storage = PostgresStorage(_storage_config())
+        assert await storage.connect()
+        return storage
+
+    def test_cursor_walk_has_no_gaps_or_overlap(self):
+        async def body():
+            storage = await self._seeded_storage()
+            try:
+                pages = []
+                before = None
+                for _ in range(5):
+                    result = await storage.query_all_traceroutes(
+                        limit=3, slim=True, before=before, with_cursor=True
+                    )
+                    pages.append([r["id"] for r in result["traceroutes"]])
+                    before = result["next_cursor"]
+                    if before is None:
+                        break
+                # DESC created_at with DESC id tiebreak inside each shared second
+                assert pages == [[1006, 1005, 1004], [1003, 1002, 1001], [1000]]
+            finally:
+                await storage.close()
+
+        run(body())
+
+    def test_malformed_cursor_serves_first_page(self):
+        async def body():
+            storage = await self._seeded_storage()
+            try:
+                result = await storage.query_all_traceroutes(
+                    limit=3, slim=True, before="garbage", with_cursor=True
+                )
+                assert [r["id"] for r in result["traceroutes"]] == [1006, 1005, 1004]
+            finally:
+                await storage.close()
+
+        run(body())
+
+    def test_slim_and_default_row_shapes(self):
+        async def body():
+            storage = await self._seeded_storage()
+            try:
+                slim_rows = await storage.query_all_traceroutes(limit=1, slim=True)
+                assert sorted(slim_rows[0].keys()) == sorted(
+                    [
+                        "from", "to", "id", "packet_id", "hops_away", "rssi",
+                        "snr", "timestamp", "created_at", "route_ids",
+                        "route_back_ids", "payload",
+                    ]
+                )
+                assert isinstance(slim_rows[0]["created_at"], int)
+                # Default (third-party) rows must carry NO new keys
+                full_rows = await storage.query_all_traceroutes(limit=1, slim=False)
+                assert "route_back_ids" not in full_rows[0]
+                assert "created_at" not in full_rows[0]
+            finally:
+                await storage.close()
+
+        run(body())
+
+    def test_node_involvement_containment(self):
+        async def body():
+            storage = await self._seeded_storage()
+            try:
+                rows = await storage.query_node_traceroutes("cccccccc")
+                # Relay on the forward leg (row 1002) and return leg (1005)
+                assert sorted(r["id"] for r in rows) == [1002, 1005]
+                # Initiator/target arms still work
+                rows = await storage.query_node_traceroutes(FROM_ID, limit=3)
+                assert len(rows) == 3
+            finally:
+                await storage.close()
 
         run(body())


### PR DESCRIPTION
## What was wrong

- **Reply rows rendered backwards everywhere.** Meshtastic traceroute replies arrive with
  header endpoints swapped while the route stays request-ordered. Only the map's path
  analysis handled this; the Traceroutes page, map link layer, graph edges, live comet, and
  node-details links all walked `[from, ...route, to]` raw — drawing phantom endpoint links,
  reversing pair labels, and double-counting request+reply captures as two runs.
- **Storage kept the least complete copy.** `ON CONFLICT DO NOTHING` kept the first-arriving
  gateway copy of each packet; RouteDiscovery payloads accumulate hop-by-hop, so reply rows
  systematically lost `route_back`/`snr_back` to whichever gateway sat closest to the responder.
- **Ingest dropped or fabricated metadata.** Proto3 zero-omission made `hops_away` NULL for
  exactly the farthest-traveled packets (`hop_limit == 0`), self-gatewayed packets stored
  fabricated `rssi=0/snr=0.0` readings (36% of all rows), primary channel stored NULL, and
  unresolved hops stored raw ints that never re-resolved and fragmented route grouping.

## What changed

**Frontend** — new shared `utils/traceroute.ts` (`orientTraceroute`, exchange dedup,
`isResolvedHop`) adopted by every consumer. Runs count exchanges with packet counts alongside
("12 runs (19 pkts)"); directed A|B / B|A pairs merge under one ⇄ entry; unanswered probes get
an explicit badge ("awaiting reply" aging to "no reply") instead of masquerading as complete
routes; unresolvable and `0xffffffff` hops render as non-link chips; `normNodeId` pads to
canonical 8-hex, fixing latent low-id lookup misses.

**Ingest** — `hops_away`/`rssi`/`snr`/`channel` read directly off the protobuf with honest
null semantics; unknown hops stored as canonical hex (a one-time backfill script normalizes
historical rows: `scripts/backfill_traceroute_route_ids.py --dry-run` first); the JSON
decoder's exclusivity with the protobuf decoder is now explicit — running both would
double-process packets from gateways that publish to both topic namespaces.

**Storage** — guarded richer-wins upsert: whole-copy replacement when a strictly richer copy
arrives within 1h, with per-array caps and a route-prefix guard so recorded hops can be
extended but never rewritten by a hostile publisher, and timestamps never regressed by
clock-less gateways. Measured on a live instance: multi-hop replies retaining their return
path went from ~69% to ~87%. SSE broadcasts now mirror storage outcomes (one event per
insert/upgrade, not per gateway copy).

**API** — replies carry `packet_id` (the request's id) for exact exchange pairing;
`route_back_ids` resolved at ingest; slim rows gain `created_at` and the back-leg arrays;
keyset pagination behind `?envelope=1` (`{traceroutes, next_cursor}`); the node-scoped
endpoint matches gateway and relay involvement on both legs (GIN-indexed). The default
`/v1/traceroutes` response is byte-identical to before.

**Map tool** — per-leg SNR and distances render without 3D terrain or a Mapbox token;
unpositioned leading/trailing hops get visible ghost chips; alternates split at gaps instead
of splicing fabricated lines; pair switches no longer leak the previous pair's rows;
share links reproduce the selected alternate (`&sel=`); flyovers pin the toured path.

**Graph** — missing neighbor SNR stays undefined instead of a fabricated 0 dB out-ranking
real readings; genuine 0 dB displays; kind filters keep dual-evidence links.

## Behavior changes to be aware of

- Run/corridor/edge counts drop roughly 2× where both packets of an exchange were captured —
  that's double-counting disappearing, not data loss.
- Traceroute rows are mutable for up to 1h after first insert (richer-copy upgrades);
  `created_at` never changes, keeping cursors and ordering stable.
- SSE `traceroute` event rate drops to one per stored insert/upgrade.
- Instances with both decoders enabled: `/2/json` topics are skipped while protobuf is on.

## Migrations & testing

Schema changes (one column, four indexes) apply automatically at startup via the migrations
block with long timeouts; no manual steps. The route_ids backfill is optional and idempotent.
Tests: 238 backend, 283 frontend, plus 13 opt-in tests driving the production upsert SQL and
pagination against a real postgres (`TRACEROUTE_PG_DSN`, refuses populated databases).
API.md documents the SSE events, pagination, SNR encoding, and reply-orientation rule.
Deployed and verified live on a production-scale instance for 24h+.

Closes #558 