### PR TITLE
fix(map): contextual persistent legend (#564), merge overlapping clusters (#567)

### DIFF
--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -30,6 +30,7 @@ import { type CorridorSort, type TraceCorridor } from "./map/components/MapTrace
 import { useCoverageCompute } from "./map/hooks/useCoverageCompute";
 import { useCoverageMergeOrigins } from "./map/hooks/useCoverageMergeOrigins";
 import { useCoverageState } from "./map/hooks/useCoverageState";
+import { useLegendContext } from "./map/hooks/useLegendContext";
 import { useLivePacketArcs } from "./map/hooks/useLivePacketArcs";
 import { useLosCompute } from "./map/hooks/useLosCompute";
 import { useLosState } from "./map/hooks/useLosState";
@@ -43,6 +44,7 @@ import { useTraceFlyover } from "./map/hooks/useTraceFlyover";
 import { useTraceLiveEvents } from "./map/hooks/useTraceLiveEvents";
 import { useUrlMapSync } from "./map/hooks/useUrlMapSync";
 import type { ActivityLayer } from "./map/layers/activityLayer";
+import { parseClusterMembers } from "./map/layers/clusterDisplay";
 import type { ClusterDonutLayer } from "./map/layers/clusterDonutLayer";
 import type { LosTubeLayer } from "./map/layers/losTubeLayer";
 import { bindMapHoverUi } from "./map/layers/mapHoverUi";
@@ -324,12 +326,22 @@ export function Map() {
     // Desktop default open
     return stored ?? (typeof window !== "undefined" && window.innerWidth >= 1024);
   });
+  // Legend is a persistent preference: it stays up while the user pans/zooms
+  // (#564) and survives reloads. Drawn only while the settings panel is closed.
+  const [legendOpen, setLegendOpen] = useState<boolean>(() => readJson<boolean>(LS_KEYS.legendOpen, false));
   // Which accordion section is expanded in the settings panel. Lifted to
   // Map.tsx so the tools drawer can jump the user to the "terrain" section
   // when they click a terrain-gated tool with 3D off.
   const [settingsOpenSections, setSettingsOpenSections] = useState<Set<string>>(
     () => new Set(["appearance"]),
   );
+  // Contextual legend rows: what the viewport is rendering (idle-driven query,
+  // only while the legend is actually shown).
+  const legendContext = useLegendContext(mbMapRef, {
+    enabled: legendOpen && !settingsPanelOpen && activeTool == null,
+    mapLoaded,
+    styleEpoch,
+  });
 
   useEffect(() => writeJson(LS_KEYS.provider, provider), [provider]);
   useEffect(() => writeJson(LS_KEYS.mapboxStyle, mapboxStyle), [mapboxStyle]);
@@ -340,6 +352,7 @@ export function Map() {
   useEffect(() => writeJson(LS_KEYS.linkMode, linkMode), [linkMode]);
   useEffect(() => writeJson(LS_KEYS.myNodeId, myNodeId), [myNodeId]);
   useEffect(() => writeJson(LS_KEYS.settingsPanelOpen, settingsPanelOpen), [settingsPanelOpen]);
+  useEffect(() => writeJson(LS_KEYS.legendOpen, legendOpen), [legendOpen]);
   useEffect(() => writeJson(LS_KEYS.terrain3D, terrain3D), [terrain3D]);
   useEffect(() => writeJson(LS_KEYS.buildings3D, buildings3D), [buildings3D]);
   useEffect(() => {
@@ -393,6 +406,9 @@ export function Map() {
       // FilterDropup menus are portaled to <body>, outside the panel tree.
       // A click on one of them shouldn't close the settings panel.
       if ((target as Element | null)?.closest?.("[data-filter-menu]")) return;
+      // The legend toggle closes settings itself (and shows the legend); if
+      // mousedown closed it first, the click would toggle the legend off.
+      if ((target as Element | null)?.closest?.("[data-legend-toggle]")) return;
 
       setSettingsPanelOpen(false);
     };
@@ -2021,7 +2037,7 @@ export function Map() {
         // leaf click be handled by onNodeLayerClick instead of re-spiderfying.
         if (hitsSpiderfyNode(e.point)) return;
 
-        const clusterId = cluster.properties?.cluster_id;
+        let clusterId = cluster.properties?.cluster_id;
         const source = map.getSource("nodes_clustered") as MlGeoJSONSource;
         if (!source || clusterId == null) return;
 
@@ -2043,6 +2059,21 @@ export function Map() {
 
         const currentZoom = map.getZoom();
         const maxZoom = map.getMaxZoom();
+
+        // Merged display marker (overlapping donuts, #567): zoom just far
+        // enough for the members to separate. If that isn't possible (at max
+        // zoom), act on the largest member below.
+        const members = parseClusterMembers(cluster.properties);
+        if (members.length > 1) {
+          const split = Number(cluster.properties?.split_zoom);
+          const target = Math.min(Math.max(Number.isFinite(split) ? split + 0.05 : currentZoom + 1, currentZoom + 0.5), maxZoom);
+          if (target > currentZoom + 0.05) {
+            removeSpiderfyLayers(map);
+            map.easeTo({ center: [lng, lat], zoom: target });
+            return;
+          }
+          clusterId = members[0];
+        }
 
         let handled = false;
         const zoomFallback = () => {
@@ -2093,41 +2124,43 @@ export function Map() {
       // Live cluster hover card (display-only; closes on map move to avoid drift)
       let clusterHoverTimer: number | null = null;
       let hoveredClusterId: number | null = null;
-      const readCluster = (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }) => {
+      type ClusterIntent = { cid: number; lng: number; lat: number; count: number; online: number; members: number[] };
+      const readCluster = (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }): ClusterIntent | null => {
         const f = e.features?.[0];
         const cid = f?.properties?.cluster_id;
         if (f == null || cid == null) return null;
         const [lng, lat] = (f.geometry as any).coordinates as [number, number];
+        const members = parseClusterMembers(f.properties);
         return {
           cid: cid as number,
           lng,
           lat,
           count: (f.properties?.point_count as number) ?? 0,
           online: (f.properties?.onlineCount as number) ?? 0,
+          // Merged display marker: leaves come from every member cluster.
+          members: members.length > 1 ? members : [cid as number],
         };
       };
-      const fillClusterHover = (cid: number, lng: number, lat: number, count: number, online: number) => {
-        const p = map.project([lng, lat]);
-        setClusterHover({ ids: [], count, online, x: p.x, y: p.y });
+      const fillClusterHover = (c: ClusterIntent) => {
+        const p = map.project([c.lng, c.lat]);
+        setClusterHover({ ids: [], count: c.count, online: c.online, x: p.x, y: p.y });
         const source = map.getSource("nodes_clustered") as MlGeoJSONSource | undefined;
-        source
-          ?.getClusterLeaves(cid, Infinity, 0)
-          .then((feats) => {
-            if (hoveredClusterId !== cid) return;
-            const ids = (feats ?? [])
-              .map((f) => String((f.properties as any)?.id ?? ""))
+        if (!source) return;
+        Promise.all(c.members.map((m) => source.getClusterLeaves(m, Infinity, 0).catch(() => [])))
+          .then((lists) => {
+            if (hoveredClusterId !== c.cid) return;
+            const ids = lists
+              .flat()
+              .map((f) => String((f?.properties as any)?.id ?? ""))
               .filter(Boolean);
             setClusterHover((prev) => (prev ? { ...prev, ids } : null));
           })
           .catch(() => {});
       };
-      const onClusterIntent = (c: { cid: number; lng: number; lat: number; count: number; online: number }) => {
+      const onClusterIntent = (c: ClusterIntent) => {
         hoveredClusterId = c.cid;
         if (clusterHoverTimer != null) clearTimeout(clusterHoverTimer);
-        clusterHoverTimer = window.setTimeout(
-          () => fillClusterHover(c.cid, c.lng, c.lat, c.count, c.online),
-          120,
-        );
+        clusterHoverTimer = window.setTimeout(() => fillClusterHover(c), 120);
       };
       const closeClusterHover = () => {
         hoveredClusterId = null;
@@ -2304,7 +2337,15 @@ export function Map() {
         const hitNode = map.queryRenderedFeatures(bbox, { layers: nodeLayers }).length > 0;
         const hitCluster =
           map.queryRenderedFeatures(bbox, { layers: ["clusters"] }).length > 0;
-        if (hitNode || hitCluster) return;
+        // The hit circles trail the drawn rings by the display source's worker
+        // round-trip; a click on a ring must never read as empty space.
+        const hitDonut =
+          clusterEnabledRef.current &&
+          !!clusterDonutLayerRef.current?.visibleClusters().some((c) => {
+            const p = map.project([c.lng, c.lat]);
+            return Math.hypot(p.x - e.point.x, p.y - e.point.y) <= c.r + PAD;
+          });
+        if (hitNode || hitCluster || hitDonut) return;
 
         // Dismiss-and-remember in both modes so the auto pass won't immediately
         // re-open the set the user just closed.
@@ -2724,6 +2765,12 @@ export function Map() {
         settingsToggleRef={settingsToggleRef}
         settingsPanelOpen={settingsPanelOpen}
         setSettingsPanelOpen={setSettingsPanelOpen}
+        legendOpen={legendOpen}
+        setLegendOpen={setLegendOpen}
+        legendContext={legendContext}
+        legendSuppressed={activeTool != null}
+        dodgeDetails={!!detailsData}
+        nodesHidden={nodesHidden}
         openSections={settingsOpenSections}
         setOpenSections={setSettingsOpenSections}
         setProvider={setProvider}

--- a/frontend/src/pages/map/components/MapLegend.test.tsx
+++ b/frontend/src/pages/map/components/MapLegend.test.tsx
@@ -1,0 +1,223 @@
+// jsdom tests for the contextual legend (#564): it never auto-closes on map
+// interaction, and it only lists the encodings the viewport is showing.
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EMPTY_LEGEND_CONTEXT, type LegendContext } from "../hooks/useLegendContext";
+import { MapLegend } from "./MapLegend";
+import { MapSettingsPanel } from "./MapSettingsPanel";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let mounted: { root: Root; el: HTMLElement } | null = null;
+function mount(node: React.ReactElement) {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  act(() => root.render(node));
+  mounted = { root, el };
+  return el;
+}
+afterEach(() => {
+  if (mounted) act(() => mounted!.root.unmount());
+  document.body.innerHTML = "";
+  mounted = null;
+});
+
+const text = () => document.getElementById("legend")?.textContent ?? "";
+
+describe("MapLegend (contextual rows)", () => {
+  it("shows every row when no context is known yet", () => {
+    mount(<MapLegend context={null} livePackets />);
+    const t = text();
+    for (const row of [
+      "Online node", "Online router", "Offline node", "Cluster (ring", "Brightness = recency",
+      "Link quality", "SNR unknown", "This node heard neighbor", "Neighbor heard this node", "Mutual link",
+      "Traceroute path", "Live packets", "Online = seen in last 6 hours",
+    ]) expect(t, row).toContain(row);
+  });
+
+  it("lists only what is on screen", () => {
+    const ctx: LegendContext = { ...EMPTY_LEGEND_CONTEXT, onlineNode: true, cluster: true, linkHeardBy: true, linkSnr: true };
+    mount(<MapLegend context={ctx} livePackets={false} linkMode="all" />);
+    const t = text();
+    expect(t).toContain("Online node");
+    expect(t).toContain("Cluster (ring");
+    expect(t).toContain("Neighbor heard this node");
+    expect(t).toContain("Link quality");
+    expect(t).toContain("Brightness = recency");
+    expect(t).not.toContain("Online router");
+    expect(t).not.toContain("Offline node");
+    expect(t).not.toContain("SNR unknown");
+    expect(t).not.toContain("This node heard neighbor");
+    expect(t).not.toContain("Mutual link");
+    expect(t).not.toContain("Traceroute path");
+    expect(t).not.toContain("Live packets");
+    expect(t).toContain("Showing links for all nodes.");
+  });
+
+  it("explains an empty viewport instead of listing nothing", () => {
+    mount(<MapLegend context={EMPTY_LEGEND_CONTEXT} livePackets={false} />);
+    const t = text();
+    expect(t).toContain("Nothing in view");
+    expect(t).not.toContain("Online node");
+    expect(t).not.toContain("Brightness = recency");
+    expect(t).toContain("Online = seen in last 6 hours");
+  });
+
+  it("keeps the recency row in a links-only view (endpoints off screen)", () => {
+    const ctx: LegendContext = { ...EMPTY_LEGEND_CONTEXT, linkSnr: true, linkHeard: true };
+    mount(<MapLegend context={ctx} livePackets={false} />);
+    const t = text();
+    expect(t).toContain("Brightness = recency");
+    expect(t).toContain("Link quality");
+    expect(t).not.toContain("Online node");
+  });
+
+  it("keeps the live-packets section while the toggle is on, even with an empty view", () => {
+    mount(<MapLegend context={EMPTY_LEGEND_CONTEXT} livePackets />);
+    expect(text()).toContain("Live packets");
+  });
+
+  it("empty-state copy explains hidden nodes / active filters", () => {
+    mount(<MapLegend context={EMPTY_LEGEND_CONTEXT} livePackets={false} nodesHidden />);
+    expect(text()).toContain("Nodes are hidden");
+    act(() => mounted!.root.unmount());
+    document.body.innerHTML = "";
+    mount(<MapLegend context={EMPTY_LEGEND_CONTEXT} livePackets={false} filtersActive />);
+    expect(text()).toContain("widen the filters");
+  });
+
+  it("wording follows the link mode", () => {
+    const ctx: LegendContext = { ...EMPTY_LEGEND_CONTEXT, linkHeard: true, linkHeardBy: true, linkTrace: true };
+    mount(<MapLegend context={ctx} livePackets={false} linkMode="all" />);
+    expect(text()).toContain("One-way link");
+    expect(text()).toContain("Traceroute path");
+    expect(text()).not.toContain("(on select)");
+    act(() => mounted!.root.unmount());
+    document.body.innerHTML = "";
+    mount(<MapLegend context={ctx} livePackets={false} linkMode="mynode" myNodeLabel="BASE" />);
+    expect(text()).toContain("BASE heard neighbor");
+    expect(text()).toContain("Neighbor heard BASE");
+    act(() => mounted!.root.unmount());
+    document.body.innerHTML = "";
+    mount(<MapLegend context={ctx} livePackets={false} linkMode="selected" />);
+    expect(text()).toContain("This node heard neighbor");
+    expect(text()).toContain("Traceroute path (on select)");
+  });
+});
+
+function panel(overrides: Partial<React.ComponentProps<typeof MapSettingsPanel>> = {}) {
+  const props: React.ComponentProps<typeof MapSettingsPanel> = {
+    settingsPanelRef: { current: null },
+    settingsToggleRef: { current: null },
+    settingsPanelOpen: false,
+    setSettingsPanelOpen: vi.fn(),
+    legendOpen: true,
+    setLegendOpen: vi.fn(),
+    legendContext: null,
+    openSections: new Set(),
+    setOpenSections: vi.fn(),
+    setProvider: vi.fn(),
+    mapboxStyle: "",
+    setMapboxStyle: vi.fn(),
+    osmBasemap: "dark" as never,
+    setOsmBasemap: vi.fn(),
+    linkMode: "selected",
+    setLinkMode: vi.fn(),
+    myNodeId: "",
+    setMyNodeId: vi.fn(),
+    nodeList: [],
+    canUseMapbox: false,
+    usingMapbox: false,
+    terrain3D: false,
+    setTerrain3D: vi.fn(),
+    buildings3D: false,
+    setBuildings3D: vi.fn(),
+    livePackets: true,
+    setLivePackets: vi.fn(),
+    recentDays: 30,
+    setRecentDays: vi.fn(),
+    clusterEnabled: true,
+    setClusterEnabled: vi.fn(),
+    roleFilter: null,
+    setRoleFilter: vi.fn(),
+    channelFilter: null,
+    setChannelFilter: vi.fn(),
+    resolveChannelLabel: (id) => id,
+    ...overrides,
+  };
+  return props;
+}
+
+describe("MapSettingsPanel legend (#564: stays open on map interaction)", () => {
+  it("does not close on outside pointerdown or Escape", () => {
+    const setLegendOpen = vi.fn();
+    mount(<MapSettingsPanel {...panel({ setLegendOpen })} />);
+    expect(document.getElementById("legend")).not.toBeNull();
+
+    act(() => {
+      document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(setLegendOpen).not.toHaveBeenCalled();
+    expect(document.getElementById("legend")).not.toBeNull();
+  });
+
+  it("toggle button closes it, and reports its state via aria-expanded", () => {
+    const setLegendOpen = vi.fn();
+    mount(<MapSettingsPanel {...panel({ setLegendOpen })} />);
+    const btn = document.querySelector('button[aria-label="Toggle legend"]')!;
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
+    expect(btn.getAttribute("aria-controls")).toBe("legend");
+    act(() => btn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(setLegendOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("is hidden (not forgotten) while the settings panel is open; its button then re-shows it", () => {
+    const setLegendOpen = vi.fn();
+    const setSettingsPanelOpen = vi.fn();
+    mount(<MapSettingsPanel {...panel({ settingsPanelOpen: true, setLegendOpen, setSettingsPanelOpen })} />);
+    expect(document.getElementById("legend")).toBeNull();
+    const btn = document.querySelector('button[aria-label="Toggle legend"]')!;
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    act(() => btn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(setSettingsPanelOpen).toHaveBeenCalledWith(false);
+    expect(setLegendOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("opening settings leaves the legend preference alone", () => {
+    const setLegendOpen = vi.fn();
+    mount(<MapSettingsPanel {...panel({ setLegendOpen })} />);
+    const btn = document.querySelector('button[aria-label="Toggle Map Settings"]')!;
+    act(() => btn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(setLegendOpen).not.toHaveBeenCalled();
+  });
+
+  it("marks its toggle so Map.tsx's outside-click handler leaves settings open until the click runs", () => {
+    // Map.tsx closes the settings panel on mousedown outside it and exempts
+    // [data-legend-toggle]; without the marker, mousedown would close settings
+    // first and the click would then toggle an already-open legend OFF.
+    mount(<MapSettingsPanel {...panel({ settingsPanelOpen: true })} />);
+    expect(document.querySelector('button[aria-label="Toggle legend"]')!.hasAttribute("data-legend-toggle")).toBe(true);
+  });
+
+  it("is suppressed (preference kept) while a tool is active; clicking is inert", () => {
+    const setLegendOpen = vi.fn();
+    mount(<MapSettingsPanel {...panel({ legendSuppressed: true, setLegendOpen })} />);
+    expect(document.getElementById("legend")).toBeNull();
+    const btn = document.querySelector('button[aria-label="Toggle legend"]')!;
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
+    act(() => btn.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(setLegendOpen).not.toHaveBeenCalled();
+  });
+
+  it("shifts the stack left of the desktop details column when it is open", () => {
+    mount(<MapSettingsPanel {...panel({ dodgeDetails: true })} />);
+    const root = document.querySelector('button[aria-label="Toggle legend"]')!.closest("div.fixed")!;
+    expect(root.className).toContain("sm:right-[calc(21.25rem+1rem)]");
+  });
+});

--- a/frontend/src/pages/map/components/MapLegend.tsx
+++ b/frontend/src/pages/map/components/MapLegend.tsx
@@ -1,12 +1,52 @@
+import type { ReactNode } from "react";
+
+import { type LegendContext, legendContextIsEmpty } from "../hooks/useLegendContext";
 import { PACKET_TYPE_LABELS, packetColorCss } from "../lib/packetColors";
 import type { LinkMode } from "../lib/types";
 
+function Row({ swatch, children }: { swatch: ReactNode; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2">
+      {swatch}
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function Dot({ color }: { color: string }) {
+  return <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: color }} />;
+}
+
+function Line({ dash, color = "#cbd5e1" }: { dash?: string; color?: string }) {
+  return (
+    <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
+      <line x1="0" y1="2" x2="24" y2="2" stroke={color} strokeWidth="2.5" strokeLinecap="round" strokeDasharray={dash} />
+    </svg>
+  );
+}
+
+/**
+ * Contextual map legend: with a `context` (what the viewport is rendering) only
+ * the rows that apply are shown; without one (first paint) every row is shown.
+ */
 export function MapLegend({
   linkMode = "selected",
   myNodeLabel,
+  livePackets = true,
+  context = null,
+  nodesHidden = false,
+  filtersActive = false,
 }: {
   linkMode?: LinkMode;
   myNodeLabel?: string;
+  /** Live packet-arc animation enabled (Settings → Live packets). */
+  livePackets?: boolean;
+  /** Viewport contents; `null` → show everything. */
+  context?: LegendContext | null;
+  /** Node markers hidden (Live coverage → Hide nodes). */
+  nodesHidden?: boolean;
+  /** A node filter (days / role / channel) is narrowing the map. */
+  filtersActive?: boolean;
 }) {
   const linkHint =
     linkMode === "all"
@@ -14,113 +54,145 @@ export function MapLegend({
       : linkMode === "mynode"
         ? `Showing links for ${myNodeLabel || "My Node"}.`
         : "Links shown when a node is selected.";
+  // Link-direction wording depends on who the focal node is: the selected
+  // node, My Node, or nobody (all-nodes mode draws one-way links without a
+  // focal node, and never dashed heard_by links).
+  const focal = linkMode === "mynode" ? myNodeLabel || "My Node" : "This node";
+  const heardLabel = linkMode === "all" ? "One-way link" : `${focal} heard neighbor`;
+  const heardByLabel = `Neighbor heard ${linkMode === "mynode" ? focal : "this node"}`;
+  const traceLabel = linkMode === "selected" ? "Traceroute path (on select)" : "Traceroute path";
+  const emptyCopy = nodesHidden
+    ? "Nodes are hidden (Live coverage → Hide nodes)."
+    : filtersActive
+      ? "Nothing in view — pan or zoom out, or widen the filters."
+      : "Nothing in view — pan or zoom out to see nodes.";
 
-  return (
-    <div
-      id="legend"
-      role="group"
-      aria-labelledby="legend-heading"
-      className="bg-gray-900/80 backdrop-blur-xl rounded-xl shadow-2xl border border-white/10 p-3"
+  const show = (flag: boolean) => context == null || flag;
+  const c = context;
+  const empty = c != null && legendContextIsEmpty(c);
+
+  const anyNode = show(c?.onlineNode || c?.onlineRouter || c?.offlineNode || false);
+  const anyLink = show(c?.linkSnr || c?.linkSnrUnknown || c?.linkHeard || c?.linkHeardBy || c?.linkMutual || c?.linkTrace || false);
+  const showNodes = anyNode || show(c?.cluster ?? false);
+
+  const sections: ReactNode[] = [];
+
+  // Applies to nodes and links alike, so it must survive a links-only view.
+  const recencyRow = (
+    <Row
+      swatch={
+        <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
+          <defs>
+            <linearGradient id="legend-recency-fade" x1="0" x2="1" y1="0" y2="0">
+              <stop offset="0%" stopColor="#FFFFFF" stopOpacity="1.0" />
+              <stop offset="100%" stopColor="#FFFFFF" stopOpacity="0.2" />
+            </linearGradient>
+          </defs>
+          <rect x="0" y="0" width="24" height="4" fill="url(#legend-recency-fade)" />
+        </svg>
+      }
     >
-      <div id="legend-heading" className="text-xs font-semibold text-gray-300 mb-2">
-        Legend
-      </div>
-      <div className="space-y-1.5 text-[11px] text-gray-400">
-        {/* Nodes */}
-        <div className="flex items-center gap-2">
-          <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: "#32f032" }} />
-          <span>Online node</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: "#3b82f6" }} />
-          <span>Online router</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-2.5 h-2.5 rounded-full shadow-sm shrink-0" style={{ backgroundColor: "#72798a" }} />
-          <span>Offline node (any role)</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
-            <defs>
-              <linearGradient id="legend-recency-fade" x1="0" x2="1" y1="0" y2="0">
-                <stop offset="0%" stopColor="#FFFFFF" stopOpacity="1.0" />
-                <stop offset="100%" stopColor="#FFFFFF" stopOpacity="0.2" />
-              </linearGradient>
-            </defs>
-            <rect x="0" y="0" width="24" height="4" fill="url(#legend-recency-fade)" />
-          </svg>
-          <span>Brightness = recency (nodes &amp; links)</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 20 20" className="w-4 h-4 shrink-0" aria-hidden="true">
-            <circle cx="10" cy="10" r="7" fill="none" stroke="#72798a" strokeWidth="3" />
-            <circle
-              cx="10" cy="10" r="7"
-              fill="none" stroke="#32f032" strokeWidth="3"
-              strokeDasharray="30 100"
-              transform="rotate(-90 10 10)"
-            />
-            <circle cx="10" cy="10" r="4" fill="#0f172a" />
-          </svg>
-          <span>Cluster (ring = online ratio)</span>
-        </div>
+      Brightness = recency (nodes &amp; links)
+    </Row>
+  );
 
-        <div className="border-t border-white/10 my-1" />
+  if (empty) {
+    sections.push(
+      <div key="empty" className="text-gray-500 leading-tight">
+        {emptyCopy}
+      </div>,
+    );
+  }
 
-        {/* Links — color = SNR (quality); kind = line style */}
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
-            <defs>
-              <linearGradient id="legend-snr-gradient" x1="0" x2="1" y1="0" y2="0">
-                <stop offset="0%" stopColor="#FF4444" />
-                <stop offset="50%" stopColor="#FFDD00" />
-                <stop offset="100%" stopColor="#44CC44" />
-              </linearGradient>
-            </defs>
-            <rect x="0" y="0" width="24" height="4" fill="url(#legend-snr-gradient)" />
-          </svg>
-          <span>Link quality (low → high SNR)</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 bg-gray-400 rounded-full shrink-0" />
-          <span>SNR unknown</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
-            <line x1="0" y1="2" x2="24" y2="2" stroke="#cbd5e1" strokeWidth="2.5" strokeLinecap="round" />
-          </svg>
-          <span>This node heard neighbor</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
-            <line x1="0" y1="2" x2="24" y2="2" stroke="#cbd5e1" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="4 3" />
-          </svg>
-          <span>Neighbor heard this node</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 8" preserveAspectRatio="none" className="w-4 h-2 shrink-0" aria-hidden="true">
-            <path d="M 1 6 Q 12 -2 23 6" stroke="#cbd5e1" strokeWidth="2.5" fill="none" strokeLinecap="round" />
-          </svg>
-          <span>Mutual link</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
-            <line x1="0" y1="2" x2="24" y2="2" stroke="#F59E0B" strokeWidth="2.5" strokeLinecap="round" strokeDasharray="1 3" />
-          </svg>
-          <span>Traceroute path (on select)</span>
-        </div>
+  if (showNodes) {
+    sections.push(
+      <div key="nodes" className="space-y-1.5">
+        {show(c?.onlineNode ?? false) && <Row swatch={<Dot color="#32f032" />}>Online node</Row>}
+        {show(c?.onlineRouter ?? false) && <Row swatch={<Dot color="#3b82f6" />}>Online router</Row>}
+        {show(c?.offlineNode ?? false) && <Row swatch={<Dot color="#72798a" />}>Offline node (any role)</Row>}
+        {(anyNode || anyLink) && recencyRow}
+        {show(c?.cluster ?? false) && (
+          <Row
+            swatch={
+              <svg viewBox="0 0 20 20" className="w-4 h-4 shrink-0" aria-hidden="true">
+                <circle cx="10" cy="10" r="7" fill="none" stroke="#72798a" strokeWidth="3" />
+                <circle
+                  cx="10" cy="10" r="7"
+                  fill="none" stroke="#32f032" strokeWidth="3"
+                  strokeDasharray="30 100"
+                  transform="rotate(-90 10 10)"
+                />
+                <circle cx="10" cy="10" r="4" fill="#0f172a" />
+              </svg>
+            }
+          >
+            Cluster (ring = online ratio)
+          </Row>
+        )}
+      </div>,
+    );
+  }
 
-        <div className="border-t border-white/10 my-1" />
+  if (anyLink) {
+    // Links — colour = SNR (quality); kind = line style
+    sections.push(
+      <div key="links" className="space-y-1.5">
+        {!showNodes && recencyRow}
+        {show(c?.linkSnr ?? false) && (
+          <Row
+            swatch={
+              <svg viewBox="0 0 24 4" preserveAspectRatio="none" className="w-4 h-0.5 shrink-0" aria-hidden="true">
+                <defs>
+                  <linearGradient id="legend-snr-gradient" x1="0" x2="1" y1="0" y2="0">
+                    <stop offset="0%" stopColor="#FF4444" />
+                    <stop offset="50%" stopColor="#FFDD00" />
+                    <stop offset="100%" stopColor="#44CC44" />
+                  </linearGradient>
+                </defs>
+                <rect x="0" y="0" width="24" height="4" fill="url(#legend-snr-gradient)" />
+              </svg>
+            }
+          >
+            Link quality (low → high SNR)
+          </Row>
+        )}
+        {show(c?.linkSnrUnknown ?? false) && (
+          <Row swatch={<div className="w-4 h-0.5 bg-gray-400 rounded-full shrink-0" />}>SNR unknown</Row>
+        )}
+        {show(c?.linkHeard ?? false) && <Row swatch={<Line />}>{heardLabel}</Row>}
+        {show(c?.linkHeardBy ?? false) && <Row swatch={<Line dash="4 3" />}>{heardByLabel}</Row>}
+        {show(c?.linkMutual ?? false) && (
+          <Row
+            swatch={
+              <svg viewBox="0 0 24 8" preserveAspectRatio="none" className="w-4 h-2 shrink-0" aria-hidden="true">
+                <path d="M 1 6 Q 12 -2 23 6" stroke="#cbd5e1" strokeWidth="2.5" fill="none" strokeLinecap="round" />
+              </svg>
+            }
+          >
+            Mutual link
+          </Row>
+        )}
+        {show(c?.linkTrace ?? false) && (
+          <Row swatch={<Line dash="1 3" color="#F59E0B" />}>{traceLabel}</Row>
+        )}
+      </div>,
+    );
+  }
 
-        {/* Live packets (SSE) */}
+  if (livePackets) {
+    sections.push(
+      <div key="live" className="space-y-1.5">
         <div className="text-[10px] uppercase tracking-wider text-gray-500">Live packets</div>
-        <div className="flex items-center gap-2">
-          <svg viewBox="0 0 24 10" preserveAspectRatio="none" className="w-4 h-2.5 shrink-0" aria-hidden="true">
-            <path d="M 2 8 Q 12 -1 21 4" stroke="#94a3b8" strokeWidth="1.5" fill="none" strokeLinecap="round" />
-            <circle cx="21" cy="4" r="2.6" fill="#e2e8f0" />
-          </svg>
-          <span>Packet → gateway that heard it</span>
-        </div>
+        <Row
+          swatch={
+            <svg viewBox="0 0 24 10" preserveAspectRatio="none" className="w-4 h-2.5 shrink-0" aria-hidden="true">
+              <path d="M 2 8 Q 12 -1 21 4" stroke="#94a3b8" strokeWidth="1.5" fill="none" strokeLinecap="round" />
+              <circle cx="21" cy="4" r="2.6" fill="#e2e8f0" />
+            </svg>
+          }
+        >
+          Packet → gateway that heard it
+        </Row>
         <div className="grid grid-cols-2 gap-x-2 gap-y-1">
           {PACKET_TYPE_LABELS.map(({ type, label }) => (
             <div key={type} className="flex items-center gap-1.5 min-w-0">
@@ -135,13 +207,37 @@ export function MapLegend({
         <div className="text-[10px] text-gray-500 leading-tight">
           Traceroutes animate the full multi-hop path.
         </div>
+      </div>,
+    );
+  }
 
-        <div className="border-t border-white/10 my-1" />
-        <div className="text-[10px] text-gray-500 leading-tight">
-          Online = seen in last 6 hours.
-          <br />
-          {linkHint}
-        </div>
+  sections.push(
+    <div key="footer" className="text-[10px] text-gray-500 leading-tight">
+      Online = seen in last 6 hours.
+      <br />
+      {linkHint}
+    </div>,
+  );
+
+  return (
+    <div
+      id="legend"
+      role="group"
+      aria-labelledby="legend-heading"
+      tabIndex={0}
+      className="bg-gray-900/80 backdrop-blur-xl rounded-xl shadow-2xl border border-white/10 p-3
+                 max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-7rem)] overflow-y-auto overscroll-contain"
+    >
+      <div id="legend-heading" className="text-xs font-semibold text-gray-300 mb-2">
+        Legend
+      </div>
+      <div className="text-[11px] text-gray-400">
+        {sections.map((s, i) => (
+          <div key={i}>
+            {i > 0 && <div className="border-t border-white/10 my-1.5" />}
+            {s}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/pages/map/components/MapSettingsPanel.tsx
+++ b/frontend/src/pages/map/components/MapSettingsPanel.tsx
@@ -2,7 +2,9 @@ import { type Dispatch, type RefObject, type SetStateAction, useEffect, useMemo,
 
 import type { OsmBasemap } from "../../../maps/mapStyle";
 import { NodeRole, roleTitles } from "../../../types";
+import { prefersReducedMotion } from "../../../utils/reducedMotion";
 import { useBottomSheetGesture } from "../hooks/useBottomSheet";
+import type { LegendContext } from "../hooks/useLegendContext";
 import type { LinkMode, MapProvider } from "../lib/types";
 import { ROLE_COLORS } from "../lib/utils";
 import { type DropupOption,FilterDropup } from "./FilterDropup";
@@ -193,6 +195,12 @@ export function MapSettingsPanel({
   settingsToggleRef,
   settingsPanelOpen,
   setSettingsPanelOpen,
+  legendOpen,
+  setLegendOpen,
+  legendContext = null,
+  legendSuppressed = false,
+  dodgeDetails = false,
+  nodesHidden = false,
   openSections,
   setOpenSections,
 
@@ -238,6 +246,18 @@ export function MapSettingsPanel({
   settingsToggleRef: RefObject<HTMLButtonElement | null>;
   settingsPanelOpen: boolean;
   setSettingsPanelOpen: Dispatch<SetStateAction<boolean>>;
+  /** Legend preference (persisted by the parent). The legend is only drawn
+   *  while the settings panel is closed; it never auto-closes on map use. */
+  legendOpen: boolean;
+  setLegendOpen: Dispatch<SetStateAction<boolean>>;
+  /** What the viewport is rendering (contextual rows); null → full legend. */
+  legendContext?: LegendContext | null;
+  /** RF tool active: keep the preference but don't draw the legend (tool panels own the bottom). */
+  legendSuppressed?: boolean;
+  /** Desktop details column open: shift the stack left of it so the legend never covers it. */
+  dodgeDetails?: boolean;
+  /** Node markers hidden (Live coverage → Hide nodes); tunes the legend's empty-state copy. */
+  nodesHidden?: boolean;
   openSections: Set<string>;
   setOpenSections: Dispatch<SetStateAction<Set<string>>>;
 
@@ -281,8 +301,8 @@ export function MapSettingsPanel({
 }) {
   const [nodeSearch, setNodeSearch] = useState("");
   const [myNodeHighlight, setMyNodeHighlight] = useState(0);
-  const [legendOpen, setLegendOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const legendVisible = legendOpen && !settingsPanelOpen && !legendSuppressed;
+  const filtersActive = recentDays !== 30 || roleFilter != null || channelFilter != null;
   const headingRef = useRef<HTMLHeadingElement>(null);
 
   // Move focus into the panel on open; return it to the toggle on close.
@@ -337,21 +357,6 @@ export function MapSettingsPanel({
     }
   };
 
-  useEffect(() => {
-    if (!legendOpen) return;
-    const onPointerDown = (e: PointerEvent) => {
-      if (containerRef.current?.contains(e.target as Node)) return;
-      setLegendOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setLegendOpen(false); };
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [legendOpen]);
-
   const sheet = useBottomSheetGesture(() => setSettingsPanelOpen(false));
 
   const selectClasses =
@@ -370,10 +375,22 @@ export function MapSettingsPanel({
   };
 
   return (
-    <div ref={containerRef} className={`fixed bottom-4 right-4 z-1100 flex flex-col items-end ${hidden ? "max-sm:hidden" : ""}`}>
-      {legendOpen && !settingsPanelOpen && (
+    <div
+      className={`fixed bottom-4 right-4 z-1100 flex flex-col items-end ${hidden ? "max-sm:hidden" : ""} ${
+        // MapDetailsPanel is a right column (sm:w-85) — sit beside it, not on it.
+        dodgeDetails ? "sm:right-[calc(21.25rem+1rem)]" : ""
+      }`}
+    >
+      {legendVisible && (
         <div className="mb-2">
-          <MapLegend linkMode={linkMode} myNodeLabel={myNodeLabel} />
+          <MapLegend
+            linkMode={linkMode}
+            myNodeLabel={myNodeLabel}
+            livePackets={livePackets && !prefersReducedMotion()}
+            context={legendContext}
+            nodesHidden={nodesHidden}
+            filtersActive={filtersActive}
+          />
         </div>
       )}
 
@@ -694,18 +711,30 @@ export function MapSettingsPanel({
         <button
           type="button"
           onClick={() => {
-            setLegendOpen(!legendOpen);
-            if (settingsPanelOpen) setSettingsPanelOpen(false);
+            // Suppressed (RF tool active): inert, keeps the persisted preference.
+            if (legendSuppressed) return;
+            // Settings open hides the legend; the button then means "show it".
+            if (settingsPanelOpen) {
+              setSettingsPanelOpen(false);
+              setLegendOpen(true);
+            } else {
+              setLegendOpen(!legendOpen);
+            }
           }}
           className={`${iconBtnBase} ${
-            legendOpen
+            legendVisible
               ? "bg-gray-900/95 border-cyan-500/50"
               : "bg-gray-900/95 border-white/10 hover:bg-gray-900"
           }`}
           aria-label="Toggle legend"
+          aria-expanded={legendVisible}
+          aria-controls="legend"
+          aria-disabled={legendSuppressed || undefined}
+          title={legendSuppressed ? "Legend hidden while a tool is active" : undefined}
+          data-legend-toggle
         >
           <div className="w-5 h-5 flex items-center justify-center">
-            <svg className={`w-4 h-4 ${legendOpen ? "text-cyan-400" : "text-gray-400"}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className={`w-4 h-4 ${legendVisible ? "text-cyan-400" : "text-gray-400"}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
@@ -714,10 +743,7 @@ export function MapSettingsPanel({
         <button
           ref={settingsToggleRef}
           type="button"
-          onClick={() => {
-            setSettingsPanelOpen(!settingsPanelOpen);
-            if (legendOpen) setLegendOpen(false);
-          }}
+          onClick={() => setSettingsPanelOpen(!settingsPanelOpen)}
           className={`${iconBtnBase} ${
             settingsPanelOpen
               ? "bg-gray-900/95 border-cyan-500/50"

--- a/frontend/src/pages/map/hooks/useLegendContext.hook.test.tsx
+++ b/frontend/src/pages/map/hooks/useLegendContext.hook.test.tsx
@@ -1,0 +1,141 @@
+// Hook behaviour against a stub map: disabled → null, idle-driven + debounced
+// queries, unknown layer ids filtered before querying, stable identity.
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type LegendContext, useLegendContext } from "./useLegendContext";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type Handler = (e?: unknown) => void;
+function stubMap(opts: { layers: string[]; features?: Array<{ layer: { id: string }; properties: Record<string, unknown> }>; loaded?: boolean }) {
+  const handlers = new Map<string, Set<Handler>>();
+  const query = vi.fn((_o?: { layers: string[] }) => opts.features ?? []);
+  const map = {
+    on: vi.fn((ev: string, h: Handler) => { if (!handlers.has(ev)) handlers.set(ev, new Set()); handlers.get(ev)!.add(h); }),
+    off: vi.fn((ev: string, h: Handler) => handlers.get(ev)?.delete(h)),
+    getLayer: vi.fn((id: string) => (opts.layers.includes(id) ? { id } : undefined)),
+    queryRenderedFeatures: query,
+    loaded: vi.fn(() => opts.loaded ?? true),
+    fire: (ev: string) => handlers.get(ev)?.forEach((h) => h()),
+    fireWith: (ev: string, e: unknown) => handlers.get(ev)?.forEach((h) => h(e)),
+    listenerCount: (ev: string) => handlers.get(ev)?.size ?? 0,
+  };
+  return { map, query };
+}
+
+let latest: LegendContext | null | undefined;
+function Probe({ mapRef, enabled, mapLoaded = true, styleEpoch = 0 }: { mapRef: { current: unknown }; enabled: boolean; mapLoaded?: boolean; styleEpoch?: number }) {
+  latest = useLegendContext(mapRef as never, { enabled, mapLoaded, styleEpoch });
+  return null;
+}
+
+let mounted: { root: Root; el: HTMLElement } | null = null;
+function mount(node: React.ReactElement) {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  act(() => root.render(node));
+  mounted = { root, el };
+  return root;
+}
+afterEach(() => {
+  if (mounted) act(() => mounted!.root.unmount());
+  document.body.innerHTML = "";
+  mounted = null;
+  latest = undefined;
+  vi.useRealTimers();
+});
+
+describe("useLegendContext", () => {
+  it("returns null and touches nothing while disabled", () => {
+    const { map, query } = stubMap({ layers: ["clusters"] });
+    mount(<Probe mapRef={{ current: map }} enabled={false} />);
+    expect(latest).toBeNull();
+    expect(query).not.toHaveBeenCalled();
+    expect(map.on).not.toHaveBeenCalled();
+  });
+
+  it("queries immediately when the map is already idle, filtering to existing layers", () => {
+    const { map, query } = stubMap({
+      layers: ["clusters", "links-solid"],
+      features: [{ layer: { id: "clusters" }, properties: { point_count: 5 } }],
+    });
+    mount(<Probe mapRef={{ current: map }} enabled />);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toEqual({ layers: ["clusters", "links-solid"] });
+    expect(latest?.cluster).toBe(true);
+    expect(latest?.linkHeard).toBe(false);
+    expect(map.listenerCount("idle")).toBe(1);
+  });
+
+  it("waits for idle when the map is still loading, then debounces idle bursts", () => {
+    vi.useFakeTimers();
+    const { map, query } = stubMap({ layers: ["clusters"], loaded: false });
+    mount(<Probe mapRef={{ current: map }} enabled />);
+    expect(query).not.toHaveBeenCalled();
+    act(() => { map.fire("idle"); map.fire("idle"); map.fire("idle"); });
+    expect(query).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the same context object when nothing changed, and detaches on disable", () => {
+    vi.useFakeTimers();
+    const { map } = stubMap({ layers: ["clusters"], features: [{ layer: { id: "clusters" }, properties: {} }] });
+    const ref = { current: map };
+    const root = mount(<Probe mapRef={ref} enabled />);
+    const first = latest;
+    act(() => { map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(latest).toBe(first);
+    act(() => root.render(<Probe mapRef={ref} enabled={false} />));
+    expect(latest).toBeNull();
+    expect(map.listenerCount("idle")).toBe(0);
+  });
+
+  it("does not clobber the context when no layers exist (mid style swap)", () => {
+    vi.useFakeTimers();
+    const { map, query } = stubMap({ layers: ["clusters"], features: [{ layer: { id: "clusters" }, properties: {} }] });
+    mount(<Probe mapRef={{ current: map }} enabled />);
+    expect(latest?.cluster).toBe(true);
+    map.getLayer.mockImplementation(() => undefined);
+    act(() => { map.fire("moveend"); map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(1); // no layers → query skipped, ctx kept
+    expect(latest?.cluster).toBe(true);
+  });
+
+  it("attaches once the map instance exists (mapLoaded) and re-attaches on a style swap (styleEpoch)", () => {
+    const { map, query } = stubMap({ layers: ["clusters"], features: [{ layer: { id: "clusters" }, properties: {} }] });
+    const ref: { current: unknown } = { current: null };
+    const root = mount(<Probe mapRef={ref} enabled mapLoaded={false} />);
+    expect(query).not.toHaveBeenCalled();
+    ref.current = map; // map created after mount…
+    act(() => root.render(<Probe mapRef={ref} enabled mapLoaded />)); // …and 'load' flips the flag
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(map.listenerCount("idle")).toBe(1);
+    act(() => root.render(<Probe mapRef={ref} enabled mapLoaded styleEpoch={1} />));
+    expect(map.listenerCount("idle")).toBe(1); // old listener detached, new one attached
+    expect(query).toHaveBeenCalledTimes(2); // layers back → immediate re-query
+    expect(latest?.cluster).toBe(true);
+  });
+
+  it("re-queries on idle only after a move or a source reload (hover repaints are ignored)", () => {
+    vi.useFakeTimers();
+    const { map, query } = stubMap({ layers: ["clusters"], features: [{ layer: { id: "clusters" }, properties: {} }] });
+    mount(<Probe mapRef={{ current: map }} enabled />);
+    expect(query).toHaveBeenCalledTimes(1);
+    // idle from a hover-only repaint: nothing armed → no query
+    act(() => { map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(1);
+    act(() => { map.fire("moveend"); map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(2);
+    act(() => { map.fireWith("sourcedata", { isSourceLoaded: false }); map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(2);
+    act(() => { map.fireWith("sourcedata", { isSourceLoaded: true }); map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(3);
+    // paint-only changes (hover dimming) fire styledata + idle: not a reason to re-query
+    act(() => { map.fire("styledata"); map.fire("idle"); vi.advanceTimersByTime(250); });
+    expect(query).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/pages/map/hooks/useLegendContext.hook.test.tsx
+++ b/frontend/src/pages/map/hooks/useLegendContext.hook.test.tsx
@@ -9,14 +9,23 @@ import { type LegendContext, useLegendContext } from "./useLegendContext";
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 type Handler = (e?: unknown) => void;
-function stubMap(opts: { layers: string[]; features?: Array<{ layer: { id: string }; properties: Record<string, unknown> }>; loaded?: boolean }) {
+type Feat = { layer: { id: string }; properties: Record<string, unknown> };
+/** Stub map: each configured layer id doubles as its source id; features are
+ *  served per source by querySourceFeatures (like maplibre, minus the map). */
+function stubMap(opts: { layers: string[]; features?: Feat[]; loaded?: boolean; hidden?: string[]; minzoom?: Record<string, number>; zoom?: number }) {
   const handlers = new Map<string, Set<Handler>>();
-  const query = vi.fn((_o?: { layers: string[] }) => opts.features ?? []);
+  const query = vi.fn((source: string, _o?: { filter?: unknown; sourceLayer?: string }) =>
+    (opts.features ?? []).filter((f) => f.layer.id === source).map((f) => ({ properties: f.properties })),
+  );
   const map = {
     on: vi.fn((ev: string, h: Handler) => { if (!handlers.has(ev)) handlers.set(ev, new Set()); handlers.get(ev)!.add(h); }),
     off: vi.fn((ev: string, h: Handler) => handlers.get(ev)?.delete(h)),
-    getLayer: vi.fn((id: string) => (opts.layers.includes(id) ? { id } : undefined)),
-    queryRenderedFeatures: query,
+    getLayer: vi.fn((id: string) => (opts.layers.includes(id) ? { id, source: id, minzoom: opts.minzoom?.[id] } : undefined)),
+    getSource: vi.fn((id: string) => (opts.layers.includes(id) ? { id } : undefined)),
+    getLayoutProperty: vi.fn((id: string, _p: string) => (opts.hidden?.includes(id) ? "none" : "visible")),
+    getFilter: vi.fn(() => undefined),
+    getZoom: vi.fn(() => opts.zoom ?? 10),
+    querySourceFeatures: query,
     loaded: vi.fn(() => opts.loaded ?? true),
     fire: (ev: string) => handlers.get(ev)?.forEach((h) => h()),
     fireWith: (ev: string, e: unknown) => handlers.get(ev)?.forEach((h) => h(e)),
@@ -57,17 +66,35 @@ describe("useLegendContext", () => {
     expect(map.on).not.toHaveBeenCalled();
   });
 
-  it("queries immediately when the map is already idle, filtering to existing layers", () => {
+  it("queries immediately when the map is already idle, one source query per existing layer", () => {
     const { map, query } = stubMap({
       layers: ["clusters", "links-solid"],
       features: [{ layer: { id: "clusters" }, properties: { point_count: 5 } }],
     });
     mount(<Probe mapRef={{ current: map }} enabled />);
-    expect(query).toHaveBeenCalledTimes(1);
-    expect(query.mock.calls[0][0]).toEqual({ layers: ["clusters", "links-solid"] });
+    expect(query.mock.calls.map((c) => c[0]).sort()).toEqual(["clusters", "links-solid"]);
     expect(latest?.cluster).toBe(true);
     expect(latest?.linkHeard).toBe(false);
     expect(map.listenerCount("idle")).toBe(1);
+  });
+
+  it("skips hidden layers and layers below their minzoom", () => {
+    const { map, query } = stubMap({
+      layers: ["clusters", "plain-nodes", "links-solid"],
+      hidden: ["clusters"],
+      minzoom: { "links-solid": 12 },
+      zoom: 10,
+      features: [
+        { layer: { id: "clusters" }, properties: { point_count: 5 } },
+        { layer: { id: "plain-nodes" }, properties: { online: true, role: 0 } },
+        { layer: { id: "links-solid" }, properties: { kind: "neighbor", snr: 3 } },
+      ],
+    });
+    mount(<Probe mapRef={{ current: map }} enabled />);
+    expect(query.mock.calls.map((c) => c[0])).toEqual(["plain-nodes"]);
+    expect(latest?.cluster).toBe(false);
+    expect(latest?.onlineNode).toBe(true);
+    expect(latest?.linkHeard).toBe(false);
   });
 
   it("waits for idle when the map is still loading, then debounces idle bursts", () => {

--- a/frontend/src/pages/map/hooks/useLegendContext.test.ts
+++ b/frontend/src/pages/map/hooks/useLegendContext.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { NodeRole } from "../../../types";
+import { EMPTY_LEGEND_CONTEXT, legendContextFromFeatures, legendContextIsEmpty } from "./useLegendContext";
+
+const feat = (layerId: string, properties: Record<string, unknown>) =>
+  ({ layer: { id: layerId } as never, properties }) as never;
+
+describe("legendContextFromFeatures", () => {
+  it("is empty for no features", () => {
+    const ctx = legendContextFromFeatures([]);
+    expect(ctx).toEqual(EMPTY_LEGEND_CONTEXT);
+    expect(legendContextIsEmpty(ctx)).toBe(true);
+  });
+
+  it("classifies nodes by online + router-family role", () => {
+    const ctx = legendContextFromFeatures([
+      feat("unclustered-nodes", { online: true, role: NodeRole.CLIENT }),
+      feat("plain-nodes", { online: true, role: NodeRole.ROUTER_LATE }),
+      feat("spiderfy-node-circles", { online: false, role: NodeRole.ROUTER }),
+    ]);
+    expect(ctx.onlineNode).toBe(true);
+    expect(ctx.onlineRouter).toBe(true);
+    expect(ctx.offlineNode).toBe(true); // offline router is gray, not blue
+    expect(ctx.cluster).toBe(false);
+    expect(legendContextIsEmpty(ctx)).toBe(false);
+  });
+
+  it("treats non-router online roles as plain online nodes", () => {
+    const ctx = legendContextFromFeatures([feat("unclustered-nodes", { online: true, role: NodeRole.REPEATER })]);
+    expect(ctx.onlineNode).toBe(true);
+    expect(ctx.onlineRouter).toBe(false);
+  });
+
+  it("flags clusters from the hit-test layer", () => {
+    const ctx = legendContextFromFeatures([feat("clusters", { point_count: 12, onlineCount: 3 })]);
+    expect(ctx.cluster).toBe(true);
+    expect(ctx.onlineNode).toBe(false);
+  });
+
+  it("splits links by kind and SNR presence; traceroute never counts toward SNR rows", () => {
+    const ctx = legendContextFromFeatures([
+      feat("links-solid", { kind: "neighbor", snr: 4.5 }),
+      feat("links-dashed", { kind: "heard_by", snr: null }),
+      feat("links-dotted", { kind: "traceroute", snr: null }),
+    ]);
+    expect(ctx.linkHeard).toBe(true);
+    expect(ctx.linkHeardBy).toBe(true);
+    expect(ctx.linkTrace).toBe(true);
+    expect(ctx.linkMutual).toBe(false);
+    expect(ctx.linkSnr).toBe(true);
+    expect(ctx.linkSnrUnknown).toBe(true);
+  });
+
+  it("only traceroute links → no SNR rows", () => {
+    const ctx = legendContextFromFeatures([feat("links-dotted", { kind: "traceroute", snr: null })]);
+    expect(ctx.linkSnrUnknown).toBe(false);
+    expect(ctx.linkSnr).toBe(false);
+    expect(ctx.linkTrace).toBe(true);
+  });
+
+  it("mutual (arc) links", () => {
+    const ctx = legendContextFromFeatures([feat("links-solid", { kind: "both", snr: -3 })]);
+    expect(ctx.linkMutual).toBe(true);
+    expect(ctx.linkHeard).toBe(false);
+    expect(ctx.linkSnr).toBe(true);
+  });
+
+  it("ignores unrelated layers", () => {
+    const ctx = legendContextFromFeatures([feat("coverage-fill", { cls: "good" }), feat("clusters-count", { point_count: 3 })]);
+    expect(legendContextIsEmpty(ctx)).toBe(true);
+  });
+});

--- a/frontend/src/pages/map/hooks/useLegendContext.ts
+++ b/frontend/src/pages/map/hooks/useLegendContext.ts
@@ -1,4 +1,4 @@
-import type { Map as MlMap, MapGeoJSONFeature, MapSourceDataEvent } from "maplibre-gl";
+import type { Map as MlMap, MapSourceDataEvent } from "maplibre-gl";
 import { useLayoutEffect, useState } from "react";
 
 import { MAP_ROUTER_COLORS } from "../../../palette";
@@ -50,11 +50,17 @@ const ALL_LAYERS = [...NODE_LAYERS, ...CLUSTER_LAYERS, ...LINK_LAYERS];
 /** Trailing debounce for `idle` bursts (hover feature-state churn re-idles the map). */
 const QUERY_DEBOUNCE_MS = 200;
 
+/** A rendered feature reduced to what the legend needs. */
+export interface LegendFeature {
+  layer?: { id: string } | null;
+  properties?: Record<string, unknown> | null;
+}
+
 /** Reduce the viewport's rendered features to legend flags. Exported for tests. */
-export function legendContextFromFeatures(features: Pick<MapGeoJSONFeature, "layer" | "properties">[]): LegendContext {
+export function legendContextFromFeatures(features: readonly LegendFeature[]): LegendContext {
   const ctx = { ...EMPTY_LEGEND_CONTEXT };
   for (const f of features) {
-    const layerId = f.layer?.id;
+    const layerId = f.layer?.id ?? "";
     const p = f.properties ?? {};
     if (CLUSTER_LAYERS.includes(layerId)) {
       ctx.cluster = true;
@@ -78,6 +84,36 @@ export function legendContextFromFeatures(features: Pick<MapGeoJSONFeature, "lay
   return ctx;
 }
 
+/**
+ * Features of every visible legend layer, from its source's loaded tiles.
+ * Source queries (not queryRenderedFeatures): the whole-viewport box breaks
+ * under 3D terrain at high pitch — sky corners have no terrain hit and the
+ * query polygon degenerates to nothing — and they skip the per-feature
+ * geometry tests. Loaded tiles ≈ the viewport plus a margin, which is what
+ * a legend should describe anyway. Returns null when no layer exists yet.
+ */
+export function collectLegendFeatures(map: MlMap): LegendFeature[] | null {
+  const zoom = map.getZoom();
+  const out: LegendFeature[] = [];
+  let anyLayer = false;
+  for (const id of ALL_LAYERS) {
+    const layer = map.getLayer(id);
+    if (!layer) continue;
+    anyLayer = true;
+    if (map.getLayoutProperty(id, "visibility") === "none") continue;
+    if (layer.minzoom != null && zoom < layer.minzoom) continue;
+    if (layer.maxzoom != null && zoom >= layer.maxzoom) continue;
+    const source = (layer as { source?: string }).source;
+    if (!source || !map.getSource(source)) continue;
+    const filter = map.getFilter(id) ?? undefined;
+    const sourceLayer = (layer as { sourceLayer?: string }).sourceLayer;
+    for (const f of map.querySourceFeatures(source, { sourceLayer, filter })) {
+      out.push({ layer: { id }, properties: f.properties });
+    }
+  }
+  return anyLayer ? out : null;
+}
+
 function sameContext(a: LegendContext | null, b: LegendContext): boolean {
   if (!a) return false;
   for (const k of Object.keys(b) as (keyof LegendContext)[]) if (a[k] !== b[k]) return false;
@@ -85,7 +121,7 @@ function sameContext(a: LegendContext | null, b: LegendContext): boolean {
 }
 
 /**
- * Query the map (on `idle`, debounced) for what is actually rendered in the
+ * Query the map (on `idle`, debounced) for what is actually drawn around the
  * viewport, so the legend can show only the rows that apply. Only runs while
  * `enabled` (legend open); `null` when disabled or before the first result.
  */
@@ -115,16 +151,15 @@ export function useLegendContext(
     const run = () => {
       timer = null;
       pending = false;
-      const layers = ALL_LAYERS.filter((id) => map.getLayer(id));
-      // No layers yet (style swap in progress) — keep what we have; the idle
-      // after the layers come back re-runs.
-      if (layers.length === 0) return;
-      let features: MapGeoJSONFeature[] = [];
+      let features: LegendFeature[] | null;
       try {
-        features = map.queryRenderedFeatures({ layers });
+        features = collectLegendFeatures(map);
       } catch {
         return;
       }
+      // No layers yet (style swap in progress) — keep what we have; the idle
+      // after the layers come back re-runs.
+      if (!features) return;
       const next = legendContextFromFeatures(features);
       setCtx((prev) => (sameContext(prev, next) ? prev : next));
     };

--- a/frontend/src/pages/map/hooks/useLegendContext.ts
+++ b/frontend/src/pages/map/hooks/useLegendContext.ts
@@ -1,0 +1,153 @@
+import type { Map as MlMap, MapGeoJSONFeature, MapSourceDataEvent } from "maplibre-gl";
+import { useLayoutEffect, useState } from "react";
+
+import { MAP_ROUTER_COLORS } from "../../../palette";
+import { SPIDERFY_LAYER_NODES } from "../layers/spiderfy";
+
+/** Which encodings are on screen right now; drives the contextual legend.
+ *  `null` until the first query resolves (legend shows every row until then). */
+export interface LegendContext {
+  onlineNode: boolean;
+  onlineRouter: boolean;
+  offlineNode: boolean;
+  cluster: boolean;
+  /** Any non-traceroute link with a known SNR (colour ramp applies). */
+  linkSnr: boolean;
+  linkSnrUnknown: boolean;
+  /** kind=neighbor — solid straight line. */
+  linkHeard: boolean;
+  /** kind=heard_by — dashed line. */
+  linkHeardBy: boolean;
+  /** kind=both — curved arc. */
+  linkMutual: boolean;
+  /** kind=traceroute — dotted amber. */
+  linkTrace: boolean;
+}
+
+export const EMPTY_LEGEND_CONTEXT: LegendContext = {
+  onlineNode: false,
+  onlineRouter: false,
+  offlineNode: false,
+  cluster: false,
+  linkSnr: false,
+  linkSnrUnknown: false,
+  linkHeard: false,
+  linkHeardBy: false,
+  linkMutual: false,
+  linkTrace: false,
+};
+
+/** True when nothing the legend describes is on screen. */
+export function legendContextIsEmpty(ctx: LegendContext): boolean {
+  return !Object.values(ctx).some(Boolean);
+}
+
+const NODE_LAYERS = ["unclustered-nodes", "plain-nodes", SPIDERFY_LAYER_NODES];
+const CLUSTER_LAYERS = ["clusters"];
+const LINK_LAYERS = ["links-solid", "links-dashed", "links-dotted"];
+const ALL_LAYERS = [...NODE_LAYERS, ...CLUSTER_LAYERS, ...LINK_LAYERS];
+
+/** Trailing debounce for `idle` bursts (hover feature-state churn re-idles the map). */
+const QUERY_DEBOUNCE_MS = 200;
+
+/** Reduce the viewport's rendered features to legend flags. Exported for tests. */
+export function legendContextFromFeatures(features: Pick<MapGeoJSONFeature, "layer" | "properties">[]): LegendContext {
+  const ctx = { ...EMPTY_LEGEND_CONTEXT };
+  for (const f of features) {
+    const layerId = f.layer?.id;
+    const p = f.properties ?? {};
+    if (CLUSTER_LAYERS.includes(layerId)) {
+      ctx.cluster = true;
+    } else if (NODE_LAYERS.includes(layerId)) {
+      if (!p.online) ctx.offlineNode = true;
+      else if (typeof p.role === "number" && MAP_ROUTER_COLORS[p.role]) ctx.onlineRouter = true;
+      else ctx.onlineNode = true;
+    } else if (LINK_LAYERS.includes(layerId)) {
+      switch (p.kind) {
+        case "traceroute": ctx.linkTrace = true; break;
+        case "heard_by": ctx.linkHeardBy = true; break;
+        case "both": ctx.linkMutual = true; break;
+        default: ctx.linkHeard = true;
+      }
+      if (p.kind !== "traceroute") {
+        if (p.snr == null) ctx.linkSnrUnknown = true;
+        else ctx.linkSnr = true;
+      }
+    }
+  }
+  return ctx;
+}
+
+function sameContext(a: LegendContext | null, b: LegendContext): boolean {
+  if (!a) return false;
+  for (const k of Object.keys(b) as (keyof LegendContext)[]) if (a[k] !== b[k]) return false;
+  return true;
+}
+
+/**
+ * Query the map (on `idle`, debounced) for what is actually rendered in the
+ * viewport, so the legend can show only the rows that apply. Only runs while
+ * `enabled` (legend open); `null` when disabled or before the first result.
+ */
+export function useLegendContext(
+  mapRef: { current: MlMap | null },
+  opts: { enabled: boolean; mapLoaded: boolean; styleEpoch: number },
+): LegendContext | null {
+  const { enabled, mapLoaded, styleEpoch } = opts;
+  const [ctx, setCtx] = useState<LegendContext | null>(null);
+
+  // Layout effect: the immediate query lands before the legend's first paint,
+  // so an already-idle map never flashes the full legend.
+  useLayoutEffect(() => {
+    const map = mapRef.current;
+    if (!enabled || !map) {
+      setCtx(null);
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    // 'idle' also follows hover-only repaints (feature-state / paint swaps);
+    // only re-query after a move or a source reload — visibility and filter
+    // changes reload their source, so they arrive as loaded sourcedata too.
+    let pending = true;
+    const arm = () => { pending = true; };
+    const armOnLoaded = (e: MapSourceDataEvent) => { if (e.isSourceLoaded) pending = true; };
+
+    const run = () => {
+      timer = null;
+      pending = false;
+      const layers = ALL_LAYERS.filter((id) => map.getLayer(id));
+      // No layers yet (style swap in progress) — keep what we have; the idle
+      // after the layers come back re-runs.
+      if (layers.length === 0) return;
+      let features: MapGeoJSONFeature[] = [];
+      try {
+        features = map.queryRenderedFeatures({ layers });
+      } catch {
+        return;
+      }
+      const next = legendContextFromFeatures(features);
+      setCtx((prev) => (sameContext(prev, next) ? prev : next));
+    };
+    const schedule = () => {
+      if (!pending) return;
+      if (timer != null) clearTimeout(timer);
+      timer = setTimeout(run, QUERY_DEBOUNCE_MS);
+    };
+
+    map.on("moveend", arm);
+    map.on("sourcedata", armOnLoaded);
+    map.on("idle", schedule);
+    // Already idle → no idle event is coming; query now.
+    if (map.loaded()) run();
+
+    return () => {
+      map.off("moveend", arm);
+      map.off("sourcedata", armOnLoaded);
+      map.off("idle", schedule);
+      if (timer != null) clearTimeout(timer);
+    };
+    // mapLoaded: map instance appears after mount; styleEpoch: layers re-added
+  }, [mapRef, enabled, mapLoaded, styleEpoch]);
+
+  return ctx;
+}

--- a/frontend/src/pages/map/layers/clusterDisplay.test.ts
+++ b/frontend/src/pages/map/layers/clusterDisplay.test.ts
@@ -97,6 +97,22 @@ describe("mergeOverlappingClusters", () => {
     expect(mergeOverlappingClusters(same, 6)).toHaveLength(1);
   });
 
+  it("with a screen projection (pitched view), overlap is judged in screen px", () => {
+    // 200 map-px apart at z6 → no merge un-pitched…
+    const src = pair(200, 6, 246, 211);
+    expect(mergeOverlappingClusters(src, 6)).toHaveLength(2);
+    // …but a far-field view compresses them to 60 screen px → merge; the
+    // marker still sits at the geographic (Mercator) centroid.
+    const squash = (lng: number, lat: number) => ({ x: (lng + 118) * pxPerDegLng(6) * 0.3, y: lat });
+    const out = mergeOverlappingClusters(src, 6, { project: squash });
+    expect(out).toHaveLength(1);
+    expect(out[0].lng).toBeGreaterThan(-118);
+    expect(out[0].lng).toBeLessThan(-118 + 200 / pxPerDegLng(6));
+    // items the projection cannot place (behind the camera) never merge
+    const offscreen = (lng: number) => (lng === -118 ? null : { x: 0, y: 0 });
+    expect(mergeOverlappingClusters(pair(30, 6, 246, 211), 6, { project: (lng) => offscreen(lng) })).toHaveLength(2);
+  });
+
   it("is deterministic regardless of input order", () => {
     const src = pair(30, 6, 246, 211);
     const a = mergeOverlappingClusters(src, 6);

--- a/frontend/src/pages/map/layers/clusterDisplay.test.ts
+++ b/frontend/src/pages/map/layers/clusterDisplay.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  abbreviateCount,
+  displayFeatureCollection,
+  dropDominatedByFinerTiles,
+  mergeOverlappingClusters,
+  parseClusterMembers,
+  pixelRadiusForCount,
+  type SourceCluster,
+  zoomDeltaToSeparate,
+} from "./clusterDisplay";
+
+// px per degree of longitude at zoom z (512 px tiles)
+const pxPerDegLng = (z: number) => (512 * Math.pow(2, z)) / 360;
+
+function pair(sepPx: number, zoom: number, countA: number, countB: number, lat = 34): SourceCluster[] {
+  const dLng = sepPx / pxPerDegLng(zoom);
+  return [
+    { lng: -118, lat, count: countA, online: countA, clusterId: 1 },
+    { lng: -118 + dLng, lat, count: countB, online: 0, clusterId: 2 },
+  ];
+}
+
+describe("mergeOverlappingClusters", () => {
+  it("leaves well-separated clusters alone", () => {
+    const out = mergeOverlappingClusters(pair(200, 6, 246, 211), 6);
+    expect(out).toHaveLength(2);
+    expect(out.map((c) => c.members)).toEqual([[1], [2]]);
+    expect(out.map((c) => c.count).sort()).toEqual([211, 246]);
+  });
+
+  it("merges two big clusters whose donuts overlap (issue #567, LA at z6: 30 px apart)", () => {
+    const out = mergeOverlappingClusters(pair(30, 6, 246, 211), 6);
+    expect(out).toHaveLength(1);
+    const m = out[0];
+    expect(m.count).toBe(457);
+    expect(m.online).toBe(246);
+    expect(m.members.sort()).toEqual([1, 2]);
+    expect(m.r).toBe(pixelRadiusForCount(457));
+    // count-weighted centroid sits between the two, nearer the bigger one
+    expect(m.lng).toBeGreaterThan(-118);
+    expect(m.lng).toBeLessThan(-118 + 30 / pxPerDegLng(6) / 2);
+    expect(m.lat).toBeCloseTo(34, 3);
+  });
+
+  it("merges when the gap is smaller than the pad, not when it clears it", () => {
+    const need = pixelRadiusForCount(370) + pixelRadiusForCount(32); // 52 + ~34
+    expect(mergeOverlappingClusters(pair(need + 1, 8, 370, 32), 8)).toHaveLength(1); // inside 2 px pad
+    expect(mergeOverlappingClusters(pair(need + 3, 8, 370, 32), 8)).toHaveLength(2);
+  });
+
+  it("the same pair separates again at a higher zoom, and reports that zoom", () => {
+    const src = pair(80, 6, 246, 211); // need 106 px → separates 0.41 zoom levels in
+    const [m] = mergeOverlappingClusters(src, 6);
+    const dz = zoomDeltaToSeparate(80, 52 + 52 + 2);
+    expect(dz).toBeLessThan(1);
+    expect(m.splitZoom).toBeCloseTo(6 + dz, 2);
+    expect(mergeOverlappingClusters(src, 6 + dz + 0.05)).toHaveLength(2);
+    expect(mergeOverlappingClusters(src, 6 + dz - 0.05)).toHaveLength(1);
+  });
+
+  it("caps splitZoom at the next integer zoom (source clusters change there anyway)", () => {
+    const [m] = mergeOverlappingClusters(pair(5, 6.4, 246, 211), 6.4);
+    expect(m.splitZoom).toBe(7);
+  });
+
+  it("merge:false keeps every cluster (past clusterMaxZoom)", () => {
+    const out = mergeOverlappingClusters(pair(5, 21.5, 40, 40), 21.5, { merge: false });
+    expect(out).toHaveLength(2);
+    expect(out.every((c) => c.splitZoom === undefined)).toBe(true);
+  });
+
+  it("chains: a merged marker that grows absorbs a third neighbour", () => {
+    // A(100) and B(100) overlap; C(20) is just outside A but inside the merged marker.
+    const z = 7;
+    const rA = pixelRadiusForCount(100), rC = pixelRadiusForCount(20);
+    const sepAB = 40;
+    const sepAC = rA + rC + 4; // clear of A alone by 2 px beyond the pad
+    const src: SourceCluster[] = [
+      { lng: -118, lat: 34, count: 100, online: 50, clusterId: 1 },
+      { lng: -118 + sepAB / pxPerDegLng(z), lat: 34, count: 100, online: 50, clusterId: 2 },
+      { lng: -118 - sepAC / pxPerDegLng(z), lat: 34, count: 20, online: 5, clusterId: 3 },
+    ];
+    const out = mergeOverlappingClusters(src, z);
+    // AB merge → r=52 and centroid moves toward B, so C stays separate; verify
+    // the fixpoint loop ran without double-counting either way.
+    const total = out.reduce((s, c) => s + c.count, 0);
+    expect(total).toBe(220);
+    expect(out.flatMap((c) => c.members).sort()).toEqual([1, 2, 3]);
+  });
+
+  it("never merges clusters from different tile zooms (parent would double-count its children)", () => {
+    const src = pair(30, 6, 246, 211).map((c, i) => ({ ...c, z: 6 + i }));
+    expect(mergeOverlappingClusters(src, 6)).toHaveLength(2);
+    const same = pair(30, 6, 246, 211).map((c) => ({ ...c, z: 6 }));
+    expect(mergeOverlappingClusters(same, 6)).toHaveLength(1);
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const src = pair(30, 6, 246, 211);
+    const a = mergeOverlappingClusters(src, 6);
+    const b = mergeOverlappingClusters([...src].reverse(), 6);
+    expect(a).toEqual(b);
+  });
+
+  it("empty input → empty output", () => {
+    expect(mergeOverlappingClusters([], 5)).toEqual([]);
+  });
+});
+
+describe("abbreviateCount", () => {
+  it("matches supercluster's point_count_abbreviated", () => {
+    expect(abbreviateCount(457)).toBe("457");
+    expect(abbreviateCount(1234)).toBe("1.2k");
+    expect(abbreviateCount(12345)).toBe("12k");
+  });
+});
+
+describe("displayFeatureCollection / parseClusterMembers", () => {
+  it("unmerged markers keep their source cluster_id and feature id; merged get a negative id + members", () => {
+    const display = mergeOverlappingClusters(
+      [...pair(30, 6, 246, 211), { lng: -100, lat: 40, count: 9, online: 4, clusterId: 77 }],
+      6,
+    );
+    const fc = displayFeatureCollection(display);
+    expect(fc.features).toHaveLength(2);
+    const merged = fc.features.find((f) => f.properties!.merged)!;
+    const single = fc.features.find((f) => !f.properties!.merged)!;
+
+    expect(single.id).toBe(77);
+    expect(single.properties).toMatchObject({ cluster: true, cluster_id: 77, point_count: 9, onlineCount: 4, point_count_abbreviated: "9" });
+    expect(parseClusterMembers(single.properties)).toEqual([]);
+
+    expect(merged.id).toBeUndefined();
+    expect(merged.properties!.cluster_id).toBe(-1);
+    expect(merged.properties).toMatchObject({ point_count: 457, onlineCount: 246, point_count_abbreviated: "457" });
+    expect(typeof merged.properties!.members).toBe("string"); // survives the tile pbf as a string
+    expect(parseClusterMembers(merged.properties).sort()).toEqual([1, 2]);
+    expect(merged.properties!.split_zoom).toBeGreaterThan(6);
+  });
+
+  it("parseClusterMembers tolerates junk", () => {
+    expect(parseClusterMembers(null)).toEqual([]);
+    expect(parseClusterMembers({ members: "not json" })).toEqual([]);
+    expect(parseClusterMembers({ members: "[1,\"x\",3]" })).toEqual([1, 3]);
+    expect(parseClusterMembers({ members: [4, 5] })).toEqual([4, 5]);
+  });
+});
+
+describe("dropDominatedByFinerTiles", () => {
+  // Web-Mercator tile containing a point at zoom z (matches the helper's projection)
+  const tileAt = (lng: number, lat: number, z: number) => {
+    const n = 2 ** z;
+    const x = Math.floor((lng / 360 + 0.5) * n);
+    const sin = Math.sin((lat * Math.PI) / 180);
+    const y = Math.floor((0.5 - (0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI) * n);
+    return { x, y };
+  };
+
+  it("keeps everything when only one zoom is present", () => {
+    const items = [
+      { z: 6, ...tileAt(-118, 34, 6), lng: -118, lat: 34, id: "a" },
+      { z: 6, ...tileAt(-122, 37, 6), lng: -122, lat: 37, id: "b" },
+    ];
+    expect(dropDominatedByFinerTiles(items).map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  it("drops a parent-tile feature where a child tile is present, keeps it elsewhere", () => {
+    const f = (z: number, lng: number, lat: number, id: string) => ({ z, ...tileAt(lng, lat, z), lng, lat, id });
+    const la7 = f(7, -118.25, 34.05, "child-LA");
+    const la6 = f(6, -118.26, 34.06, "parent-LA"); // same z7 tile as the child
+    expect(tileAt(la6.lng, la6.lat, 7)).toEqual({ x: la7.x, y: la7.y });
+    const sd6 = f(6, -117.1, 32.7, "parent-SD"); // no z7 tile present here
+    expect(tileAt(sd6.lng, sd6.lat, 7)).not.toEqual({ x: la7.x, y: la7.y });
+    const out = dropDominatedByFinerTiles([la6, la7, sd6]).map((i) => i.id);
+    expect(out).toContain("child-LA");
+    expect(out).not.toContain("parent-LA");
+    expect(out).toContain("parent-SD");
+  });
+
+  it("with mixed zooms, buffer copies (features outside their own tile) are dropped", () => {
+    const child = { z: 7, ...tileAt(-118.2, 34.0, 7), lng: -118.2, lat: 34.0, id: "child" };
+    // z6 copy that a neighbouring tile's buffer returned (tile x/y unrelated to the point)
+    const parentBufferCopy = { z: 6, x: 0, y: 0, lng: -118.2, lat: 34.0, id: "parent-copy" };
+    // z7 buffer copy of a cluster that actually lies in a region only a z6 tile covers
+    const fineBufferCopy = { z: 7, ...tileAt(-118.2, 34.0, 7), lng: -117.0, lat: 32.7, id: "fine-buffer" };
+    const coarseThere = { z: 6, ...tileAt(-117.0, 32.7, 6), lng: -117.05, lat: 32.72, id: "coarse-there" };
+    const out = dropDominatedByFinerTiles([child, parentBufferCopy, fineBufferCopy, coarseThere]).map((i) => i.id);
+    expect(out).toEqual(["child", "coarse-there"]);
+  });
+
+  it("with a single zoom, buffer copies are kept (position dedupe handles them)", () => {
+    const a = { z: 7, ...tileAt(-118.2, 34.0, 7), lng: -118.2, lat: 34.0, id: "a" };
+    const aBuffer = { z: 7, x: 0, y: 0, lng: -118.2, lat: 34.0, id: "a-buffer" };
+    expect(dropDominatedByFinerTiles([a, aBuffer]).map((i) => i.id)).toEqual(["a", "a-buffer"]);
+  });
+});

--- a/frontend/src/pages/map/layers/clusterDisplay.ts
+++ b/frontend/src/pages/map/layers/clusterDisplay.ts
@@ -1,0 +1,234 @@
+/**
+ * Display-space cluster merging (#567).
+ *
+ * MapLibre's clustering (supercluster) guarantees nothing about the distance
+ * between cluster *centroids*: greedy per-zoom merging lets two centroids end up
+ * far closer than `clusterRadius`, and even well-spaced ones sit closer than
+ * two large donuts (up to 52 px each) need. So the donuts/count labels/hit
+ * circles are driven from this "display set": source clusters whose donuts
+ * would overlap on screen at the current zoom are merged into one marker
+ * (count-weighted centroid, summed counts, member ids kept for click/hover).
+ * Zooming in separates them again — the merge is a pure function of the
+ * viewport's cluster set and scale.
+ */
+// Matches the "clusters" circle hit-test layer radius curve. Spiderfy legs
+// start at this edge; the donut shader sizes quads from it.
+export function pixelRadiusForCount(count: number): number {
+  const c = Math.max(count, 2);
+  if (c <= 10)  return 16 + (22 - 16) * ((c - 2)   / (10 - 2));
+  if (c <= 25)  return 22 + (30 - 22) * ((c - 10)  / (25 - 10));
+  if (c <= 100) return 30 + (44 - 30) * ((c - 25)  / (100 - 25));
+  if (c <= 200) return 44 + (52 - 44) * ((c - 100) / (200 - 100));
+  return 52;
+}
+
+export interface SourceCluster {
+  lng: number;
+  lat: number;
+  count: number;
+  online: number;
+  clusterId: number;
+  /** Tile zoom the cluster came from; clusters from different zooms never merge
+   *  (a parent and its own children would double-count). */
+  z?: number;
+}
+
+export interface DisplayCluster {
+  lng: number;
+  lat: number;
+  count: number;
+  online: number;
+  /** Donut radius (CSS px) for `count`. */
+  r: number;
+  /** Source cluster_ids folded into this marker (1 = plain, unmerged). */
+  members: number[];
+  /** Position key (rounded lng/lat) — matches the donut tween/dedupe key. */
+  key: string;
+  /** Merged only: zoom at which the members stop overlapping (≤ next integer zoom). */
+  splitZoom?: number;
+}
+
+/** Derived GeoJSON source holding the display set (drives "clusters" + "clusters-count"). */
+export const CLUSTER_DISPLAY_SOURCE = "clusters_display";
+/** nodes_clustered `clusterMaxZoom` — at/after it clusters are stacked nodes (spiderfy territory). */
+export const CLUSTER_MAX_ZOOM = 21;
+
+/** Minimum gap between two rings after merging (CSS px). */
+export const DISPLAY_MERGE_PAD_PX = 2;
+
+const TILE = 512;
+
+// Web Mercator (0..1 world) — same projection as supercluster's centroids.
+function projX(lng: number): number { return lng / 360 + 0.5; }
+function projY(lat: number): number {
+  const sin = Math.sin((lat * Math.PI) / 180);
+  const y = 0.5 - (0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI;
+  return y < 0 ? 0 : y > 1 ? 1 : y;
+}
+function unprojX(x: number): number { return (x - 0.5) * 360; }
+function unprojY(y: number): number {
+  const y2 = ((180 - y * 360) * Math.PI) / 180;
+  return (360 * Math.atan(Math.exp(y2))) / Math.PI - 90;
+}
+
+/**
+ * querySourceFeatures can return the same area at two tile zooms (a parent
+ * kept as a substitute while children load; variable-zoom LOD with 3D terrain
+ * on). Merging those would fold a parent cluster into its own children, so
+ * drop every feature from a lower-zoom tile wherever a higher-zoom tile is
+ * present at that point — each region then comes from one zoom.
+ */
+export function dropDominatedByFinerTiles<T extends { z: number; x: number; y: number; lng: number; lat: number }>(items: readonly T[]): T[] {
+  const present = new Set<string>();
+  const zooms = new Set<number>();
+  for (const it of items) {
+    present.add(`${it.z}/${it.x}/${it.y}`);
+    zooms.add(it.z);
+  }
+  if (zooms.size <= 1) return items.slice();
+  const finer = [...zooms].sort((a, b) => a - b);
+  return items.filter((it) => {
+    const px = projX(it.lng), py = projY(it.lat);
+    // Buffer copies (a tile also carries clusters just outside its bounds)
+    // could smuggle a fine-zoom cluster into a region drawn from a coarser
+    // tile and get merged with the parent covering the same nodes — with
+    // mixed zooms, only trust features inside their own tile.
+    const nOwn = Math.pow(2, it.z);
+    if (Math.floor(px * nOwn) !== it.x || Math.floor(py * nOwn) !== it.y) return false;
+    for (const z of finer) {
+      if (z <= it.z) continue;
+      const n = Math.pow(2, z);
+      if (present.has(`${z}/${Math.floor(px * n)}/${Math.floor(py * n)}`)) return false;
+    }
+    return true;
+  });
+}
+
+export function displayClusterKey(lng: number, lat: number): string {
+  return `${Math.round(lng * 1e5)},${Math.round(lat * 1e5)}`;
+}
+
+/** Zoom delta needed so two markers `sepPx` apart (at the current zoom) clear each other. */
+export function zoomDeltaToSeparate(sepPx: number, needPx: number): number {
+  if (sepPx <= 0) return Infinity;
+  return Math.max(0, Math.log2(needPx / sepPx));
+}
+
+/**
+ * Merge clusters whose donuts overlap on screen at `zoom`. Deterministic:
+ * bigger clusters absorb smaller ones; passes repeat until stable (a merged
+ * marker grows and may newly overlap a neighbour).
+ */
+export function mergeOverlappingClusters(
+  input: readonly SourceCluster[],
+  zoom: number,
+  opts: { radiusFor?: (count: number) => number; padPx?: number; merge?: boolean } = {},
+): DisplayCluster[] {
+  const radiusFor = opts.radiusFor ?? pixelRadiusForCount;
+  const pad = opts.padPx ?? DISPLAY_MERGE_PAD_PX;
+  const doMerge = opts.merge ?? true;
+  const scale = TILE * Math.pow(2, zoom);
+  // A merge that needs more than the next integer zoom is moot — the tile
+  // zoom changes there and the source clusters are re-derived.
+  const zoomCap = Math.floor(zoom) + 1;
+
+  type Work = { x: number; y: number; count: number; online: number; r: number; members: number[]; splitZoom: number; z: number | undefined };
+  const items: Work[] = input.map((c) => ({
+    x: projX(c.lng) * scale,
+    y: projY(c.lat) * scale,
+    count: c.count,
+    online: c.online,
+    r: radiusFor(c.count),
+    members: [c.clusterId],
+    splitZoom: zoom,
+    z: c.z,
+  }));
+  // Stable order: count desc, then position — the same input always merges the same way.
+  items.sort((a, b) => b.count - a.count || a.x - b.x || a.y - b.y);
+
+  let merged = doMerge;
+  while (merged) {
+    merged = false;
+    for (let i = 0; i < items.length; i++) {
+      const a = items[i];
+      for (let j = i + 1; j < items.length; j++) {
+        const b = items[j];
+        if (a.z !== b.z) continue;
+        const need = a.r + b.r + pad;
+        const dx = a.x - b.x, dy = a.y - b.y;
+        const d2 = dx * dx + dy * dy;
+        if (d2 >= need * need) continue;
+        const total = a.count + b.count;
+        const split = zoom + zoomDeltaToSeparate(Math.sqrt(d2), need);
+        a.splitZoom = Math.min(zoomCap, Math.max(a.splitZoom, b.splitZoom, split));
+        a.x = (a.x * a.count + b.x * b.count) / total;
+        a.y = (a.y * a.count + b.y * b.count) / total;
+        a.count = total;
+        a.online += b.online;
+        a.r = radiusFor(total);
+        a.members.push(...b.members);
+        items.splice(j, 1);
+        j--;
+        merged = true;
+      }
+    }
+  }
+
+  return items.map((w) => {
+    const lng = unprojX(w.x / scale);
+    const lat = unprojY(w.y / scale);
+    const out: DisplayCluster = { lng, lat, count: w.count, online: w.online, r: w.r, members: w.members, key: displayClusterKey(lng, lat) };
+    if (w.members.length > 1) out.splitZoom = w.splitZoom;
+    return out;
+  });
+}
+
+/** Same abbreviation supercluster uses for `point_count_abbreviated`. */
+export function abbreviateCount(count: number): string {
+  return count >= 10000 ? `${Math.round(count / 1000)}k`
+    : count >= 1000 ? `${Math.round(count / 100) / 10}k`
+      : String(count);
+}
+
+/** Member source cluster_ids of a display feature (`members` JSON); [] when unmerged/absent. */
+export function parseClusterMembers(properties: Record<string, unknown> | null | undefined): number[] {
+  const raw = properties?.members;
+  if (Array.isArray(raw)) return raw.filter((v): v is number => typeof v === "number");
+  if (typeof raw !== "string" || !raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((v): v is number => typeof v === "number") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Display-set → GeoJSON for the "clusters" hit layer and "clusters-count"
+ * labels. Unmerged markers keep their source `cluster_id`; merged ones get a
+ * negative `cluster_id` (never collides with supercluster ids) plus `members`.
+ * Feature `id` is set only for unmerged markers: ids travel through the tile
+ * pbf as unsigned varints, so a negative one would not round-trip.
+ */
+export function displayFeatureCollection(display: readonly DisplayCluster[]): GeoJSON.FeatureCollection<GeoJSON.Point> {
+  return {
+    type: "FeatureCollection",
+    features: display.map((d) => {
+      const merged = d.members.length > 1;
+      const clusterId = merged ? -Math.min(...d.members) : d.members[0];
+      return {
+        type: "Feature",
+        ...(merged ? {} : { id: clusterId }),
+        geometry: { type: "Point", coordinates: [d.lng, d.lat] },
+        properties: {
+          cluster: true,
+          cluster_id: clusterId,
+          point_count: d.count,
+          point_count_abbreviated: abbreviateCount(d.count),
+          onlineCount: d.online,
+          ...(merged ? { merged: true, members: JSON.stringify(d.members), split_zoom: d.splitZoom } : {}),
+        },
+      };
+    }),
+  };
+}

--- a/frontend/src/pages/map/layers/clusterDisplay.ts
+++ b/frontend/src/pages/map/layers/clusterDisplay.ts
@@ -114,35 +114,62 @@ export function zoomDeltaToSeparate(sepPx: number, needPx: number): number {
   return Math.max(0, Math.log2(needPx / sepPx));
 }
 
+/** Screen projection for pitched views: lng/lat → CSS px, or null when the
+ *  point isn't meaningfully on screen (behind the camera, off the horizon). */
+export type ScreenProject = (lng: number, lat: number) => { x: number; y: number } | null;
+
+// Beyond this the point is behind the camera / past the horizon — maplibre
+// returns absurd coordinates rather than null.
+const SCREEN_SANE_PX = 1e5;
+
 /**
  * Merge clusters whose donuts overlap on screen at `zoom`. Deterministic:
  * bigger clusters absorb smaller ones; passes repeat until stable (a merged
  * marker grows and may newly overlap a neighbour).
+ *
+ * Distances are un-pitched map px unless `project` is given (pitched views):
+ * then overlap is tested in real screen px while the merged marker's position
+ * stays the count-weighted geographic centroid.
  */
 export function mergeOverlappingClusters(
   input: readonly SourceCluster[],
   zoom: number,
-  opts: { radiusFor?: (count: number) => number; padPx?: number; merge?: boolean } = {},
+  opts: { radiusFor?: (count: number) => number; padPx?: number; merge?: boolean; project?: ScreenProject } = {},
 ): DisplayCluster[] {
   const radiusFor = opts.radiusFor ?? pixelRadiusForCount;
   const pad = opts.padPx ?? DISPLAY_MERGE_PAD_PX;
   const doMerge = opts.merge ?? true;
+  const project = opts.project;
   const scale = TILE * Math.pow(2, zoom);
   // A merge that needs more than the next integer zoom is moot — the tile
   // zoom changes there and the source clusters are re-derived.
   const zoomCap = Math.floor(zoom) + 1;
 
-  type Work = { x: number; y: number; count: number; online: number; r: number; members: number[]; splitZoom: number; z: number | undefined };
-  const items: Work[] = input.map((c) => ({
-    x: projX(c.lng) * scale,
-    y: projY(c.lat) * scale,
-    count: c.count,
-    online: c.online,
-    r: radiusFor(c.count),
-    members: [c.clusterId],
-    splitZoom: zoom,
-    z: c.z,
-  }));
+  type Work = {
+    x: number; y: number;              // Mercator px (output centroid)
+    sx: number | null; sy: number | null; // screen px when `project` is used (overlap test)
+    count: number; online: number; r: number; members: number[]; splitZoom: number; z: number | undefined;
+  };
+  const items: Work[] = input.map((c) => {
+    let sx: number | null = null, sy: number | null = null;
+    if (project) {
+      const s = project(c.lng, c.lat);
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Math.abs(s.x) < SCREEN_SANE_PX && Math.abs(s.y) < SCREEN_SANE_PX) {
+        sx = s.x; sy = s.y;
+      }
+    }
+    return {
+      x: projX(c.lng) * scale,
+      y: projY(c.lat) * scale,
+      sx, sy,
+      count: c.count,
+      online: c.online,
+      r: radiusFor(c.count),
+      members: [c.clusterId],
+      splitZoom: zoom,
+      z: c.z,
+    };
+  });
   // Stable order: count desc, then position — the same input always merges the same way.
   items.sort((a, b) => b.count - a.count || a.x - b.x || a.y - b.y);
 
@@ -155,7 +182,14 @@ export function mergeOverlappingClusters(
         const b = items[j];
         if (a.z !== b.z) continue;
         const need = a.r + b.r + pad;
-        const dx = a.x - b.x, dy = a.y - b.y;
+        let dx: number, dy: number;
+        if (project) {
+          // Off-screen / behind-camera items never merge.
+          if (a.sx == null || b.sx == null) continue;
+          dx = a.sx - b.sx; dy = (a.sy as number) - (b.sy as number);
+        } else {
+          dx = a.x - b.x; dy = a.y - b.y;
+        }
         const d2 = dx * dx + dy * dy;
         if (d2 >= need * need) continue;
         const total = a.count + b.count;
@@ -163,6 +197,10 @@ export function mergeOverlappingClusters(
         a.splitZoom = Math.min(zoomCap, Math.max(a.splitZoom, b.splitZoom, split));
         a.x = (a.x * a.count + b.x * b.count) / total;
         a.y = (a.y * a.count + b.y * b.count) / total;
+        if (a.sx != null && b.sx != null) {
+          a.sx = (a.sx * a.count + b.sx * b.count) / total;
+          a.sy = ((a.sy as number) * a.count + (b.sy as number) * b.count) / total;
+        }
         a.count = total;
         a.online += b.online;
         a.r = radiusFor(total);

--- a/frontend/src/pages/map/layers/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/layers/clusterDonutLayer.ts
@@ -347,9 +347,14 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     }
 
     // Overlapping donuts collapse into one marker (#567). Past clusterMaxZoom
-    // clusters are physically stacked nodes — leave those to spiderfy.
+    // clusters are physically stacked nodes — leave those to spiderfy. Pitched:
+    // rings are screen-space billboards, so test overlap in screen px
+    // (map.project is CPU-only, terrain-aware — safe inside render()).
     const zoom = map.getZoom();
-    const display = mergeOverlappingClusters(src, zoom, { merge: zoom < CLUSTER_MAX_ZOOM });
+    const project = map.getPitch() > 0
+      ? (lng: number, lat: number) => { const p = map.project([lng, lat]); return { x: p.x, y: p.y }; }
+      : undefined;
+    const display = mergeOverlappingClusters(src, zoom, { merge: zoom < CLUSTER_MAX_ZOOM, project });
     const next: Donut[] = display.map((d) => ({ ...d, ratio: d.count > 0 ? d.online / d.count : 0 }));
 
     this.pushDisplaySource(next);

--- a/frontend/src/pages/map/layers/clusterDonutLayer.ts
+++ b/frontend/src/pages/map/layers/clusterDonutLayer.ts
@@ -2,13 +2,33 @@
  * WebGL custom layer: billboarded proportional donut markers for clusters.
  * Buffer rebuilds on debounced moveend and on loaded sourcedata; pixel→NDC
  * sizing happens in the shader.
- * Hit-testing is handled by the companion "clusters" circle layer.
+ *
+ * Owns the cluster "display set": source clusters (nodes_clustered) whose
+ * donuts would overlap on screen are merged (see clusterDisplay.ts) and the
+ * result is pushed to the `clusters_display` GeoJSON source that drives the
+ * companion "clusters" hit-test circles and "clusters-count" labels — rings,
+ * labels and hit areas share one display set (labels/hits trail the rings by
+ * the source's worker round-trip).
  */
 import * as maplibregl from "maplibre-gl";
 import { type CustomRenderMethodInput } from "maplibre-gl";
 
 import { MAP_STYLE_IDS } from "../../../maps/mapStyle";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
+import {
+  CLUSTER_DISPLAY_SOURCE,
+  CLUSTER_MAX_ZOOM,
+  type DisplayCluster,
+  displayFeatureCollection,
+  dropDominatedByFinerTiles,
+  mergeOverlappingClusters,
+  pixelRadiusForCount,
+  type SourceCluster,
+} from "./clusterDisplay";
+
+export { pixelRadiusForCount };
+
+type Donut = DisplayCluster & { ratio: number };
 
 const VS = `
 attribute vec3 a_pos;          // Mercator xyz (z = altitude → terrain-aware)
@@ -111,17 +131,6 @@ function compile(gl: WebGLRenderingContext, type: number, src: string): WebGLSha
   return s;
 }
 
-// Matches the "clusters" circle hit-test layer radius curve.
-// Exported so spiderfy legs can start at the donut edge.
-export function pixelRadiusForCount(count: number): number {
-  const c = Math.max(count, 2);
-  if (c <= 10)  return 16 + (22 - 16) * ((c - 2)   / (10 - 2));
-  if (c <= 25)  return 22 + (30 - 22) * ((c - 10)  / (25 - 10));
-  if (c <= 100) return 30 + (44 - 30) * ((c - 25)  / (100 - 25));
-  if (c <= 200) return 44 + (52 - 44) * ((c - 100) / (200 - 100));
-  return 52;
-}
-
 export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
   readonly id = "clusters-donuts";
   readonly type = "custom" as const;
@@ -146,7 +155,11 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
   private dirty = true;
   /** Cache of the last queryRenderedFeatures pass — render() rebuilds the GPU
    *  buffer from this each frame with fresh terrain z when terrain is on. */
-  private lastClusters: { lng: number; lat: number; r: number; ratio: number; key: string }[] = [];
+  private lastClusters: Donut[] = [];
+  /** Signature of the display set last pushed to `clusters_display` (skip no-op setData). */
+  private lastDisplaySig = "";
+  /** Source the signature belongs to — a recreated source (style swap) starts empty. */
+  private lastDisplaySource: maplibregl.GeoJSONSource | null = null;
 
   /** Per-cluster ratio tween (keyed by rounded position, like the dedupe). */
   private anim = new Map<string, { from: number; to: number; start: number }>();
@@ -245,6 +258,9 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
     this.onSourceData = null;
     this.anim.clear();
     this.vertScratch = null;
+    this.lastClusters = [];
+    this.lastDisplaySig = "";
+    this.lastDisplaySource = null;
   }
 
   /** Layer-wide opacity multiplier (0..1). Used to dim donuts when an RF tool is active. */
@@ -300,32 +316,65 @@ export class ClusterDonutLayer implements maplibregl.CustomLayerInterface {
       return;
     }
 
-    // Dedupe by position — cluster_ids can flip across setData calls, and
-    // querySourceFeatures duplicates features that straddle tile borders
-    const seen = new Set<string>();
-    const next: { lng: number; lat: number; r: number; ratio: number; key: string }[] = [];
-
+    // Tile of origin comes along as _z/_x/_y — needed to keep one zoom per
+    // region when parent and child tiles are both queryable.
+    const tiled: (SourceCluster & { z: number; x: number; y: number })[] = [];
     for (const f of features) {
       const coords = (f.geometry as any)?.coordinates;
       if (!Array.isArray(coords) || coords.length < 2) continue;
       const lng = coords[0] as number;
       const lat = coords[1] as number;
       if (!Number.isFinite(lng) || !Number.isFinite(lat)) continue;
-
-      const key = `${Math.round(lng * 1e5)},${Math.round(lat * 1e5)}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-
-      const count = (f.properties?.point_count as number) ?? 0;
-      const online = (f.properties?.onlineCount as number) ?? 0;
-      const ratio = count > 0 ? online / count : 0;
-
-      next.push({ lng, lat, r: pixelRadiusForCount(count), ratio, key });
+      const clusterId = f.properties?.cluster_id as number | undefined;
+      if (clusterId == null) continue;
+      tiled.push({
+        lng, lat, clusterId,
+        count: (f.properties?.point_count as number) ?? 0,
+        online: (f.properties?.onlineCount as number) ?? 0,
+        z: f._z ?? 0, x: f._x ?? 0, y: f._y ?? 0,
+      });
     }
 
+    // Dedupe by position — cluster_ids can flip across setData calls, and
+    // querySourceFeatures duplicates features that straddle tile borders
+    const seen = new Set<string>();
+    const src: SourceCluster[] = [];
+    for (const c of dropDominatedByFinerTiles(tiled)) {
+      const key = `${Math.round(c.lng * 1e5)},${Math.round(c.lat * 1e5)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      src.push({ lng: c.lng, lat: c.lat, count: c.count, online: c.online, clusterId: c.clusterId, z: c.z });
+    }
+
+    // Overlapping donuts collapse into one marker (#567). Past clusterMaxZoom
+    // clusters are physically stacked nodes — leave those to spiderfy.
+    const zoom = map.getZoom();
+    const display = mergeOverlappingClusters(src, zoom, { merge: zoom < CLUSTER_MAX_ZOOM });
+    const next: Donut[] = display.map((d) => ({ ...d, ratio: d.count > 0 ? d.online / d.count : 0 }));
+
+    this.pushDisplaySource(next);
     this.reconcileTweens(next);
     this.lastClusters = next;
     this.uploadVerts();
+  }
+
+  /** Mirror the display set into `clusters_display` for the native hit/label layers. */
+  private pushDisplaySource(display: Donut[]): void {
+    const map = this.map;
+    const source = map?.getSource(CLUSTER_DISPLAY_SOURCE) as maplibregl.GeoJSONSource | undefined;
+    if (!source) return;
+    if (source !== this.lastDisplaySource) {
+      this.lastDisplaySource = source;
+      this.lastDisplaySig = "";
+    }
+    // Member ids are part of the signature: supercluster reassigns cluster_ids
+    // on every setData, and stale ids would break click/hover lookups.
+    const sig = display
+      .map((d) => `${d.key}:${d.count}:${d.online}:${d.members.join(",")}:${d.splitZoom?.toFixed(2) ?? ""}`)
+      .join("|");
+    if (sig === this.lastDisplaySig) return;
+    this.lastDisplaySig = sig;
+    source.setData(displayFeatureCollection(display));
   }
 
   /** Start a tween for each cluster whose ratio target changed; prune the rest. */

--- a/frontend/src/pages/map/layers/mapLayers.ts
+++ b/frontend/src/pages/map/layers/mapLayers.ts
@@ -5,6 +5,7 @@ import type { Map as MlMap } from "maplibre-gl";
 import { mbNodeColorExpr, TRANSPARENT_1PX_PNG } from "../lib/helpers";
 import { emptyLineFeatureCollection } from "../lib/utils";
 import { ActivityLayer } from "./activityLayer";
+import { CLUSTER_DISPLAY_SOURCE, CLUSTER_MAX_ZOOM } from "./clusterDisplay";
 import { ClusterDonutLayer } from "./clusterDonutLayer";
 import { LosTubeLayer } from "./losTubeLayer";
 
@@ -62,14 +63,26 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
       type: "geojson",
       data: ctx.getNodesData(),
       cluster: true,
-      // 80 (vs default 50) spaces large donut centroids enough to avoid overlap
+      // 80 (vs default 50) spaces centroids; it can't prevent donut overlap
+      // (greedy centroids drift closer than the radius) — the display-merge in
+      // clusterDonutLayer/clusterDisplay handles that (#567).
       clusterRadius: 80,
       // Align zoom range with map's (default 22); source defaults (18/17) break auto-spiderfy for stacked nodes
       maxzoom: 22,
-      clusterMaxZoom: 21,
+      clusterMaxZoom: CLUSTER_MAX_ZOOM,
       clusterProperties: {
         onlineCount: ["+", ["case", ["get", "online"], 1, 0]],
       },
+    });
+  }
+
+  // Display set (source clusters with overlapping donuts merged), fed by the
+  // donut layer; the hit-test circles and count labels read from here so they
+  // always match the rings.
+  if (!map.getSource(CLUSTER_DISPLAY_SOURCE)) {
+    map.addSource(CLUSTER_DISPLAY_SOURCE, {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
     });
   }
 
@@ -514,7 +527,7 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
     map.addLayer({
       id: "clusters",
       type: "circle",
-      source: "nodes_clustered",
+      source: CLUSTER_DISPLAY_SOURCE,
       filter: ["has", "point_count"],
       paint: {
         // ~2 px larger than donut for forgiving click target
@@ -540,7 +553,7 @@ export function ensureMapSourcesAndLayers(map: MlMap, ctx: EnsureLayersCtx): voi
     map.addLayer({
       id: "clusters-count",
       type: "symbol",
-      source: "nodes_clustered",
+      source: CLUSTER_DISPLAY_SOURCE,
       filter: ["has", "point_count"],
       layout: {
         "text-field": ["get", "point_count_abbreviated"],

--- a/frontend/src/pages/map/layers/spiderfy.ts
+++ b/frontend/src/pages/map/layers/spiderfy.ts
@@ -14,7 +14,7 @@ import type { GeoJSONSource as MlGeoJSONSource, Map as MlMap } from "maplibre-gl
 
 import { mbNodeColorExpr } from "../../../palette";
 import { prefersReducedMotion } from "../../../utils/reducedMotion";
-import { pixelRadiusForCount } from "./clusterDonutLayer";
+import { parseClusterMembers, pixelRadiusForCount } from "./clusterDisplay";
 
 export const SPIDERFY_SOURCE_NODES = "spiderfy-nodes";
 export const SPIDERFY_SOURCE_LEGS = "spiderfy-legs";
@@ -546,6 +546,9 @@ export async function autoSpiderfyVisibleClusters(
     for (const cluster of clusterFeatures) {
       const clusterId = cluster.properties?.cluster_id;
       if (clusterId == null) continue;
+      // Merged display marker (overlapping donuts): its members separate on
+      // zoom-in; the auto pass fans single source clusters only.
+      if (parseClusterMembers(cluster.properties).length > 1) continue;
 
       // Timeout guards against stale cluster_ids after setData
       const expansionZoom = await new Promise<number | null>((resolve) => {

--- a/frontend/src/pages/map/lib/storage.ts
+++ b/frontend/src/pages/map/lib/storage.ts
@@ -9,6 +9,8 @@ export const LS_KEYS = {
   /** Live packet-arc animation on/off (on by default, opt-out). */
   livePackets: "meshinfo.map.livePackets",
   settingsPanelOpen: "meshinfo.map.settingsPanelOpen",
+  /** Legend panel shown (off by default). Never auto-closes on map interaction. */
+  legendOpen: "meshinfo.map.legendOpen",
   linkMode: "meshinfo.map.linkMode",
   myNodeId: "meshinfo.map.myNodeId",
   terrain3D: "meshinfo.map.terrain3D",


### PR DESCRIPTION
Closes #564, closes #567.

## Legend (#564)
- The legend closed on any map interaction because `MapSettingsPanel` had a document-level `pointerdown` listener. Removed; the legend now closes only via its own toggle (Escape no longer closes it either).
- `legendOpen` is lifted to `Map.tsx` and persisted (`meshinfo.map.legendOpen`, default off), so it survives reloads.
- Hidden — not reset — while the Settings panel is open (its button re-shows it), suppressed while an RF tool is active (button inert), and the bottom-right stack shifts left of the desktop details column so it never covers it.
- **Viewport-aware rows.** New `useLegendContext` hook runs one debounced `queryRenderedFeatures` over the node/cluster/link layers on `idle` (only after a move or a source reload, only while the legend is shown) and the legend lists just the encodings actually on screen: node colours present, cluster ring, link kinds / SNR ramp / unknown SNR / traceroute, live packets when enabled. Full legend until the first result; "Nothing in view" empty state (with hidden-nodes / active-filter variants); wording follows the link mode; capped to the viewport height and scrollable.

## Overlapping clusters (#567)
- Root cause is not the maplibre v6 upgrade: 5.24 already used the same `@maplibre/geojson-vt` ClusterTileIndex and TileManager. Supercluster's greedy per-zoom merge guarantees nothing about *centroid* spacing — on real node data two LA clusters at z6 sit 30 px apart under 52 px donuts (the 246/211 screenshot), and big clusters routinely sit ~75 px apart vs. the 83–104 px two large rings need. Donuts grew to 52 px in e31a409 (April) against `clusterRadius: 80`, so it became visible as the mesh grew. Raising `clusterRadius` (100/110/130) does not eliminate it.
- **Fix: screen-space display merge** (`layers/clusterDisplay.ts`). Source clusters whose donuts would overlap at the current zoom are merged into one marker (bigger absorbs smaller, count-weighted centroid, summed counts/online, member ids, `split_zoom`). The donut layer pushes that display set to a new `clusters_display` GeoJSON source, which now feeds the `clusters` hit circles and `clusters-count` labels so rings, labels and hit areas share one set. On real data: zero overlaps at every zoom, node counts conserved, ≤2 merged markers per integer zoom, all separated again by z+0.5.
- Merged markers: click zooms just far enough for the members to separate; hover card unions the member leaves; auto-spiderfy skips them; merging is off past `clusterMaxZoom` (stacked nodes are spiderfy territory); clusters from different tile zooms never merge; a dominance filter keeps one tile zoom per region (parent-substitute / terrain-LOD cases). The empty-map click handler also checks the drawn rings so a click on a ring never clears the selection while the hit circles catch up.

## Tests
- `clusterDisplay.test.ts` (merge, split zoom, tile-zoom guard, feature encoding), `useLegendContext.test.ts` + `useLegendContext.hook.test.tsx` (feature → rows reduction; idle/debounce/re-arm/attach lifecycle), `MapLegend.test.tsx` (contextual rows, empty states, wording; legend survives outside pointerdown/Escape, toggle/aria behaviour, suppressed/dodge).
- Full suite green (385 tests), lint and `tsc` clean; verified live on the test box.

## Notes
- Merge geometry is computed in un-pitched map px; under heavy pitch far-field rings may still touch.
- Hit circles/labels trail the rings by the display source's worker round-trip (a few frames) after the set changes.
