### PR TITLE
fix(chat): file decoded uplinks by wire name when the hash is unlearned

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,25 @@ hasn't). Safe to interrupt, re-run, and run while ingest is live.
 New rows store their wire channel name (`chat_messages.channel_name`); the
 backfill also fills it for historical rows while their archive copies exist.
 
+### Name-keyed buckets for decode-only meshes
+
+When every gateway on a channel uplinks already-decoded packets (MQTT
+`encryption_enabled = false`), its real hash never appears on the wire, so it
+can't be learned. Those packets used to keep the gateway's slot index, which
+conflated every such channel sharing a slot. They now file under a stable
+bucket derived from the wire channel name (a large id, ≥ 2^30), labeled with
+that name automatically. If the real hash is ever observed later, the name
+bucket merges into it on its own. This applies to new traffic; messages already
+stored under a slot index stay where they are. These buckets are "named
+channels" for `broker.channels.mode` purposes: visible under `"all"`, hidden
+under `"presets"` unless the name is a stock preset.
+
+A named channel is never bucketed in 0–7 anymore, even when that is its genuine
+hash (roughly 3% of name/PSK pairs hash into the slot-index range — `ares`
+hashes to 7). Those ids cannot be told apart from a gateway slot index and
+cannot carry a channel name in storage, so such a channel gets a name bucket
+too. If you have one, its ids will differ from instances that bucket it by hash.
+
 First start after this upgrade also builds a `pg_trgm` GIN index over
 `mqtt_messages.topic` (backs the Log page's channel filters) — expect roughly
 40s per 3M archived rows. `pg_trgm` is a trusted extension (PostgreSQL 13+), so

--- a/channels.py
+++ b/channels.py
@@ -1,21 +1,51 @@
 #!/usr/bin/env python3
 """Meshtastic channel identity resolution: ``MeshPacket.channel`` is the 8-bit
 (name, PSK) hash on encrypted uplinks but a gateway-local slot index (0-7) on
-decoded ones; ChannelResolver learns name -> hash off the wire to remap indices."""
+decoded ones; ChannelResolver learns name -> hash off the wire to remap indices.
+Decoded uplinks whose name has no learned hash file under a name-keyed bucket
+(the wire name is authoritative; the index is not) and merge into the real hash
+if one is ever observed."""
 
 import logging
+import zlib
 from collections import OrderedDict
 from functools import reduce
 from operator import xor
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 # Firmware MAX_NUM_CHANNELS is 8, so a slot index is always 0-7.
 MAX_CHANNEL_INDEX = 7
 
+# Real (name, PSK) hashes are 8-bit.
+MAX_CHANNEL_HASH = 255
+
 # Pseudo-channel gateways stamp on PKI DMs; no real channel behind it to resolve.
 PKI_CHANNEL = "PKI"
+
+# Name-keyed buckets live at 0x40000000 | crc32(name)&0x3FFFFFFF: disjoint from
+# real hashes, positive int32 (telemetry/traceroutes.channel are INTEGER), and
+# at most 10 digits (chat_channels.id is VARCHAR(10)).
+NAME_BUCKET_FLAG = 0x4000_0000
+
+
+def normalize_wire_name(name: Optional[str]) -> Optional[str]:
+    """Canonical wire name: NUL-stripped, trimmed, DB-length-capped, else None.
+    Every consumer (resolver keys, bucket derivation, stored channel_name) must
+    see the same spelling or one channel splits into several buckets."""
+    if not name:
+        return None
+    return name.replace("\x00", "").strip()[:100] or None
+
+
+def name_bucket_id(name: str) -> int:
+    """Stable synthetic bucket for a wire name with no learned hash."""
+    return NAME_BUCKET_FLAG | (zlib.crc32(name.encode("utf-8")) & 0x3FFF_FFFF)
+
+
+def is_name_bucket(bucket: int) -> bool:
+    return bucket >= NAME_BUCKET_FLAG
 
 
 def xor_hash(data: bytes) -> int:
@@ -49,6 +79,10 @@ class ChannelResolver:
         self._by_name: "OrderedDict[str, int]" = OrderedDict()
         # Conflicting observations awaiting corroboration: name -> (hash, packet id).
         self._pending: "OrderedDict[str, Tuple[int, Optional[int]]]" = OrderedDict()
+        # Names whose hash was just learned/re-keyed; drained by ingest so
+        # storage can merge that name's bucket into the hash. Seeding stays
+        # silent — seeded names were healed when first learned.
+        self._learn_events: List[Tuple[str, int]] = []
         self._max_entries = max_entries
 
     def seed(self, mapping: Dict[str, int]) -> int:
@@ -108,10 +142,33 @@ class ChannelResolver:
             )
 
         self._pending.pop(channel_name, None)
+        # New learn or corroborated re-key, never a reaffirmation. Index-range
+        # hashes emit nothing: resolve() keeps those names at their name bucket,
+        # so there is no bucket to merge.
+        if known != channel_hash_value and channel_hash_value > MAX_CHANNEL_INDEX:
+            self._learn_events.append((channel_name, channel_hash_value))
+            del self._learn_events[:-self._max_entries]
         self._by_name[channel_name] = channel_hash_value
         self._by_name.move_to_end(channel_name)
         while len(self._by_name) > self._max_entries:
             self._by_name.popitem(last=False)
+
+    def drain_learn_events(self) -> List[Tuple[str, int]]:
+        """(name, hash) pairs learned since the last drain; clears the queue."""
+        events, self._learn_events = self._learn_events, []
+        return events
+
+    def requeue_learn_event(self, channel_name: str, channel_hash_value: int) -> None:
+        """Put a drained event back after its merge failed. Reaffirmations never
+        re-emit, so without this one failed merge strands the name bucket for good."""
+        pair = (channel_name, channel_hash_value)
+        if pair not in self._learn_events:
+            self._learn_events.append(pair)
+            del self._learn_events[:-self._max_entries]
+
+    def lookup(self, channel_name: str) -> Optional[int]:
+        """The learned hash for a name, or None. Read-only: no LRU promotion."""
+        return self._by_name.get(channel_name)
 
     def resolve(
         self,
@@ -122,7 +179,8 @@ class ChannelResolver:
         packet_id: Optional[int] = None,
     ) -> int:
         """Canonical channel bucket: encrypted uplinks teach and pass through;
-        decoded slot indices remap to the learned hash, else raw_channel."""
+        decoded slot indices remap to the learned hash, else to a name-keyed
+        bucket — a decoded index carries no channel identity, the name does."""
         if is_pki or channel_name == PKI_CHANNEL:
             return raw_channel
 
@@ -138,6 +196,10 @@ class ChannelResolver:
                         channel_name, raw_channel, learned,
                     )
                     return learned
+                # A real hash inside the index range (e.g. 'ares' -> 7) is
+                # indistinguishable from a slot index and can't carry a name in
+                # storage, so the named channel lives at its name bucket instead.
+                return name_bucket_id(channel_name)
             return raw_channel
 
         if not channel_name:
@@ -152,12 +214,13 @@ class ChannelResolver:
             return raw_channel
 
         learned = self._by_name.get(channel_name)
-        if learned is None:
+        if learned is None or learned <= MAX_CHANNEL_INDEX:
+            bucket = name_bucket_id(channel_name)
             logger.debug(
-                "No hash learned for channel %r yet — keeping raw index %d",
-                channel_name, raw_channel,
+                "No usable hash for channel %r — filing raw index %d at name bucket %d",
+                channel_name, raw_channel, bucket,
             )
-            return raw_channel
+            return bucket
 
         self._by_name.move_to_end(channel_name)
         return learned

--- a/mqtt.py
+++ b/mqtt.py
@@ -86,6 +86,52 @@ class MQTT:
 
         # Learns name -> hash from encrypted uplinks so decoded slot indices remap.
         self._channel_resolver = channels.ChannelResolver()
+        # Name bucket -> when its label row was last confirmed written.
+        self._labeled_name_buckets: dict = {}
+        self._last_stranded_sweep = time.monotonic()
+
+    # Re-confirmed periodically rather than cached for the process lifetime, so
+    # a row deleted behind our back (a merge, an operator) is written again
+    # without waiting for a restart.
+    _LABEL_RECHECK_S = 900
+
+    async def _ensure_name_bucket_label(self, bucket: int, channel_name: str) -> None:
+        """One label write per name bucket per recheck window; failures retry."""
+        now = time.monotonic()
+        last = self._labeled_name_buckets.get(bucket)
+        if last is not None and now - last < self._LABEL_RECHECK_S:
+            return
+        try:
+            written = await self.data.pg_storage.ensure_channel_label(str(bucket), channel_name)
+        except Exception:
+            logger.exception("Labeling name bucket %d (%r) failed", bucket, channel_name)
+            return
+        if written:
+            self._labeled_name_buckets[bucket] = now
+
+    async def _merge_stranded_name_buckets(self) -> None:
+        """Sweep name buckets whose name has a learned hash back into it.
+        The learn-event merge fires once, but a bucket can repopulate after it:
+        write-retry replays carry the pre-merge bucket, the operator backfill
+        can race a mid-run learn, and a merge that failed before a restart
+        loses its in-memory requeue. Runs at connect and every recheck window."""
+        try:
+            names = await self.data.pg_storage.get_name_bucket_names()
+        except Exception:
+            logger.exception("Stranded name-bucket sweep failed")
+            return
+        for name in names:
+            learned = self._channel_resolver.lookup(name)
+            # <= 7 (e.g. 'ares' -> 7) is unusable as a bucket; that name bucket
+            # is the channel's permanent home, not a stranding.
+            if learned is None or learned <= channels.MAX_CHANNEL_INDEX:
+                continue
+            try:
+                await self.data.pg_storage.rebucket_name_channel(name, learned)
+            except Exception:
+                logger.exception("Sweep merge for %r -> %d failed; next sweep retries", name, learned)
+            else:
+                self._labeled_name_buckets.pop(channels.name_bucket_id(name), None)
 
     def _record_discord_drop(self, event_type: str) -> None:
         self._discord_drops_total += 1
@@ -106,6 +152,8 @@ class MQTT:
             self._channel_resolver.seed(seedable)
         except Exception as e:
             logger.warning("Channel resolver seeding skipped: %s", e)
+        await self._merge_stranded_name_buckets()
+        self._last_stranded_sweep = time.monotonic()
 
         logger.info("Connecting to MQTT broker at %s:%d", self.config['broker']['host'], self.config['broker']['port'])
         try:
@@ -211,7 +259,11 @@ class MQTT:
                 # MessageToJson omits channel 0 (primary); read it off mp.
                 # mp.channel is the (name,PSK) hash on encrypted uplinks but a
                 # gateway-local slot index on decoded ones — resolve to one bucket.
-                channel_name = se.channel_id or channels.name_from_topic(msg.topic.value)
+                # Normalized so resolver keys, name buckets, and stored
+                # channel_name all agree on one spelling.
+                channel_name = channels.normalize_wire_name(
+                    se.channel_id or channels.name_from_topic(msg.topic.value)
+                )
                 outs['channel'] = self._channel_resolver.resolve(
                     raw_channel=mp.channel,
                     is_encrypted=is_encrypted,
@@ -222,6 +274,34 @@ class MQTT:
                 )
                 if channel_name:
                     outs['channel_name'] = channel_name
+
+                # A just-learned hash merges that name's bucket into it. Requeue
+                # on failure: a reaffirmation never re-emits, so dropping the
+                # event would strand that name's rows in the old bucket for good.
+                for learned_name, learned_hash in self._channel_resolver.drain_learn_events():
+                    try:
+                        await self.data.pg_storage.rebucket_name_channel(learned_name, learned_hash)
+                    except Exception:
+                        logger.exception("Bucket merge for %r -> %d failed; will retry",
+                                         learned_name, learned_hash)
+                        self._channel_resolver.requeue_learn_event(learned_name, learned_hash)
+                    else:
+                        # The merge drops the label row, so a name that later
+                        # re-derives its bucket (LRU eviction, re-key into 0-7)
+                        # must be able to write it again.
+                        self._labeled_name_buckets.pop(
+                            channels.name_bucket_id(learned_name), None
+                        )
+
+                if time.monotonic() - self._last_stranded_sweep >= self._LABEL_RECHECK_S:
+                    self._last_stranded_sweep = time.monotonic()
+                    await self._merge_stranded_name_buckets()
+
+                # Name buckets are derived, not stored: without this the label
+                # only exists once the channel carries a chat message, so
+                # telemetry/position-only channels render as "Channel <bigint>".
+                if channel_name and channels.is_name_bucket(outs['channel']):
+                    await self._ensure_name_bucket_label(outs['channel'], channel_name)
 
                 # Fallback: extract gateway from topic suffix if gateway_id was empty
                 if not outs.get('sender'):

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -31,6 +31,7 @@ from storage.db.uplink_dedup import (
     reconstruct_copy,
 )
 from storage.db.write_retry import WriteRetryQueue, WriteStillFailing
+import channels
 import utils
 
 logger = logging.getLogger(__name__)
@@ -1400,6 +1401,112 @@ class PostgresStorage:
         except Exception as e:
             logger.warning(f"get_wire_channel_names failed: {e}")
             return {}
+
+    async def ensure_channel_label(self, channel_id: str, name: str) -> bool:
+        """Name a bucket that has no chat rows yet (node-only traffic), so the
+        UI never has to render a bare id. Placeholder-only, like ingest.
+        Returns whether the row is known to exist, so the caller only caches
+        writes that actually happened."""
+        if not self.enabled or not self.pool or not bucket_can_have_name(channel_id):
+            return False
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO chat_channels (id, name)
+                VALUES ($1, $2)
+                ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
+                WHERE chat_channels.name IS DISTINCT FROM EXCLUDED.name
+                  AND (chat_channels.name = 'General'
+                       OR chat_channels.name ~ '^Channel [0-9]+$')
+                """,
+                channel_id, name[:100],
+            )
+        return True
+
+    async def get_name_bucket_names(self) -> List[str]:
+        """Names of existing name-keyed buckets (id > 255), for the stranded-
+        bucket sweep. Tiny table; cheap to poll."""
+        if not self.enabled or not self.pool:
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """
+                    SELECT name FROM chat_channels
+                    WHERE id ~ '^[0-9]+$' AND id::bigint > 255
+                      AND name IS NOT NULL AND name <> 'PKI'
+                    """
+                )
+                return [r["name"] for r in rows]
+        except Exception as e:
+            logger.warning(f"get_name_bucket_names failed: {e}")
+            return []
+
+    async def rebucket_name_channel(self, name: str, learned_hash: int) -> None:
+        """Merge a name-keyed bucket into its just-learned hash bucket.
+        Called on resolver learn events; idempotent and cheap when the name
+        never had a synthetic bucket. telemetry/traceroutes keep old synthetic
+        values (unindexed scans; same deferral as their raw-channel display)."""
+        if not self.enabled or not self.pool:
+            return
+        # resolve() keeps index-range hashes at the name bucket — a 0-7 target
+        # would re-conflate the channel with slot-index traffic.
+        if learned_hash <= channels.MAX_CHANNEL_INDEX:
+            return
+        synthetic = str(channels.name_bucket_id(name))
+        target = str(learned_hash)
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                # FK target first; same placeholder-only naming rule as ingest.
+                await conn.execute(
+                    """
+                    INSERT INTO chat_channels (id, name)
+                    VALUES ($1, $2)
+                    ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
+                    WHERE chat_channels.name IS DISTINCT FROM EXCLUDED.name
+                      AND (chat_channels.name = 'General'
+                           OR chat_channels.name ~ '^Channel [0-9]+$')
+                    """,
+                    target, name[:100],
+                )
+                moved = await conn.execute(
+                    "UPDATE chat_messages SET channel_id = $1 WHERE channel_id = $2",
+                    target, synthetic,
+                )
+                await conn.execute(
+                    "UPDATE nodes SET last_channel = $1 WHERE last_channel = $2",
+                    target, synthetic,
+                )
+                # Drop the emptied source row: a dataless duplicate of the same
+                # name renders as a second, identical pill on the Log page.
+                # Best-effort inside a savepoint — NOT EXISTS races a concurrent
+                # write (its FK check uses a later snapshot than our subquery),
+                # and losing that race just means the bucket is populated again,
+                # so the row should stay. Letting it abort would roll the whole
+                # merge back.
+                try:
+                    async with conn.transaction():
+                        await conn.execute(
+                            """
+                            DELETE FROM chat_channels
+                            WHERE id = $1
+                              AND NOT EXISTS (
+                                  SELECT 1 FROM chat_messages WHERE channel_id = $1
+                              )
+                            """,
+                            synthetic,
+                        )
+                except asyncpg.ForeignKeyViolationError:
+                    logger.debug("Name bucket %s repopulated mid-merge; label kept", synthetic)
+        try:
+            n = int(moved.rsplit(" ", 1)[-1])
+        except (ValueError, IndexError):
+            n = 0
+        if n:
+            logger.info(
+                "Channel %r learned hash %s: merged %d row(s) from name bucket %s",
+                name, target, n, synthetic,
+            )
 
     async def write_traceroute(self, node_id: str, traceroute_msg: Dict[str, Any]) -> Optional[str]:
         """Richer-wins traceroute upsert. Returns 'inserted' | 'upgraded' |

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -21,8 +21,25 @@ class FakePgStorage:
         self.telemetry_writes: list = []
         self.traceroute_writes: list = []
         self.mqtt_writes: list = []
+        self.rebucket_calls: list = []
+        self.name_bucket_names: list = []
+        self.label_calls: list = []
+        self.rebucket_fail_times = 0
         self._mqtt_row_seq = 0
         self.pool = None  # disables _write_node_telemetry_current side-branch
+
+    async def rebucket_name_channel(self, name: str, learned_hash: int) -> None:
+        self.rebucket_calls.append((name, learned_hash))
+        if self.rebucket_fail_times > 0:
+            self.rebucket_fail_times -= 1
+            raise RuntimeError("simulated merge failure")
+
+    async def get_name_bucket_names(self) -> list:
+        return list(self.name_bucket_names)
+
+    async def ensure_channel_label(self, channel_id: str, name: str) -> bool:
+        self.label_calls.append((channel_id, name))
+        return True
 
     async def write_mqtt_message(self, mqtt_msg) -> int:
         self.mqtt_writes.append(dict(mqtt_msg))

--- a/tests/test_channel_resolve.py
+++ b/tests/test_channel_resolve.py
@@ -92,11 +92,20 @@ class TestNameFromTopic:
 class TestResolver:
     def test_encrypted_passes_through_and_teaches(self):
         r = channels.ChannelResolver()
-        # Encrypted claims are the hash by definition, even index-looking ones.
-        for raw in (0, 6, 8, 19, 31, 255):
+        # Encrypted claims are the hash by definition; those above the index
+        # range pass through as-is.
+        for raw in (8, 19, 31, 255):
             assert r.resolve(raw_channel=raw, is_encrypted=True, channel_name="C") == raw
         # No conflicting sighting repeated, so the first learned hash stands.
-        assert r.resolve(raw_channel=3, is_encrypted=False, channel_name="C") == 0
+        assert r.resolve(raw_channel=3, is_encrypted=False, channel_name="C") == 8
+
+    def test_named_encrypted_index_claim_files_at_the_name_bucket(self):
+        """A hash of 0-6 can't be told from a slot index and can't hold a name."""
+        r = channels.ChannelResolver()
+        for raw in (0, 6):
+            assert r.resolve(raw_channel=raw, is_encrypted=True, channel_name="C") == (
+                channels.name_bucket_id("C")
+            )
 
     def test_decoded_index_remaps_to_learned_hash(self):
         r = channels.ChannelResolver()
@@ -104,10 +113,16 @@ class TestResolver:
         assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="LongFast") == 8
         assert r.resolve(raw_channel=3, is_encrypted=False, channel_name="LongFast") == 8
 
-    def test_unlearned_name_keeps_raw_rather_than_guessing(self):
-        """A merely-unmerged bucket is recoverable; a fabricated one is not."""
+    def test_unlearned_name_files_at_name_bucket_not_raw_index(self):
+        """A decoded index carries no channel identity; the wire name does. Two
+        channels sharing a slot must not conflate while their hashes are unknown."""
         r = channels.ChannelResolver()
-        assert r.resolve(raw_channel=1, is_encrypted=False, channel_name="Test") == 1
+        got = r.resolve(raw_channel=1, is_encrypted=False, channel_name="Test")
+        assert got == channels.name_bucket_id("Test")
+        # Same slot, different name -> different bucket.
+        other = r.resolve(raw_channel=1, is_encrypted=False, channel_name="Test2")
+        assert other == channels.name_bucket_id("Test2")
+        assert got != other
 
     def test_decoded_without_name_keeps_raw(self):
         r = channels.ChannelResolver()
@@ -143,8 +158,10 @@ class TestResolver:
         r = channels.ChannelResolver(max_entries=2)
         for name, h in (("a", 10), ("b", 20), ("c", 30)):
             r.resolve(raw_channel=h, is_encrypted=True, channel_name=name)
-        # "a" evicted; "b" and "c" retained.
-        assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="a") == 0
+        # "a" evicted -> unlearned again, so it files by name; "b"/"c" retained.
+        assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="a") == (
+            channels.name_bucket_id("a")
+        )
         assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="b") == 20
         assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="c") == 30
 
@@ -170,16 +187,22 @@ class TestResolver:
         r.resolve(raw_channel=77, is_encrypted=True, channel_name="MediumFast")
         assert r.resolve(raw_channel=1, is_encrypted=False, channel_name="MediumFast") == 77
 
-    def test_first_sighting_of_a_low_hash_is_still_trusted(self):
-        """'ares' hashes to 7 — a real hash inside the index range must still be learnable."""
+    def test_low_hash_channel_lives_at_its_name_bucket(self):
+        """'ares' hashes to 7 — a real hash, but indistinguishable from a slot
+        index and unable to carry a name in storage, so the name bucket wins.
+        Both uplink kinds must agree or the channel splits."""
         r = channels.ChannelResolver()
-        r.resolve(raw_channel=7, is_encrypted=True, channel_name="ares")
-        assert r.resolve(raw_channel=2, is_encrypted=False, channel_name="ares") == 7
+        want = channels.name_bucket_id("ares")
+        assert r.resolve(raw_channel=7, is_encrypted=True, channel_name="ares") == want
+        assert r.resolve(raw_channel=2, is_encrypted=False, channel_name="ares") == want
 
     def test_observe_rejects_out_of_range(self):
         r = channels.ChannelResolver()
         r.observe("x", 999)
-        assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="x") == 0
+        # Nothing learned, so the decoded copy files by name, not at 999.
+        assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="x") == (
+            channels.name_bucket_id("x")
+        )
 
     def test_seed_preloads_learned_names(self):
         """Seeding from chat_channels closes the post-restart cold-start misfile window."""
@@ -216,6 +239,83 @@ class TestResolver:
             raw_channel=0, is_encrypted=True, channel_name="MediumFast", packet_id=5
         )
         assert got == 31
+
+
+class TestNameBuckets:
+    def test_derivation_is_stable_int32_and_disjoint_from_hashes(self):
+        b = channels.name_bucket_id("GSMC Tech")
+        assert b == channels.name_bucket_id("GSMC Tech")  # deterministic
+        # Outside the 8-bit hash space, positive int32 (INTEGER columns), and
+        # at most 10 digits (chat_channels.id is VARCHAR(10)).
+        assert b > channels.MAX_CHANNEL_HASH
+        assert channels.NAME_BUCKET_FLAG <= b <= 0x7FFF_FFFF
+        assert len(str(b)) <= 10
+        assert channels.is_name_bucket(b)
+        assert not channels.is_name_bucket(255)
+
+    def test_normalize_wire_name(self):
+        assert channels.normalize_wire_name("  GSMC Tech\x00 ") == "GSMC Tech"
+        assert channels.normalize_wire_name("x" * 200) == "x" * 100
+        assert channels.normalize_wire_name("\x00 ") is None
+        assert channels.normalize_wire_name("") is None
+        assert channels.normalize_wire_name(None) is None
+
+    def test_unnamed_encrypted_index_claim_passes_through(self):
+        """Only NAMED channels move to name buckets; a nameless copy keeps raw."""
+        r = channels.ChannelResolver()
+        assert r.resolve(raw_channel=7, is_encrypted=True, channel_name=None) == 7
+
+    def test_decoded_files_at_learned_hash_once_taught(self):
+        r = channels.ChannelResolver()
+        syn = r.resolve(raw_channel=0, is_encrypted=False, channel_name="SVComm")
+        assert syn == channels.name_bucket_id("SVComm")
+        r.resolve(raw_channel=43, is_encrypted=True, channel_name="SVComm")
+        assert r.resolve(raw_channel=0, is_encrypted=False, channel_name="SVComm") == 43
+
+
+class TestLearnEvents:
+    def test_first_learn_emits_one_event_and_drain_clears(self):
+        r = channels.ChannelResolver()
+        r.resolve(raw_channel=43, is_encrypted=True, channel_name="SVComm", packet_id=1)
+        assert r.drain_learn_events() == [("SVComm", 43)]
+        assert r.drain_learn_events() == []
+
+    def test_reaffirmation_does_not_emit(self):
+        r = channels.ChannelResolver()
+        r.resolve(raw_channel=43, is_encrypted=True, channel_name="SVComm", packet_id=1)
+        r.drain_learn_events()
+        r.resolve(raw_channel=43, is_encrypted=True, channel_name="SVComm", packet_id=2)
+        assert r.drain_learn_events() == []
+
+    def test_corroborated_rekey_emits(self):
+        r = channels.ChannelResolver()
+        r.seed({"MediumFast": 31})
+        r.resolve(raw_channel=99, is_encrypted=True, channel_name="MediumFast", packet_id=2)
+        r.resolve(raw_channel=99, is_encrypted=True, channel_name="MediumFast", packet_id=3)
+        assert r.drain_learn_events() == [("MediumFast", 99)]
+
+    def test_seed_does_not_emit(self):
+        """Seeded names were healed when first learned; re-healing every restart
+        would hammer the tables for nothing."""
+        r = channels.ChannelResolver()
+        r.seed({"MediumFast": 31, "SVComm": 43})
+        assert r.drain_learn_events() == []
+
+    def test_index_range_hash_emits_nothing(self):
+        """'ares' stays at its name bucket, so there is no bucket to merge."""
+        r = channels.ChannelResolver()
+        r.resolve(raw_channel=7, is_encrypted=True, channel_name="ares", packet_id=1)
+        assert r.drain_learn_events() == []
+
+    def test_requeue_survives_a_failed_merge(self):
+        """A reaffirmation never re-emits, so a dropped event would strand the
+        name bucket permanently — the retry has to come from the queue."""
+        r = channels.ChannelResolver()
+        r.resolve(raw_channel=43, is_encrypted=True, channel_name="SVComm", packet_id=1)
+        (name, h), = r.drain_learn_events()
+        r.requeue_learn_event(name, h)          # merge failed
+        r.requeue_learn_event(name, h)          # idempotent, no duplicate work
+        assert r.drain_learn_events() == [("SVComm", 43)]
 
 
 def _decoded_envelope(name, channel_value, text="hi", pkt_id=999001):
@@ -314,11 +414,15 @@ class TestIngestEndToEnd:
         ))
         assert _buckets(data)[-1] == "8", "single flap copy escaped the learned bucket"
 
-        # Distinct packet repeats the claim: that is a re-key, not a flap.
+        # Distinct packet repeats the claim: that is a re-key, not a flap. The
+        # new hash is in the index range, so the channel moves to its name
+        # bucket rather than into the shared slot bucket.
         run(mqtt.process_mqtt_msg(
             None, FakeMsg(_topic("LongFast"), _encrypted_envelope("LongFast", 3, pkt_id=2203))
         ))
-        assert _buckets(data)[-1] == "3", "corroborated re-key was not honored"
+        assert _buckets(data)[-1] == str(channels.name_bucket_id("LongFast")), (
+            "corroborated re-key was not honored"
+        )
 
     def test_double_publish_of_one_packet_cannot_confirm_a_change(self):
         """Gateways can publish one packet twice; corroboration must require distinct packets."""
@@ -337,17 +441,6 @@ class TestIngestEndToEnd:
             None, FakeMsg(_topic("MediumFast"), _decoded_envelope("MediumFast", 0, pkt_id=2213))
         ))
         assert _buckets(data)[-1] == "31", "one double-published packet re-taught the hash"
-
-    def test_encrypted_low_hash_passes_through(self):
-        """'ares' hashes to 7 — a real hash inside the index range, not a slot index."""
-        assert channels.channel_hash("ares", DEFAULT_PSK) == 7
-        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
-
-        run(mqtt.process_mqtt_msg(
-            None, FakeMsg(_topic("ares"), _encrypted_envelope("ares", 7, pkt_id=2301))
-        ))
-
-        assert _buckets(data) == ["7"]
 
     def test_name_recovered_from_topic_when_envelope_omits_it(self):
         mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
@@ -412,3 +505,160 @@ class TestIngestEndToEnd:
 
         _, chat = data.pg_storage.chat_writes[-1]
         assert chat["channel_name"] == "LongFast"
+
+    def test_decode_only_channels_sharing_a_slot_get_distinct_name_buckets(self):
+        """The GSMC case: a decode-only gateway publishes two channels' packets
+        with channel=0; the topic name must separate them, not the slot."""
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("GSMC Tech"), _decoded_envelope("GSMC Tech", 0, pkt_id=2801))
+        ))
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("GSMC Main"), _decoded_envelope("GSMC Main", 0, pkt_id=2802))
+        ))
+
+        tech = str(channels.name_bucket_id("GSMC Tech"))
+        main = str(channels.name_bucket_id("GSMC Main"))
+        assert _buckets(data) == [tech, main]
+        assert tech != main
+        _, chat = data.pg_storage.chat_writes[-1]
+        assert chat["channel_name"] == "GSMC Main"
+
+    def test_learning_the_hash_merges_the_name_bucket(self):
+        """Decoded rows pile up in the name bucket; the first encrypted sighting
+        teaches the hash, triggers the storage merge, and re-files new traffic."""
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _decoded_envelope("SVComm", 2, pkt_id=2901))
+        ))
+        assert _buckets(data) == [str(channels.name_bucket_id("SVComm"))]
+        assert data.pg_storage.rebucket_calls == []
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _encrypted_envelope("SVComm", 43, pkt_id=2902))
+        ))
+        assert data.pg_storage.rebucket_calls == [("SVComm", 43)]
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _decoded_envelope("SVComm", 2, pkt_id=2903))
+        ))
+        assert _buckets(data)[-1] == "43"
+        # Reaffirmations must not re-run the merge.
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _encrypted_envelope("SVComm", 43, pkt_id=2904))
+        ))
+        assert data.pg_storage.rebucket_calls == [("SVComm", 43)]
+
+    def test_low_hash_channel_does_not_ping_pong_between_bucket_7_and_its_name(self):
+        """'ares' hashes to 7. Encrypted and decoded copies must agree on the
+        name bucket, or ingest and the backfill fight over the rows forever."""
+        assert channels.channel_hash("ares", DEFAULT_PSK) == 7
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("ares"), _decoded_envelope("ares", 0, pkt_id=2971))
+        ))
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("ares"), _encrypted_envelope("ares", 7, pkt_id=2972))
+        ))
+
+        want = str(channels.name_bucket_id("ares"))
+        assert _buckets(data) == [want, want]
+        assert data.pg_storage.rebucket_calls == [], "merged into the slot-index bucket"
+
+    def test_name_bucket_label_is_written_for_node_only_traffic(self):
+        """chat_channels rows come from chat writes; without this a telemetry-only
+        channel renders as a bare 10-digit id."""
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("GSMC Tech"), _decoded_envelope("GSMC Tech", 0, pkt_id=2981))
+        ))
+
+        bucket = str(channels.name_bucket_id("GSMC Tech"))
+        assert data.pg_storage.label_calls == [(bucket, "GSMC Tech")]
+
+        # One write per bucket per process, not per packet.
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("GSMC Tech"), _decoded_envelope("GSMC Tech", 0, pkt_id=2982))
+        ))
+        assert data.pg_storage.label_calls == [(bucket, "GSMC Tech")]
+
+    def test_stranded_sweep_merges_repopulated_name_buckets(self):
+        """The learn-event merge fires once, but a name bucket can repopulate
+        afterwards (write-retry replay, backfill race, failed merge + restart).
+        The sweep re-merges any bucket whose name has a learned hash."""
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+        mqtt._channel_resolver.seed({"SVComm": 43, "ares": 7})
+        data.pg_storage.name_bucket_names = ["SVComm", "ares", "NeverLearned"]
+
+        run(mqtt._merge_stranded_name_buckets())
+
+        # Learned hash -> merged; hash <= 7 is the bucket's permanent home;
+        # unlearned names have nowhere to go.
+        assert data.pg_storage.rebucket_calls == [("SVComm", 43)]
+
+    def test_sweep_survives_a_failing_merge(self):
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+        mqtt._channel_resolver.seed({"A": 43, "B": 44})
+        data.pg_storage.name_bucket_names = ["A", "B"]
+
+        async def boom(name, learned_hash):
+            data.pg_storage.rebucket_calls.append((name, learned_hash))
+            if name == "A":
+                raise RuntimeError("db blip")
+        data.pg_storage.rebucket_name_channel = boom
+
+        run(mqtt._merge_stranded_name_buckets())
+        # B still merged after A failed.
+        assert ("B", 44) in data.pg_storage.rebucket_calls
+
+    def test_label_is_rewritten_after_a_merge_drops_the_row(self):
+        """The merge deletes the label row; a name that later re-derives its
+        bucket (LRU eviction, re-key into 0-7) must write it again."""
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+        bucket = str(channels.name_bucket_id("SVComm"))
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _decoded_envelope("SVComm", 0, pkt_id=2961))
+        ))
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _encrypted_envelope("SVComm", 43, pkt_id=2962))
+        ))
+        assert data.pg_storage.rebucket_calls == [("SVComm", 43)]
+
+        # Name falls out of the resolver, so the bucket is derived again.
+        mqtt._channel_resolver = channels.ChannelResolver()
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _decoded_envelope("SVComm", 0, pkt_id=2963))
+        ))
+        assert data.pg_storage.label_calls == [
+            (bucket, "SVComm"), (bucket, "SVComm")
+        ], "stale cache entry suppressed the label rewrite"
+
+    def test_failed_merge_is_retried_on_the_next_packet(self):
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+        data.pg_storage.rebucket_fail_times = 1
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _encrypted_envelope("SVComm", 43, pkt_id=2991))
+        ))
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("SVComm"), _encrypted_envelope("SVComm", 43, pkt_id=2992))
+        ))
+
+        assert data.pg_storage.rebucket_calls == [("SVComm", 43), ("SVComm", 43)]
+
+    def test_wire_name_is_normalized_before_resolution(self):
+        """Padded envelope names must not fork a second bucket or miss the seed."""
+        mqtt, data = make_mqtt_pb([DEFAULT_PSK_B64])
+
+        run(mqtt.process_mqtt_msg(
+            None, FakeMsg(_topic("GSMC Tech"), _decoded_envelope(" GSMC Tech ", 0, pkt_id=2951))
+        ))
+
+        assert _buckets(data) == [str(channels.name_bucket_id("GSMC Tech"))]
+        _, chat = data.pg_storage.chat_writes[-1]
+        assert chat["channel_name"] == "GSMC Tech"

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -639,12 +639,19 @@ class TestProcessEnvelope:
         assert archived["snr"] == 5.5
 
     def test_primary_channel_zero_archived(self):
-        archived, _ = self._archived(build_envelope(channel=0))
-        assert archived["channel"] == 0
+        """proto3 omits channel=0 in MessageToJson; it must still reach outs.
+        build_envelope is decoded with an unlearned name, so it resolves to
+        that name's bucket — the guard is that the field exists at all."""
+        import channels
 
-    def test_nonzero_channel_unchanged(self):
+        archived, _ = self._archived(build_envelope(channel=0))
+        assert archived["channel"] == channels.name_bucket_id("LongFast")
+
+    def test_decoded_slot_value_is_irrelevant_when_name_is_known(self):
+        import channels
+
         archived, _ = self._archived(build_envelope(channel=2))
-        assert archived["channel"] == 2
+        assert archived["channel"] == channels.name_bucket_id("LongFast")
 
     def test_zero_hop_traceroute_not_dropped(self):
         """Empty route (direct neighbor) still reaches write_traceroute;


### PR DESCRIPTION
A gateway running mqtt.encryption_enabled=false republishes packets it already decoded, and MeshPacket.channel arrives as that gateway's slot index rather than the (name, PSK) hash. The resolver could re-file those only after learning the name's hash from an encrypted uplink — on a decode-only mesh no encrypted copy ever arrives, so unlearned names kept the raw index and every such channel sharing a slot conflated.

The wire name is the channel's identity; a decoded index carries none. Decoded uplinks whose name has no learned hash now file under a stable name-keyed bucket: 0x40000000 | crc32(name) & 0x3FFFFFFF — disjoint from real 8-bit hashes, positive int32 (telemetry/traceroutes.channel), and at most 10 digits (chat_channels.id, nodes.last_channel).

- channels.py: normalize_wire_name() gives resolver keys, bucket derivation, and stored channel_name one spelling; name_bucket_id(); learn events fire on first learn or corroborated re-key only (never reaffirmations or seeding), with requeue-on-failure.
- mqtt.py: names normalized at the envelope boundary (also fixes seeded names missed on padded spellings); learn events drain into the bucket merge; name buckets label themselves even on node-only traffic, with a periodic recheck; a sweep at connect and every recheck window re-merges any bucket that repopulated after its once-only merge (write-retry replays, an operator backfill racing a mid-run learn, a merge that failed before a restart).
- postgres.py: rebucket_name_channel() merges a name bucket into its just-learned hash — chat rows and nodes.last_channel, FK target first, emptied label row dropped best-effort in a savepoint; ensure_channel_label(); get_name_bucket_names() for the sweep.
- Names whose genuine hash lands in 0-7 ('ares' -> 7) also live at their name bucket: those ids can't be told from a slot index and can't carry a name in storage.

Display-side, name buckets are named channels: labeled from chat_channels, custom group, visible under mode = "all". Ingest-forward only — rows already stored under a slot index stay where they are.