### PR TITLE
fix(discord): eliminate duplicate bridge posts from straggler gateways; name-keyed channel maps

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -119,6 +119,18 @@ MeshInfo logs a warning and runs without it — topic filters just get slower.
 startup warning and shows automatic pills instead. Set `mode = "manual"` to keep
 your curated list, or drop the lists and use `"presets"` (default) or `"all"`.
 
+## Discord bridge: straggler copies edit instead of re-posting
+
+The bridge used to forget a packet 60 s after first sight, so a gateway copy
+arriving later (measured up to ~14 min on a real mesh) re-posted the same
+packet as a fresh embed with `Gateways 1` (#585). Posted embeds now stay
+editable for `[integrations.discord.bridge] edit_window_seconds` (default
+900 s): late copies update the original embed's gateway list, and the embed
+timestamp stays the packet's own time instead of shifting on each edit. The
+"View All Gateways" detail view is also capped to Discord's per-message
+limits (10 embeds / 6000 chars) with a truncation note when a very large
+reception list is cut.
+
 ## Discord bridge channel maps
 
 `[integrations.discord.bridge.channels]` and `position_channels` keys keyed on

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -133,10 +133,20 @@ reception list is cut.
 
 ## Discord bridge channel maps
 
-`[integrations.discord.bridge.channels]` and `position_channels` keys keyed on
-legacy slot-index values (e.g. `"0"`) stop matching once traffic resolves to
-hashes. Re-key them to hash ids — find yours via `/v1/channels` or the `?ch=`
-value in Chat URLs.
+`[integrations.discord.bridge.channels]` and `position_channels` now accept
+wire channel **names** as keys (`"MediumFast" = "<discord id>"`) — the
+recommended form: names are what operators know, they follow a channel across
+PSK re-keys, and they also match decode-only channels whose hash never appears
+on the wire. Matching is case-sensitive (wire names are). Numeric keys still
+work and take precedence — use one to pin a single name+PSK domain when two
+communities share a channel name, or for a channel whose *name* is all digits.
+Caveat: messages from the JSON decoder carry no wire name, so JSON-only
+deployments should keep numeric keys.
+
+Legacy slot-index keys (e.g. `"0"`) stop matching once the protobuf decoder
+resolves traffic to hash buckets; JSON-only deployments are unaffected and
+keep their slot-index keys. Protobuf deployments should re-key to names, or
+find bucket ids via `/v1/channels` or the `?ch=` value in Chat URLs.
 
 ## Coverage preset renames
 

--- a/bot/cogs/main_commands.py
+++ b/bot/cogs/main_commands.py
@@ -10,6 +10,7 @@ from discord.ext import commands
 from meshtastic import mesh_pb2, config_pb2
 
 import utils
+import channels
 from bot.embeds import resolve_channel_name
 from data_store import DataStore
 
@@ -328,9 +329,20 @@ class MainCommands(commands.Cog):
         discord_ch_id = str(interaction.channel_id)
         for mesh_ch, disc_ch in bridge_channels.items():
             if str(disc_ch) == discord_ch_id:
-                mesh_channel = mesh_ch
-                # Resolve a friendly label from channel meta
-                channel_label = resolve_channel_name(mesh_ch, self.config)
+                key = str(mesh_ch)
+                if key.isascii() and key.isdigit():
+                    mesh_channel = key
+                    # Resolve a friendly label from channel meta
+                    channel_label = resolve_channel_name(key, self.config)
+                else:
+                    # Name-keyed map entry: history spans the name bucket and,
+                    # once the hash is learned, the hash bucket.
+                    name = channels.normalize_wire_name(key)
+                    channel_label = name
+                    mesh_channel = [str(channels.name_bucket_id(name))]
+                    learned = (await self.data.pg_storage.get_wire_channel_names()).get(name)
+                    if learned is not None:
+                        mesh_channel.append(str(learned))
                 break
 
         stats = await self.data.pg_storage.query_top_nodes(hours=hours, limit=5, channel_id=mesh_channel)

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -19,6 +19,7 @@ import discord
 from discord.ext import commands, tasks
 
 from bot.embeds import build_text_embed, build_position_embed, build_gateway_detail_embed
+from channels import normalize_wire_name
 from data_store import DataStore
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,27 @@ def _sanitize_webhook_username(name: str) -> str:
     if len(name) > WEBHOOK_USERNAME_LIMIT:
         name = name[: WEBHOOK_USERNAME_LIMIT - 1] + "…"
     return name
+
+
+def _split_channel_map(raw: dict) -> tuple[dict, dict]:
+    """Split a bridge channel map into (bucket-id keys, name keys).
+
+    All-digit keys are channel bucket ids (hashes or name-bucket ids); anything
+    else is a wire channel name, matched case-sensitively after the same
+    normalization stored channel_name gets. A channel whose *name* is all
+    digits must be mapped by its bucket id.
+    """
+    by_id: dict[str, str] = {}
+    by_name: dict[str, str] = {}
+    for key, value in (raw or {}).items():
+        k = str(key)
+        if k.isascii() and k.isdigit():  # bucket ids are str(int); "٣١" is a name
+            by_id[k] = value
+        else:
+            norm = normalize_wire_name(k)
+            if norm:
+                by_name[norm] = value
+    return by_id, by_name
 
 
 def _chunk_mentions(user_ids: list, limit: int = MESSAGE_CONTENT_LIMIT - 100) -> list[str]:
@@ -115,6 +137,7 @@ class _PendingPacket:
         "node_id",
         "gateways",
         "first_seen",
+        "wall_first_seen",
         "last_post",
         "discord_message",
         "sent_via_webhook",
@@ -130,6 +153,7 @@ class _PendingPacket:
         self.node_id = node_id
         self.gateways: list[dict] = []
         self.first_seen: float = time.monotonic()
+        self.wall_first_seen: float = time.time()
         self.last_post: float = 0.0
         self.discord_message: Optional[discord.Message] = None
         self.sent_via_webhook: bool = False
@@ -179,8 +203,11 @@ class MeshBridge(commands.Cog):
         self.edit_window_seconds = max(
             float(self.aggregate_seconds), float(bridge_cfg.get("edit_window_seconds", 900))
         )
+        # Maps accept bucket ids ("31") or wire channel names ("MediumFast").
         self.channel_map: dict[str, str] = bridge_cfg.get("channels", {})
         self.position_channel_map: dict[str, str] = bridge_cfg.get("position_channels", {})
+        self._chat_by_id, self._chat_by_name = _split_channel_map(self.channel_map)
+        self._pos_by_id, self._pos_by_name = _split_channel_map(self.position_channel_map)
 
         # packet_key -> _PendingPacket, insertion-ordered (oldest first)
         self._pending: dict[str, _PendingPacket] = {}
@@ -238,6 +265,26 @@ class MeshBridge(commands.Cog):
             if node:
                 enriched[nid] = node
         return enriched
+
+    @staticmethod
+    def _map_lookup(by_id: dict, by_name: dict, bucket, channel_name) -> Optional[str]:
+        """Discord channel id for a message: exact bucket-id key first (pins one
+        crypto domain), then the wire name (follows the channel across re-keys
+        and name buckets). None when unmapped."""
+        hit = by_id.get(str(bucket if bucket is not None else "0"))
+        if hit is not None:
+            return hit
+        name = normalize_wire_name(channel_name)
+        return by_name.get(name) if name else None
+
+    def _chat_discord_channel(self, bucket, channel_name) -> Optional[str]:
+        return self._map_lookup(self._chat_by_id, self._chat_by_name, bucket, channel_name)
+
+    def _position_discord_channel(self, bucket, channel_name) -> Optional[str]:
+        hit = self._map_lookup(self._pos_by_id, self._pos_by_name, bucket, channel_name)
+        if hit is not None:
+            return hit
+        return self._chat_discord_channel(bucket, channel_name)
 
     # ─── Webhook management ──────────────────────────────────────────
 
@@ -305,13 +352,13 @@ class MeshBridge(commands.Cog):
             # weight would evict packets that DID post (re-opening #585).
             if event_type == "text":
                 chat = event.get("chat", {})
-                if str(chat.get("channel", "0")) not in self.channel_map:
+                if self._chat_discord_channel(chat.get("channel", "0"),
+                                              chat.get("channel_name")) is None:
                     return
                 pending = _PendingPacket("text", msg, chat=chat)
             elif event_type == "position":
-                channel_hash = str(msg.get("channel", "0"))
-                if (channel_hash not in self.position_channel_map
-                        and channel_hash not in self.channel_map):
+                if self._position_discord_channel(msg.get("channel", "0"),
+                                                  msg.get("channel_name")) is None:
                     return
                 node_id = event.get("node_id", from_id)
                 if not await self.data.pg_storage.is_node_tracked(node_id):
@@ -389,9 +436,9 @@ class MeshBridge(commands.Cog):
         """Post or update a text message embed."""
         chat = pending.chat or {}
         msg = pending.msg
-        channel_hash = str(chat.get("channel", "0"))
 
-        discord_channel_id = self.channel_map.get(channel_hash)
+        discord_channel_id = self._chat_discord_channel(
+            chat.get("channel", "0"), chat.get("channel_name"))
         if not discord_channel_id:
             return
 
@@ -440,6 +487,7 @@ class MeshBridge(commands.Cog):
             config=self.config,
             owner_id=owner_id,
             gateway_entries=pending.gateways,
+            fallback_ts=pending.wall_first_seen,
         )
 
         # Only show "View All Gateways" button if gateway data was truncated
@@ -526,10 +574,8 @@ class MeshBridge(commands.Cog):
         if not await self.data.pg_storage.is_node_tracked(node_id):
             return
 
-        channel_hash = str(msg.get("channel", "0"))
-        discord_channel_id = self.position_channel_map.get(channel_hash)
-        if not discord_channel_id:
-            discord_channel_id = self.channel_map.get(channel_hash)
+        discord_channel_id = self._position_discord_channel(
+            msg.get("channel", "0"), msg.get("channel_name"))
         if not discord_channel_id:
             return
 
@@ -569,6 +615,7 @@ class MeshBridge(commands.Cog):
             track_type=track_type,
             owner_id=owner_id,
             gateway_entries=pending.gateways,
+            fallback_ts=pending.wall_first_seen,
         )
 
         webhook = await self._get_webhook(channel)

--- a/bot/cogs/mesh_bridge.py
+++ b/bot/cogs/mesh_bridge.py
@@ -3,12 +3,15 @@ MeshBridge cog — live mesh-to-Discord message bridge.
 
 Consumes events from DataStore.discord_event_queue, aggregates gateway
 reports for the same packet over a configurable window (default 5s), then
-posts or edits a Discord embed via webhook. Each mesh node appears as a
-unique "sender" with its own name and avatar in Discord.
+posts or edits a Discord embed via webhook. The packet stays editable for
+edit_window_seconds (default 900) so straggler gateway copies — measured up
+to ~14 min late — update the posted embed instead of re-posting it (#585).
+Each mesh node appears as a unique "sender" with its own name and avatar.
 """
 
 import asyncio
 import logging
+import re
 import time
 from typing import Optional
 
@@ -22,22 +25,59 @@ logger = logging.getLogger(__name__)
 
 WEBHOOK_NAME = "MeshInfo Bridge"
 
+WEBHOOK_USERNAME_LIMIT = 80  # Discord: 1-80 chars, some substrings rejected
+MESSAGE_CONTENT_LIMIT = 2000
+
+
+def _sanitize_webhook_username(name: str) -> str:
+    """Keep a node-derived name valid as a webhook username."""
+    name = re.sub(r"(?i)clyde", "clyd3", name)
+    name = re.sub(r"(?i)discord", "disc0rd", name)
+    name = name.strip() or "Mesh Node"
+    if len(name) > WEBHOOK_USERNAME_LIMIT:
+        name = name[: WEBHOOK_USERNAME_LIMIT - 1] + "…"
+    return name
+
+
+def _chunk_mentions(user_ids: list, limit: int = MESSAGE_CONTENT_LIMIT - 100) -> list[str]:
+    """Join mention tokens into content-sized chunks, never splitting a token."""
+    chunks, current = [], ""
+    for uid in user_ids:
+        token = f"<@{uid}>"
+        joined = f"{current} {token}" if current else token
+        if len(joined) > limit and current:
+            chunks.append(current)
+            current = token
+        else:
+            current = joined
+    if current:
+        chunks.append(current)
+    return chunks
+
 # Module-level cache for gateway data (packet_id -> {msg, gateways, nodes})
 # Used by the ViewGateways button to retrieve data after the embed is posted
 _gateway_cache: dict[str, dict] = {}
 _GATEWAY_CACHE_MAX = 200
 
 
-class _ViewGatewaysButton(discord.ui.Button):
-    """Button that shows full gateway breakdown when clicked."""
+class _ViewGatewaysButton(
+    discord.ui.DynamicItem[discord.ui.Button], template=r"viewgw:(?P<pid>.+)"
+):
+    """Button that shows the full gateway breakdown. A DynamicItem so clicks
+    still resolve after a bot restart (the cache may be gone; that degrades
+    to the "expired" reply)."""
 
     def __init__(self, packet_id: str):
-        super().__init__(
+        super().__init__(discord.ui.Button(
             style=discord.ButtonStyle.secondary,
             label="View All Gateways",
             custom_id=f"viewgw:{packet_id}",
-        )
+        ))
         self.packet_id = packet_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match):
+        return cls(match["pid"])
 
     async def callback(self, interaction: discord.Interaction):
         data = _gateway_cache.get(self.packet_id)
@@ -75,9 +115,13 @@ class _PendingPacket:
         "node_id",
         "gateways",
         "first_seen",
+        "last_post",
         "discord_message",
+        "sent_via_webhook",
         "dirty",
     )
+
+    MAX_GATEWAYS = 200  # keeps the embed and the detail view bounded
 
     def __init__(self, event_type: str, msg: dict, chat: Optional[dict] = None, node_id: Optional[str] = None):
         self.event_type = event_type
@@ -86,16 +130,20 @@ class _PendingPacket:
         self.node_id = node_id
         self.gateways: list[dict] = []
         self.first_seen: float = time.monotonic()
+        self.last_post: float = 0.0
         self.discord_message: Optional[discord.Message] = None
+        self.sent_via_webhook: bool = False
         self.dirty: bool = True
 
     def add_gateway(self, msg: dict):
         """Add a gateway report for this packet."""
         topic = msg.get("topic", "")
-        topic_parts = topic.split("/")
-        gw_id = ""
-        if topic_parts and topic_parts[-1].startswith("!"):
-            gw_id = topic_parts[-1].replace("!", "")
+        # The decoder's normalized sender is the gateway; topic !suffix as fallback.
+        gw_id = msg.get("sender") or ""
+        if not gw_id:
+            topic_parts = topic.split("/")
+            if topic_parts and topic_parts[-1].startswith("!"):
+                gw_id = topic_parts[-1].replace("!", "")
 
         entry = {
             "gateway_id": gw_id,
@@ -109,6 +157,8 @@ class _PendingPacket:
         for existing in self.gateways:
             if existing["gateway_id"] == gw_id and gw_id:
                 return
+        if len(self.gateways) >= self.MAX_GATEWAYS:
+            return
         self.gateways.append(entry)
         self.dirty = True
 
@@ -124,15 +174,17 @@ class MeshBridge(commands.Cog):
         bridge_cfg = config.get("integrations", {}).get("discord", {}).get("bridge", {})
         self.bridge_enabled = bridge_cfg.get("enabled", False)
         self.aggregate_seconds = bridge_cfg.get("aggregate_seconds", 5)
+        # How long a posted packet keeps accepting straggler-gateway edits;
+        # copies arrive up to ~14 min late, so shorter windows re-post (#585).
+        self.edit_window_seconds = max(
+            float(self.aggregate_seconds), float(bridge_cfg.get("edit_window_seconds", 900))
+        )
         self.channel_map: dict[str, str] = bridge_cfg.get("channels", {})
         self.position_channel_map: dict[str, str] = bridge_cfg.get("position_channels", {})
 
-        # packet_key -> _PendingPacket
+        # packet_key -> _PendingPacket, insertion-ordered (oldest first)
         self._pending: dict[str, _PendingPacket] = {}
-        # Cache of recently sent Discord message IDs for reply threading
-        # mesh_packet_id -> discord.Message
-        self._reply_cache: dict[int, discord.Message] = {}
-        self._reply_cache_max = 500
+        self._pending_max = 500
 
         # Webhook cache: discord_channel_id -> discord.Webhook
         self._webhooks: dict[int, discord.Webhook] = {}
@@ -144,11 +196,17 @@ class MeshBridge(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
+        # on_ready re-fires on session resume; starts must be idempotent.
         if self.bridge_enabled:
             logger.info("Discord: MeshBridge enabled — starting event consumer and flush loop")
-            self._consume_task = asyncio.create_task(self._consume_events())
-            self._flush_loop.start()
-            self._status_check_loop.start()
+            self.bot.add_dynamic_items(_ViewGatewaysButton)
+            task = getattr(self, "_consume_task", None)
+            if task is None or task.done():
+                self._consume_task = asyncio.create_task(self._consume_events())
+            if not self._flush_loop.is_running():
+                self._flush_loop.start()
+            if not self._status_check_loop.is_running():
+                self._status_check_loop.start()
         else:
             logger.info("Discord: MeshBridge disabled in config")
 
@@ -242,35 +300,75 @@ class MeshBridge(commands.Cog):
             # Additional gateway for an already-seen packet
             self._pending[key].add_gateway(msg)
         else:
+            # Never-postable packets don't get a pending: with the long edit
+            # window each entry holds a slot for edit_window_seconds, and dead
+            # weight would evict packets that DID post (re-opening #585).
             if event_type == "text":
                 chat = event.get("chat", {})
+                if str(chat.get("channel", "0")) not in self.channel_map:
+                    return
                 pending = _PendingPacket("text", msg, chat=chat)
             elif event_type == "position":
+                channel_hash = str(msg.get("channel", "0"))
+                if (channel_hash not in self.position_channel_map
+                        and channel_hash not in self.channel_map):
+                    return
                 node_id = event.get("node_id", from_id)
+                if not await self.data.pg_storage.is_node_tracked(node_id):
+                    return
                 pending = _PendingPacket("position", msg, node_id=node_id)
             else:
                 return
 
             pending.add_gateway(msg)
+            self._evict_for_room()
             self._pending[key] = pending
+
+    def _evict_for_room(self):
+        """Make room in _pending: posted-and-clean entries first (they only
+        lose future straggler edits), oldest-first as the last resort."""
+        while len(self._pending) >= self._pending_max:
+            victim = next(
+                (k for k, p in self._pending.items()
+                 if p.discord_message is not None and not p.dirty),
+                next(iter(self._pending)),
+            )
+            evicted = self._pending.pop(victim, None)
+            if evicted is not None and time.monotonic() - evicted.first_seen < self.edit_window_seconds:
+                logger.warning(
+                    "MeshBridge: evicted packet %s before its edit window ended — "
+                    "consider a larger pending capacity", victim,
+                )
 
     @tasks.loop(seconds=1)
     async def _flush_loop(self):
-        """Periodically flush pending packets that have aged past the aggregation window."""
-        now = time.monotonic()
+        await self._flush_once()
+
+    async def _flush_once(self, now: Optional[float] = None):
+        """Post aged-past-aggregation packets; edit when late gateways landed."""
+        now = time.monotonic() if now is None else now
         keys_to_remove = []
 
         for key, pending in list(self._pending.items()):
             age = now - pending.first_seen
-            if age >= self.aggregate_seconds and pending.dirty:
+            # Edits are throttled to one per aggregate window per packet.
+            expiring = age > self.edit_window_seconds
+            # The expiry pass waives the edit throttle so a straggler that
+            # landed just after the last edit still reaches the embed.
+            if (pending.dirty and age >= self.aggregate_seconds
+                    and (expiring or now - pending.last_post >= self.aggregate_seconds)):
+                # Cleared before the await: a gateway landing mid-post re-dirties
+                # and gets picked up next tick instead of being clobbered.
+                pending.dirty = False
                 try:
                     await self._post_or_update(pending)
-                    pending.dirty = False
                 except Exception:
+                    pending.dirty = True
                     logger.exception("MeshBridge: Error posting packet %s", key)
+                # Set either way: failed posts retry once per window, not per tick.
+                pending.last_post = now
 
-            # Clean up old entries (keep for 60s for late gateways, then discard)
-            if age > 60:
+            if expiring:
                 keys_to_remove.append(key)
 
         for key in keys_to_remove:
@@ -364,7 +462,9 @@ class MeshBridge(commands.Cog):
         # Try webhook first (makes each node look like a unique sender)
         webhook = await self._get_webhook(channel)
 
-        if pending.discord_message and webhook:
+        # A message is edited the way it was sent: editing a bot-sent message
+        # through the webhook (or vice versa) 404s and would re-post instead.
+        if pending.discord_message and pending.sent_via_webhook and webhook:
             # Edit existing webhook message — include view if truncation now requires it
             try:
                 edit_kwargs = {"embed": embed}
@@ -391,17 +491,13 @@ class MeshBridge(commands.Cog):
                     send_kwargs["view"] = view
                 sent = await webhook.send(**send_kwargs)
                 pending.discord_message = sent
-                if packet_id:
-                    self._reply_cache[packet_id] = sent
-                    if len(self._reply_cache) > self._reply_cache_max:
-                        oldest_key = next(iter(self._reply_cache))
-                        self._reply_cache.pop(oldest_key, None)
+                pending.sent_via_webhook = True
                 return
             except Exception:
                 logger.exception("MeshBridge: Webhook send failed, falling back to bot message")
 
-        # Fallback: send as bot
-        if pending.discord_message:
+        # Fallback: edit/send as bot
+        if pending.discord_message and not pending.sent_via_webhook:
             try:
                 edit_kwargs = {"embed": embed}
                 if view is not None:
@@ -417,11 +513,7 @@ class MeshBridge(commands.Cog):
                 send_kwargs["view"] = view
             sent = await channel.send(**send_kwargs)
             pending.discord_message = sent
-            if packet_id:
-                self._reply_cache[packet_id] = sent
-                if len(self._reply_cache) > self._reply_cache_max:
-                    oldest_key = next(iter(self._reply_cache))
-                    self._reply_cache.pop(oldest_key, None)
+            pending.sent_via_webhook = False
         except Exception:
             logger.exception("MeshBridge: Failed to send text message to channel %s", discord_channel_id)
 
@@ -481,7 +573,8 @@ class MeshBridge(commands.Cog):
 
         webhook = await self._get_webhook(channel)
 
-        if pending.discord_message and webhook:
+        # Same routing as _post_text: edit the way it was sent.
+        if pending.discord_message and pending.sent_via_webhook and webhook:
             try:
                 await webhook.edit_message(pending.discord_message.id, embed=embed)
                 return
@@ -497,12 +590,13 @@ class MeshBridge(commands.Cog):
                     wait=True,
                 )
                 pending.discord_message = sent
+                pending.sent_via_webhook = True
                 return
             except Exception:
                 logger.exception("MeshBridge: Webhook send failed for position, falling back")
 
-        # Fallback
-        if pending.discord_message:
+        # Fallback: edit/send as bot
+        if pending.discord_message and not pending.sent_via_webhook:
             try:
                 await pending.discord_message.edit(embed=embed)
                 return
@@ -512,6 +606,7 @@ class MeshBridge(commands.Cog):
         try:
             sent = await channel.send(embed=embed)
             pending.discord_message = sent
+            pending.sent_via_webhook = False
         except Exception:
             logger.exception("MeshBridge: Failed to send position to channel %s", discord_channel_id)
 
@@ -577,7 +672,8 @@ class MeshBridge(commands.Cog):
                 display_name = self._get_display_name(node, node_id)
                 node_url = f"{base_url}/nodes?node={node_id}" if base_url else ""
 
-                mentions = " ".join(f"<@{uid}>" for uid in watcher_ids)
+                # Message content caps at 2000 chars; chunk so no ping is lost.
+                mention_chunks = _chunk_mentions(watcher_ids)
 
                 if current_active:
                     embed = discord.Embed(
@@ -596,7 +692,9 @@ class MeshBridge(commands.Cog):
                 embed.set_footer(text=f"Node: !{node_id}")
 
                 try:
-                    await channel.send(content=mentions, embed=embed)
+                    await channel.send(content=mention_chunks[0] if mention_chunks else None, embed=embed)
+                    for extra in mention_chunks[1:]:
+                        await channel.send(content=extra)
                 except Exception:
                     logger.debug("MeshBridge: Failed to send status alert for %s", node_id)
 
@@ -609,13 +707,12 @@ class MeshBridge(commands.Cog):
     @staticmethod
     def _get_display_name(node: Optional[dict], node_id: str) -> str:
         """Get a display name for a node, suitable for webhook username."""
+        name = f"!{node_id}"
         if node:
             longname = node.get("longname", "")
             shortname = node.get("shortname", "")
             if longname and longname != "Unknown":
-                if shortname and shortname != "UNK":
-                    return f"{longname} [{shortname}]"
-                return longname
-            if shortname and shortname != "UNK":
-                return shortname
-        return f"!{node_id}"
+                name = f"{longname} [{shortname}]" if shortname and shortname != "UNK" else longname
+            elif shortname and shortname != "UNK":
+                name = shortname
+        return _sanitize_webhook_username(name)

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -2,11 +2,12 @@
 Rich Discord embed builders for Meshtastic mesh messages.
 
 Inspired by RATM 2.0's presentation layer — gateway grouping by hop count,
-SNR/RSSI display, static map thumbnails for position packets, and reply
-threading support.
+SNR/RSSI display, and static map thumbnails for position packets.
 """
 
+import datetime
 import logging
+import math
 from typing import Optional
 
 import discord
@@ -15,10 +16,34 @@ import utils
 
 logger = logging.getLogger(__name__)
 
-# Discord embed limits
+# Discord embed limits. TOTAL applies to one embed AND to the sum of all
+# embeds in one message; a message carries at most MESSAGE_EMBED_LIMIT embeds.
 EMBED_TOTAL_LIMIT = 6000
 EMBED_DESC_LIMIT = 4096
 EMBED_FIELD_VALUE_LIMIT = 1024
+EMBED_AUTHOR_LIMIT = 256
+MESSAGE_EMBED_LIMIT = 10
+_TRUNCATED_NOTE = " — list truncated; full receptions via the packet link above"
+
+
+def _author_name(display_name: str, short_name: str) -> str:
+    """'display [short]' clamped to the embed author limit, keeping the suffix."""
+    suffix = f" [{short_name}]"
+    if len(display_name) + len(suffix) <= EMBED_AUTHOR_LIMIT:
+        return f"{display_name}{suffix}"
+    return display_name[: EMBED_AUTHOR_LIMIT - len(suffix) - 1] + "…" + suffix
+
+
+def _packet_timestamp(*epochs) -> datetime.datetime:
+    """Embed timestamp from the packet's own clock — stable across edits
+    (utcnow would shift the displayed time every straggler edit)."""
+    for e in epochs:
+        try:
+            if e:
+                return datetime.datetime.fromtimestamp(int(e), datetime.timezone.utc)
+        except (TypeError, ValueError, OverflowError, OSError):
+            continue
+    return discord.utils.utcnow()
 
 
 def _safe_truncate(text: str, limit: int = EMBED_FIELD_VALUE_LIMIT) -> str:
@@ -255,12 +280,12 @@ def build_text_embed(
     embed = discord.Embed(
         description=description,
         color=_snr_color(gateway_entries, msg),
-        timestamp=discord.utils.utcnow(),
+        timestamp=_packet_timestamp(chat.get("timestamp"), msg.get("timestamp")),
     )
 
     # Author = sender node (linked to node page)
     avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={from_id}"
-    embed.set_author(name=f"{display_name} [{short_name}]", url=node_link, icon_url=avatar_url)
+    embed.set_author(name=_author_name(display_name, short_name), url=node_link, icon_url=avatar_url)
 
     # Owner mention
     if owner_id:
@@ -269,6 +294,28 @@ def build_text_embed(
     embed.set_footer(text=f"Node: !{from_id}")
 
     return embed, was_truncated
+
+
+def _split_oversized(sections: list) -> list:
+    """Split any section past the description limit on line boundaries, so the
+    chunking loop (which owns the truncation decision) sees fitting pieces."""
+    out = []
+    for section in sections:
+        if len(section) <= EMBED_DESC_LIMIT:
+            out.append(section)
+            continue
+        piece = ""
+        for line in section.split("\n"):
+            line = line if len(line) <= EMBED_DESC_LIMIT else _safe_truncate(line, EMBED_DESC_LIMIT)
+            joined = f"{piece}\n{line}" if piece else line
+            if len(joined) <= EMBED_DESC_LIMIT:
+                piece = joined
+            else:
+                out.append(piece)
+                piece = line
+        if piece:
+            out.append(piece)
+    return out
 
 
 def build_gateway_detail_embed(
@@ -297,29 +344,44 @@ def build_gateway_detail_embed(
     if hop_limit is not None:
         header += f" \u2014 hop limit {hop_limit}"
 
-    # Split into chunks that fit in embed descriptions (4096 limit)
-    sections = gw_text.split("\n\n")
-    embeds = []
+    # Split into description-sized chunks; one message holds at most
+    # MESSAGE_EMBED_LIMIT embeds and EMBED_TOTAL_LIMIT chars across them all.
+    footer = f"Node: !{from_id}"
+    budget = EMBED_TOTAL_LIMIT - len(footer) - len(_TRUNCATED_NOTE)
+    chunks: list[str] = []
+    truncated = False
     current = header
-    for section in sections:
-        test = current + "\n\n" + section
-        if len(test) <= EMBED_DESC_LIMIT:
-            current = test
+    for section in _split_oversized(gw_text.split("\n\n")):
+        joined = f"{current}\n\n{section}" if current else section
+        if len(joined) <= EMBED_DESC_LIMIT:
+            current = joined
         else:
-            embeds.append(discord.Embed(
-                description=current,
-                color=discord.Color.from_rgb(69, 179, 186),
-            ))
+            chunks.append(current)
             current = section
     if current:
+        chunks.append(current)
+
+    embeds = []
+    used = 0
+    for i, chunk in enumerate(chunks):
+        if len(embeds) >= MESSAGE_EMBED_LIMIT or used + len(chunk) > budget:
+            truncated = True
+            room = budget - used
+            if len(embeds) < MESSAGE_EMBED_LIMIT and room >= 64:
+                partial = _safe_truncate(chunk, room)
+                embeds.append(discord.Embed(
+                    description=partial,
+                    color=discord.Color.from_rgb(69, 179, 186),
+                ))
+            break
         embeds.append(discord.Embed(
-            description=current,
+            description=chunk,
             color=discord.Color.from_rgb(69, 179, 186),
         ))
+        used += len(chunk)
 
-    # Footer on last embed
     if embeds:
-        embeds[-1].set_footer(text=f"Node: !{from_id}")
+        embeds[-1].set_footer(text=(footer + _TRUNCATED_NOTE) if truncated else footer)
 
     return embeds
 
@@ -349,11 +411,11 @@ def build_position_embed(
         title=f"{label} Position Update",
         url=map_link or node_link,
         color=discord.Color.orange() if track_type == "balloon" else discord.Color.blue(),
-        timestamp=discord.utils.utcnow(),
+        timestamp=_packet_timestamp(msg.get("timestamp")),
     )
 
     avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node_id}"
-    embed.set_author(name=f"{display_name} [{short_name}]", url=node_link, icon_url=avatar_url)
+    embed.set_author(name=_author_name(display_name, short_name), url=node_link, icon_url=avatar_url)
 
     # Position fields
     lat_i = payload.get("latitude_i")
@@ -369,8 +431,9 @@ def build_position_embed(
         # Clickable coordinates linking to MeshInfo map
         coord_text = f"[{lat:.6f}, {lon:.6f}]({map_link})" if map_link else f"{lat:.6f}, {lon:.6f}"
         embed.add_field(name="Position", value=coord_text, inline=True)
-        if alt is not None:
-            embed.add_field(name="Altitude", value=f"{alt}m", inline=True)
+        # Numeric only — payload junk (strings, bools, NaN) must not render.
+        if isinstance(alt, (int, float)) and not isinstance(alt, bool) and math.isfinite(alt):
+            embed.add_field(name="Altitude", value=f"{alt:.0f}m", inline=True)
 
         # Static map thumbnail (self-hosted, provider from config)
         thumbnail_url = _map_thumbnail_url(lat, lon, base_url, maps_cfg)

--- a/bot/embeds.py
+++ b/bot/embeds.py
@@ -34,15 +34,20 @@ def _author_name(display_name: str, short_name: str) -> str:
     return display_name[: EMBED_AUTHOR_LIMIT - len(suffix) - 1] + "…" + suffix
 
 
-def _packet_timestamp(*epochs) -> datetime.datetime:
+def _packet_timestamp(*epochs, fallback: Optional[float] = None) -> datetime.datetime:
     """Embed timestamp from the packet's own clock — stable across edits
-    (utcnow would shift the displayed time every straggler edit)."""
+    (utcnow would shift the displayed time every straggler edit). A clock more
+    than a day off is a broken node clock, not history: use `fallback` (the
+    bridge's first-seen wall time, also edit-stable) instead."""
+    anchor = fallback if fallback is not None else datetime.datetime.now(datetime.timezone.utc).timestamp()
     for e in epochs:
         try:
-            if e:
+            if e and anchor - 86400 <= int(e) <= anchor + 3600:
                 return datetime.datetime.fromtimestamp(int(e), datetime.timezone.utc)
         except (TypeError, ValueError, OverflowError, OSError):
             continue
+    if fallback is not None:
+        return datetime.datetime.fromtimestamp(fallback, datetime.timezone.utc)
     return discord.utils.utcnow()
 
 
@@ -206,6 +211,7 @@ def build_text_embed(
     config: dict,
     owner_id: Optional[str] = None,
     gateway_entries: Optional[list] = None,
+    fallback_ts: Optional[float] = None,
 ) -> tuple[discord.Embed, bool]:
     """
     Build a rich embed for a text message from the mesh.
@@ -280,7 +286,8 @@ def build_text_embed(
     embed = discord.Embed(
         description=description,
         color=_snr_color(gateway_entries, msg),
-        timestamp=_packet_timestamp(chat.get("timestamp"), msg.get("timestamp")),
+        timestamp=_packet_timestamp(chat.get("timestamp"), msg.get("timestamp"),
+                                    fallback=fallback_ts),
     )
 
     # Author = sender node (linked to node page)
@@ -395,6 +402,7 @@ def build_position_embed(
     track_type: str = "tracker",
     owner_id: Optional[str] = None,
     gateway_entries: Optional[list] = None,
+    fallback_ts: Optional[float] = None,
 ) -> discord.Embed:
     """
     Build a rich embed for a position update from a tracked node.
@@ -411,7 +419,7 @@ def build_position_embed(
         title=f"{label} Position Update",
         url=map_link or node_link,
         color=discord.Color.orange() if track_type == "balloon" else discord.Color.blue(),
-        timestamp=_packet_timestamp(msg.get("timestamp")),
+        timestamp=_packet_timestamp(msg.get("timestamp"), fallback=fallback_ts),
     )
 
     avatar_url = f"https://api.dicebear.com/9.x/bottts-neutral/png?seed={node_id}"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -320,17 +320,21 @@ edit_window_seconds = 900  # posted embeds keep absorbing straggler gateway copi
                            # (as edits) this long; shorter windows re-post duplicates
 # alert_channel = "1234567890123456789"  # Channel for node online/offline alerts (linked nodes only)
 
-# Map Meshtastic channel hashes to Discord channel IDs for text messages.
-# Key = Meshtastic channel hash (from broker.channels.display), value = Discord channel ID.
+# Map mesh channels to Discord channel IDs for text messages.
+# Key = wire channel name (case-sensitive, recommended) or a channel bucket id
+# (hash / name-bucket number from /v1/channels). A bucket-id key pins one
+# name+PSK domain and wins over a name key; a name key follows the channel
+# across re-keys and also matches channels whose hash was never learned.
 # Messages on unmapped channels are ignored.
 [integrations.discord.bridge.channels]
-# "8" = "1234567890123456789"    # LongFast -> #longfast
-# "31" = "1234567890123456790"   # MediumFast -> #mediumfast
+# "LongFast" = "1234567890123456789"     # -> #longfast
+# "MediumFast" = "1234567890123456790"   # -> #mediumfast
+# "31" = "1234567890123456790"           # same, pinned to the default-PSK hash
 
-# Map Meshtastic channel hashes to Discord channel IDs for position updates.
-# Only nodes flagged as "trackers" via /addtracker will have positions forwarded.
+# Same key rules for position updates. Only nodes flagged as "trackers" via
+# /addtracker will have positions forwarded.
 [integrations.discord.bridge.position_channels]
-# "8" = "1234567890123456791"    # LongFast positions -> #position-tracking
+# "LongFast" = "1234567890123456791"     # positions -> #position-tracking
 
 # Static map thumbnails for position tracking embeds.
 # Renders map images server-side by fetching tiles and compositing them locally.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -315,7 +315,9 @@ guild = "REPLACE_WITH_GUILD_ID"
 # Forwards mesh text messages and position updates into Discord channels.
 [integrations.discord.bridge]
 enabled = false
-aggregate_seconds = 5  # seconds to wait for additional gateways before posting
+aggregate_seconds = 5      # seconds to wait for additional gateways before posting
+edit_window_seconds = 900  # posted embeds keep absorbing straggler gateway copies
+                           # (as edits) this long; shorter windows re-post duplicates
 # alert_channel = "1234567890123456789"  # Channel for node online/offline alerts (linked nodes only)
 
 # Map Meshtastic channel hashes to Discord channel IDs for text messages.

--- a/storage/db/postgres.py
+++ b/storage/db/postgres.py
@@ -3471,10 +3471,12 @@ class PostgresStorage:
             logger.error("Failed to list bans: %s", e)
             return []
 
-    async def query_top_nodes(self, hours: int = 24, limit: int = 5, channel_id: Optional[str] = None) -> dict:
+    async def query_top_nodes(self, hours: int = 24, limit: int = 5,
+                              channel_id: Optional[Any] = None) -> dict:
         """Query leaderboard stats for the mesh. Returns dict of categories.
-        If channel_id is provided, chat-based stats are scoped to that channel,
-        and node-based categories (such as iron_man) are scoped via nodes.last_channel."""
+        channel_id — one bucket id or a list of them (a name-mapped channel's
+        history can span its name bucket and its learned hash) — scopes
+        chat-based stats via channel_id and node-based ones via last_channel."""
         if not self._ready("query_top_nodes"):
             return {}
 
@@ -3486,8 +3488,9 @@ class PostgresStorage:
         ch_filter = ""
         ch_params: list = []
         if channel_id is not None:
-            ch_filter = " AND channel_id = $3"
-            ch_params = [channel_id]
+            ids = [str(c) for c in (channel_id if isinstance(channel_id, (list, tuple, set)) else [channel_id])]
+            ch_filter = " AND channel_id = ANY($3)"
+            ch_params = [ids]
 
         try:
             async with self.pool.acquire() as conn:
@@ -3507,9 +3510,9 @@ class PostgresStorage:
                         """SELECT id AS node_id,
                                   EXTRACT(EPOCH FROM (NOW() - created_at)) AS uptime_seconds
                            FROM nodes
-                           WHERE active = TRUE AND created_at IS NOT NULL AND last_channel = $2
+                           WHERE active = TRUE AND created_at IS NOT NULL AND last_channel = ANY($2)
                            ORDER BY created_at ASC LIMIT $1""",
-                        limit, channel_id,
+                        limit, ch_params[0],
                     )
                 else:
                     rows = await conn.fetch(

--- a/tests/test_mesh_bridge.py
+++ b/tests/test_mesh_bridge.py
@@ -83,8 +83,10 @@ class FakeChannel:
 class FakeBot:
     def __init__(self, channel):
         self._channel = channel
+        self.requested = []
 
     def get_channel(self, cid):
+        self.requested.append(cid)
         return self._channel
 
 
@@ -433,7 +435,8 @@ class TestDiscordLimits:
     def test_embed_timestamp_is_packet_time_not_build_time(self):
         kw = dict(msg={"from": "d952bddd", "id": 1, "timestamp": 1787000000},
                   chat={"from": "d952bddd", "text": "hi", "timestamp": 1787000000},
-                  nodes={}, base_url="", config={}, gateway_entries=big_gateways(2))
+                  nodes={}, base_url="", config={}, gateway_entries=big_gateways(2),
+                  fallback_ts=1787000300.0)
         e1, _ = build_text_embed(**kw)
         e2, _ = build_text_embed(**kw)
         assert e1.timestamp == e2.timestamp
@@ -497,3 +500,148 @@ class TestNameAndContentLimits:
         assert len(embeds) >= 2  # spilled, not squeezed into one
         assert all(len(e.description) <= EMBED_DESC_LIMIT for e in embeds)
         assert sum(len(e) for e in embeds) <= EMBED_TOTAL_LIMIT
+
+
+class TestNameKeyedChannelMaps:
+    def _bridge(self, channels, position_channels=None):
+        return make_bridge(position_channels=position_channels, channels=channels)
+
+    def test_name_key_matches_by_channel_name(self):
+        async def scenario():
+            bridge, webhook = self._bridge({"MediumFast": "555"})
+            ev = copy_msg("00000001")
+            ev["chat"]["channel"] = "31"
+            ev["chat"]["channel_name"] = "MediumFast"
+            await bridge._handle_event(ev)
+            assert len(bridge._pending) == 1
+            next(iter(bridge._pending.values())).first_seen -= 10
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1
+        run(scenario())
+
+    def test_name_key_follows_channel_to_name_bucket(self):
+        # decode-only channel: filed at its name bucket, hash never learned
+        async def scenario():
+            bridge, _ = self._bridge({"DiabloView": "555"})
+            ev = copy_msg("00000001")
+            ev["chat"]["channel"] = "1605169579"
+            ev["chat"]["channel_name"] = "DiabloView"
+            await bridge._handle_event(ev)
+            assert len(bridge._pending) == 1
+        run(scenario())
+
+    def test_numeric_key_takes_precedence_over_name_key(self):
+        async def scenario():
+            bridge, webhook = self._bridge({"31": "555", "MediumFast": "999"})
+            assert bridge._chat_discord_channel("31", "MediumFast") == "555"   # bucket key wins
+            assert bridge._chat_discord_channel("99", "MediumFast") == "999"   # name as fallback
+            ev = copy_msg("00000001")
+            ev["chat"]["channel"] = "31"
+            ev["chat"]["channel_name"] = "MediumFast"
+            await bridge._handle_event(ev)
+            next(iter(bridge._pending.values())).first_seen -= 10
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1
+            assert bridge.bot.requested == [555]  # routed to the numeric key's channel
+        run(scenario())
+
+    def test_name_match_is_case_sensitive(self):
+        async def scenario():
+            bridge, _ = self._bridge({"mediumfast": "555"})
+            ev = copy_msg("00000001")
+            ev["chat"]["channel"] = "31"
+            ev["chat"]["channel_name"] = "MediumFast"
+            await bridge._handle_event(ev)
+            assert bridge._pending == {}  # wire names are case-sensitive
+        run(scenario())
+
+    def test_message_without_channel_name_needs_numeric_key(self):
+        async def scenario():
+            bridge, _ = self._bridge({"MediumFast": "555"})
+            ev = copy_msg("00000001")
+            ev["chat"]["channel"] = "31"
+            ev["chat"].pop("channel_name", None)  # JSON decoder shape
+            await bridge._handle_event(ev)
+            assert bridge._pending == {}
+        run(scenario())
+
+    def test_position_maps_accept_names_with_chat_fallback(self):
+        bridge, _ = self._bridge({"LongFast": "555"}, position_channels={"MediumFast": "777"})
+        for name, expect in (("MediumFast", "777"), ("LongFast", "555"), ("ShortSlow", None)):
+            got = bridge._position_discord_channel("12345", name)
+            assert got == expect, (name, got, expect)
+
+    def test_position_event_admitted_by_name_key(self):
+        """The position admission path itself must honor name keys."""
+        async def scenario():
+            bridge, _ = self._bridge({"99": "555"}, position_channels={"MediumFast": "777"})
+
+            async def tracked(node_id):
+                return True
+            bridge.data.pg_storage.is_node_tracked = tracked
+            ev = {"type": "position",
+                  "msg": {"from": "d952bddd", "id": 42, "channel": 31,
+                          "channel_name": "MediumFast",
+                          "sender": "00000001", "topic": "msh/x/2/e/Y/!00000001"},
+                  "node_id": "d952bddd"}
+            await bridge._handle_event(ev)
+            assert len(bridge._pending) == 1
+            ev2 = dict(ev, msg=dict(ev["msg"], id=43, channel_name="ShortSlow"))
+            await bridge._handle_event(ev2)
+            assert len(bridge._pending) == 1  # unmapped name rejected
+        run(scenario())
+
+    def test_split_classifies_digit_keys_as_bucket_ids(self):
+        from bot.cogs.mesh_bridge import _split_channel_map
+        by_id, by_name = _split_channel_map(
+            {"31": "a", "1605169579": "b", "MediumFast": "c", " Padded Name ": "d", "": "e"})
+        assert by_id == {"31": "a", "1605169579": "b"}
+        assert by_name == {"MediumFast": "c", "Padded Name": "d"}
+        by_id2, by_name2 = _split_channel_map({"٣١": "x", "³¹": "y"})
+        assert by_id2 == {} and set(by_name2) == {"٣١", "³¹"}  # unicode digits are names
+
+
+class TestBrokenNodeClocks:
+    """Node a3040ad9 shipped rx_time ~8 months in the past; the embed must
+    show arrival time then, not the broken clock — and stay edit-stable."""
+
+    def _embed(self, ts, fallback):
+        return build_text_embed(
+            msg={"from": "a3040ad9", "id": 1, "timestamp": ts},
+            chat={"from": "a3040ad9", "text": "Hello", "timestamp": ts},
+            nodes={}, base_url="", config={}, gateway_entries=big_gateways(1),
+            fallback_ts=fallback,
+        )[0]
+
+    def test_past_bogus_clock_uses_first_seen_wall_time(self):
+        now = 1787000000.0
+        e = self._embed(1765796786, fallback=now)  # ~8 months slow
+        assert int(e.timestamp.timestamp()) == int(now)
+
+    def test_future_bogus_clock_uses_first_seen_wall_time(self):
+        now = 1787000000.0
+        e = self._embed(int(now) + 86400 * 30, fallback=now)
+        assert int(e.timestamp.timestamp()) == int(now)
+
+    def test_sane_clock_still_wins(self):
+        now = 1787000000.0
+        e = self._embed(int(now) - 300, fallback=now)  # 5 min ago: plausible
+        assert int(e.timestamp.timestamp()) == int(now) - 300
+
+    def test_stable_across_edits_even_when_bogus(self):
+        now = 1787000000.0
+        e1 = self._embed(1765796786, fallback=now)
+        e2 = self._embed(1765796786, fallback=now)  # rebuilt on a straggler edit
+        assert e1.timestamp == e2.timestamp
+
+    def test_bridge_passes_wall_first_seen(self):
+        async def scenario():
+            bridge, webhook = make_bridge()
+            ev = copy_msg("00000001", ts=1765796786)  # broken clock
+            await bridge._handle_event(ev)
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10
+            await bridge._flush_once()
+            sent_embed = webhook.sends[0]["embed"]
+            assert abs(sent_embed.timestamp.timestamp() - pending.wall_first_seen) < 2
+        run(scenario())

--- a/tests/test_mesh_bridge.py
+++ b/tests/test_mesh_bridge.py
@@ -1,0 +1,499 @@
+"""
+MeshBridge (#585): straggler gateway copies must edit the posted embed, not
+re-post it, and every Discord payload must respect the platform limits
+(4096/description, 6000/message, 10 embeds/message).
+"""
+
+import asyncio
+
+import discord
+
+from bot.cogs.mesh_bridge import MeshBridge, _PendingPacket, WEBHOOK_NAME
+from bot.embeds import (
+    EMBED_DESC_LIMIT,
+    EMBED_TOTAL_LIMIT,
+    MESSAGE_EMBED_LIMIT,
+    build_gateway_detail_embed,
+    build_text_embed,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ─── fakes ───────────────────────────────────────────────────────────────────
+
+
+class FakePg:
+    async def get_node_cached(self, node_id):
+        return None
+
+    async def is_node_banned(self, node_id):
+        return False
+
+    async def get_node_owner(self, node_id):
+        return None
+
+    async def is_node_tracked(self, node_id):
+        return False
+
+    async def get_tracker_type(self, node_id):
+        return None
+
+
+class FakeData:
+    def __init__(self):
+        self.pg_storage = FakePg()
+        self.discord_event_queue = asyncio.Queue()
+
+
+class FakeSent:
+    def __init__(self, i=1):
+        self.id = i
+
+
+class FakeWebhook:
+    def __init__(self):
+        self.name = WEBHOOK_NAME
+        self.sends = []
+        self.edits = []
+        self.on_send = None  # optional side effect (dirty-race test)
+
+    async def send(self, **kw):
+        self.sends.append(kw)
+        if self.on_send:
+            self.on_send()
+        # discord.py contract: without wait=True the send returns None
+        return FakeSent(len(self.sends)) if kw.get("wait") else None
+
+    async def edit_message(self, message_id, **kw):
+        self.edits.append((message_id, kw))
+
+
+class FakeChannel:
+    def __init__(self, webhook):
+        self.id = 555
+        self._webhook = webhook
+
+    async def webhooks(self):
+        return [self._webhook]
+
+
+class FakeBot:
+    def __init__(self, channel):
+        self._channel = channel
+
+    def get_channel(self, cid):
+        return self._channel
+
+
+def make_bridge(position_channels=None, **bridge_cfg):
+    cfg = {"enabled": True, "channels": {"31": "555"}}
+    if position_channels:
+        cfg["position_channels"] = position_channels
+    cfg.update(bridge_cfg)
+    config = {
+        "integrations": {"discord": {"bridge": cfg}},
+        "server": {"base_url": "https://mesh.example.com"},
+    }
+    webhook = FakeWebhook()
+    bridge = MeshBridge(FakeBot(FakeChannel(webhook)), config, FakeData())
+    return bridge, webhook
+
+
+def copy_msg(sender, ts=1787000000, text="hello mesh"):
+    """One uplink copy of packet 933111847 as handle_text emits it."""
+    return {
+        "type": "text",
+        "msg": {
+            "from": "d952bddd", "to": "ffffffff", "id": 933111847,
+            "sender": sender, "topic": f"msh/US/x/2/e/MediumFast/!{sender}",
+            "hop_start": 5, "hop_limit": 3, "hops_away": 2,
+            "rssi": -100, "snr": 1.5, "timestamp": ts,
+        },
+        "chat": {
+            "id": 933111847, "from": "d952bddd", "channel": "31",
+            "text": text, "timestamp": ts,
+        },
+    }
+
+
+# ─── aggregation / straggler behavior ────────────────────────────────────────
+
+
+class TestStragglerEditsNotReposts:
+    def test_copies_aggregate_into_one_post(self):
+        async def scenario():
+            bridge, webhook = make_bridge()
+            for i in range(3):
+                await bridge._handle_event(copy_msg(f"{i:08x}"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10  # age past the aggregate window
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1
+            assert len(pending.gateways) == 3
+        run(scenario())
+
+    def test_straggler_within_window_edits_same_embed(self):
+        """The #585 shape: a copy 2 minutes late must edit, not re-post."""
+        async def scenario():
+            bridge, webhook = make_bridge()
+            for i in range(3):
+                await bridge._handle_event(copy_msg(f"{i:08x}"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 125
+            pending.last_post = 0.0
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1
+
+            await bridge._handle_event(copy_msg("aabbccdd"))  # straggler
+            assert len(bridge._pending) == 1  # same pending, no new entry
+            pending.last_post -= 10  # past the edit throttle
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1
+            assert len(webhook.edits) == 1
+            assert len(pending.gateways) == 4
+        run(scenario())
+
+    def test_entry_expires_after_edit_window(self):
+        async def scenario():
+            bridge, webhook = make_bridge(edit_window_seconds=900)
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 901
+            await bridge._flush_once()
+            assert bridge._pending == {}
+        run(scenario())
+
+    def test_same_gateway_repeat_does_not_redirty(self):
+        async def scenario():
+            bridge, webhook = make_bridge()
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.dirty = False
+            await bridge._handle_event(copy_msg("00000001"))
+            assert pending.dirty is False
+            assert len(pending.gateways) == 1
+        run(scenario())
+
+    def test_gateway_id_prefers_sender_over_topic(self):
+        p = _PendingPacket("text", {})
+        p.add_gateway({"sender": "aabbccdd", "topic": "msh/US/x/2/map/"})
+        p.add_gateway({"sender": "aabbccdd", "topic": "msh/other/suffix"})
+        assert [g["gateway_id"] for g in p.gateways] == ["aabbccdd"]
+
+    def test_gateway_list_is_capped(self):
+        p = _PendingPacket("text", {})
+        for i in range(_PendingPacket.MAX_GATEWAYS + 50):
+            p.add_gateway({"sender": f"{i:08x}", "topic": ""})
+        assert len(p.gateways) == _PendingPacket.MAX_GATEWAYS
+
+    def test_pending_map_evicts_oldest(self):
+        async def scenario():
+            bridge, _ = make_bridge()
+            bridge._pending_max = 5
+            for i in range(8):
+                ev = copy_msg("00000001")
+                ev["msg"] = dict(ev["msg"], id=1000 + i)
+                await bridge._handle_event(ev)
+            assert len(bridge._pending) == 5
+            assert "1000:d952bddd" not in bridge._pending
+            assert "1007:d952bddd" in bridge._pending
+        run(scenario())
+
+    def test_gateway_landing_mid_post_survives(self):
+        """dirty set during the awaited post must not be clobbered."""
+        async def scenario():
+            bridge, webhook = make_bridge()
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10
+            webhook.on_send = lambda: pending.add_gateway(
+                {"sender": "eeeeeeee", "topic": "msh/US/x/2/e/MediumFast/!eeeeeeee"})
+            await bridge._flush_once()
+            assert pending.dirty is True  # picked up next tick as an edit
+            pending.last_post -= 10
+            await bridge._flush_once()
+            assert len(webhook.edits) == 1
+        run(scenario())
+
+    def test_edits_throttled_to_one_per_aggregate_window(self):
+        async def scenario():
+            bridge, webhook = make_bridge()
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10
+            await bridge._flush_once()
+            await bridge._handle_event(copy_msg("00000002"))
+            await bridge._flush_once()  # within the throttle: no edit yet
+            assert webhook.edits == []
+            pending.last_post -= bridge.aggregate_seconds + 1
+            await bridge._flush_once()
+            assert len(webhook.edits) == 1
+        run(scenario())
+
+    def test_failed_post_stays_dirty_for_retry(self):
+        """An exception escaping the post (e.g. a DB hiccup) re-dirties the
+        pending so the next tick retries; webhook failures themselves fall
+        back to bot-send inside _post_text."""
+        async def scenario():
+            bridge, webhook = make_bridge()
+            calls = {"n": 0}
+
+            async def flaky(node_id):
+                calls["n"] += 1
+                raise RuntimeError("db hiccup")
+            bridge.data.pg_storage.is_node_banned = flaky
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10
+            await bridge._flush_once()
+            assert pending.dirty is True and webhook.sends == []
+
+            async def ok(node_id):
+                return False
+            bridge.data.pg_storage.is_node_banned = ok
+            pending.last_post = 0.0
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1 and pending.dirty is False
+        run(scenario())
+
+    def test_unmapped_channel_never_occupies_a_pending_slot(self):
+        async def scenario():
+            bridge, webhook = make_bridge()
+            ev = copy_msg("00000001")
+            ev["chat"]["channel"] = "99"
+            await bridge._handle_event(ev)
+            assert bridge._pending == {}
+            await bridge._flush_once()
+            assert webhook.sends == []
+        run(scenario())
+
+    def test_untracked_position_never_occupies_a_pending_slot(self):
+        async def scenario():
+            bridge, _ = make_bridge(position_channels={"31": "555"})
+            ev = {"type": "position",
+                  "msg": {"from": "d952bddd", "id": 42, "channel": "31",
+                          "sender": "00000001", "topic": "msh/x/2/e/Y/!00000001"},
+                  "node_id": "d952bddd"}
+            await bridge._handle_event(ev)  # FakePg.is_node_tracked -> False
+            assert bridge._pending == {}
+        run(scenario())
+
+    def test_eviction_prefers_posted_clean_entries(self):
+        """Capacity pressure must not evict an unposted packet while a
+        posted-and-clean one is available to drop."""
+        async def scenario():
+            bridge, webhook = make_bridge()
+            bridge._pending_max = 2
+            await bridge._handle_event(copy_msg("00000001"))  # will be posted
+            posted = next(iter(bridge._pending.values()))
+            posted.first_seen -= 10
+            await bridge._flush_once()
+            assert len(webhook.sends) == 1 and posted.dirty is False
+            ev2 = copy_msg("00000002"); ev2["msg"] = dict(ev2["msg"], id=2)
+            await bridge._handle_event(ev2)  # unposted, dirty
+            ev3 = copy_msg("00000003"); ev3["msg"] = dict(ev3["msg"], id=3)
+            await bridge._handle_event(ev3)  # forces eviction
+            keys = set(bridge._pending)
+            assert "933111847:d952bddd" not in keys  # posted+clean evicted first
+            assert "2:d952bddd" in keys and "3:d952bddd" in keys
+        run(scenario())
+
+    def test_expiring_dirty_pending_gets_final_flush(self):
+        """A straggler landing just after the last edit, at the end of the
+        window, must reach the embed before the entry is discarded."""
+        async def scenario():
+            bridge, webhook = make_bridge()
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 901          # past the edit window
+            pending.last_post = 0.0
+            pending.discord_message = FakeSent()
+            pending.sent_via_webhook = True
+            # throttle would normally block: pretend an edit just happened
+            import time as _t
+            pending.last_post = _t.monotonic() - 1
+            await bridge._flush_once()
+            assert len(webhook.edits) == 1     # throttle waived on expiry
+            assert bridge._pending == {}
+        run(scenario())
+
+    def test_failed_post_retries_once_per_window_not_per_tick(self):
+        async def scenario():
+            bridge, webhook = make_bridge()
+
+            async def flaky(node_id):
+                raise RuntimeError("db hiccup")
+            bridge.data.pg_storage.is_node_banned = flaky
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10
+            await bridge._flush_once()
+            first_stamp = pending.last_post
+            assert pending.dirty is True and first_stamp > 0
+            await bridge._flush_once()  # inside the window: no second attempt
+            assert pending.last_post == first_stamp
+        run(scenario())
+
+    def test_bot_sent_message_edits_as_bot_even_when_webhook_appears(self):
+        """A message sent via channel.send must never be edited through the
+        webhook (404 -> duplicate)."""
+        async def scenario():
+            bridge, webhook = make_bridge()
+            await bridge._handle_event(copy_msg("00000001"))
+            pending = next(iter(bridge._pending.values()))
+            pending.first_seen -= 10
+
+            class FakeBotMsg(FakeSent):
+                def __init__(self):
+                    super().__init__()
+                    self.edits = []
+
+                async def edit(self, **kw):
+                    self.edits.append(kw)
+            bot_msg = FakeBotMsg()
+            pending.discord_message = bot_msg
+            pending.sent_via_webhook = False
+            await bridge._flush_once()
+            assert webhook.edits == [] and webhook.sends == []
+            assert len(bot_msg.edits) == 1
+        run(scenario())
+
+
+# ─── Discord payload limits ──────────────────────────────────────────────────
+
+
+def big_gateways(n, hops_spread=8):
+    return [{"gateway_id": f"{i:08x}", "rssi": -110, "snr": -3.25,
+             "hops_away": i % hops_spread,
+             "topic": f"msh/US/somewhere/2/e/LongFast/!{i:08x}"} for i in range(n)]
+
+
+def named_nodes(gws):
+    return {g["gateway_id"]: {"shortname": "GWXX", "longname": "A Rather Long Gateway Name " + g["gateway_id"]}
+            for g in gws}
+
+
+class TestDiscordLimits:
+    def test_text_embed_respects_all_limits(self):
+        gws = big_gateways(300)
+        embed, was_truncated = build_text_embed(
+            msg={"from": "d952bddd", "id": 933111847, "hop_start": 5, "timestamp": 1787000000},
+            chat={"from": "d952bddd", "text": "x" * 200, "timestamp": 1787000000},
+            nodes=named_nodes(gws), base_url="https://mesh.example.com",
+            config={}, owner_id="123456789012345678", gateway_entries=gws,
+        )
+        assert was_truncated is True
+        assert len(embed.description) <= EMBED_DESC_LIMIT
+        assert len(embed) <= EMBED_TOTAL_LIMIT
+
+    def test_text_embed_small_case_untruncated(self):
+        gws = big_gateways(3)
+        embed, was_truncated = build_text_embed(
+            msg={"from": "d952bddd", "id": 1, "timestamp": 1787000000},
+            chat={"from": "d952bddd", "text": "hi", "timestamp": 1787000000},
+            nodes={}, base_url="", config={}, gateway_entries=gws,
+        )
+        assert was_truncated is False
+        assert len(embed) <= EMBED_TOTAL_LIMIT
+
+    def test_detail_view_fits_one_discord_message(self):
+        for n in (12, 120, 400, 1000):
+            gws = big_gateways(n)
+            embeds = build_gateway_detail_embed(
+                msg={"from": "d952bddd", "id": 933111847, "hop_start": 5},
+                nodes=named_nodes(gws), base_url="https://mesh.example.com",
+                gateway_entries=gws,
+            )
+            assert embeds, f"n={n}: no embeds"
+            assert len(embeds) <= MESSAGE_EMBED_LIMIT
+            assert all(len(e.description) <= EMBED_DESC_LIMIT for e in embeds)
+            assert sum(len(e) for e in embeds) <= EMBED_TOTAL_LIMIT, f"n={n}"
+
+    def test_detail_view_truncation_is_flagged(self):
+        gws = big_gateways(1000)
+        embeds = build_gateway_detail_embed(
+            msg={"from": "d952bddd", "id": 1}, nodes=named_nodes(gws),
+            base_url="https://mesh.example.com", gateway_entries=gws,
+        )
+        assert "truncated" in embeds[-1].footer.text
+
+    def test_single_oversized_hop_group_is_chunked_safely(self):
+        gws = big_gateways(600, hops_spread=1)  # all one hop group
+        embeds = build_gateway_detail_embed(
+            msg={"from": "d952bddd", "id": 1}, nodes=named_nodes(gws),
+            base_url="https://mesh.example.com", gateway_entries=gws,
+        )
+        assert embeds
+        assert all(len(e.description) <= EMBED_DESC_LIMIT for e in embeds)
+        assert sum(len(e) for e in embeds) <= EMBED_TOTAL_LIMIT
+
+    def test_embed_timestamp_is_packet_time_not_build_time(self):
+        kw = dict(msg={"from": "d952bddd", "id": 1, "timestamp": 1787000000},
+                  chat={"from": "d952bddd", "text": "hi", "timestamp": 1787000000},
+                  nodes={}, base_url="", config={}, gateway_entries=big_gateways(2))
+        e1, _ = build_text_embed(**kw)
+        e2, _ = build_text_embed(**kw)
+        assert e1.timestamp == e2.timestamp
+        assert int(e1.timestamp.timestamp()) == 1787000000
+
+
+class TestNameAndContentLimits:
+    def test_webhook_username_is_sanitized_and_capped(self):
+        from bot.cogs.mesh_bridge import MeshBridge
+        name = MeshBridge._get_display_name({"longname": "x" * 255, "shortname": "ABCD"}, "id")
+        assert 1 <= len(name) <= 80
+        name = MeshBridge._get_display_name({"longname": "Team Clyde Discord Relay", "shortname": "TC"}, "id")
+        assert "clyde" not in name.lower() and "discord" not in name.lower()
+        assert MeshBridge._get_display_name(None, "ab12cd34") == "!ab12cd34"
+
+    def test_author_name_clamped_to_256(self):
+        gws = big_gateways(2)
+        nodes = {"d952bddd": {"longname": "L" * 300, "shortname": "SHRT"}}
+        embed, _ = build_text_embed(
+            msg={"from": "d952bddd", "id": 1, "timestamp": 1787000000},
+            chat={"from": "d952bddd", "text": "hi", "timestamp": 1787000000},
+            nodes=nodes, base_url="", config={}, gateway_entries=gws,
+        )
+        assert len(embed.author.name) <= 256
+        assert embed.author.name.endswith("[SHRT]")
+
+    def test_mention_chunks_never_split_a_token_or_exceed_content_limit(self):
+        from bot.cogs.mesh_bridge import MESSAGE_CONTENT_LIMIT, _chunk_mentions
+        ids = [str(10**17 + i) for i in range(300)]
+        chunks = _chunk_mentions(ids)
+        assert all(len(c) <= MESSAGE_CONTENT_LIMIT for c in chunks)
+        rejoined = " ".join(chunks).split(" ")
+        assert rejoined == [f"<@{i}>" for i in ids]
+
+    def test_altitude_junk_is_dropped(self):
+        from bot.embeds import build_position_embed
+        for alt in ("a" * 1200, True, float("nan"), None):
+            embed = build_position_embed(
+                msg={"from": "d952bddd", "id": 1, "timestamp": 1787000000,
+                     "payload": {"latitude_i": 393412608, "longitude_i": -1210384384,
+                                 "altitude": alt}},
+                node_id="d952bddd", nodes={}, base_url="", config={},
+            )
+            assert not any(f.name == "Altitude" for f in embed.fields)
+        embed = build_position_embed(
+            msg={"from": "d952bddd", "id": 1, "timestamp": 1787000000,
+                 "payload": {"latitude_i": 393412608, "longitude_i": -1210384384,
+                             "altitude": 853}},
+            node_id="d952bddd", nodes={}, base_url="", config={},
+        )
+        assert any(f.name == "Altitude" and f.value == "853m" for f in embed.fields)
+
+    def test_oversized_hop_group_spills_into_more_embeds_not_silent_cuts(self):
+        """A single huge hop group must chunk across embeds; anything actually
+        cut must raise the truncation note."""
+        gws = big_gateways(200, hops_spread=1)
+        embeds = build_gateway_detail_embed(
+            msg={"from": "d952bddd", "id": 1}, nodes=named_nodes(gws),
+            base_url="https://mesh.example.com", gateway_entries=gws,
+        )
+        assert len(embeds) >= 2  # spilled, not squeezed into one
+        assert all(len(e.description) <= EMBED_DESC_LIMIT for e in embeds)
+        assert sum(len(e) for e in embeds) <= EMBED_TOTAL_LIMIT


### PR DESCRIPTION
Fixes #585.

## Problem

The mesh-to-Discord bridge aggregated gateway reports for a packet for only
60 seconds. Real uplink copies straggle much longer (measured on a live
instance: 5.6% of text packets have a copy arriving >60 s after the first,
average lag ~145 s, worst ~14 min), so a late copy re-created the packet from
scratch and posted a **second embed with `Gateways 1`** — the duplicates in
#585. The channel-bucket unification made this visible: previously most
stragglers resolved to unmapped channel keys and were silently ignored.

## What this does

**Duplicate fix**

- Posted packets stay editable for `[integrations.discord.bridge]
  edit_window_seconds` (default 900 s): straggler copies **edit** the original
  embed's gateway list instead of re-posting. Edits are throttled to one per
  aggregate window, a packet expiring with pending changes gets a final flush,
  and messages are edited the way they were sent (webhook vs bot fallback —
  editing across the two 404s and re-posts).
- Never-postable events (unmapped channels, untracked positions) no longer
  occupy aggregation slots, and eviction prefers already-posted entries, so
  capacity pressure can't resurrect the duplicate.
- Embed timestamps are the packet's own time (stable across edits) — clamped
  to a sane window of first sight, so a node with a broken clock (one ships
  rx_time 8 months in the past) shows arrival time instead.
- The "View All Gateways" button survives bot restarts (`DynamicItem`).

**Discord payload limits** (audited every send site)

- Detail view capped to Discord's per-message limits — 10 embeds / 6000 chars
  total — with a truncation note; oversized hop groups spill across embeds.
- Author names ≤256; webhook usernames ≤80 with disallowed substrings
  sanitized; status-alert mentions chunked under the 2000-char content limit
  without splitting a ping; junk altitude values dropped.

**Name-keyed channel maps**

- `[integrations.discord.bridge.channels]` / `position_channels` keys can now
  be wire channel names (`"MediumFast" = "<discord channel id>"`) — what
  operators actually know. Numeric bucket-id keys still work and take
  precedence (useful to pin one name+PSK domain when communities share a
  name); a name key follows the channel across PSK re-keys and matches
  decode-only channels whose hash never appears on the wire.
- `/topnodes` translates a name key to its bucket ids (name bucket + learned
  hash), so channel-scoped leaderboards keep working with either key form.
- JSON-only deployments keep numeric keys (their messages carry no wire
  name); documented in UPGRADING.md alongside the new knobs.

## Notes for reviewers

- No schema migration; no ingest/storage behavior changes — everything here
  is bridge/display side. Existing numeric-key configs work unchanged.
- `tests/test_mesh_bridge.py` is new: 45 tests covering straggler-edit
  behavior, aggregation/eviction/throttle races, key precedence, broken
  clocks, and adversarial payload-limit cases (up to 1000 gateways).
- Verified on a live instance: same-packet stragglers edit the posted embed
  in place.
