### PR TITLE
fix(map): simplify node status colors + hover-card dimming and spiderfy leg polish (#559)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -72,9 +72,8 @@ import type { IMapNode, LinkMode, MapProvider, NodeDetailsData, NodeLike } from 
 import {
   applyClusterVisibility,
   createNodesGeoJSONBuilder,
-  DEFAULT_NODE_COLOR,
   emptyLineFeatureCollection,
-  ROLE_COLORS,
+  nodeColor,
 } from "./map/lib/utils";
 import { CoverageLookupCard } from "./map/live/CoverageLookupCard";
 import { type CoverageParam, nextCoverageSearch, parseCoverageParam } from "./map/live/coverageUrlParam";
@@ -1823,13 +1822,12 @@ export function Map() {
         const coverageSrc = map.getSource("coverage") as MlGeoJSONSource | undefined;
         if (coverageSrc) {
           if (maxRangeKm) {
-            const roleColor = ROLE_COLORS[(node as any).role] ?? DEFAULT_NODE_COLOR;
             const circle = geodesicCircleCoords([nodeLike.position[0], nodeLike.position[1]], maxRangeKm);
             coverageSrc.setData({
               type: "FeatureCollection",
               features: [{
                 type: "Feature",
-                properties: { color: roleColor },
+                properties: { color: nodeColor(nodeLike.role, nodeLike.online) },
                 geometry: { type: "Polygon", coordinates: [circle] },
               }],
             });

--- a/frontend/src/pages/map/components/ClusterHoverCard.tsx
+++ b/frontend/src/pages/map/components/ClusterHoverCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useReducer } from "react";
 
 import { NodeRole, roleTitles } from "../../../types";
 import { relativeTime } from "../lib/helpers";
-import { DEFAULT_NODE_COLOR, nodeColor, OFFLINE_NODE_COLOR } from "../lib/utils";
+import { DEFAULT_NODE_COLOR, dimForLastSeen, nodeColor, OFFLINE_NODE_COLOR } from "../lib/utils";
 
 export type ClusterHover = {
   ids: string[]; // leaf node ids, captured at hover (empty while resolving)
@@ -106,7 +106,15 @@ export function ClusterHoverCard({
             <ul className="space-y-0.5">
               {topHeard.map((n) => (
                 <li key={n.id} className="flex items-center gap-1.5 text-[11px]">
-                  <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: nodeColor(n.role, !!n.online) }} />
+                  <span
+                    className="w-1.5 h-1.5 rounded-full shrink-0"
+                    style={{
+                      background: nodeColor(n.role, !!n.online),
+                      // Brightness = recency, matching the map dots (dimForLastSeen
+                      // is quantized, so the per-second ticks rarely change it).
+                      opacity: dimForLastSeen(n.last_seen, Date.now()),
+                    }}
+                  />
                   <span className="truncate flex-1">{n.shortname || n.longname || n.id}</span>
                   <span className="text-gray-500 tabular-nums shrink-0">{relativeTime(n.last_seen)}</span>
                 </li>

--- a/frontend/src/pages/map/components/ClusterHoverCard.tsx
+++ b/frontend/src/pages/map/components/ClusterHoverCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useReducer } from "react";
 
 import { NodeRole, roleTitles } from "../../../types";
 import { relativeTime } from "../lib/helpers";
-import { DEFAULT_NODE_COLOR, OFFLINE_NODE_COLOR, ROLE_COLORS } from "../lib/utils";
+import { DEFAULT_NODE_COLOR, nodeColor, OFFLINE_NODE_COLOR } from "../lib/utils";
 
 export type ClusterHover = {
   ids: string[]; // leaf node ids, captured at hover (empty while resolving)
@@ -25,11 +25,6 @@ export interface ClusterHoverLeaf {
 }
 
 const LEADERBOARD_MAX = 6;
-
-function roleColor(role: number | null | undefined, online: boolean): string {
-  if (!online) return OFFLINE_NODE_COLOR;
-  return (role != null && ROLE_COLORS[role]) || DEFAULT_NODE_COLOR;
-}
 
 /** Display-only card anchored beside a hovered cluster. Counts come from the
  *  cluster aggregate; the member breakdown/leaderboard render from the leaf
@@ -99,7 +94,6 @@ export function ClusterHoverCard({
                 key={role}
                 className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] bg-white/5"
               >
-                <span className="w-1.5 h-1.5 rounded-full" style={{ background: ROLE_COLORS[role] ?? DEFAULT_NODE_COLOR }} />
                 {n} {roleTitles[role as NodeRole]?.title ?? "Node"}
               </span>
             ))}
@@ -112,7 +106,7 @@ export function ClusterHoverCard({
             <ul className="space-y-0.5">
               {topHeard.map((n) => (
                 <li key={n.id} className="flex items-center gap-1.5 text-[11px]">
-                  <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: roleColor(n.role, !!n.online) }} />
+                  <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: nodeColor(n.role, !!n.online) }} />
                   <span className="truncate flex-1">{n.shortname || n.longname || n.id}</span>
                   <span className="text-gray-500 tabular-nums shrink-0">{relativeTime(n.last_seen)}</span>
                 </li>

--- a/frontend/src/pages/map/components/MapLegend.tsx
+++ b/frontend/src/pages/map/components/MapLegend.tsx
@@ -32,14 +32,12 @@ export function MapLegend({
           <span>Online node</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: "#72798a" }} />
-          <span>Offline node</span>
+          <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: "#3b82f6" }} />
+          <span>Online router</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-3.5 h-3.5 flex items-center justify-center shrink-0">
-            <div className="w-2.5 h-2.5 rounded-full ring-2 ring-orange-400 shadow-sm" style={{ backgroundColor: "#32f032" }} />
-          </div>
-          <span>Selected node</span>
+          <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: "#72798a" }} />
+          <span>Offline node (any role)</span>
         </div>
         <div className="flex items-center gap-2">
           <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">

--- a/frontend/src/pages/map/components/MapSearchBar.tsx
+++ b/frontend/src/pages/map/components/MapSearchBar.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { type NodeRole,roleTitles } from "../../../types";
 import type { IMapNode } from "../lib/types";
-import { DEFAULT_NODE_COLOR,ROLE_COLORS } from "../lib/utils";
+import { nodeColor } from "../lib/utils";
 
 export function MapSearchBar({
   nodes,
@@ -181,7 +181,7 @@ export function MapSearchBar({
           {results.map(({ id, node }, i) => {
             const roleVal = (node as any).role as number | undefined;
             const roleName = roleVal != null ? roleTitles[roleVal as NodeRole]?.title : null;
-            const roleColor = roleVal != null ? ROLE_COLORS[roleVal] : DEFAULT_NODE_COLOR;
+            const dotColor = nodeColor(roleVal, Boolean(node.online));
             return (
               <button
                 key={id}
@@ -199,9 +199,7 @@ export function MapSearchBar({
               >
                 <span
                   className="w-2 h-2 rounded-full shrink-0"
-                  style={{
-                    backgroundColor: node.online ? roleColor : "rgba(107,114,128,0.5)",
-                  }}
+                  style={{ backgroundColor: dotColor }}
                   aria-hidden="true"
                 />
                 <span className="truncate font-medium text-gray-200">

--- a/frontend/src/pages/map/layers/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/layers/clusterDonutLayer.ts
@@ -111,8 +111,9 @@ function compile(gl: WebGLRenderingContext, type: number, src: string): WebGLSha
   return s;
 }
 
-// Matches the "clusters" circle hit-test layer radius curve
-function pixelRadiusForCount(count: number): number {
+// Matches the "clusters" circle hit-test layer radius curve.
+// Exported so spiderfy legs can start at the donut edge.
+export function pixelRadiusForCount(count: number): number {
   const c = Math.max(count, 2);
   if (c <= 10)  return 16 + (22 - 16) * ((c - 2)   / (10 - 2));
   if (c <= 25)  return 22 + (30 - 22) * ((c - 10)  / (25 - 10));

--- a/frontend/src/pages/map/layers/mapLayers.ts
+++ b/frontend/src/pages/map/layers/mapLayers.ts
@@ -2,7 +2,7 @@
 import type { FeatureCollection, GeoJsonProperties, Point as GeoPoint } from "geojson";
 import type { Map as MlMap } from "maplibre-gl";
 
-import { mbRoleColorExpr, TRANSPARENT_1PX_PNG } from "../lib/helpers";
+import { mbNodeColorExpr, TRANSPARENT_1PX_PNG } from "../lib/helpers";
 import { emptyLineFeatureCollection } from "../lib/utils";
 import { ActivityLayer } from "./activityLayer";
 import { ClusterDonutLayer } from "./clusterDonutLayer";
@@ -566,7 +566,7 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
       filter: ["all", ["!", ["has", "point_count"]], ["==", ["get", "online"], true]],
       paint: {
         "circle-radius": 16,
-        "circle-color": mbRoleColorExpr,
+        "circle-color": mbNodeColorExpr,
         "circle-opacity": 0.28,
         "circle-stroke-width": 0,
       },
@@ -582,7 +582,7 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
       filter: ["!", ["has", "point_count"]],
       paint: {
         "circle-radius": ["case", ["boolean", ["feature-state", "selected"], false], 12, 8],
-        "circle-color": mbRoleColorExpr,
+        "circle-color": mbNodeColorExpr,
         // Recency brightness via `dim`; selected stays full-bright.
         "circle-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 1, ["coalesce", ["get", "dim"], 1]],
         "circle-stroke-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 1, ["coalesce", ["get", "dim"], 1]],
@@ -628,7 +628,7 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
       filter: ["==", ["get", "online"], true],
       paint: {
         "circle-radius": 16,
-        "circle-color": mbRoleColorExpr,
+        "circle-color": mbNodeColorExpr,
         "circle-opacity": 0.28,
         "circle-stroke-width": 0,
       },
@@ -643,7 +643,7 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
       source: "nodes_plain",
       paint: {
         "circle-radius": ["case", ["boolean", ["feature-state", "selected"], false], 12, 8],
-        "circle-color": mbRoleColorExpr,
+        "circle-color": mbNodeColorExpr,
         // Recency brightness via `dim`; selected stays full-bright.
         "circle-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 1, ["coalesce", ["get", "dim"], 1]],
         "circle-stroke-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 1, ["coalesce", ["get", "dim"], 1]],

--- a/frontend/src/pages/map/layers/spiderfy.ts
+++ b/frontend/src/pages/map/layers/spiderfy.ts
@@ -14,6 +14,7 @@ import type { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl
 
 import { mbNodeColorExpr } from "../../../palette";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
+import { pixelRadiusForCount } from "./clusterDonutLayer";
 
 export const SPIDERFY_SOURCE_NODES = "spiderfy-nodes";
 export const SPIDERFY_SOURCE_LEGS = "spiderfy-legs";
@@ -30,6 +31,9 @@ const AUTO_SPIDERFY_MIN_ZOOM = 14;
 interface SpiderfyGroup {
   center: [number, number];
   leaves: GeoFeature<GeoPoint, GeoJsonProperties>[];
+  /** Leg start offset (px) so legs begin at the edge of whatever marks the
+   *  center — the cluster donut, or the stacked plain-node circle. */
+  centerGapPx: number;
 }
 
 interface SpiderfyState {
@@ -138,6 +142,8 @@ function composeData(
   groups.forEach((group, gi) => {
     const targets = fanPositions(group.center, group.leaves.length, zoom);
     const positions = t >= 1 ? targets : interpolatePositions(group.center, targets, t);
+    const kx = lngScaleAt(group.center[1]);
+    const gapDeg = pixelsToDegrees(group.centerGapPx, zoom);
 
     group.leaves.forEach((leaf, i) => {
       nodeFeatures.push({
@@ -146,10 +152,21 @@ function composeData(
         properties: { ...leaf.properties, _spiderfied: true },
         geometry: { type: "Point", coordinates: positions[i] },
       });
+      // Legs start at the edge of the center marker (donut/stack), not its
+      // middle. Fan motion is radial, so the animated position gives the
+      // direction; a dot still inside the gap gets no leg yet.
+      const sx = (positions[i][0] - group.center[0]) / kx;
+      const sy = positions[i][1] - group.center[1];
+      const len = Math.hypot(sx, sy);
+      if (len <= gapDeg) return;
+      const start: [number, number] = [
+        group.center[0] + (sx / len) * gapDeg * kx,
+        group.center[1] + (sy / len) * gapDeg,
+      ];
       legFeatures.push({
         type: "Feature",
         properties: { index: i, centerLng: group.center[0], centerLat: group.center[1] },
-        geometry: { type: "LineString", coordinates: [group.center, positions[i]] },
+        geometry: { type: "LineString", coordinates: [start, positions[i]] },
       });
     });
   });
@@ -395,15 +412,17 @@ export async function spiderfy(
 
   if (leaves.length === 0) return;
 
+  const group: SpiderfyGroup = { center, leaves, centerGapPx: pixelRadiusForCount(leaves.length) + 2 };
+
   if (origin === "auto") {
     // A fan opened (or a dismissal started) during the async lookup wins.
     if (activeState || collapsing) return;
     // Don't re-fan the set the user just dismissed.
-    if (groupsSignature([{ center, leaves }]) === dismissedSignature) return;
+    if (groupsSignature([group]) === dismissedSignature) return;
   }
 
   removeSpiderfyLayers(map);
-  return renderSpiderfy(map, [{ center, leaves }], map.getZoom(), animate, origin);
+  return renderSpiderfy(map, [group], map.getZoom(), animate, origin);
 }
 
 /** Spiderfy an explicit set of co-located features. Used when clustering is OFF
@@ -417,7 +436,7 @@ export async function spiderfyFeatures(
 ): Promise<void> {
   if (leaves.length === 0) return;
   removeSpiderfyLayers(map);
-  return renderSpiderfy(map, [{ center, leaves }], map.getZoom(), animate, "click");
+  return renderSpiderfy(map, [{ center, leaves, centerGapPx: PLAIN_STACK_GAP_PX }], map.getZoom(), animate, "click");
 }
 
 export async function unspiderfy(map: MlMap): Promise<void> {
@@ -568,6 +587,9 @@ export async function autoSpiderfyVisibleClusters(
 
 // Plain-node circle radius (px) — must match the "plain-nodes" layer paint.
 const PLAIN_NODE_RADIUS_PX = 8;
+// Leg gap for plain-node fans: stacked-circle edge (radius + half the 2.5px
+// stroke) plus breathing room.
+const PLAIN_STACK_GAP_PX = PLAIN_NODE_RADIUS_PX + 4;
 
 /** Build a centered group from member feature indices into `pts`. */
 function groupFromIndices(
@@ -581,7 +603,7 @@ function groupFromIndices(
     lng += c[0];
     lat += c[1];
   }
-  return { center: [lng / leaves.length, lat / leaves.length], leaves };
+  return { center: [lng / leaves.length, lat / leaves.length], leaves, centerGapPx: PLAIN_STACK_GAP_PX };
 }
 
 /** Clustering-OFF analogue of autoSpiderfyVisibleClusters: there is no cluster

--- a/frontend/src/pages/map/layers/spiderfy.ts
+++ b/frontend/src/pages/map/layers/spiderfy.ts
@@ -12,7 +12,7 @@ import type {
 } from "geojson";
 import type { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl";
 
-import { mbRoleColorExpr } from "../../../palette";
+import { mbNodeColorExpr } from "../../../palette";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
 
 export const SPIDERFY_SOURCE_NODES = "spiderfy-nodes";
@@ -299,7 +299,7 @@ function addSpiderfyLayers(map: MlMap): void {
         12,
         8,
       ],
-      "circle-color": mbRoleColorExpr,
+      "circle-color": mbNodeColorExpr,
       "circle-stroke-width": 2.5,
       "circle-stroke-color": [
         "case",

--- a/frontend/src/pages/map/lib/helpers.ts
+++ b/frontend/src/pages/map/lib/helpers.ts
@@ -8,7 +8,7 @@ import { normNodeId } from "./linkFeatures";
 import type { IMapNode } from "./types";
 import { calculateGeodesicDistance } from "./utils";
 // Role-color expression now lives in the shared palette; re-export for existing importers.
-export { mbRoleColorExpr } from "../../../palette";
+export { mbNodeColorExpr } from "../../../palette";
 
 // 1×1 transparent PNG placeholder for the coverage-raster source
 export const TRANSPARENT_1PX_PNG =

--- a/frontend/src/pages/map/lib/utils.ts
+++ b/frontend/src/pages/map/lib/utils.ts
@@ -12,7 +12,7 @@ import type { IMapNode } from "./types";
 
 // Canonical palette lives in src/palette.ts; re-exported so the map's many
 // `from "./utils"` call sites keep working unchanged.
-export { DEFAULT_NODE_COLOR, OFFLINE_NODE_COLOR, ROLE_COLORS } from "../../../palette";
+export { DEFAULT_NODE_COLOR, nodeColor, OFFLINE_NODE_COLOR, ROLE_COLORS } from "../../../palette";
 
 const HTML_ESCAPES: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;" };
 export function escapeHtml(text: string): string {

--- a/frontend/src/palette.test.ts
+++ b/frontend/src/palette.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_NODE_COLOR, MAP_ROUTER_COLORS, mbNodeColorExpr, nodeColor, OFFLINE_NODE_COLOR } from "./palette";
+import { NodeRole } from "./types";
+
+describe("nodeColor", () => {
+  it("colors offline nodes gray regardless of role", () => {
+    for (const role of Object.values(NodeRole).filter((v) => typeof v === "number")) {
+      expect(nodeColor(role as number, false)).toBe(OFFLINE_NODE_COLOR);
+    }
+  });
+
+  it("colors online router-family roles blue", () => {
+    expect(nodeColor(NodeRole.ROUTER, true)).toBe(MAP_ROUTER_COLORS[NodeRole.ROUTER]);
+    expect(nodeColor(NodeRole.ROUTER_CLIENT, true)).toBe(MAP_ROUTER_COLORS[NodeRole.ROUTER_CLIENT]);
+    expect(nodeColor(NodeRole.ROUTER_LATE, true)).toBe(MAP_ROUTER_COLORS[NodeRole.ROUTER_LATE]);
+  });
+
+  // Issue #559: these roles used to render a gray indistinguishable from offline.
+  it("colors every other online role the default green", () => {
+    expect(nodeColor(NodeRole.CLIENT_MUTE, true)).toBe(DEFAULT_NODE_COLOR);
+    expect(nodeColor(NodeRole.CLIENT_HIDDEN, true)).toBe(DEFAULT_NODE_COLOR);
+    expect(nodeColor(NodeRole.REPEATER, true)).toBe(DEFAULT_NODE_COLOR);
+    expect(nodeColor(null, true)).toBe(DEFAULT_NODE_COLOR);
+    expect(nodeColor(undefined, true)).toBe(DEFAULT_NODE_COLOR);
+    expect(nodeColor(999, true)).toBe(DEFAULT_NODE_COLOR);
+  });
+});
+
+describe("mbNodeColorExpr", () => {
+  // The rule is encoded twice — here in the MapLibre DSL and in nodeColor().
+  // Nothing but this test keeps the two from drifting apart.
+  it("mirrors nodeColor", () => {
+    const [op, offlineTest, offlineColor, roleMatch] = mbNodeColorExpr as unknown as [
+      string,
+      unknown,
+      string,
+      [string, unknown, ...unknown[]],
+    ];
+
+    expect(op).toBe("case");
+    expect(offlineTest).toEqual(["!", ["boolean", ["get", "online"], false]]);
+    expect(offlineColor).toBe(OFFLINE_NODE_COLOR);
+
+    const [matchOp, matchInput, ...arms] = roleMatch;
+    expect(matchOp).toBe("match");
+    expect(matchInput).toEqual(["get", "role"]);
+
+    const fallback = arms.pop();
+    expect(fallback).toBe(DEFAULT_NODE_COLOR);
+
+    const pairs = Object.fromEntries(
+      Array.from({ length: arms.length / 2 }, (_, i) => [arms[i * 2], arms[i * 2 + 1]]),
+    );
+    expect(pairs).toEqual(
+      Object.fromEntries(Object.entries(MAP_ROUTER_COLORS).map(([k, v]) => [Number(k), v])),
+    );
+  });
+});

--- a/frontend/src/palette.ts
+++ b/frontend/src/palette.ts
@@ -2,7 +2,9 @@ import type { ExpressionSpecification } from "maplibre-gl";
 
 import { NodeRole } from "./types";
 
-/** Node-role → color. Single source for map, graph, legend, and role badges. */
+/** Node-role → color. Used only where the role is named next to the swatch:
+ *  role badges, the role filter menu, graph views. The map does not color
+ *  individual nodes by role — see {@link nodeColor}. */
 export const ROLE_COLORS: Record<number, string> = {
   [NodeRole.CLIENT]: "#32f032",        // green (default)
   [NodeRole.CLIENT_MUTE]: "#6b7280",   // gray
@@ -26,13 +28,27 @@ export const OFFLINE_NODE_COLOR = "#72798a";
 /** Origin marker color shared by LoS, coverage, and scan. */
 export const ORIGIN_COLOR = "#06b6d4";
 
-/** MapLibre circle-color expression: offline → gray, else role color. */
-export const mbRoleColorExpr = [
+/** Router-family roles keep their blue on the map; every other role renders as
+ *  a plain online node, so gray means offline and nothing else. */
+export const MAP_ROUTER_COLORS: Record<number, string> = {
+  [NodeRole.ROUTER]: ROLE_COLORS[NodeRole.ROUTER],
+  [NodeRole.ROUTER_CLIENT]: ROLE_COLORS[NodeRole.ROUTER_CLIENT],
+  [NodeRole.ROUTER_LATE]: ROLE_COLORS[NodeRole.ROUTER_LATE],
+};
+
+/** Map node fill: offline → gray, online router → blue, online → green. */
+export function nodeColor(role: number | null | undefined, online: boolean): string {
+  if (!online) return OFFLINE_NODE_COLOR;
+  return (role != null && MAP_ROUTER_COLORS[role]) || DEFAULT_NODE_COLOR;
+}
+
+/** MapLibre form of {@link nodeColor}. */
+export const mbNodeColorExpr = [
   "case",
   ["!", ["boolean", ["get", "online"], false]],
   OFFLINE_NODE_COLOR,
   ["match", ["get", "role"],
-    ...Object.entries(ROLE_COLORS).flatMap(([k, v]) => [Number(k), v]),
+    ...Object.entries(MAP_ROUTER_COLORS).flatMap(([k, v]) => [Number(k), v]),
     DEFAULT_NODE_COLOR,
   ],
 ] as unknown as ExpressionSpecification;


### PR DESCRIPTION
Fixes #559 — nodes with role Client_Mute (or Client_Hidden) rendered their
role color, a gray nearly identical to the offline gray, so online nodes
read as offline on the map while the details panel correctly said Online.

## What changed

**Individual map nodes no longer encode role by color.** The map's legend,
cluster donuts, and node lists all teach one story — green = online,
gray = offline — and the role palette was contradicting it. The rule is now:

- **Green** — online node
- **Blue** — online router family (Router, Router Client, Router Late keep
  their existing blues)
- **Gray** — offline, any role

The rule lives in one place (`nodeColor()` / `mbNodeColorExpr` in
`palette.ts`, renamed from `mbRoleColorExpr`) and feeds all four node
circle layers, spiderfy leaves, search-result dots, the cluster hover
card, and the selected-node coverage circle. `ROLE_COLORS` remains for
surfaces where the role is named next to the swatch: graph views, the
role filter menu, and the details-panel role badge. The legend gains an
"Online router" row, drops "Selected node", and relabels gray as
"Offline node (any role)". A new `palette.test.ts` pins the TS function
and the MapLibre expression in parity.

**Cluster hover card: recency dimming.** The "Last heard" dots now use the
same quantized brightness as the map dots (`dimForLastSeen` as opacity),
so a node that's dim on the map is equally dim in the card. The role
breakdown chips drop their color dot — they're text-labeled, and the dot
carried no information under the new scheme.

**Spiderfy legs start at the donut edge.** Leg lines previously crossed
the cluster donut. Each leg's start is now trimmed by the donut's pixel
radius (`pixelRadiusForCount`, exported from `clusterDonutLayer` so donut
sizing and leg gaps can't drift), converted to degrees at the current
zoom and recomputed on zoomend, so the gap holds at any zoom. Plain-node
fans use the stacked-circle radius. A leg only renders once its dot
clears the gap, so fan/collapse animations retract cleanly.

## Verification

- 287 tests pass; typecheck and lint clean.
- Verified visually: online Client_Mute renders green on the map, in
  spiderfied fans, search results, and the cluster hover card.