### PR TITLE
fix(ingest): dedup id-less packets by content; per-node flood guard; ingest denylist

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,73 @@
 
 Release-specific notes. The routine update command is in [README.md](README.md#3-update).
 
+## Per-node flood guard
+
+A single node looping Meshtastic MapReports at ~50/s filled a production disk
+in days: MapReports carry no packet id, so uplink dedup never applied and every
+copy became an `mqtt_messages` row. Three changes, none needing a migration:
+
+- **Id-less packets dedup by content.** A packet without a packet id (MapReport,
+  `MeshPacket.id = 0`) now merges with identical-content copies from the same
+  node inside `[storage] content_dedup_window_seconds` (default 120 s — real
+  re-publications are minutes apart; the window is short so they stay separate
+  rows), recording one `packet_receptions` row per gateway. A same-gateway
+  repeat inside the window writes nothing and skips the node update too. A node
+  whose copies keep being absorbed (30+ in a minute) is called out in the logs:
+  once when it starts —
+  `Node eba3d8e8 keeps re-sending identical packets (30 duplicate copies this minute); dedup is absorbing them (add "eba3d8e8" to [storage] ingest_denylist to drop it at the decoder)`
+  — then per minute while it continues:
+  `Node eba3d8e8: 2900 duplicate copies absorbed by dedup in the last minute`.
+  This is part of uplink dedup: with `dedup_uplinks = false` id-less packets are
+  stored per copy again.
+- **`[storage] max_packets_per_node_per_minute = 60` / `max_packets_per_node_per_hour = 600`**
+  cap *new* archive rows per originating node. Uplink copies that dedup folds
+  into `packet_receptions` don't count, so dense meshes are unaffected (measured
+  legit peaks ≈ 28/min and 119/hour). Overflow is dropped before it reaches the
+  database, and a node over budget stops writing anywhere — telemetry/chat/
+  traceroute history rows and node/position/telemetry state — until its window
+  rolls over (it still gets 60 rows a minute until the 600-per-hour tier is
+  spent, then nothing until the hour rolls over). WARNING per node — once when
+  dropping starts, then a per-minute summary:
+  `Node eba3d8e8: dropped 2880 writes in the last minute (over 60/min or 600/hour new rows)`.
+  Set a tier to `0` to disable it. The guard needs `dedup_uplinks = true`
+  (without dedup every copy is a row and the caps would clip busy nodes; the
+  config check warns if you have dedup off). Uplink copies have a ceiling of
+  their own: roughly 1000 receptions per archived packet per dedup window (the
+  densest legit packet seen carries ~90), so replaying one packet id at flood
+  rate can't grow `packet_receptions` without bound either. Known gap: while
+  the database is down nothing can be charged, so a flood whose content varies
+  per message is bounded only by the 10,000-item retry buffer, as before.
+- **`[storage] ingest_denylist = ["eba3d8e8"]`** drops a node's packets at the
+  decoder — as origin or as the uplinking gateway — so nothing is archived and no
+  node/position/telemetry update runs (logged once per node at INFO when its
+  packets start being dropped). Blunt, for a node you have given up on; note a
+  denylisted gateway silences every packet it uplinks.
+
+Rows a flood already wrote stay put: `scripts/compact_mqtt_partitions.py`
+passes id-less rows through unchanged. Purge them by hand, with the app up
+(row locks only). Always bound the `DELETE` by node **and** the flood dates:
+archive rows from before uplink dedup (#526) also carry `packet_id IS NULL` and
+are legit history. Delete in batches — a day at a time, or an hour at a time
+while the disk is critical (a day of flood is millions of rows and the DELETE
+writes WAL first). A plain `VACUUM` only marks the space reusable inside that
+monthly partition, and once the month is over nothing new lands there, so `df`
+won't move; to get the space back on the volume run `VACUUM FULL` on the leaf
+partition later, when there is headroom for a copy of its live rows (it locks
+that partition for the duration):
+
+```sql
+SELECT from_node_id, count(*) FROM mqtt_messages
+ WHERE packet_id IS NULL AND created_at > now() - interval '7 days'
+ GROUP BY 1 ORDER BY 2 DESC LIMIT 5;
+
+DELETE FROM mqtt_messages
+ WHERE from_node_id = 'eba3d8e8' AND packet_id IS NULL
+   AND created_at >= '2026-08-13' AND created_at < '2026-08-14';   -- repeat per day
+VACUUM (VERBOSE) mqtt_messages_2026_08;          -- space reusable within the month
+-- later, with headroom: VACUUM FULL mqtt_messages_2026_08;   -- returns it to the OS
+```
+
 ## Channel ids are now resolved hashes
 
 Chat channels are bucketed by the firmware channel id — a hash of the channel name

--- a/config.py
+++ b/config.py
@@ -17,6 +17,8 @@ import uuid
 from copy import deepcopy
 from typing import Any
 
+from utils import normalize_node_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -142,6 +144,17 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # How long copies of one (from, packet id) keep merging into the same
         # canonical row; also bounds the restart-recovery DB lookup.
         "dedup_window_seconds": 900,
+        # Packets without a packet id (MapReport) dedup by content inside this
+        # shorter window — real re-publications are minutes apart.
+        "content_dedup_window_seconds": 120,
+        # Per-node flood guard: at most this many new archive rows per
+        # originating node per minute / per hour (dedup'd copies don't count;
+        # needs dedup_uplinks). 0 disables a tier.
+        "max_packets_per_node_per_minute": 60,
+        "max_packets_per_node_per_hour": 600,
+        # Node ids (hex) whose packets — as origin or uplinking gateway — are
+        # dropped at the decoder entirely.
+        "ingest_denylist": [],
         "postgres": {
             "enabled": False,
             "host": "postgres",
@@ -541,6 +554,28 @@ def validate(config: dict) -> list[str]:
     # ── uplink dedup (#526) ───────────────────────────────────────────
     check(_validate_type(config, "storage.dedup_uplinks", bool))
     check(_validate_positive_number(config, "storage.dedup_window_seconds"))
+
+    # ── per-node flood guard ──────────────────────────────────────────
+    check(_validate_positive_number(config, "storage.content_dedup_window_seconds"))
+    for tier in ("max_packets_per_node_per_minute", "max_packets_per_node_per_hour"):
+        rate = storage_cfg.get(tier)
+        if rate is not None and (isinstance(rate, bool) or not isinstance(rate, int) or rate < 0):
+            warn(f"Config field 'storage.{tier}' must be an integer >= 0 (0 disables), got {rate!r}")
+    if storage_cfg.get("dedup_uplinks") is False and (
+        storage_cfg.get("max_packets_per_node_per_minute", 60) or storage_cfg.get("max_packets_per_node_per_hour", 600)
+    ):
+        warn("storage.dedup_uplinks = false: content dedup for id-less packets is off and the "
+             "per-node flood guard (max_packets_per_node_*) is disabled — without dedup every "
+             "uplink copy is a row and the caps would clip busy nodes. Enable dedup_uplinks, "
+             "or set both caps to 0 to silence this and rely on ingest_denylist.")
+    denylist = storage_cfg.get("ingest_denylist")
+    if denylist is not None:
+        if not isinstance(denylist, list) or not all(isinstance(n, str) for n in denylist):
+            warn(f"Config field 'storage.ingest_denylist' must be a list of node id strings, got {denylist!r}")
+        else:
+            for n in denylist:
+                if normalize_node_id(n) is None:
+                    warn(f"Config field 'storage.ingest_denylist' has an invalid node id {n!r} (expected hex like \"eba3d8e8\")")
 
     # ── backups ───────────────────────────────────────────────────────
     check(_validate_one_of(config, "backups.schedule", ["off", "daily", "weekly", "monthly"]))

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -12,10 +12,25 @@ debug = false
 
 [storage]
 # Uplink dedup (#526): store one canonical mqtt_messages row per mesh packet;
-# every per-gateway uplink copy is kept losslessly in packet_receptions.
-# Disable to restore the legacy one-row-per-copy firehose (~10x the disk).
+# every per-gateway uplink copy is kept losslessly in packet_receptions (id-less
+# repeats from the same gateway inside content_dedup_window_seconds are not
+# re-recorded). Disable to restore the legacy one-row-per-copy firehose (~10x
+# the disk) — that also turns off content dedup and the flood guard below.
 dedup_uplinks = true
 dedup_window_seconds = 900            # copies of one packet merge within this window
+content_dedup_window_seconds = 120    # packets without a packet id (MapReport) merge
+                                      # by content within this shorter window
+# Per-node flood guard: caps on NEW archive rows per originating node — copies
+# dedup folds into packet_receptions don't count, so dense meshes are unaffected
+# (measured legit peaks: 28/min, 119/hour). Overflow is dropped before the
+# database with a throttled WARNING naming the node. 0 disables a tier; the
+# guard needs dedup_uplinks.
+max_packets_per_node_per_minute = 60
+max_packets_per_node_per_hour = 600
+# Blunt escape hatch: node ids whose packets — as origin or uplinking gateway —
+# are dropped at the decoder (nothing archived, no node/position/telemetry
+# updates). Hex ids.
+ingest_denylist = []                  # e.g. ["eba3d8e8"]
 
 # Database snapshot backups. The app schedules these itself — the schedule is
 # applied automatically on (re)start, no host cron needed. The raw archive is

--- a/mqtt.py
+++ b/mqtt.py
@@ -84,6 +84,17 @@ class MQTT:
         # Track drops so the warning at every Nth surfaces a stalled consumer.
         self._discord_drops_total: int = 0
 
+        # Packets from these nodes (as origin or uplinking gateway) are dropped
+        # at the decoder entirely.
+        denylist = config.get('storage', {}).get('ingest_denylist') or ()
+        if not isinstance(denylist, (list, tuple)):
+            logger.warning("storage.ingest_denylist must be a list of node ids; ignoring %r", denylist)
+            denylist = ()
+        self._denied_nodes = frozenset(
+            filter(None, (normalize_node_id(n) for n in denylist if isinstance(n, str)))
+        )
+        self._denied_logged: set = set()
+
         # Learns name -> hash from encrypted uplinks so decoded slot indices remap.
         self._channel_resolver = channels.ChannelResolver()
         # Name bucket -> when its label row was last confirmed written.
@@ -209,6 +220,9 @@ class MQTT:
                 except Exception as e:
                     # Returning early avoids logging a noisy type='unknown' row for a packet we can't read.
                     logger.exception("Unexpected error decoding protobuf envelope on %s: %s", msg.topic.value, e)
+                    return
+
+                if self._is_denied_packet(getattr(mp, "from", None), se.gateway_id, msg.topic.value):
                     return
 
                 if mp.HasField("encrypted") and not mp.HasField("decoded"):
@@ -346,7 +360,16 @@ class MQTT:
                     except DecodeError as e:
                         logger.debug("Protobuf decode error: text: %s", e)
                     else:
-                        await self._safe_handle("handle_mapreport", self.handle_mapreport(outs))
+                        # Skip the node upsert for a repeat; normalize first so
+                        # the peek keys the dict exactly as handle_log archives it.
+                        self._normalize_msg_addrs(outs)
+                        try:
+                            repeat = self.data.pg_storage.idless_repeat(outs)
+                        except Exception:
+                            logger.exception("idless_repeat peek failed; handling the packet")
+                            repeat = False
+                        if not repeat:
+                            await self._safe_handle("handle_mapreport", self.handle_mapreport(outs))
 
                 elif mp.decoded.portnum == portnums_pb2.NEIGHBORINFO_APP:
                     try:
@@ -492,6 +515,8 @@ class MQTT:
                 try:
                     decoded = msg.payload.decode("utf-8")
                     j = json.loads(decoded, cls=_JSONDecoder)
+                    if self._is_denied_packet(j.get('from'), j.get('sender'), msg.topic.value):
+                        return
                     j['topic'] = msg.topic.value
                     j["qos"] = getattr(msg, "qos", None)
                     j["retain"] = getattr(msg, "retain", None)
@@ -521,6 +546,37 @@ class MQTT:
                     logger.error("JSON message processing error: %s", e, exc_info=True)
 
     ### message handlers
+
+    def _is_denied(self, node_id) -> bool:
+        if not self._denied_nodes:
+            return False
+        nid = normalize_node_id(node_id)
+        if nid in self._denied_nodes:
+            if nid not in self._denied_logged:
+                self._denied_logged.add(nid)
+                logger.info("Dropping packets originated or uplinked by denylisted node %s ([storage] ingest_denylist)", nid)
+            else:
+                logger.debug("Dropping packet originated or uplinked by denylisted node %s", nid)
+            return True
+        return False
+
+    def _is_denied_packet(self, from_id, gateway, topic: str) -> bool:
+        """Denylist match on the origin or the uplinking gateway (envelope
+        gateway id, else the topic's !suffix — same fallback sender uses)."""
+        if not self._denied_nodes:
+            return False
+        if not gateway:
+            tail = topic.rsplit('/', 1)[-1] if isinstance(topic, str) else ''
+            gateway = tail if tail.startswith('!') else None
+        return self._is_denied(from_id) or self._is_denied(gateway)
+
+    def _over_budget(self, node_id: str, label: str) -> bool:
+        """Handlers share the archive's flood budget: a node over it stops
+        writing anywhere until its window rolls over."""
+        if self.data.pg_storage.node_over_budget(node_id):
+            logger.debug("%s: node %s over its ingest budget; skipping", label, node_id)
+            return True
+        return False
 
     async def _safe_handle(self, label: str, coro) -> None:
         """Run a handler coroutine; log + swallow exceptions so one bad packet
@@ -579,6 +635,8 @@ class MQTT:
         if id is None:
             logger.debug("handle_neighborinfo: missing/invalid 'from'; skipping: %s", msg)
             return
+        if self._over_budget(id, "handle_neighborinfo"):
+            return
         payload = msg.get('payload')
         if not isinstance(payload, dict):
             logger.debug("handle_neighborinfo: missing/invalid payload for %s; skipping", id)
@@ -604,6 +662,8 @@ class MQTT:
         id = normalize_node_id(payload.get('id')) or from_id
         if id is None:
             logger.debug("handle_nodeinfo: no usable node id; skipping: %s", msg)
+            return
+        if self._over_budget(id, "handle_nodeinfo"):
             return
 
         node = await self.data.pg_storage.get_node_cached(id)
@@ -647,6 +707,8 @@ class MQTT:
         from_id = self._normalize_msg_addrs(msg)
         if from_id is None:
             logger.debug("handle_mapreport: missing/invalid 'from'; skipping: %s", msg)
+            return
+        if self._over_budget(from_id, "handle_mapreport"):
             return
         payload = msg.get('payload')
         if not isinstance(payload, dict):
@@ -693,6 +755,8 @@ class MQTT:
         if id is None:
             logger.debug("handle_position: missing/invalid 'from'; skipping: %s", msg)
             return
+        if self._over_budget(id, "handle_position"):
+            return
 
         node = await self.data.pg_storage.get_node_cached(id)
         if node is None:
@@ -722,6 +786,8 @@ class MQTT:
         id = self._normalize_msg_addrs(msg)
         if id is None:
             logger.debug("handle_telemetry: missing/invalid 'from'; skipping: %s", msg)
+            return
+        if self._over_budget(id, "handle_telemetry"):
             return
         telemetry_type = msg.get('telemetry_type')
         payload = msg.get('payload')
@@ -775,6 +841,8 @@ class MQTT:
         from_id = self._normalize_msg_addrs(msg)
         if from_id is None:
             logger.debug("handle_text: missing/invalid 'from'; skipping: %s", msg)
+            return
+        if self._over_budget(from_id, "handle_text"):
             return
 
         payload = msg.get('payload')
@@ -863,6 +931,8 @@ class MQTT:
         id = self._normalize_msg_addrs(msg)
         if id is None:
             logger.debug("handle_traceroute: missing/invalid 'from'; skipping: %s", msg)
+            return
+        if self._over_budget(id, "handle_traceroute"):
             return
         payload = msg.get('payload')
         route = payload.get('route') if isinstance(payload, dict) else None

--- a/storage/db/ingest_guard.py
+++ b/storage/db/ingest_guard.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Per-node ingest rate limit for the mqtt_messages archive: caps new rows per
+originating node per minute/hour so one looping publisher can't own the disk.
+Dedup'd uplink copies don't count, so dense meshes are unaffected (measured
+legit peaks: ~30 rows/node/minute, ~120/hour).
+"""
+
+import logging
+import time
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Shared budget bucket for messages with no usable `from`.
+NO_FROM = "<no-from>"
+
+
+class NodeRateLimiter:
+    """Fixed-window (minute + hour) row budget per originating node.
+
+    `allow` peeks, `charge` spends — charging only on the actual insert means
+    a DB outage never consumes budget, so buffered-for-retry copies survive.
+    Denials WARN once when dropping starts, then one summary per minute.
+    A limit of 0 disables that tier.
+    """
+
+    def __init__(self, per_minute: int = 60, per_hour: int = 600, max_nodes: int = 50000):
+        self.per_minute = max(0, int(per_minute))
+        self.per_hour = max(0, int(per_hour))
+        self.max_nodes = int(max_nodes)
+        # node -> [minute start, minute rows, hour start, hour rows,
+        #          denied this minute, denied previous minute]
+        self._nodes: Dict[str, List[float]] = {}
+        self.denied_total = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.per_minute > 0 or self.per_hour > 0
+
+    def _limits(self) -> str:
+        tiers = []
+        if self.per_minute:
+            tiers.append(f"{self.per_minute}/min")
+        if self.per_hour:
+            tiers.append(f"{self.per_hour}/hour")
+        return " or ".join(tiers)
+
+    def _entry(self, node_id: str, now: float) -> List[float]:
+        e = self._nodes.get(node_id)
+        if e is None:
+            if len(self._nodes) >= self.max_nodes:
+                self._purge(now)
+            e = self._nodes[node_id] = [now, 0, now, 0, 0, 0]
+            return e
+        if now - e[0] >= 60.0:
+            if e[4]:
+                logger.warning(
+                    "Node %s: dropped %d writes in the last minute (over %s new rows)",
+                    node_id, int(e[4]), self._limits(),
+                )
+            e[0], e[1], e[5], e[4] = now, 0, e[4], 0
+        if now - e[2] >= 3600.0:
+            e[2], e[3] = now, 0
+        return e
+
+    def exhausted(self, node_id: Optional[str], now: Optional[float] = None) -> bool:
+        """Is this node over either budget right now? Counts/logs no denial."""
+        if not self.enabled:
+            return False
+        e = self._entry(node_id or NO_FROM, time.monotonic() if now is None else now)
+        return bool((self.per_minute and e[1] >= self.per_minute)
+                    or (self.per_hour and e[3] >= self.per_hour))
+
+    def allow(self, node_id: Optional[str], now: Optional[float] = None) -> bool:
+        """False (and counted/logged as a drop) once the node is over budget."""
+        if not self.enabled:
+            return True
+        now = time.monotonic() if now is None else now
+        if not self.exhausted(node_id, now):
+            return True
+        node_id = node_id or NO_FROM
+        e = self._entry(node_id, now)
+        e[4] += 1
+        self.denied_total += 1
+        if e[4] == 1 and not e[5]:
+            logger.warning(
+                "Node %s exceeded %s new archive rows; dropping its further archive, "
+                "node-state and history writes this window (add \"%s\" to [storage] "
+                "ingest_denylist to silence it entirely)", node_id, self._limits(), node_id,
+            )
+        return False
+
+    def charge(self, node_id: Optional[str], now: Optional[float] = None) -> None:
+        """Record one archive row created for the node."""
+        if not self.enabled:
+            return
+        e = self._entry(node_id or NO_FROM, time.monotonic() if now is None else now)
+        e[1] += 1
+        e[3] += 1
+
+    def _purge(self, now: float) -> None:
+        stale = [n for n, e in self._nodes.items() if now - e[2] >= 3600.0]
+        for n in stale:
+            del self._nodes[n]
+        if len(self._nodes) >= self.max_nodes:
+            self._nodes.clear()  # pathological node churn: reset, stays correct
+
+
+class SuppressedCopyLog:
+    """WARNs when dedup keeps absorbing a node's copies (nothing else would
+    log a looping node): once on crossing `threshold` per window, then one
+    summary per window. Summaries emit lazily on the node's next copy, so a
+    flood's final partial window may go unsummarized.
+    """
+
+    def __init__(self, threshold: int = 30, window_seconds: float = 60.0,
+                 max_nodes: int = 10000):
+        self.threshold = max(1, int(threshold))
+        self.window = float(window_seconds)
+        self.max_nodes = int(max_nodes)
+        # node -> [window start, absorbed, crossed previous window]
+        self._nodes: Dict[str, List[float]] = {}
+
+    def note(self, node_id: Optional[str], now: Optional[float] = None) -> None:
+        """Record one absorbed duplicate copy for the node."""
+        if node_id is None:
+            return
+        now = time.monotonic() if now is None else now
+        e = self._nodes.get(node_id)
+        if e is None or now - e[0] >= self.window:
+            # Only a just-ended window summarizes; after a gap the crossing warning re-arms.
+            crossed = (e is not None and e[1] >= self.threshold
+                       and now - e[0] < 2 * self.window)
+            if crossed:
+                logger.warning(
+                    "Node %s: %d duplicate copies absorbed by dedup in the last minute",
+                    node_id, int(e[1]),
+                )
+            elif e is None and len(self._nodes) >= self.max_nodes:
+                stale = [n for n, v in self._nodes.items() if now - v[0] >= self.window]
+                for n in stale:
+                    del self._nodes[n]
+                if len(self._nodes) >= self.max_nodes:
+                    self._nodes.clear()
+            e = self._nodes[node_id] = [now, 0, crossed]
+        e[1] += 1
+        if e[1] == self.threshold and not e[2]:
+            logger.warning(
+                "Node %s keeps re-sending identical packets (%d duplicate copies this "
+                "minute); dedup is absorbing them (add \"%s\" to [storage] "
+                "ingest_denylist to drop it at the decoder)",
+                node_id, self.threshold, node_id,
+            )

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -21,9 +21,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional, List, Tuple
 from zoneinfo import ZoneInfo
 
+from storage.db.ingest_guard import NodeRateLimiter, SuppressedCopyLog
 from storage.db.uplink_dedup import (
     UplinkDedupCache,
     coerce_packet_id,
+    content_key,
     gateway_from_msg,
     reception_fields,
     reception_patch,
@@ -319,6 +321,22 @@ class PostgresStorage:
         self.dedup_enabled = bool(storage_cfg.get("dedup_uplinks", True))
         self.dedup_window = int(storage_cfg.get("dedup_window_seconds", 900))
         self._dedup_cache = UplinkDedupCache(self.dedup_window)
+        # Id-less packets (MapReport ships id 0) dedup by content digest in a
+        # shorter window; separate cache so churn can't evict (from, id) entries.
+        self.content_dedup_window = int(storage_cfg.get("content_dedup_window_seconds", 120))
+        self._content_dedup_cache = UplinkDedupCache(self.content_dedup_window)
+        # Per-node cap on new archive rows. Needs dedup: without it every copy
+        # is a row and the cap would clip dense-mesh nodes.
+        self._ingest_limiter = NodeRateLimiter(
+            int(storage_cfg.get("max_packets_per_node_per_minute", 60) or 0) if self.dedup_enabled else 0,
+            int(storage_cfg.get("max_packets_per_node_per_hour", 600) or 0) if self.dedup_enabled else 0,
+        )
+        # Absorbed copies never reach the limiter — this is the only signal
+        # that a node is looping.
+        self._suppressed_log = SuppressedCopyLog()
+        # Receptions per canonical row are otherwise unbounded (copies never
+        # spend the row budget); ~10x the densest legit packet observed (91).
+        self.max_receptions_per_packet = 1000
         self._topic_ids: Dict[str, int] = {}
         # How far past a canonical row's created_at its receptions can land —
         # derived from the dedup window so reads never undercount, with a
@@ -1655,7 +1673,8 @@ class PostgresStorage:
           topic (text), payload (text), qos (int), retain (bool), timestamp (bigint), created_at (timestamptz default now())
 
         Returns the inserted row's id (the `mqtt_row_id` the read path exposes),
-        or None if storage is unavailable or the write failed.
+        or None if storage is unavailable, the write failed, or the copy was
+        dropped by policy (row budget, id-less repeat, reception ceiling).
 
         _dedup_lookback_s: retry-replay only — widens the canonical lookup
         window to cover the time the message spent buffered.
@@ -1704,10 +1723,24 @@ class PostgresStorage:
         from_node_id = None
         to_node_id = None
         packet_id = None
+        dedup_cache = dedup_key = None
         if isinstance(mqtt_msg, dict):
             from_node_id = self._normalize_node_id(mqtt_msg.get("from"))
             to_node_id = self._normalize_node_id(mqtt_msg.get("to"))
-            packet_id = coerce_packet_id(mqtt_msg.get("id"))
+            packet_id, dedup_cache, dedup_key = self._dedup_key(clean, from_node_id)
+
+        # Admission runs pre-pool (a rejected copy is never buffered for retry)
+        # but budget is charged on insert, so an outage never spends it.
+        if not _REPLAYING.get():
+            hit = dedup_cache.get(dedup_key) if dedup_key is not None else None
+            if hit is None:
+                if not self._ingest_limiter.allow(from_node_id):
+                    return None
+            elif packet_id is None and dedup_cache.gateway_seen(dedup_key, gateway_from_msg(clean)):
+                self._suppressed_log.note(from_node_id)
+                return None  # id-less repeat from the same gateway: nothing new to record
+            elif dedup_cache.receptions(dedup_key) >= self.max_receptions_per_packet:
+                return None  # replay flood of one packet: reception ceiling reached
 
         try:
             async with self.pool.acquire() as conn:
@@ -1715,7 +1748,7 @@ class PostgresStorage:
                 # packet_receptions rows under the canonical (first-heard) row.
                 # Any dedup-path failure falls back to a plain per-copy insert
                 # below so a copy is never lost to a dedup bug.
-                if self.dedup_enabled and from_node_id is not None and packet_id is not None:
+                if dedup_key is not None:
                     try:
                         # Serialized: the retry drain is a second writer, and
                         # the dedup check-then-insert must stay atomic per task.
@@ -1723,7 +1756,7 @@ class PostgresStorage:
                             return await self._write_deduped(
                                 conn, clean, topic, payload_text, qos_i, retain_b,
                                 ts_i, from_node_id, to_node_id, packet_id,
-                                lookback_s=_dedup_lookback_s,
+                                dedup_cache, dedup_key, lookback_s=_dedup_lookback_s,
                             )
                     except Exception as e:
                         if _is_retryable_write_error(e):
@@ -1734,13 +1767,53 @@ class PostgresStorage:
                     conn, topic, payload_text, qos_i, retain_b, ts_i,
                     from_node_id, to_node_id, packet_id,
                 )
+                if row_id is not None and not _REPLAYING.get():
+                    self._ingest_limiter.charge(from_node_id)
             return int(row_id) if row_id is not None else None
         except Exception as e:
+            if dedup_key is not None and packet_id is None and _is_retryable_write_error(e):
+                # DB down: pin a placeholder so repeats of this content are
+                # dropped pre-pool instead of flooding the retry buffer; the
+                # replay inserts the real canonical over it.
+                if dedup_cache.get(dedup_key) is None:
+                    dedup_cache.put(dedup_key, None, {})
+                dedup_cache.mark_gateway(dedup_key, gateway_from_msg(clean))
             self._handle_write_failure(
                 "mqtt message", "mqtt_message",
                 (mqtt_msg,) if isinstance(mqtt_msg, dict) else None, e,
             )
             return None
+
+    def _dedup_key(self, msg: Optional[Dict[str, Any]], from_node_id: Optional[str]):
+        """(packet_id, cache, key): (from, packet id) in the uplink cache, or
+        (from, content digest) for id-less packets. cache/key are None when the
+        message can't be deduped (dedup off, no from, unhashable shape)."""
+        packet_id = coerce_packet_id(msg.get("id")) if msg is not None else None
+        if not self.dedup_enabled or msg is None or from_node_id is None:
+            return packet_id, None, None
+        if packet_id is not None:
+            return packet_id, self._dedup_cache, (from_node_id, packet_id)
+        try:
+            return None, self._content_dedup_cache, (from_node_id, content_key(msg, _json_default))
+        except Exception as e:  # unhashable shape: store verbatim
+            logger.warning("Content dedup key failed (storing copy verbatim): %s", e)
+            return None, None, None
+
+    def idless_repeat(self, msg: Dict[str, Any]) -> bool:
+        """True if `msg` is an id-less repeat the archive would record nothing
+        for — handlers can skip it too."""
+        if not isinstance(msg, dict):
+            return False
+        clean = {k: v for k, v in msg.items() if k not in ("decoded", "encrypted")}
+        packet_id, cache, key = self._dedup_key(clean, self._normalize_node_id(msg.get("from")))
+        if packet_id is not None or key is None or cache.get(key) is None:
+            return False
+        return cache.gateway_seen(key, gateway_from_msg(clean))
+
+    def node_over_budget(self, node_id: Optional[str]) -> bool:
+        """True while `node_id` is over its archive-row budget (pure peek; the
+        archive write does the counting/logging)."""
+        return self._ingest_limiter.exhausted(self._normalize_node_id(node_id))
 
     @staticmethod
     async def _insert_mqtt_row(
@@ -1755,7 +1828,8 @@ class PostgresStorage:
         packet_id: Optional[int],
     ) -> Optional[int]:
         """Single INSERT shared by the dedup and verbatim-fallback paths so the
-        two can't drift when mqtt_messages gains a column."""
+        two can't drift when mqtt_messages gains a column. Callers charge the
+        node's flood budget once the row is durable."""
         return await conn.fetchval(
             """
             INSERT INTO mqtt_messages (topic, payload, qos, retain, timestamp, from_node_id, to_node_id, packet_id)
@@ -1777,28 +1851,48 @@ class PostgresStorage:
         ts_i: Optional[int],
         from_node_id: str,
         to_node_id: Optional[str],
-        packet_id: int,
+        packet_id: Optional[int],
+        cache: UplinkDedupCache,
+        key: Tuple[str, Any],
         lookback_s: Optional[float] = None,
     ) -> Optional[int]:
         """Dedup-aware archive write: returns the canonical row id for every
         uplink copy of a packet, inserting a canonical row only for the first.
 
+        packet_id None = id-less packet keyed by content: cache-only (no DB
+        fallback) and one reception per gateway — a same-gateway repeat writes
+        nothing and returns None.
+
         lookback_s widens the DB lookup beyond dedup_window for retry replays,
         whose packet may have been canonicalized before the outage."""
-        key = (from_node_id, packet_id)
-        hit = self._dedup_cache.get(key)
-        if hit is None:
+        hit = cache.get(key)
+        if hit is not None and hit[0] is None:
+            hit = None  # placeholder from a failed write: no row yet
+        if hit is None and packet_id is not None:
             # Cache miss (e.g. app restart mid-window): the canonical row may
             # still exist in the DB — window-bounded lookup via idx_mqtt_messages_packet.
             db_hit = await self._dedup_lookup_db(conn, from_node_id, packet_id, lookback_s)
             if db_hit is not None:
                 row_id, canonical, age = db_hit
-                self._dedup_cache.put(key, row_id, canonical, ttl=max(0.0, self.dedup_window - age))
+                cache.put(key, row_id, canonical, ttl=max(0.0, self.dedup_window - age))
                 hit = (row_id, canonical)
 
+        gateway = gateway_from_msg(clean) if packet_id is None else None
         if hit is not None:
             row_id, canonical = hit
+            if packet_id is None and cache.gateway_seen(key, gateway):
+                if not _REPLAYING.get():  # drain repeats aren't a live flood
+                    self._suppressed_log.note(from_node_id)
+                return None
+            if cache.receptions(key) >= self.max_receptions_per_packet:
+                return None
             await self._write_reception(conn, row_id, clean, canonical)
+            if packet_id is None:
+                cache.mark_gateway(key, gateway)
+            if cache.count_reception(key) == self.max_receptions_per_packet:
+                logger.warning("Packet %s/%s reached %d receptions; further copies are not recorded",
+                               from_node_id, packet_id if packet_id is not None else "idless",
+                               self.max_receptions_per_packet)
             return row_id
 
         # Cache the canonical as readers will see it — parsed from the stored
@@ -1817,7 +1911,13 @@ class PostgresStorage:
             if row_id is None:
                 raise RuntimeError("canonical insert returned no id")
             await self._write_reception(conn, int(row_id), clean, canonical)
-        self._dedup_cache.put(key, int(row_id), canonical)
+        # Replays were admitted live and must not starve recovery traffic.
+        if not _REPLAYING.get():
+            self._ingest_limiter.charge(from_node_id)
+        cache.put(key, int(row_id), canonical)
+        cache.count_reception(key)
+        if packet_id is None:
+            cache.mark_gateway(key, gateway)
         return int(row_id)
 
     async def _dedup_lookup_db(

--- a/storage/db/uplink_dedup.py
+++ b/storage/db/uplink_dedup.py
@@ -16,6 +16,8 @@ and `reconstruct_copy` replays it. Template and patch MUST stay in sync — a
 template change invalidates previously stored patches.
 """
 
+import hashlib
+import json
 import time
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
@@ -53,6 +55,20 @@ def coerce_packet_id(value: Any) -> Optional[int]:
         v = int(value)
         return v if 0 < v < 2 ** 63 else None
     return None
+
+
+# content_key ignores the per-copy envelope plus relay-rewritten header fields.
+# Separate from PER_COPY_KEYS, which the reception template/patch depend on.
+CONTENT_KEY_IGNORED = PER_COPY_KEYS | frozenset({"priority", "next_hop", "hop_start", "via_mqtt"})
+
+
+def content_key(msg: Dict[str, Any], default: Any = str) -> str:
+    """Dedup key for a packet-id-less message (MapReport ships id 0): digest of
+    everything but CONTENT_KEY_IGNORED. A stray per-copy key outside that set
+    only splits copies into extra rows — over-count, never loss."""
+    body = {k: v for k, v in msg.items() if k not in CONTENT_KEY_IGNORED}
+    text = json.dumps(body, sort_keys=True, separators=(",", ":"), default=default)
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
 
 
 def contains_nul(value: Any) -> bool:
@@ -197,28 +213,29 @@ def reconstruct_copy(
 
 
 class UplinkDedupCache:
-    """TTL map (from_node_id, packet_id) -> (row_id, canonical dict).
+    """TTL map (from_node_id, packet_id | content key) -> (row_id, canonical dict).
 
     Single-writer only (the MQTT loop awaits one insert at a time). The TTL is
     anchored at first sight and never refreshed on hit, matching the DB
-    fallback's `created_at > now() - window` semantics.
+    fallback's `created_at > now() - window` semantics. Entries also track
+    gateways with a reception (id-less path: one reception per gateway).
     """
 
     def __init__(self, window_seconds: int = 900, max_entries: int = 20000):
         self.window = float(window_seconds)
         self.max_entries = int(max_entries)
-        # key -> (expiry deadline, row_id, canonical dict); insertion-ordered,
-        # so expired entries cluster at the head.
-        self._entries: "OrderedDict[Tuple[str, int], Tuple[float, int, Dict[str, Any]]]" = OrderedDict()
+        # key -> [deadline, row_id, canonical, gateways seen, receptions];
+        # insertion-ordered, so expired entries cluster at the head.
+        self._entries: "OrderedDict[Tuple[str, Any], List[Any]]" = OrderedDict()
 
     def _purge(self, now: float) -> None:
         while self._entries:
-            _, (deadline, _, _) = next(iter(self._entries.items()))
+            deadline = next(iter(self._entries.values()))[0]
             if deadline > now:
                 break
             self._entries.popitem(last=False)
 
-    def get(self, key: Tuple[str, int], now: Optional[float] = None) -> Optional[Tuple[int, Dict[str, Any]]]:
+    def get(self, key: Tuple[str, Any], now: Optional[float] = None) -> Optional[Tuple[int, Dict[str, Any]]]:
         now = time.monotonic() if now is None else now
         self._purge(now)
         entry = self._entries.get(key)
@@ -232,7 +249,7 @@ class UplinkDedupCache:
 
     def put(
         self,
-        key: Tuple[str, int],
+        key: Tuple[str, Any],
         row_id: int,
         canonical: Dict[str, Any],
         now: Optional[float] = None,
@@ -245,6 +262,41 @@ class UplinkDedupCache:
         remaining = self.window if ttl is None else ttl
         if remaining <= 0:
             return
-        self._entries[key] = (now + remaining, row_id, canonical)
+        self._entries[key] = [now + remaining, row_id, canonical, None, 0]
         while len(self._entries) > self.max_entries:
             self._entries.popitem(last=False)
+
+    def receptions(self, key: Tuple[str, Any], now: Optional[float] = None) -> int:
+        """Receptions recorded under a live entry for `key` (0 if none/expired)."""
+        now = time.monotonic() if now is None else now
+        entry = self._entries.get(key)
+        return 0 if entry is None or entry[0] <= now else int(entry[4])
+
+    def count_reception(self, key: Tuple[str, Any], now: Optional[float] = None) -> int:
+        """Bump and return the reception count for `key` (0 if entry is gone)."""
+        now = time.monotonic() if now is None else now
+        entry = self._entries.get(key)
+        if entry is None or entry[0] <= now:
+            return 0
+        entry[4] += 1
+        return int(entry[4])
+
+    def gateway_seen(self, key: Tuple[str, Any], gateway: Optional[str],
+                     now: Optional[float] = None) -> bool:
+        """True if `gateway` was already marked under a live entry for `key`."""
+        now = time.monotonic() if now is None else now
+        entry = self._entries.get(key)
+        if entry is None or entry[0] <= now or entry[3] is None:
+            return False
+        return gateway in entry[3]
+
+    def mark_gateway(self, key: Tuple[str, Any], gateway: Optional[str],
+                     now: Optional[float] = None) -> None:
+        """Record that `gateway` has a reception under `key`'s canonical row."""
+        now = time.monotonic() if now is None else now
+        entry = self._entries.get(key)
+        if entry is None or entry[0] <= now:
+            return
+        if entry[3] is None:
+            entry[3] = set()
+        entry[3].add(gateway)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -46,6 +46,19 @@ class FakePgStorage:
         self._mqtt_row_seq += 1
         return self._mqtt_row_seq
 
+    # Flood-guard peeks (per-node budget + id-less repeat); tests flip these.
+    over_budget_nodes: set = frozenset()
+    idless_repeats: int = 0  # >0: the next N idless_repeat() calls answer True
+
+    def node_over_budget(self, node_id) -> bool:
+        return node_id in self.over_budget_nodes
+
+    def idless_repeat(self, msg) -> bool:
+        if self.idless_repeats > 0:
+            self.idless_repeats -= 1
+            return True
+        return False
+
     async def get_node_cached(self, node_id: str):
         return self._nodes.get(node_id)
 

--- a/tests/test_config_samples.py
+++ b/tests/test_config_samples.py
@@ -81,3 +81,39 @@ def test_cleanse_redacts_encryption_keys_in_both_shapes():
     as_dict = {"broker": {"channels": {"encryption": {"key": "s2", "key_name": "B"}}}}
     out = config_mod.Config.cleanse(as_dict)
     assert out["broker"]["channels"]["encryption"]["key"] == "***REDACTED***"
+
+
+def _flood_guard_warnings(**storage_over):
+    import config as config_mod
+
+    cfg = _validatable_base()
+    cfg["storage"].update(storage_over)
+    return [w for w in config_mod.validate(cfg)
+            if "flood guard" in w or "max_packets" in w or "denylist" in w or "content_dedup" in w]
+
+
+def test_flood_guard_defaults_validate_clean():
+    assert _flood_guard_warnings() == []
+    assert _flood_guard_warnings(max_packets_per_node_per_minute=0, max_packets_per_node_per_hour=0,
+                                 ingest_denylist=["eba3d8e8", "!ABCD"]) == []
+
+
+def test_flood_guard_tier_must_be_non_negative_int():
+    for bad in (-1, 1.5, True):
+        assert any("max_packets_per_node_per_minute" in w for w in _flood_guard_warnings(max_packets_per_node_per_minute=bad))
+    assert any("max_packets_per_node_per_hour" in w for w in _flood_guard_warnings(max_packets_per_node_per_hour=-5))
+    assert any("content_dedup_window_seconds" in w for w in _flood_guard_warnings(content_dedup_window_seconds=0))
+
+
+def test_denylist_shape_and_ids_validated():
+    assert any("list of node id strings" in w for w in _flood_guard_warnings(ingest_denylist="eba3d8e8"))
+    assert any("list of node id strings" in w for w in _flood_guard_warnings(ingest_denylist=[12]))
+    warns = _flood_guard_warnings(ingest_denylist=["zz", "!EBA3D8E8", "1f"])
+    assert len(warns) == 1 and "'zz'" in warns[0]
+
+
+def test_dedup_off_warns_that_guard_is_inactive():
+    warns = _flood_guard_warnings(dedup_uplinks=False)
+    assert len(warns) == 1 and "disabled" in warns[0]
+    assert _flood_guard_warnings(dedup_uplinks=False, max_packets_per_node_per_minute=0,
+                                 max_packets_per_node_per_hour=0) == []

--- a/tests/test_ingest_flood_guard.py
+++ b/tests/test_ingest_flood_guard.py
@@ -1,0 +1,524 @@
+"""
+write_mqtt_message under a one-node flood: id-less packets dedup by
+content, same-gateway repeats write nothing, the per-node limiter drops before
+the pool is touched, and the (from, packet id) path is unchanged. Fake pool
+and connection, no database.
+"""
+
+import asyncio
+import json
+import logging
+
+from storage.db.postgres import PostgresStorage, _REPLAYING
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeConn:
+    def __init__(self):
+        self.rows = []          # mqtt_messages inserts (args tuples)
+        self.receptions = []    # packet_receptions inserts (args tuples)
+        self.lookups = 0        # _dedup_lookup_db calls
+        self._seq = 0
+        self.fail_receptions = False  # raise a non-retryable error on reception insert
+
+    async def fetchval(self, sql, *args):
+        if "INSERT INTO mqtt_messages" in sql:
+            self._seq += 1
+            self.rows.append(args)
+            return self._seq
+        if "INSERT INTO mqtt_topics" in sql:
+            return 1
+        return 1
+
+    async def fetchrow(self, sql, *args):
+        self.lookups += 1
+        return None
+
+    async def execute(self, sql, *args):
+        if "INSERT INTO packet_receptions" in sql:
+            if self.fail_receptions:
+                raise ValueError("simulated DataError on reception")
+            self.receptions.append(args)
+
+    def transaction(self):
+        conn = self
+
+        class _Tx:
+            async def __aenter__(self_inner):
+                self_inner.mark = (len(conn.rows), len(conn.receptions))
+                return None
+
+            async def __aexit__(self_inner, exc_type, *exc):
+                if exc_type is not None:  # rollback: discard rows written in the txn
+                    del conn.rows[self_inner.mark[0]:]
+                    del conn.receptions[self_inner.mark[1]:]
+                return False
+        return _Tx()
+
+
+class FakePool:
+    def __init__(self):
+        self.conn = FakeConn()
+        self.acquires = 0
+        self.fail = False
+
+    async def close(self):
+        pass
+
+    def acquire(self, timeout=None):
+        pool = self
+
+        class _CM:
+            async def __aenter__(self):
+                pool.acquires += 1
+                if pool.fail:
+                    raise ConnectionRefusedError("db down")
+                return pool.conn
+
+            async def __aexit__(self, *exc):
+                return False
+        return _CM()
+
+
+def make_storage(**storage_cfg):
+    cfg = {"dedup_uplinks": True, "max_packets_per_node_per_hour": 0,
+           "postgres": {"enabled": True, "raise_on_write_error": False}}
+    cfg.update(storage_cfg)
+    storage = PostgresStorage({"storage": cfg, "server": {"timezone": "UTC"}})
+    storage.pool = FakePool()
+    return storage
+
+
+ROGUE = "eba3d8e8"
+
+
+def mapreport(ts, online=191, sender=ROGUE, **extra):
+    """One MapReport copy as mqtt.py archives it: no packet id, self-uplinked."""
+    m = {
+        "from": ROGUE, "to": "ffffffff", "sender": sender, "timestamp": ts,
+        "topic": "msh/US/bayarea/2/map/", "qos": 0, "retain": False,
+        "channel": 31, "channel_name": "MediumFast", "type": "mapreport",
+        "payload": {"altitude": 853, "firmware_version": "2.7.15", "hw_model": 37,
+                    "latitude_i": 393412608, "longitude_i": -1210384384,
+                    "long_name": "River Dragon - Base", "num_online_local_nodes": online,
+                    "role": 11, "short_name": "RD"},
+    }
+    m.update(extra)
+    return m
+
+
+def rf_copy(packet_id, sender, rssi=-90, from_id="1f1ffa8b"):
+    return {
+        "from": from_id, "to": "ffffffff", "id": packet_id, "sender": sender,
+        "topic": f"msh/US/2/e/LongFast/!{sender}", "timestamp": 1787025877,
+        "rssi": rssi, "snr": 5.0, "hop_start": 3, "hop_limit": 2, "hops_away": 1,
+        "type": "text", "payload": {"text": "hi"}, "qos": 0, "retain": False,
+    }
+
+
+class TestIdlessContentDedup:
+    def test_incident_replay_collapses_to_distinct_content(self):
+        """~49 copies/s for 10 min, timestamp ticking, 4 contents rotating ->
+        4 canonical rows + 4 receptions, everything else writes nothing."""
+        async def scenario():
+            storage = make_storage()
+            conn = storage.pool.conn
+            written = 0
+            for sec in range(600):
+                for i in range(49):
+                    rid = await storage.write_mqtt_message(
+                        mapreport(1787025877 + sec, online=191 + ((sec * 49 + i) // 7000)))
+                    if rid is not None:
+                        written += 1
+            # 600*49 = 29400 copies; online drifts through 191..195 -> 5 contents
+            # (all inside one content window: the loop runs in well under 120 s)
+            assert len(conn.rows) == 5
+            assert len(conn.receptions) == 5
+            assert written == 5
+            assert storage._ingest_limiter.denied_total == 0
+            assert conn.lookups == 0  # id-less path is cache-only
+            await storage.close()
+        run(scenario())
+
+    def test_repeat_from_same_gateway_returns_none_without_touching_pool(self):
+        async def scenario():
+            storage = make_storage()
+            first = await storage.write_mqtt_message(mapreport(1))
+            assert first == 1
+            acquires = storage.pool.acquires
+            assert await storage.write_mqtt_message(mapreport(2)) is None
+            assert storage.pool.acquires == acquires  # short-circuited pre-pool
+            await storage.close()
+        run(scenario())
+
+    def test_second_gateway_gets_a_reception(self):
+        async def scenario():
+            storage = make_storage()
+            conn = storage.pool.conn
+            assert await storage.write_mqtt_message(mapreport(1)) == 1
+            assert await storage.write_mqtt_message(mapreport(2, sender="aabbccdd")) == 1
+            assert await storage.write_mqtt_message(mapreport(3, sender="aabbccdd")) is None
+            assert len(conn.rows) == 1
+            assert [r[1] for r in conn.receptions] == [ROGUE, "aabbccdd"]
+            await storage.close()
+        run(scenario())
+
+    def test_canonical_row_carries_no_packet_id(self):
+        async def scenario():
+            storage = make_storage()
+            await storage.write_mqtt_message(mapreport(1))
+            (row,) = storage.pool.conn.rows
+            topic, payload_text, qos, retain, ts, from_id, to_id, packet_id = row
+            assert from_id == ROGUE and packet_id is None
+            assert json.loads(payload_text)["type"] == "mapreport"
+            await storage.close()
+        run(scenario())
+
+    def test_outage_does_not_buffer_repeat_copies(self):
+        """Repeats of already-cached content are dropped before the pool during
+        a DB outage, so they never reach the retry queue."""
+        async def scenario():
+            storage = make_storage()
+            assert await storage.write_mqtt_message(mapreport(1)) == 1
+            storage.pool.fail = True
+            for i in range(200):
+                assert await storage.write_mqtt_message(mapreport(2 + i)) is None
+            assert len(storage._write_retry) == 0
+            await storage.close()
+        run(scenario())
+
+    def test_dedup_disabled_means_guard_off(self):
+        """Without dedup every copy is a row, so the caps would clip busy
+        legit nodes: the guard is inactive and the config check warns."""
+        async def scenario():
+            storage = make_storage(dedup_uplinks=False, max_packets_per_node_per_minute=10)
+            assert storage._ingest_limiter.enabled is False
+            written = [await storage.write_mqtt_message(mapreport(i)) for i in range(50)]
+            assert all(w is not None for w in written)
+            assert len(storage.pool.conn.rows) == 50
+            assert len(storage.pool.conn.receptions) == 0
+            await storage.close()
+        run(scenario())
+
+    def test_content_window_is_the_short_one(self):
+        async def scenario():
+            storage = make_storage(dedup_window_seconds=900, content_dedup_window_seconds=120)
+            assert storage._content_dedup_cache.window == 120.0
+            assert storage._dedup_cache.window == 900.0
+            await storage.close()
+        run(scenario())
+
+    def test_repeat_after_window_is_a_new_row(self):
+        async def scenario():
+            storage = make_storage(content_dedup_window_seconds=100)
+            assert await storage.write_mqtt_message(mapreport(1)) == 1
+            assert await storage.write_mqtt_message(mapreport(2)) is None
+            # age the entry past the content window
+            key = next(iter(storage._content_dedup_cache._entries))
+            storage._content_dedup_cache._entries[key][0] = 0.0
+            assert await storage.write_mqtt_message(mapreport(3)) == 2
+            await storage.close()
+        run(scenario())
+
+
+class TestRateLimiterPlacement:
+    def test_varying_content_capped_per_minute_before_pool(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=5)
+            for i in range(100):
+                await storage.write_mqtt_message(mapreport(i, online=i))
+            assert len(storage.pool.conn.rows) == 5
+            assert storage.pool.acquires == 5  # dropped copies never reach the pool
+            assert storage._ingest_limiter.denied_total == 95
+            assert len(storage._write_retry) == 0
+            await storage.close()
+        run(scenario())
+
+    def test_dedup_copies_do_not_count(self):
+        """100 gateway copies of ONE packet with limit 1: canonical + 100
+        receptions, nothing dropped — dense meshes are unaffected."""
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=1)
+            conn = storage.pool.conn
+            for i in range(100):
+                assert await storage.write_mqtt_message(rf_copy(777, f"{i:08x}")) == 1
+            assert len(conn.rows) == 1
+            assert len(conn.receptions) == 100
+            assert storage._ingest_limiter.denied_total == 0
+            # the second distinct packet from that node this minute is over the cap
+            assert await storage.write_mqtt_message(rf_copy(778, "00000001")) is None
+            assert storage._ingest_limiter.denied_total == 1
+            await storage.close()
+        run(scenario())
+
+    def test_other_nodes_unaffected(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=1)
+            assert await storage.write_mqtt_message(rf_copy(1, "aa", from_id="00000001")) == 1
+            assert await storage.write_mqtt_message(rf_copy(2, "aa", from_id="00000001")) is None
+            assert await storage.write_mqtt_message(rf_copy(3, "aa", from_id="00000002")) == 2
+            await storage.close()
+        run(scenario())
+
+    def test_zero_disables(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=0)
+            for i in range(200):
+                assert await storage.write_mqtt_message(mapreport(i, online=i)) == i + 1
+            assert storage._ingest_limiter.denied_total == 0
+            await storage.close()
+        run(scenario())
+
+    def test_replay_bypasses_limiter(self):
+        """Buffered writes were admitted on first attempt; a post-outage drain
+        burst of one node's packets must not be dropped by the limiter."""
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=1)
+            token = _REPLAYING.set(True)
+            try:
+                for i in range(20):
+                    assert await storage.write_mqtt_message(rf_copy(1000 + i, "aa")) == i + 1
+            finally:
+                _REPLAYING.reset(token)
+            assert storage._ingest_limiter.denied_total == 0
+            await storage.close()
+        run(scenario())
+
+    def test_messages_without_from_share_one_budget(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=2)
+            got = [await storage.write_mqtt_message({"topic": "msh/x", "text": str(i)}) for i in range(5)]
+            assert got == [1, 2, None, None, None]
+            await storage.close()
+        run(scenario())
+
+    def test_outage_copies_of_legit_node_are_buffered_not_dropped(self):
+        """During an outage nothing is charged, so a busy node's copies all
+        reach the retry buffer, exactly as before the guard."""
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=5)
+            storage.pool.fail = True
+            for i in range(300):
+                assert await storage.write_mqtt_message(rf_copy(1000 + i // 30, f"{i % 30:08x}")) is None
+            assert len(storage._write_retry) == 300
+            assert storage._ingest_limiter.denied_total == 0
+            await storage.close()
+        run(scenario())
+
+    def test_hour_tier_applies(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=100, max_packets_per_node_per_hour=3)
+            got = [await storage.write_mqtt_message(mapreport(i, online=i)) for i in range(6)]
+            assert got == [1, 2, 3, None, None, None]
+            await storage.close()
+        run(scenario())
+
+    def test_charge_happens_on_insert_only(self):
+        """A copy that dedups into a reception must not spend the budget, and a
+        rejected copy costs no DB round trip."""
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=1)
+            assert await storage.write_mqtt_message(rf_copy(1, "aa")) == 1
+            for i in range(10):
+                assert await storage.write_mqtt_message(rf_copy(1, f"{i:08x}")) == 1
+            assert storage._ingest_limiter.exhausted("1f1ffa8b") is True  # 1 row charged
+            acquires = storage.pool.acquires
+            assert await storage.write_mqtt_message(rf_copy(2, "aa")) is None
+            assert storage.pool.acquires == acquires
+            await storage.close()
+        run(scenario())
+
+
+class TestRealIdPath:
+    def test_same_gateway_repeats_still_recorded_for_real_ids(self):
+        """5.6% of real (packet, gateway) pairs legitimately repeat; that data
+        stays. Only the id-less path suppresses same-gateway repeats."""
+        async def scenario():
+            storage = make_storage()
+            conn = storage.pool.conn
+            for _ in range(3):
+                assert await storage.write_mqtt_message(rf_copy(42, "aabbccdd")) == 1
+            assert len(conn.rows) == 1
+            assert len(conn.receptions) == 3
+            assert conn.lookups == 1  # DB fallback only on the first (cache miss)
+            await storage.close()
+        run(scenario())
+
+
+class TestPeeksForHandlers:
+    def test_idless_repeat_peek_matches_archive_decision(self):
+        async def scenario():
+            storage = make_storage()
+            raw = dict(mapreport(1), decoded={"raw": "x"})  # as mqtt.py hands it to handlers
+            assert storage.idless_repeat(raw) is False       # nothing archived yet
+            assert await storage.write_mqtt_message(mapreport(1)) == 1
+            assert storage.idless_repeat(dict(mapreport(2), decoded={"raw": "y"})) is True
+            assert storage.idless_repeat(mapreport(3, sender="aabbccdd")) is False  # new gateway
+            assert storage.idless_repeat(rf_copy(1, "aa")) is False                # real id: never
+            assert storage.idless_repeat(mapreport(4, online=999)) is False        # new content
+            await storage.close()
+        run(scenario())
+
+    def test_node_over_budget_peek(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=1)
+            assert storage.node_over_budget(ROGUE) is False
+            await storage.write_mqtt_message(mapreport(1))
+            assert storage.node_over_budget(ROGUE) is True
+            assert storage.node_over_budget("!EBA3D8E8") is True  # normalized
+            assert storage.node_over_budget("00000001") is False
+            assert storage._ingest_limiter.denied_total == 0     # peeks never count
+            await storage.close()
+        run(scenario())
+
+
+class TestReceptionCeiling:
+    def test_replay_of_one_real_packet_is_capped(self):
+        async def scenario():
+            storage = make_storage()
+            storage.max_receptions_per_packet = 5
+            conn = storage.pool.conn
+            assert await storage.write_mqtt_message(rf_copy(42, "aa")) == 1   # canonical + own reception
+            got = [await storage.write_mqtt_message(rf_copy(42, "aa")) for _ in range(20)]
+            assert got[:4] == [1, 1, 1, 1] and got[4:] == [None] * 16
+            assert len(conn.rows) == 1
+            assert len(conn.receptions) == 5
+            acquires = storage.pool.acquires
+            assert await storage.write_mqtt_message(rf_copy(42, "bb")) is None
+            assert storage.pool.acquires == acquires  # capped pre-pool
+            # a different packet from the same node is unaffected
+            assert await storage.write_mqtt_message(rf_copy(43, "aa")) == 2
+            await storage.close()
+        run(scenario())
+
+    def test_default_ceiling_is_far_above_legit(self):
+        async def scenario():
+            storage = make_storage()
+            assert storage.max_receptions_per_packet >= 500  # legit max observed: 91
+            for i in range(200):
+                assert await storage.write_mqtt_message(rf_copy(7, f"{i:08x}")) == 1
+            assert len(storage.pool.conn.receptions) == 200
+            await storage.close()
+        run(scenario())
+
+
+async def _wait_for(pred, timeout=5.0):
+    import time as _t
+    deadline = _t.monotonic() + timeout
+    while not pred():
+        if _t.monotonic() > deadline:
+            raise AssertionError("condition not met in time")
+        await asyncio.sleep(0.05)
+
+
+class TestOutageBehavior:
+    def test_outage_beyond_content_window_buffers_one_copy_per_content(self, caplog):
+        """Outage past the content window: one copy per content is buffered
+        (pinning a placeholder), the rest are dropped pre-pool."""
+        async def scenario():
+            storage = make_storage()
+            conn = storage.pool.conn
+            assert await storage.write_mqtt_message(mapreport(1)) == 1
+            caplog.set_level(logging.WARNING, logger="storage.db.ingest_guard")
+            storage.pool.fail = True
+            key = next(iter(storage._content_dedup_cache._entries))
+            storage._content_dedup_cache._entries[key][0] = 0.0  # window expired mid-outage
+            acquires = storage.pool.acquires
+            for i in range(100):
+                assert await storage.write_mqtt_message(mapreport(10 + i)) is None
+            assert len(storage._write_retry) == 1
+            assert storage.pool.acquires == acquires + 1
+            for i in range(50):  # a second content: one more buffered item
+                assert await storage.write_mqtt_message(mapreport(200 + i, online=999)) is None
+            assert len(storage._write_retry) == 2
+            assert storage._ingest_limiter.denied_total == 0
+            # handlers see the repeat too
+            assert storage.idless_repeat(mapreport(300)) is True
+            # the outage-time absorption is visible in the logs too
+            guard_warnings = [r for r in caplog.records
+                              if r.name == "storage.db.ingest_guard" and "keeps re-sending" in r.getMessage()]
+            assert len(guard_warnings) == 1 and ROGUE in guard_warnings[0].getMessage()
+            storage.pool.fail = False
+            await _wait_for(lambda: len(storage._write_retry) == 0)
+            assert len(conn.rows) == 3          # original + one canonical per buffered content
+            assert len(conn.receptions) == 3
+            # live copies now dedup against the replayed canonicals
+            assert await storage.write_mqtt_message(mapreport(400)) is None
+            assert await storage.write_mqtt_message(mapreport(401, online=999)) is None
+            assert len(conn.rows) == 3
+            await storage.close()
+        run(scenario())
+
+    def test_rollback_to_verbatim_fallback_charges_once(self):
+        """A reception insert failing non-retryably rolls the canonical back and
+        the copy is stored verbatim: one committed row must cost one unit."""
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=4)
+            conn = storage.pool.conn
+            conn.fail_receptions = True
+            got = [await storage.write_mqtt_message(rf_copy(100 + i, "aa")) for i in range(6)]
+            assert [g is not None for g in got] == [True] * 4 + [False] * 2
+            assert len(conn.rows) == 4
+            assert storage._ingest_limiter.denied_total == 2
+            await storage.close()
+        run(scenario())
+
+    def test_replay_inserts_are_not_charged(self):
+        async def scenario():
+            storage = make_storage(max_packets_per_node_per_minute=2)
+            token = _REPLAYING.set(True)
+            try:
+                for i in range(5):
+                    assert await storage.write_mqtt_message(rf_copy(500 + i, "aa")) == i + 1
+            finally:
+                _REPLAYING.reset(token)
+            assert storage._ingest_limiter.exhausted("1f1ffa8b") is False
+            await storage.close()
+        run(scenario())
+
+
+class TestFloodIsLogged:
+    def test_incident_absorption_emits_a_warning(self, caplog):
+        """The incident shape never trips the limiter — the absorption WARNING
+        is the only sign in the logs that a node is looping."""
+        async def scenario():
+            storage = make_storage()
+            with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+                for i in range(60):
+                    await storage.write_mqtt_message(mapreport(i))
+            msgs = [r.getMessage() for r in caplog.records]
+            assert len(msgs) == 1 and "keeps re-sending identical packets" in msgs[0]
+            assert ROGUE in msgs[0]
+            await storage.close()
+        run(scenario())
+
+    def test_normal_traffic_logs_nothing(self, caplog):
+        async def scenario():
+            storage = make_storage()
+            with caplog.at_level(logging.INFO, logger="storage.db.ingest_guard"):
+                for i in range(10):
+                    await storage.write_mqtt_message(rf_copy(700 + i, f"{i:08x}"))
+                await storage.write_mqtt_message(mapreport(1))
+                await storage.write_mqtt_message(mapreport(2))  # one absorbed copy
+            assert caplog.records == []
+            await storage.close()
+        run(scenario())
+
+    def test_replay_absorption_is_not_logged(self, caplog):
+        """The drain re-delivering outage-era repeats isn't a live flood."""
+        async def scenario():
+            storage = make_storage()
+            assert await storage.write_mqtt_message(mapreport(1)) == 1
+            token = _REPLAYING.set(True)
+            try:
+                with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+                    for i in range(100):
+                        assert await storage.write_mqtt_message(mapreport(2 + i)) is None
+            finally:
+                _REPLAYING.reset(token)
+            assert caplog.records == []
+            await storage.close()
+        run(scenario())

--- a/tests/test_ingest_guard.py
+++ b/tests/test_ingest_guard.py
@@ -1,0 +1,176 @@
+"""
+Tests for storage.db.ingest_guard.NodeRateLimiter: the per-node minute/hour
+budget of new archive rows that keeps one looping node from owning the disk.
+"""
+
+import logging
+
+from storage.db.ingest_guard import NO_FROM, NodeRateLimiter, SuppressedCopyLog
+
+
+def _spend(lim, node, n, now):
+    """Try n rows: allow() then charge() on success. Returns rows created."""
+    made = 0
+    for _ in range(n):
+        if lim.allow(node, now=now):
+            lim.charge(node, now=now)
+            made += 1
+    return made
+
+
+class TestNodeRateLimiter:
+    def test_allows_up_to_minute_limit_then_denies(self):
+        lim = NodeRateLimiter(per_minute=3, per_hour=0)
+        assert _spend(lim, "aa", 10, now=0.0) == 3
+        assert lim.denied_total == 7
+
+    def test_minute_window_rolls_over(self):
+        lim = NodeRateLimiter(per_minute=2, per_hour=0)
+        assert _spend(lim, "aa", 5, now=0.0) == 2
+        assert lim.allow("aa", now=59.9) is False
+        assert lim.allow("aa", now=60.0) is True
+        assert _spend(lim, "aa", 5, now=60.0) == 2
+
+    def test_hour_tier_caps_sustained_rate(self):
+        lim = NodeRateLimiter(per_minute=60, per_hour=100)
+        made = sum(_spend(lim, "aa", 60, now=float(m * 60)) for m in range(60))
+        assert made == 100  # 60/min allowed, but only 100 in the hour
+        assert lim.allow("aa", now=3600.0) is True  # hour rolled over
+
+    def test_legit_profile_never_denied(self):
+        # Measured legit peaks: 28/min, 39/5min, 55/15min, 119/hour.
+        lim = NodeRateLimiter(per_minute=60, per_hour=600)
+        assert _spend(lim, "aa", 28, now=0.0) == 28
+        for m in range(1, 60):
+            assert _spend(lim, "aa", 2, now=float(m * 60)) == 2
+        assert lim.denied_total == 0
+
+    def test_nodes_are_independent(self):
+        lim = NodeRateLimiter(per_minute=1, per_hour=0)
+        assert _spend(lim, "aa", 2, now=0.0) == 1
+        assert lim.allow("bb", now=0.0) is True
+
+    def test_zero_disables(self):
+        lim = NodeRateLimiter(per_minute=0, per_hour=0)
+        assert lim.enabled is False
+        assert _spend(lim, "aa", 1000, now=0.0) == 1000
+        assert lim.denied_total == 0
+        assert lim._nodes == {}
+
+    def test_none_node_shares_one_bucket(self):
+        lim = NodeRateLimiter(per_minute=2, per_hour=0)
+        assert _spend(lim, None, 5, now=0.0) == 2
+        assert lim.exhausted(None, now=0.0) is True
+        assert NO_FROM in lim._nodes
+
+    def test_charge_only_counts_rows_not_attempts(self):
+        """Admission is a peek: copies that never become rows cost nothing,
+        so a DB outage (no inserts) never spends the budget."""
+        lim = NodeRateLimiter(per_minute=1, per_hour=0)
+        for _ in range(100):
+            assert lim.allow("aa", now=0.0) is True
+        assert lim.exhausted("aa", now=0.0) is False
+        lim.charge("aa", now=0.0)
+        assert lim.allow("aa", now=0.0) is False
+
+    def test_exhausted_is_a_pure_peek(self, caplog):
+        lim = NodeRateLimiter(per_minute=1, per_hour=0)
+        lim.charge("aa", now=0.0)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            for _ in range(5):
+                assert lim.exhausted("aa", now=1.0) is True
+        assert lim.denied_total == 0
+        assert caplog.records == []
+
+    def test_incident_pattern_drops_almost_everything(self):
+        # 49 msg/s of distinct content for 10 minutes: 60/min, 600/h.
+        lim = NodeRateLimiter(per_minute=60, per_hour=600)
+        made = sum(_spend(lim, "eba3d8e8", 49, now=float(sec)) for sec in range(600))
+        assert made == 600
+        assert lim.denied_total == 600 * 49 - 600
+
+    def test_warning_once_on_start_then_per_minute_summary(self, caplog):
+        lim = NodeRateLimiter(per_minute=1, per_hour=0)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            _spend(lim, "eba3d8e8", 50, now=0.0)      # start of flood: one line
+            _spend(lim, "eba3d8e8", 50, now=30.0)     # same window: silent
+            _spend(lim, "eba3d8e8", 50, now=60.0)     # rollover: summary of last window
+            _spend(lim, "eba3d8e8", 50, now=120.0)    # rollover: summary
+        msgs = [r.getMessage() for r in caplog.records]
+        assert len(msgs) == 3, msgs
+        assert msgs[0].startswith("Node eba3d8e8 exceeded 1/min new archive rows")
+        assert 'ingest_denylist' in msgs[0] and '"eba3d8e8"' in msgs[0]
+        assert "/hour" not in msgs[0]  # disabled tier is not mentioned
+        assert "dropped 99 writes in the last minute" in msgs[1]
+        assert "dropped 49 writes in the last minute" in msgs[2]
+
+    def test_quiet_window_resets_start_warning(self, caplog):
+        lim = NodeRateLimiter(per_minute=1, per_hour=0)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            _spend(lim, "aa", 3, now=0.0)          # start warning
+            assert lim.allow("aa", now=100.0)      # clean window (summary of the previous)
+            _spend(lim, "aa", 3, now=200.0)        # flood again: start warning again
+        msgs = [r.getMessage() for r in caplog.records]
+        assert [m.startswith("Node aa exceeded") for m in msgs] == [True, False, True]
+
+    def test_purge_bounds_memory(self):
+        lim = NodeRateLimiter(per_minute=5, per_hour=0, max_nodes=3)
+        for i in range(3):
+            lim.charge(f"n{i}", now=0.0)
+        assert len(lim._nodes) == 3
+        lim.charge("n3", now=3601.0)  # all three are stale -> purged, then n3 added
+        assert set(lim._nodes) == {"n3"}
+
+
+class TestSuppressedCopyLog:
+    def _flood(self, log, node, n, now):
+        for _ in range(n):
+            log.note(node, now=now)
+
+    def test_warns_once_on_crossing_then_summary_per_window(self, caplog):
+        log = SuppressedCopyLog(threshold=30)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            self._flood(log, "eba3d8e8", 2900, now=0.0)     # crossing: one line
+            self._flood(log, "eba3d8e8", 2900, now=60.0)    # rollover: summary, no re-cross line
+            self._flood(log, "eba3d8e8", 2900, now=120.0)   # rollover: summary
+        msgs = [r.getMessage() for r in caplog.records]
+        assert len(msgs) == 3, msgs
+        assert "keeps re-sending identical packets" in msgs[0]
+        assert 'ingest_denylist' in msgs[0] and '"eba3d8e8"' in msgs[0]
+        assert "2900 duplicate copies absorbed" in msgs[1]
+        assert "2900 duplicate copies absorbed" in msgs[2]
+
+    def test_below_threshold_stays_silent(self, caplog):
+        log = SuppressedCopyLog(threshold=30)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            self._flood(log, "aa", 29, now=0.0)
+            self._flood(log, "aa", 29, now=60.0)
+        assert caplog.records == []
+
+    def test_quiet_window_re_arms_the_crossing_warning(self, caplog):
+        log = SuppressedCopyLog(threshold=5)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            self._flood(log, "aa", 10, now=0.0)     # cross
+            log.note("aa", now=100.0)               # quiet-ish window (summary of the last)
+            self._flood(log, "aa", 10, now=200.0)   # cross again
+        msgs = [r.getMessage() for r in caplog.records]
+        assert ["keeps re-sending" in m for m in msgs] == [True, False, True]
+
+    def test_quiet_gap_re_arms_and_skips_stale_summary(self, caplog):
+        """A summary is only for a window that just ended; after a long gap the
+        crossing warning fires again instead of a mislabeled old count."""
+        log = SuppressedCopyLog(threshold=30)
+        with caplog.at_level(logging.WARNING, logger="storage.db.ingest_guard"):
+            self._flood(log, "aa", 100, now=0.0)    # crossing line
+            self._flood(log, "aa", 100, now=600.0)  # 10 min later: no stale summary, re-cross
+        msgs = [r.getMessage() for r in caplog.records]
+        assert len(msgs) == 2, msgs
+        assert all("keeps re-sending" in m for m in msgs)
+
+    def test_none_node_and_memory_bound(self):
+        log = SuppressedCopyLog(threshold=5, max_nodes=2)
+        log.note(None, now=0.0)
+        assert log._nodes == {}
+        log.note("a", now=0.0); log.note("b", now=0.0)
+        log.note("c", now=61.0)  # stale entries purged
+        assert set(log._nodes) == {"c"}

--- a/tests/test_mqtt_handlers.py
+++ b/tests/test_mqtt_handlers.py
@@ -37,6 +37,13 @@ def make_mqtt(nodes=None, json_decoder=False, protobuf_decoder=True):
     return MQTT(config, data), data
 
 
+def make_mqtt_denying(denylist, **kw):
+    """make_mqtt with a [storage] ingest_denylist."""
+    mqtt, data = make_mqtt(**kw)
+    mqtt.config["storage"] = {"ingest_denylist": denylist}
+    return MQTT(mqtt.config, data), data
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # handle_nodeinfo — the headline "Unknown nodes" path
 # ─────────────────────────────────────────────────────────────────────────────
@@ -787,3 +794,184 @@ class TestNormalizeMsgAddrs:
         msg = {"from": 0x1, "sender": "!67ea9400"}
         mqtt._normalize_msg_addrs(msg)
         assert msg["sender"] == "67ea9400"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ingest_denylist — dropped at the decoder: no archive row, no handler
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIngestDenylist:
+    def test_protobuf_packet_from_denied_node_is_dropped_entirely(self):
+        mqtt, data = make_mqtt_denying(["eba3d8e8"])
+        msg = build_envelope(from_=0xEBA3D8E8, portnum=portnums_pb2.NODEINFO_APP,
+                             payload=mesh_pb2.User(id="!eba3d8e8", long_name="Rogue").SerializeToString())
+        run(mqtt.process_mqtt_msg(None, msg))
+        assert data.pg_storage.mqtt_writes == []
+        assert data.pg_storage.writes == []
+
+    def test_other_nodes_still_flow(self):
+        mqtt, data = make_mqtt_denying(["eba3d8e8"])
+        run(mqtt.process_mqtt_msg(None, build_envelope(from_=0x67EA9400)))
+        assert len(data.pg_storage.mqtt_writes) == 1
+
+    def test_config_ids_are_normalized(self):
+        # '!' prefix, upper case, short hex all match the wire id; non-strings are ignored
+        mqtt, data = make_mqtt_denying(["!EBA3D8E8", "1F", 12])
+        assert mqtt._denied_nodes == frozenset({"eba3d8e8", "0000001f"})
+        run(mqtt.process_mqtt_msg(None, build_envelope(from_=0xEBA3D8E8)))
+        run(mqtt.process_mqtt_msg(None, build_envelope(from_=0x1F)))
+        assert data.pg_storage.mqtt_writes == []
+
+    def test_json_packet_from_denied_node_is_dropped(self):
+        mqtt, data = make_mqtt_denying(["eba3d8e8"], json_decoder=True, protobuf_decoder=False)
+        payload = json.dumps({"from": 0xEBA3D8E8, "type": "position", "id": 5,
+                              "payload": {"latitude_i": 1, "longitude_i": 2}}).encode()
+        from _helpers import FakeMqttMessage
+        run(mqtt.process_mqtt_msg(None, FakeMqttMessage("msh/US/2/json/LongFast/!abcd1234", payload)))
+        assert data.pg_storage.mqtt_writes == []
+        assert data.pg_storage.writes == []
+
+    def test_bare_string_denylist_is_ignored_not_split(self):
+        mqtt, _ = make_mqtt_denying("eba3d8e8")
+        assert mqtt._denied_nodes == frozenset()
+
+    def test_empty_denylist_is_free(self):
+        mqtt, _ = make_mqtt()
+        assert mqtt._denied_nodes == frozenset()
+        assert mqtt._is_denied(0xEBA3D8E8) is False
+
+    def test_denylisted_gateway_drops_what_it_uplinks(self):
+        mqtt, data = make_mqtt_denying(["abcd1234"])  # the envelope's gateway_id
+        run(mqtt.process_mqtt_msg(None, build_envelope(from_=0x67EA9400, gateway_id="!abcd1234")))
+        assert data.pg_storage.mqtt_writes == []
+        run(mqtt.process_mqtt_msg(None, build_envelope(from_=0x67EA9400, gateway_id="!11112222",
+                                                        topic="msh/US/2/e/LongFast/!11112222")))
+        assert len(data.pg_storage.mqtt_writes) == 1
+
+    def test_protobuf_gateway_from_topic_suffix_when_envelope_blank(self):
+        mqtt, data = make_mqtt_denying(["abcd1234"])
+        run(mqtt.process_mqtt_msg(None, build_envelope(from_=0x67EA9400, gateway_id="",
+                                                        topic="msh/US/2/e/LongFast/!abcd1234")))
+        assert data.pg_storage.mqtt_writes == []
+
+    def test_hex_like_topic_segment_is_not_a_gateway(self):
+        # Only a '!'-prefixed suffix is a gateway id; 'cafe' is a channel name.
+        mqtt, data = make_mqtt_denying(["0000cafe"], json_decoder=True, protobuf_decoder=False)
+        from _helpers import FakeMqttMessage
+        payload = json.dumps({"from": 0x67EA9400, "type": "position", "id": 5,
+                              "payload": {"latitude_i": 1, "longitude_i": 2}}).encode()
+        run(mqtt.process_mqtt_msg(None, FakeMqttMessage("msh/US/2/json/cafe", payload)))
+        assert len(data.pg_storage.mqtt_writes) == 1
+
+    def test_json_sender_field_denylisted(self):
+        mqtt, data = make_mqtt_denying(["abcd1234"], json_decoder=True, protobuf_decoder=False)
+        from _helpers import FakeMqttMessage
+        payload = json.dumps({"from": 0x67EA9400, "sender": "!abcd1234", "type": "position", "id": 5,
+                              "payload": {"latitude_i": 1, "longitude_i": 2}}).encode()
+        run(mqtt.process_mqtt_msg(None, FakeMqttMessage("msh/US/2/json/LongFast/!11112222", payload)))
+        assert data.pg_storage.mqtt_writes == []
+
+    def test_json_denylisted_gateway_from_topic_suffix(self):
+        mqtt, data = make_mqtt_denying(["abcd1234"], json_decoder=True, protobuf_decoder=False)
+        from _helpers import FakeMqttMessage
+        payload = json.dumps({"from": 0x67EA9400, "type": "position", "id": 5,
+                              "payload": {"latitude_i": 1, "longitude_i": 2}}).encode()
+        run(mqtt.process_mqtt_msg(None, FakeMqttMessage("msh/US/2/json/LongFast/!abcd1234", payload)))
+        assert data.pg_storage.mqtt_writes == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# flood guard hooks in the decoder/handlers — id-less repeat skip, budget gate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFloodGuardHooks:
+    def _mapreport_envelope(self, from_=0xEBA3D8E8):
+        from meshtastic import mqtt_pb2
+        report = mqtt_pb2.MapReport(long_name="River Dragon", short_name="RD", hw_model=37, role=11,
+                                    latitude_i=393412608, longitude_i=-1210384384, num_online_local_nodes=191)
+        return build_envelope(from_=from_, packet_id=0, portnum=portnums_pb2.MAP_REPORT_APP,
+                              payload=report.SerializeToString(), gateway_id="!eba3d8e8",
+                              topic="msh/US/bayarea/2/map/")
+
+    def test_mapreport_first_copy_runs_handler_and_archives(self):
+        mqtt, data = make_mqtt()
+        run(mqtt.process_mqtt_msg(None, self._mapreport_envelope()))
+        assert len(data.pg_storage.writes) == 1          # node upsert ran
+        assert len(data.pg_storage.mqtt_writes) == 1     # archive write attempted
+        assert "id" not in data.pg_storage.mqtt_writes[0]  # id-less on the wire
+
+    def test_idless_repeat_skips_node_upsert_but_still_offers_archive(self):
+        mqtt, data = make_mqtt()
+        data.pg_storage.idless_repeats = 1
+        run(mqtt.process_mqtt_msg(None, self._mapreport_envelope()))
+        assert data.pg_storage.writes == []              # handler skipped
+        assert len(data.pg_storage.mqtt_writes) == 1     # storage decides (returns None for a repeat)
+        # Archived shape is identical to the handled copy's (from/to normalized
+        # before the peek), so both hash to the same content key.
+        skipped = data.pg_storage.mqtt_writes[0]
+        mqtt2, data2 = make_mqtt()
+        run(mqtt2.process_mqtt_msg(None, self._mapreport_envelope()))
+        handled = data2.pg_storage.mqtt_writes[0]
+        assert skipped["from"] == handled["from"] == "eba3d8e8"
+        assert skipped["to"] == handled["to"]
+        from storage.db.uplink_dedup import content_key
+        assert content_key(skipped) == content_key(handled)
+
+    def test_peek_sees_normalized_addresses(self):
+        """The storage peek receives the same dict shape handle_log archives."""
+        mqtt, data = make_mqtt()
+        seen = []
+        data.pg_storage.idless_repeat = lambda msg: (seen.append(dict(msg)), False)[1]
+        run(mqtt.process_mqtt_msg(None, self._mapreport_envelope()))
+        assert seen[0]["from"] == "eba3d8e8" and seen[0]["to"] == "abcd1234"  # ints normalized to hex
+        from storage.db.uplink_dedup import content_key
+        peeked = {k: v for k, v in seen[0].items() if k not in ("decoded", "encrypted")}
+        assert content_key(peeked) == content_key(data.pg_storage.mqtt_writes[0])
+
+    def test_peek_failure_falls_back_to_handling(self):
+        mqtt, data = make_mqtt()
+        def boom(msg):
+            raise RuntimeError("peek bug")
+        data.pg_storage.idless_repeat = boom
+        run(mqtt.process_mqtt_msg(None, self._mapreport_envelope()))
+        assert len(data.pg_storage.writes) == 1 and len(data.pg_storage.mqtt_writes) == 1
+
+    def test_over_budget_node_skips_state_handlers_too(self):
+        mqtt, data = make_mqtt()
+        data.pg_storage.over_budget_nodes = {"eba3d8e8"}
+        run(mqtt.process_mqtt_msg(None, self._mapreport_envelope()))
+        run(mqtt.handle_position({"from": 0xEBA3D8E8, "id": 3, "payload": {"latitude_i": 1, "longitude_i": 2}}))
+        run(mqtt.handle_nodeinfo({"from": 0xEBA3D8E8, "payload": {"id": "!eba3d8e8", "long_name": "x"}}))
+        run(mqtt.handle_neighborinfo({"from": 0xEBA3D8E8, "payload": {"neighbors": []}}))
+        assert data.pg_storage.writes == []
+        assert len(data.pg_storage.mqtt_writes) == 1  # archive still consulted (it drops/counts)
+
+    def test_over_budget_node_skips_history_writers(self):
+        mqtt, data = make_mqtt()
+        data.pg_storage.over_budget_nodes = {"67ea9400"}
+        run(mqtt.handle_telemetry({"from": 0x67EA9400, "telemetry_type": "device_metrics",
+                                   "payload": {"battery_level": 90}}))
+        run(mqtt.handle_text({"from": 0x67EA9400, "id": 7, "channel": "0", "payload": {"text": "hi"}}))
+        run(mqtt.handle_traceroute({"from": 0x67EA9400, "id": 8, "payload": {"route": []}}))
+        assert data.pg_storage.telemetry_writes == []
+        assert data.pg_storage.chat_writes == []
+        assert data.pg_storage.traceroute_writes == []
+        assert data.pg_storage.writes == []  # not even the node merge for telemetry
+
+    def test_in_budget_node_writes_history(self):
+        mqtt, data = make_mqtt()
+        run(mqtt.handle_telemetry({"from": 0x67EA9400, "telemetry_type": "device_metrics",
+                                   "payload": {"battery_level": 90}}))
+        assert len(data.pg_storage.telemetry_writes) == 1
+
+    def test_denylist_drop_logged_once_at_info(self, caplog):
+        import logging
+        mqtt, data = make_mqtt_denying(["eba3d8e8"])
+        with caplog.at_level(logging.INFO, logger="mqtt"):
+            run(mqtt.process_mqtt_msg(None, build_envelope(from_=0xEBA3D8E8)))
+            run(mqtt.process_mqtt_msg(None, build_envelope(from_=0xEBA3D8E8)))
+        infos = [r for r in caplog.records if r.levelno == logging.INFO and "denylisted" in r.getMessage()]
+        assert len(infos) == 1
+        assert "eba3d8e8" in infos[0].getMessage()

--- a/tests/test_uplink_dedup.py
+++ b/tests/test_uplink_dedup.py
@@ -223,3 +223,80 @@ class TestUplinkDedupCache:
         cache.put(("cc", 3), 3, {}, now=1002.0)
         assert cache.get(("aa", 1), now=1003.0) is None
         assert cache.get(("cc", 3), now=1003.0) == (3, {})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Id-less packets: content key + per-gateway reception tracking
+# ─────────────────────────────────────────────────────────────────────────────
+
+from storage.db.uplink_dedup import content_key  # noqa: E402
+
+MAPREPORT = {
+    "from": "eba3d8e8", "to": "ffffffff", "sender": "eba3d8e8",
+    "timestamp": 1787025877, "topic": "msh/US/bayarea/2/map/",
+    "qos": 0, "retain": False, "channel": 31, "channel_name": "MediumFast",
+    "type": "mapreport",
+    "payload": {"altitude": 853, "firmware_version": "2.7.15", "hw_model": 37,
+                "latitude_i": 393412608, "longitude_i": -1210384384,
+                "long_name": "River Dragon - Base", "num_online_local_nodes": 191,
+                "role": 11, "short_name": "RD"},
+}
+
+
+class TestContentKey:
+    def test_per_copy_envelope_does_not_change_key(self):
+        # The incident pattern: rx_time (-> timestamp) ticks every second, and
+        # gateway/topic/qos differ per uplink — none of it is packet content.
+        a = dict(MAPREPORT)
+        b = dict(MAPREPORT, timestamp=MAPREPORT["timestamp"] + 1, qos=1, retain=True,
+                 sender="aabbccdd", topic="msh/US/2/map/", rssi=-90, snr=3.5,
+                 rx_time=5, hop_limit=2, hops_away=1, relay_node=7)
+        assert content_key(a) == content_key(b)
+
+    def test_payload_change_changes_key(self):
+        a = dict(MAPREPORT)
+        b = dict(MAPREPORT, payload=dict(MAPREPORT["payload"], num_online_local_nodes=192))
+        assert content_key(a) != content_key(b)
+
+    def test_from_type_channel_are_content(self):
+        assert content_key(dict(MAPREPORT, **{"from": "00000001"})) != content_key(MAPREPORT)
+        assert content_key(dict(MAPREPORT, type="nodeinfo")) != content_key(MAPREPORT)
+        assert content_key(dict(MAPREPORT, channel=8)) != content_key(MAPREPORT)
+
+    def test_key_order_independent(self):
+        shuffled = {k: MAPREPORT[k] for k in reversed(list(MAPREPORT))}
+        assert content_key(shuffled) == content_key(MAPREPORT)
+
+    def test_non_json_values_use_default(self):
+        import datetime
+        msg = dict(MAPREPORT, payload={"when": datetime.datetime(2026, 8, 18, 1, 2, 3)})
+        assert content_key(msg, default=str) == content_key(dict(msg), default=str)
+
+
+class TestGatewayTracking:
+    def test_unmarked_gateway_is_new_then_seen(self):
+        cache = UplinkDedupCache(window_seconds=900)
+        key = ("eba3d8e8", "abc")
+        cache.put(key, 7, {}, now=1000.0)
+        assert cache.gateway_seen(key, "eba3d8e8", now=1001.0) is False
+        cache.mark_gateway(key, "eba3d8e8", now=1001.0)
+        assert cache.gateway_seen(key, "eba3d8e8", now=1002.0) is True
+        assert cache.gateway_seen(key, "other", now=1002.0) is False
+        # get() keeps its 2-tuple contract with the gateway set attached
+        assert cache.get(key, now=1002.0) == (7, {})
+
+    def test_gateway_set_dies_with_entry(self):
+        cache = UplinkDedupCache(window_seconds=100)
+        key = ("eba3d8e8", "abc")
+        cache.put(key, 7, {}, now=1000.0)
+        cache.mark_gateway(key, "gw", now=1000.0)
+        assert cache.gateway_seen(key, "gw", now=1101.0) is False
+        cache.mark_gateway(key, "gw", now=1101.0)  # no entry: no-op, no error
+        assert cache.get(key, now=1101.0) is None
+
+    def test_none_gateway_is_tracked_too(self):
+        cache = UplinkDedupCache(window_seconds=900)
+        key = ("aa", "k")
+        cache.put(key, 1, {}, now=0.0)
+        cache.mark_gateway(key, None, now=0.0)
+        assert cache.gateway_seen(key, None, now=1.0) is True


### PR DESCRIPTION
## Problem

A single misbehaving node ("River Dragon - Base", `eba3d8e8`, fw 2.7.15) looped
Meshtastic **MapReport** packets on a public broker at ~49 msg/s for days.
MapReports are sent with `MeshPacket.id = 0`, so `packet_id` stores as NULL and
the uplink dedup (#526) — keyed on `(from_node_id, packet_id)` — never applied:
**every copy became an `mqtt_messages` row**. Ingest went from ~42K to ~4.25M
rows/day (~3.3 GB/day).

## What this does

1. **Id-less packets dedup by content.** A packet with no packet id now merges
   with identical-content copies from the same node inside a short window
   (`[storage] content_dedup_window_seconds`, default 120 s), recording one
   `packet_receptions` row per gateway — same lossless model as #526, keyed by
   a content digest instead of the packet id. Replaying the incident collapses
   ~29,400 copies/10 min to one row per distinct content (4–5 rows).

2. **Per-node flood guard.** `[storage] max_packets_per_node_per_minute = 60`
   and `max_packets_per_node_per_hour = 600` cap *new* archive rows per
   originating node, so a rogue whose payload varies per message still can't
   own the disk. Copies that dedup folds into `packet_receptions` don't count,
   so dense meshes are unaffected (measured legit peaks on a live instance:
   28 rows/node/min, 119/hour, vs. up to 405 raw copies/node/min). Budget is
   charged on the actual insert — DB outages never spend it, so the outage
   retry buffer keeps working. Set a tier to 0 to disable. Inactive when
   `dedup_uplinks = false` (config validation warns). Per-packet receptions
   are also capped (1000; densest legit packet observed carries ~91).

3. **`[storage] ingest_denylist = []`** — blunt escape hatch: listed node ids
   are dropped at the decoder, as origin *or* uplinking gateway.

4. **Floods are visible in the logs.** Dedup absorbing 30+ copies/node/min
   WARNs once when it starts, then a per-minute summary; limiter drops WARN
   the same way (both include a ready-to-paste `ingest_denylist` line);
   denylist drops log once per node at INFO.

## Notes for reviewers / operators

- No schema migration. All knobs documented in `config.toml.sample`; defaults
  keep current behavior for healthy meshes (verified: legit rows, receptions,
  and dedup behavior unchanged in tests and on a live instance).
- UPGRADING.md documents the knobs, the new log lines, and a bounded
  DELETE + VACUUM recipe to purge rows an active flood already wrote
  (the compaction script intentionally passes id-less rows through).
- Verified against the real incident pattern: replay of one node at ~50
  id-less msg/s stores 4 rows per window; live deployment dropped the rogue
  from ~2,930 rows/min to 0 with other nodes' ingest unchanged.
- Tests: `tests/test_ingest_guard.py`, `tests/test_ingest_flood_guard.py`,
  plus additions to the dedup/handler/config suites.
